### PR TITLE
Fix missing symbols in off-worker stack traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
 name = "dial9-perf-self-profile"
 version = "0.1.1"
 dependencies = [
+ "backtrace",
  "blazesym",
  "libc",
  "perf-event-data",

--- a/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
+++ b/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
@@ -55,6 +55,9 @@ pub(crate) struct CpuProfiler {
     /// Offset to convert perf timestamps (CLOCK_MONOTONIC nanos, via use_clockid) to trace-relative nanos.
     /// trace_ns = perf_time - clock_offset
     clock_offset: u64,
+    /// Our process ID — used to filter out samples from child processes
+    /// (perf `inherit` causes child process samples to land in our ring buffer).
+    pid: u32,
     /// OS tid → worker_id mapping, populated from SharedState.worker_tids.
     tid_to_worker: HashMap<u32, usize>,
     /// OS tid → thread name, eagerly cached at drain time so short-lived threads
@@ -76,6 +79,7 @@ impl CpuProfiler {
         Ok(Self {
             sampler,
             clock_offset: trace_start_mono_ns,
+            pid: std::process::id(),
             tid_to_worker: HashMap::new(),
             tid_to_name: HashMap::new(),
         })
@@ -91,7 +95,13 @@ impl CpuProfiler {
     /// Eagerly reads `/proc/self/task/<tid>/comm` for non-worker tids so that
     /// thread names are captured before short-lived threads exit.
     pub fn drain(&mut self, mut f: impl FnMut(TelemetryEvent, Option<&str>)) {
+        let pid = self.pid;
         self.sampler.for_each_sample(|sample| {
+            // Skip samples from child processes — perf `inherit` causes their
+            // samples to land in our ring buffer, but we can't symbolize them.
+            if sample.pid != pid {
+                return;
+            }
             let timestamp_nanos = sample.time.saturating_sub(self.clock_offset);
             let worker_id = self
                 .tid_to_worker

--- a/perf-self-profile/Cargo.toml
+++ b/perf-self-profile/Cargo.toml
@@ -14,5 +14,6 @@ all-features = true
 [dependencies]
 libc = "0.2"
 blazesym = "0.2"
+backtrace = "0.3"
 perf-event-data = "0.1.8"
 perf-event-open-sys2 = "5.0.6"

--- a/perf-self-profile/src/symbolize.rs
+++ b/perf-self-profile/src/symbolize.rs
@@ -1,4 +1,4 @@
-//! Minimal symbol resolution using `blazesym`.
+//! Minimal symbol resolution using `blazesym` with `backtrace` fallback.
 
 use blazesym::symbolize::{Input, Symbolizer, source};
 use std::cell::RefCell;
@@ -129,8 +129,32 @@ pub fn resolve_symbol(addr: u64) -> SymbolInfo {
             }
         }
 
-        EMPTY
+        // Fallback: use backtrace::resolve for addresses not in /proc/self/maps
+        // (e.g. vdso, or addresses that blazesym couldn't symbolize)
+        resolve_with_backtrace(addr)
     })
+}
+
+/// Fallback symbol resolution using the `backtrace` crate.
+/// Handles addresses that blazesym can't resolve (e.g. vdso, JIT code).
+fn resolve_with_backtrace(addr: u64) -> SymbolInfo {
+    let mut info = EMPTY;
+    backtrace::resolve(addr as *mut std::ffi::c_void, |sym| {
+        if info.name.is_some() {
+            return; // take only the first resolution
+        }
+        info.name = sym.name().map(|n| n.to_string());
+        info.base_addr = sym.addr().map_or(0, |a| a as u64);
+        info.offset = addr.saturating_sub(info.base_addr);
+        if let Some(filename) = sym.filename() {
+            info.code_info = Some(CodeInfo {
+                file: filename.to_string_lossy().into_owned(),
+                line: sym.lineno(),
+                column: sym.colno().map(|c| c as u16),
+            });
+        }
+    });
+    info
 }
 
 #[cfg(test)]
@@ -170,5 +194,52 @@ mod tests {
         assert!(parse_maps_line("garbage").is_none());
         assert!(parse_maps_line("").is_none());
         assert!(parse_maps_line("not-hex r-xp 00000000 08:01 1234 /foo").is_none());
+    }
+
+    #[inline(never)]
+    fn known_function_for_test() -> u64 {
+        42
+    }
+
+    /// Verify that resolve_symbol resolves a known function in the current process.
+    #[test]
+    fn resolve_symbol_finds_known_function() {
+        let addr = known_function_for_test as *const () as u64;
+        let info = resolve_symbol(addr);
+        let name = info
+            .name
+            .expect("resolve_symbol should resolve a known function");
+        assert!(
+            name.contains("known_function_for_test"),
+            "expected symbol containing 'known_function_for_test', got: {name}"
+        );
+    }
+
+    /// Verify that a bogus kernel-space address doesn't panic and returns no name.
+    #[test]
+    fn resolve_symbol_bogus_address_returns_no_name() {
+        let info = resolve_symbol(0xffff_ffff_dead_beef);
+        assert!(info.name.is_none(), "kernel address should not resolve");
+    }
+
+    /// Verify that the backtrace fallback resolves real instruction pointers
+    /// (as would come from perf_event callchains).
+    #[test]
+    fn backtrace_fallback_resolves_real_instruction_pointer() {
+        // Capture a real IP from the current call stack
+        let mut real_ip = 0u64;
+        backtrace::trace(|frame| {
+            if real_ip == 0 {
+                real_ip = frame.ip() as u64;
+            }
+            false
+        });
+        assert_ne!(real_ip, 0, "should capture a real IP");
+        let info = resolve_with_backtrace(real_ip);
+        assert!(
+            info.name.is_some(),
+            "backtrace should resolve a real instruction pointer, got None for {:#x}",
+            real_ip
+        );
     }
 }


### PR DESCRIPTION
Fixes #36

Uses `backtrace::resolve` as a fallback when blazesym can't resolve an address. The blazesym path parses `/proc/self/maps` and resolves file offsets, which fails for addresses not in any mapping (e.g. vdso, addresses blazesym can't symbolize). The `backtrace` crate resolves virtual addresses directly via the process symbol table.

Changes:
- Added `backtrace = "0.3"` dependency to `perf-self-profile`
- Added `resolve_with_backtrace()` fallback in `symbolize.rs` that's called when the blazesym path falls through