### PR TITLE
Fix: take_rotated() side effect lost inside debug_assert in release builds

### DIFF
--- a/dial9-tokio-telemetry/src/telemetry/recorder/event_writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/event_writer.rs
@@ -58,9 +58,10 @@ impl EventWriter {
             WriteAtomicResult::Written => Ok(WriteAtomicResult::Written),
             WriteAtomicResult::OversizedBatch => Ok(WriteAtomicResult::OversizedBatch),
             WriteAtomicResult::Rotated => {
+                let was_rotated = self.writer.take_rotated();
                 debug_assert!(
-                    self.writer.take_rotated(),
-                    "write atomic returned true, rotation occured"
+                    was_rotated,
+                    "write atomic returned Rotated, but take_rotated() was false"
                 );
                 self.handle_rotation();
                 let events = self.flush_state.resolve(raw);


### PR DESCRIPTION
## Problem

`take_rotated()` was called as the expression inside `debug_assert!()`, which is compiled out in release builds. This meant the `rotated` flag was never cleared on the write retry path, causing the second `write_atomic` to see `rotated == true` and return `Rotated` again — triggering the "double failed to write events" error and disabling telemetry for the rest of the process.

This was easy to hit when `max_file_size == max_total_size` (e.g. the new `--demo` mode), but could also occur in normal usage whenever rotation happened to coincide with the total size budget.

## Fix

Move `take_rotated()` to a `let` binding before the `debug_assert`, so the side effect always runs.

## Testing

Reproduced with `--demo` mode (2MB file/total limit). Before fix: "double failed to write events" on every run. After fix: clean runs, no errors.