### PR TITLE
fix: Properly handle page sizes different than 4096

### DIFF
--- a/perf-self-profile/src/ring_buffer.rs
+++ b/perf-self-profile/src/ring_buffer.rs
@@ -119,10 +119,15 @@ impl RingBuffer {
 
     fn data_slice(&self) -> &[u8] {
         unsafe {
-            let data_ptr = self.base.add(4096); // skip metadata page
+            let data_ptr = self.base.add(page_size()); // skip metadata page
             std::slice::from_raw_parts(data_ptr, self.data_size as usize)
         }
     }
+}
+
+pub(crate) fn page_size() -> usize {
+    // Safety: sysconf(_SC_PAGESIZE) is always safe and always succeeds on Linux.
+    unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
 }
 
 impl Drop for RingBuffer {


### PR DESCRIPTION
Note that the libc call is not actually a syscall, just reading a global variable.