### PR TITLE
Docs improvements & fix ui paper cuts

### DIFF
--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -117,9 +117,7 @@ let (runtime, guard) = TracedRuntime::builder()
     .with_cpu_profiling(CpuProfilingConfig::default())
     .with_sched_events(SchedEventConfig { include_kernel: true })
     .with_inline_callframe_symbols(true)
-    .build(builder, Box::new(writer))?;
-// Note: `.build()` starts disabled — call `guard.enable()` to begin recording,
-// or use `.build_and_start()` to enable immediately.
+    .build_and_start(builder, Box::new(writer))?;
 # Ok(())
 # }
 # #[cfg(not(feature = "cpu-profiling"))]
@@ -138,13 +136,13 @@ This pulls in [`dial9-perf-self-profile`](/perf-self-profile) for `perf_event_op
 rustflags = ["-C", "force-frame-pointers=yes"]
 ```
 
-**Scheduler events** (`with_sched_events`) require `perf_event_paranoid` ≤ 1:
+**`perf_event_paranoid`**: CPU profiling features require `perf_event_paranoid` ≤ 2 for sampling, and ≤ 1 for scheduler event tracking (`with_sched_events`):
 
 ```bash
 # check current value
 cat /proc/sys/kernel/perf_event_paranoid
 
-# allow unprivileged users to collect scheduling events
+# allow CPU sampling and scheduler event tracking
 sudo sysctl kernel.perf_event_paranoid=1
 ```
 

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -371,6 +371,10 @@ impl TracedRuntimeBuilder {
         Ok((runtime, guard))
     }
 
+    /// Build the traced runtime and immediately enable recording.
+    ///
+    /// Equivalent to calling [`build`](Self::build) followed by
+    /// [`TelemetryGuard::enable`].
     pub fn build_and_start(
         self,
         builder: tokio::runtime::Builder,
@@ -417,12 +421,16 @@ impl TracedRuntime {
         .build(builder, writer)
     }
 
+    /// Build the traced runtime and immediately enable recording.
+    ///
+    /// Equivalent to calling [`build`](Self::build) followed by
+    /// [`TelemetryGuard::enable`].
     pub fn build_and_start(
         builder: tokio::runtime::Builder,
         writer: Box<dyn TraceWriter>,
     ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
         TracedRuntimeBuilder {
-            task_tracking_enabled: true,
+            task_tracking_enabled: false,
             #[cfg(feature = "cpu-profiling")]
             cpu_profiling_config: None,
             #[cfg(feature = "cpu-profiling")]

--- a/dial9-tokio-telemetry/trace_viewer/index.html
+++ b/dial9-tokio-telemetry/trace_viewer/index.html
@@ -1768,7 +1768,7 @@
                         alert("No CPU samples in this trace. Enable cpu-profiling to use shift+drag region select for flamegraphs.");
                         return;
                     }
-                    if (e.shiftKey && trace && trace.cpuSamples.length > 0) {
+                    if (e.shiftKey && trace) {
                         // Shift+drag: region select
                         regionSelecting = true;
                         dragMoved = false;


### PR DESCRIPTION
- Add alert when shift+drag is attempted with no CPU samples loaded, so users understand they need cpu-profiling enabled
- Add guard.enable() comment to README cpu-profiling example that uses .build(), and add doc comments to both build() methods noting they start disabled
- Document frame pointer requirement and perf_event_paranoid <= 1 for scheduler events under a new "Requirements" subsection
- Document how CPU samples on known workers help diagnose long polls
- Fix "2. 2." typo in CPU profiling section