### PR TITLE
Fix trace viewer crash when loading trace from URL parameter

### DIFF
--- a/dial9-tokio-telemetry/trace_viewer/index.html
+++ b/dial9-tokio-telemetry/trace_viewer/index.html
@@ -447,6 +447,8 @@
             let wakesByWorker = {}; // workerId → [{timestamp, wakerTaskId, wokenTaskId}]
             // Scheduling delays: wake → next poll for same task
             let schedDelays = []; // [{wakeTime, pollTime, delay, taskId, wakerTaskId, worker}]
+            // Lane canvases per worker (populated by buildLanes)
+            let laneCanvases = {};
 
             const LABEL_W = 100;
             const LANE_H = 60;
@@ -523,7 +525,7 @@
                 loadTraceFromUrl(traceUrl);
             }
 
-            document.getElementById("load-demo").addEventListener("click", (e) => {
+            document.getElementById("load-demo")?.addEventListener("click", (e) => {
                 e.stopPropagation();
                 e.preventDefault();
                 dropZone.innerHTML = 'Loading demo trace…';
@@ -944,7 +946,6 @@
             }
 
             // ── Lane DOM ──
-            let laneCanvases = {};
             function buildLanes() {
                 lanesContainer.innerHTML = "";
                 laneCanvases = {};


### PR DESCRIPTION
Two issues when loading via `?trace=<url>`:

1. **TDZ error on `laneCanvases`**: The variable was declared with `let` at line 949, after the `loadTraceFromUrl` call site at line 523. When the fetch resolved and `buildLanes()` tried to access it, the variable was still in the temporal dead zone. Moved the declaration up to the state variables section.

2. **Null reference on `#load-demo`**: `dropZone.innerHTML = 'Loading trace…'` destroyed the `#load-demo` link element before `getElementById('load-demo')` ran on the next line. Added optional chaining (`?.`) since the demo button isn't needed when already loading from URL.

The button-based 'load demo trace' path was unaffected because by the time a user clicks it, the entire script has finished executing.