### PR TITLE
Add kernel tracepoint support to perf-self-profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ name = "dial9-perf-self-profile"
 version = "0.1.1"
 dependencies = [
  "blazesym",
+ "dial9-trace-format",
  "libc",
  "perf-event-data",
  "perf-event-open-sys2",

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -5,17 +5,24 @@ use crate::codec::{self, PoolEntry, SymbolEntry, WireTypeId};
 use crate::schema::{SchemaEntry, SchemaRegistry};
 use crate::types::{EncodeState, EventEncoder};
 use std::any::TypeId;
+use std::collections::HashMap;
 use std::io::{self, Write};
+
+/// Key for looking up a previously registered schema.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum SchemaKey {
+    /// Keyed by Rust `TypeId` (compile-time types via `register_schema_for`).
+    Static(TypeId),
+    /// Keyed by name string (runtime-defined types via `register_dynamic_schema`).
+    Dynamic(String),
+}
 
 pub struct Encoder<W: Write = Vec<u8>> {
     state: EncodeState<W>,
     registry: SchemaRegistry,
-    string_pool: std::collections::HashMap<String, u32>,
+    string_pool: HashMap<String, u32>,
     next_pool_id: u32,
-    // Linear scan is faster than HashMap for the typical case (< 20 event types)
-    // due to cache locality and no hashing overhead.
-    // TODO: consider auto-switching to a HashMap when type_ids.len() exceeds a threshold.
-    type_ids: Vec<(TypeId, WireTypeId)>,
+    schema_ids: HashMap<SchemaKey, WireTypeId>,
 }
 
 impl Default for Encoder<Vec<u8>> {
@@ -31,9 +38,9 @@ impl Encoder<Vec<u8>> {
         Self {
             state: EncodeState::new(buf),
             registry: SchemaRegistry::new(),
-            string_pool: std::collections::HashMap::new(),
+            string_pool: HashMap::new(),
             next_pool_id: 0,
-            type_ids: Vec::new(),
+            schema_ids: HashMap::new(),
         }
     }
 
@@ -51,9 +58,9 @@ impl<W: Write> Encoder<W> {
         Ok(Self {
             state: EncodeState::new(writer),
             registry: SchemaRegistry::new(),
-            string_pool: std::collections::HashMap::new(),
+            string_pool: HashMap::new(),
             next_pool_id: 0,
-            type_ids: Vec::new(),
+            schema_ids: HashMap::new(),
         })
     }
 
@@ -62,21 +69,88 @@ impl<W: Write> Encoder<W> {
         self.state.writer
     }
 
-    fn lookup_or_register<T: TraceEvent + 'static>(&mut self) -> io::Result<WireTypeId> {
-        let rust_id = TypeId::of::<T>();
-        for &(tid, wire_id) in &self.type_ids {
-            if tid == rust_id {
+    /// Register a schema under a given key. Idempotent if the schema matches;
+    /// errors if the same key was already registered with a different schema.
+    fn register_schema_impl(
+        &mut self,
+        key: SchemaKey,
+        entry: SchemaEntry,
+    ) -> io::Result<WireTypeId> {
+        if let Some(&wire_id) = self.schema_ids.get(&key) {
+            let existing = self.registry.get(wire_id).unwrap();
+            if *existing == entry {
                 return Ok(wire_id);
             }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "schema already registered with different definition: {}",
+                    entry.name
+                ),
+            ));
         }
         let id = self.registry.next_type_id();
-        let entry = T::schema_entry();
         codec::encode_schema(id, &entry, &mut self.state.writer)?;
         self.registry
             .register(id, entry)
-            .expect("auto-register failed");
-        self.type_ids.push((rust_id, id));
+            .expect("schema registration failed");
+        self.schema_ids.insert(key, id);
         Ok(id)
+    }
+
+    /// Write field values for an event with the given wire type ID.
+    fn write_event_impl(
+        &mut self,
+        type_id: WireTypeId,
+        values: &[crate::types::FieldValue],
+    ) -> io::Result<()> {
+        use crate::types::FieldValue;
+
+        let schema = self.registry.get(type_id).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown type_id: {type_id:?}"),
+            )
+        })?;
+        let has_timestamp = schema.has_timestamp;
+        let expected_fields = schema.fields.len();
+
+        let (ts_delta, field_values) = if has_timestamp {
+            let ts_ns = match values.first() {
+                Some(FieldValue::Varint(ns)) => *ns,
+                _ => {
+                    panic!(
+                        "has_timestamp schema requires first value to be FieldValue::Varint(timestamp_ns)"
+                    )
+                }
+            };
+            let delta = self.state.encode_timestamp_delta(ts_ns)?;
+            (Some(delta), &values[1..])
+        } else {
+            (None, values)
+        };
+
+        assert_eq!(
+            field_values.len(),
+            expected_fields,
+            "value count does not match schema field count for type_id {type_id:?}"
+        );
+
+        self.state.writer.write_all(&[codec::TAG_EVENT])?;
+        self.state.writer.write_all(&type_id.0.to_le_bytes())?;
+        if let Some(delta) = ts_delta {
+            codec::encode_u24_le(delta, &mut self.state.writer)?;
+        }
+        let mut enc = EventEncoder::new(&mut self.state);
+        for v in field_values {
+            enc.write_field_value(v)?;
+        }
+        Ok(())
+    }
+
+    fn lookup_or_register<T: TraceEvent + 'static>(&mut self) -> io::Result<WireTypeId> {
+        let key = SchemaKey::Static(TypeId::of::<T>());
+        self.register_schema_impl(key, T::schema_entry())
     }
 
     /// Register a schema for a marker type `T`. The encoder assigns the wire type_id.
@@ -101,35 +175,13 @@ impl<W: Write> Encoder<W> {
         has_timestamp: bool,
         fields: Vec<crate::schema::FieldDef>,
     ) -> io::Result<WireTypeId> {
-        let rust_id = TypeId::of::<T>();
-        // If already registered, check idempotency
-        if let Some(&(_, wire_id)) = self.type_ids.iter().find(|(tid, _)| *tid == rust_id) {
-            let existing = self.registry.get(wire_id).unwrap();
-            let new_entry = SchemaEntry {
-                name: name.to_string(),
-                has_timestamp,
-                fields,
-            };
-            if *existing == new_entry {
-                return Ok(wire_id);
-            }
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("type already registered with different schema: {name}"),
-            ));
-        }
-        let id = self.registry.next_type_id();
+        let key = SchemaKey::Static(TypeId::of::<T>());
         let entry = SchemaEntry {
             name: name.to_string(),
             has_timestamp,
             fields,
         };
-        codec::encode_schema(id, &entry, &mut self.state.writer)?;
-        self.registry
-            .register(id, entry)
-            .expect("schema registration failed");
-        self.type_ids.push((rust_id, id));
-        Ok(id)
+        self.register_schema_impl(key, entry)
     }
 
     /// Write a derived TraceEvent. Auto-registers the schema on first call for this type.
@@ -158,46 +210,77 @@ impl<W: Write> Encoder<W> {
         &mut self,
         values: &[crate::types::FieldValue],
     ) -> io::Result<()> {
-        use crate::types::FieldValue;
+        let key = SchemaKey::Static(TypeId::of::<T>());
+        let tid = *self
+            .schema_ids
+            .get(&key)
+            .expect("type not registered; call register_schema_for first");
+        self.write_event_impl(tid, values)
+    }
 
-        let rust_id = TypeId::of::<T>();
-        let tid = self
-            .type_ids
-            .iter()
-            .find(|(id, _)| *id == rust_id)
-            .expect("type not registered; call register_schema_for first")
-            .1;
-        let schema = self.registry.get(tid).unwrap();
-        let has_timestamp = schema.has_timestamp;
-
-        let (ts_delta, field_values) = if has_timestamp {
-            let ts_ns = match values.first() {
-                Some(FieldValue::Varint(ns)) => *ns,
-                _ => {
-                    panic!(
-                        "has_timestamp schema requires first value to be FieldValue::Varint(timestamp_ns)"
-                    )
-                }
-            };
-            let delta = self.state.encode_timestamp_delta(ts_ns)?;
-            (Some(delta), &values[1..])
-        } else {
-            (None, values)
+    /// Register a schema by name without requiring a compile-time Rust type.
+    /// Returns the assigned [`WireTypeId`].
+    ///
+    /// All dynamic schemas have timestamps. The timestamp is passed as the first
+    /// element when writing events via [`write_dynamic_event`](Self::write_dynamic_event).
+    ///
+    /// Idempotent: re-registering the same name with the same fields returns the
+    /// existing ID. Returns an error if the name was already registered with a
+    /// different schema.
+    pub fn register_dynamic_schema(
+        &mut self,
+        name: &str,
+        fields: Vec<crate::schema::FieldDef>,
+    ) -> io::Result<WireTypeId> {
+        let key = SchemaKey::Dynamic(name.to_string());
+        let entry = SchemaEntry {
+            name: name.to_string(),
+            has_timestamp: true,
+            fields,
         };
+        self.register_schema_impl(key, entry)
+    }
 
-        assert_eq!(
-            field_values.len(),
-            schema.fields.len(),
-            "value count does not match schema field count for type_id {tid:?}"
-        );
+    /// Write an event for a dynamically registered schema (see
+    /// [`register_dynamic_schema`](Self::register_dynamic_schema)).
+    ///
+    /// `timestamp_ns` is encoded in the event header. `values` contains the
+    /// field values (must match the schema's field count).
+    pub fn write_dynamic_event(
+        &mut self,
+        type_id: WireTypeId,
+        timestamp_ns: u64,
+        values: &[crate::types::FieldValue],
+    ) -> io::Result<()> {
+        let expected_fields = self
+            .registry
+            .get(type_id)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown dynamic type_id: {type_id:?}"),
+                )
+            })?
+            .fields
+            .len();
 
-        self.state.writer.write_all(&[codec::TAG_EVENT])?;
-        self.state.writer.write_all(&tid.0.to_le_bytes())?;
-        if let Some(delta) = ts_delta {
-            codec::encode_u24_le(delta, &mut self.state.writer)?;
+        if values.len() != expected_fields {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "value count ({}) does not match schema field count ({}) for type_id {type_id:?}",
+                    values.len(),
+                    expected_fields,
+                ),
+            ));
         }
+
+        let ts_delta = self.state.encode_timestamp_delta(timestamp_ns)?;
+        self.state.writer.write_all(&[codec::TAG_EVENT])?;
+        self.state.writer.write_all(&type_id.0.to_le_bytes())?;
+        codec::encode_u24_le(ts_delta, &mut self.state.writer)?;
         let mut enc = EventEncoder::new(&mut self.state);
-        for v in field_values {
+        for v in values {
             enc.write_field_value(v)?;
         }
         Ok(())
@@ -403,6 +486,114 @@ mod tests {
         // Should at least have the header
         assert!(buf.len() >= 5);
         assert_eq!(&buf[..5], &[0x54, 0x52, 0x43, 0x00, 1]);
+    }
+
+    #[test]
+    fn dynamic_register_and_write() {
+        use crate::decoder::{DecodedFrame, Decoder};
+        use crate::types::FieldValue;
+
+        let mut enc = Encoder::new();
+        let tid = enc
+            .register_dynamic_schema(
+                "MyEvent",
+                vec![
+                    FieldDef {
+                        name: "count".into(),
+                        field_type: FieldType::Varint,
+                    },
+                    FieldDef {
+                        name: "name".into(),
+                        field_type: FieldType::String,
+                    },
+                ],
+            )
+            .unwrap();
+
+        enc.write_dynamic_event(
+            tid,
+            1_000_000,
+            &[FieldValue::Varint(42), FieldValue::String("hello".into())],
+        )
+        .unwrap();
+
+        let bytes = enc.finish();
+        let mut dec = Decoder::new(&bytes).unwrap();
+        let frames = dec.decode_all();
+        let events: Vec<_> = frames
+            .into_iter()
+            .filter_map(|f| match f {
+                DecodedFrame::Event {
+                    timestamp_ns,
+                    values,
+                    ..
+                } => Some((timestamp_ns, values)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, Some(1_000_000));
+        assert_eq!(events[0].1[0], FieldValue::Varint(42));
+        assert_eq!(events[0].1[1], FieldValue::String("hello".into()));
+    }
+
+    #[test]
+    fn dynamic_register_idempotent() {
+        let mut enc = Encoder::new();
+        let fields = vec![FieldDef {
+            name: "v".into(),
+            field_type: FieldType::Varint,
+        }];
+        let id1 = enc
+            .register_dynamic_schema("Ev", fields.clone())
+            .unwrap();
+        let id2 = enc.register_dynamic_schema("Ev", fields).unwrap();
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn dynamic_register_conflict_errors() {
+        let mut enc = Encoder::new();
+        enc.register_dynamic_schema(
+            "Ev",
+            vec![FieldDef {
+                name: "v".into(),
+                field_type: FieldType::Varint,
+            }],
+        )
+        .unwrap();
+        let result = enc.register_dynamic_schema(
+            "Ev",
+            vec![FieldDef {
+                name: "other".into(),
+                field_type: FieldType::Bool,
+            }],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn dynamic_write_wrong_field_count_errors() {
+        let mut enc = Encoder::new();
+        let tid = enc
+            .register_dynamic_schema(
+                "Ev",
+                vec![FieldDef {
+                    name: "v".into(),
+                    field_type: FieldType::Varint,
+                }],
+            )
+            .unwrap();
+        // Pass 2 values for a 1-field schema
+        let result = enc.write_dynamic_event(
+            tid,
+            0,
+            &[
+                crate::types::FieldValue::Varint(1),
+                crate::types::FieldValue::Varint(2),
+            ],
+        );
+        assert!(result.is_err());
     }
 
     /// Verify that the encoder advances the timestamp base after each event,

--- a/perf-self-profile/Cargo.toml
+++ b/perf-self-profile/Cargo.toml
@@ -14,5 +14,6 @@ all-features = true
 [dependencies]
 libc = "0.2"
 blazesym = "0.2"
+dial9-trace-format = { path = "../dial9-trace-format" }
 perf-event-data = "0.1.8"
 perf-event-open-sys2 = "5.0.6"

--- a/perf-self-profile/src/lib.rs
+++ b/perf-self-profile/src/lib.rs
@@ -40,6 +40,7 @@
 mod ring_buffer;
 mod sampler;
 mod symbolize;
+pub mod tracepoint;
 
 pub use sampler::{EventSource, PerfSampler, Sample, SamplerConfig};
 pub use symbolize::resolve_symbol;

--- a/perf-self-profile/src/sampler.rs
+++ b/perf-self-profile/src/sampler.rs
@@ -9,8 +9,8 @@ use perf_event_data::parse::{ParseConfig, Parser};
 use perf_event_open_sys::bindings::{
     PERF_COUNT_HW_CPU_CYCLES, PERF_COUNT_SW_CONTEXT_SWITCHES, PERF_COUNT_SW_CPU_CLOCK,
     PERF_COUNT_SW_TASK_CLOCK, PERF_FLAG_FD_CLOEXEC, PERF_SAMPLE_CALLCHAIN, PERF_SAMPLE_CPU,
-    PERF_SAMPLE_IP, PERF_SAMPLE_PERIOD, PERF_SAMPLE_TID, PERF_SAMPLE_TIME, PERF_TYPE_HARDWARE,
-    PERF_TYPE_SOFTWARE, perf_event_attr,
+    PERF_SAMPLE_IP, PERF_SAMPLE_PERIOD, PERF_SAMPLE_RAW, PERF_SAMPLE_TID, PERF_SAMPLE_TIME,
+    PERF_TYPE_HARDWARE, PERF_TYPE_SOFTWARE, PERF_TYPE_TRACEPOINT, perf_event_attr,
 };
 
 use crate::ring_buffer::{RingBuffer, page_size};
@@ -33,6 +33,11 @@ pub enum EventSource {
     /// Captures the stack at the moment the thread is descheduled, revealing
     /// what code path led to the thread going off-CPU (e.g. mutex, I/O, preemption).
     SwContextSwitches,
+    /// A kernel tracepoint, identified by its tracepoint ID.
+    ///
+    /// The ID comes from `/sys/kernel/debug/tracing/events/<subsystem>/<event>/id`.
+    /// Samples include raw tracepoint data accessible via [`Sample::raw`].
+    Tracepoint(u32),
 }
 
 /// Configuration for the sampler.
@@ -76,6 +81,9 @@ pub struct Sample {
     /// First entry is the instruction pointer (leaf), rest are return addresses.
     /// Kernel context markers and hypervisor frames are filtered out.
     pub callchain: Vec<u64>,
+    /// Raw tracepoint data, present only for [`EventSource::Tracepoint`] events.
+    /// Parse with [`TracepointDef::extract_fields`](crate::tracepoint::TracepointDef::extract_fields).
+    pub raw: Option<Vec<u8>>,
 }
 
 struct PerfEvent {
@@ -188,7 +196,10 @@ impl PerfSampler {
     pub fn start_for_pid(pid: i32, config: SamplerConfig) -> io::Result<Self> {
         let mut attr = Self::build_attr(&config)?;
 
-        let is_event_based = matches!(config.event_source, EventSource::SwContextSwitches);
+        let is_event_based = matches!(
+            config.event_source,
+            EventSource::SwContextSwitches | EventSource::Tracepoint(_)
+        );
         let mut events = Vec::new();
 
         if is_event_based {
@@ -291,16 +302,28 @@ impl PerfSampler {
                 attr.type_ = PERF_TYPE_SOFTWARE;
                 attr.config = PERF_COUNT_SW_CONTEXT_SWITCHES as u64;
             }
+            EventSource::Tracepoint(id) => {
+                attr.type_ = PERF_TYPE_TRACEPOINT;
+                attr.config = id as u64;
+            }
         }
 
-        let is_event_based = matches!(config.event_source, EventSource::SwContextSwitches);
+        let is_event_based = matches!(
+            config.event_source,
+            EventSource::SwContextSwitches | EventSource::Tracepoint(_)
+        );
 
         attr.sample_type = PERF_SAMPLE_IP as u64
             | PERF_SAMPLE_CALLCHAIN as u64
             | PERF_SAMPLE_TID as u64
             | PERF_SAMPLE_TIME as u64
             | PERF_SAMPLE_CPU as u64
-            | PERF_SAMPLE_PERIOD as u64;
+            | PERF_SAMPLE_PERIOD as u64
+            | if matches!(config.event_source, EventSource::Tracepoint(_)) {
+                PERF_SAMPLE_RAW as u64
+            } else {
+                0
+            };
 
         // Use CLOCK_MONOTONIC so perf timestamps are in the same clock domain
         // as Rust's `Instant::now()`. Without this, perf defaults to
@@ -384,6 +407,7 @@ impl PerfSampler {
                             cpu: s.cpu().unwrap_or(0),
                             period: s.period().unwrap_or(0),
                             callchain,
+                            raw: s.raw().map(|r| r.to_vec()),
                         }
                     }
                     _ => return,

--- a/perf-self-profile/src/tracepoint.rs
+++ b/perf-self-profile/src/tracepoint.rs
@@ -1,0 +1,791 @@
+//! Parse kernel tracepoint format files and extract typed field values from raw
+//! perf sample data.
+//!
+//! Tracepoint format files live under tracefs, typically at
+//! `/sys/kernel/debug/tracing/events/<subsystem>/<event>/format`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use dial9_perf_self_profile::tracepoint::TracepointDef;
+//!
+//! let tp = TracepointDef::from_event("sched", "sched_switch").unwrap();
+//! println!("tracepoint {} has id {}", tp.name, tp.id);
+//! for field in &tp.fields {
+//!     println!("  {}: {} (offset={}, size={})", field.name, field.field_type, field.offset, field.size);
+//! }
+//! ```
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use dial9_trace_format::codec::WireTypeId;
+use dial9_trace_format::encoder::Encoder;
+use dial9_trace_format::schema::FieldDef;
+use dial9_trace_format::types::{FieldType, FieldValue};
+
+use crate::EventSource;
+
+/// A single field parsed from a kernel tracepoint format file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TracepointField {
+    /// Field name, e.g. `"prev_pid"`.
+    pub name: String,
+    /// Raw kernel type string, e.g. `"unsigned int"`, `"char[16]"`, `"pid_t"`.
+    pub field_type: String,
+    /// Byte offset within the raw tracepoint data.
+    pub offset: usize,
+    /// Size in bytes (for `__data_loc` fields this is 4 — the loc descriptor).
+    pub size: usize,
+    /// Whether the field is signed.
+    pub signed: bool,
+    /// `true` for `__data_loc` fields whose data is appended after the
+    /// fixed-size record.  The 4 bytes at `offset` encode
+    /// `(data_offset << 16) | data_length`.
+    pub is_dynamic: bool,
+}
+
+/// A parsed kernel tracepoint definition.
+#[derive(Debug, Clone)]
+pub struct TracepointDef {
+    /// Event name, e.g. `"sched_switch"`.
+    pub name: String,
+    /// Tracepoint ID for use with `perf_event_open` (`attr.config`).
+    pub id: u32,
+    /// Non-common fields (common fields like `common_type` are excluded).
+    pub fields: Vec<TracepointField>,
+}
+
+/// Default tracefs mount point.
+const TRACEFS_PATH: &str = "/sys/kernel/debug/tracing";
+
+/// Find the tracefs mount point. Checks the default location first, then falls
+/// back to `/sys/kernel/tracing` (tracefs mounted directly on newer kernels).
+fn tracefs_root() -> io::Result<PathBuf> {
+    let default = Path::new(TRACEFS_PATH);
+    if default.exists() {
+        return Ok(default.to_path_buf());
+    }
+    let alt = Path::new("/sys/kernel/tracing");
+    if alt.exists() {
+        return Ok(alt.to_path_buf());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "tracefs not found at /sys/kernel/debug/tracing or /sys/kernel/tracing",
+    ))
+}
+
+impl TracepointDef {
+    /// Look up a tracepoint by subsystem and event name, reading from tracefs.
+    ///
+    /// Reads the format file at `<tracefs>/events/<subsystem>/<event>/format`.
+    pub fn from_event(subsystem: &str, event: &str) -> io::Result<Self> {
+        let root = tracefs_root()?;
+        let format_path = root.join("events").join(subsystem).join(event).join("format");
+        Self::from_format_file(&format_path)
+    }
+
+    /// Parse a tracepoint format file.
+    pub fn from_format_file(path: &Path) -> io::Result<Self> {
+        let contents = std::fs::read_to_string(path)?;
+        Self::parse_format(&contents)
+    }
+
+    /// Parse format file contents (useful for testing without filesystem access).
+    pub fn parse_format(contents: &str) -> io::Result<Self> {
+        let mut name = String::new();
+        let mut id: u32 = 0;
+        let mut fields = Vec::new();
+
+        for line in contents.lines() {
+            let trimmed = line.trim();
+
+            if let Some(rest) = trimmed.strip_prefix("name:") {
+                name = rest.trim().to_string();
+            } else if let Some(rest) = trimmed.strip_prefix("ID:") {
+                id = rest.trim().parse::<u32>().map_err(|e| {
+                    io::Error::new(io::ErrorKind::InvalidData, format!("bad ID: {e}"))
+                })?;
+            } else if let Some(rest) = trimmed.strip_prefix("field:") {
+                if let Some(field) = parse_field_line(rest) {
+                    // Skip common fields (kernel bookkeeping).
+                    if !field.name.starts_with("common_") {
+                        fields.push(field);
+                    }
+                }
+            }
+        }
+
+        if name.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "format file missing 'name:' line",
+            ));
+        }
+
+        Ok(TracepointDef { name, id, fields })
+    }
+
+    /// Extract typed field values from raw tracepoint data.
+    ///
+    /// Returns `(field_name, value)` pairs for each field in the definition.
+    /// Returns an error if the raw data is too short for any field.
+    pub fn extract_fields<'a>(&'a self, raw: &[u8]) -> io::Result<Vec<(&'a str, RawFieldValue)>> {
+        let mut result = Vec::with_capacity(self.fields.len());
+        for field in &self.fields {
+            let end = field.offset + field.size;
+            if end > raw.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "raw data too short for field '{}': need {} bytes, have {}",
+                        field.name,
+                        end,
+                        raw.len()
+                    ),
+                ));
+            }
+
+            if field.is_dynamic {
+                // __data_loc: 4 bytes at field.offset encode (offset << 16) | length
+                let loc = u32::from_ne_bytes(raw[field.offset..field.offset + 4].try_into().unwrap());
+                let data_off = (loc >> 16) as usize;
+                let data_len = (loc & 0xffff) as usize;
+                let data_end = data_off + data_len;
+                if data_end > raw.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "__data_loc field '{}' points beyond raw data: off={} len={}, have {}",
+                            field.name, data_off, data_len, raw.len()
+                        ),
+                    ));
+                }
+                let s = nul_terminated_str(&raw[data_off..data_end]);
+                result.push((field.name.as_str(), RawFieldValue::Str(s)));
+            } else {
+                let bytes = &raw[field.offset..end];
+                let value = extract_field_value(bytes, field.size, field.signed, &field.field_type);
+                result.push((field.name.as_str(), value));
+            }
+        }
+        Ok(result)
+    }
+
+    /// Convert field definitions to `dial9-trace-format` [`FieldDef`]s.
+    pub fn to_trace_format_fields(&self) -> Vec<FieldDef> {
+        self.fields.iter().map(|f| kernel_field_to_trace_format(f)).collect()
+    }
+
+    /// Convert extracted field values to `dial9-trace-format` [`FieldValue`]s.
+    pub fn to_trace_format_values(
+        &self,
+        extracted: &[(&str, RawFieldValue)],
+    ) -> Vec<FieldValue> {
+        extracted
+            .iter()
+            .map(|(_name, raw_val)| raw_to_trace_format_value(raw_val))
+            .collect()
+    }
+
+    /// Return an [`EventSource`] for use with [`SamplerConfig`](crate::SamplerConfig).
+    pub fn event_source(&self) -> EventSource {
+        EventSource::Tracepoint(self.id)
+    }
+
+    /// Register this tracepoint's schema with an [`Encoder`], returning the
+    /// assigned wire type ID for subsequent [`encode_raw`](Self::encode_raw)
+    /// calls.
+    pub fn register<W: Write>(&self, encoder: &mut Encoder<W>) -> io::Result<WireTypeId> {
+        encoder.register_dynamic_schema(&self.name, self.to_trace_format_fields())
+    }
+
+    /// Extract fields from `raw` tracepoint data and write a single event into
+    /// `encoder`.
+    ///
+    /// `type_id` must have been obtained from a prior [`register`](Self::register)
+    /// call on the same encoder.
+    pub fn encode_raw<W: Write>(
+        &self,
+        encoder: &mut Encoder<W>,
+        type_id: WireTypeId,
+        timestamp_ns: u64,
+        raw: &[u8],
+    ) -> io::Result<()> {
+        let extracted = self.extract_fields(raw)?;
+        let values = self.to_trace_format_values(&extracted);
+        encoder.write_dynamic_event(type_id, timestamp_ns, &values)
+    }
+}
+
+/// A concrete value extracted from raw tracepoint data.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RawFieldValue {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    /// Fixed-size string field (e.g. `char comm[16]`), NUL-trimmed.
+    Str(String),
+    /// Opaque bytes for unknown field types.
+    Bytes(Vec<u8>),
+}
+
+// ---------------------------------------------------------------------------
+// Format file parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a single field line after the `field:` prefix.
+///
+/// Expected format: `<type> <name>;\toffset:<N>;\tsize:<N>;\tsigned:<0|1>;`
+///
+/// The type+name portion may contain array brackets like `char name[16]`.
+fn parse_field_line(line: &str) -> Option<TracepointField> {
+    // Split on `;` to get the parts.
+    let parts: Vec<&str> = line.split(';').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+
+    // First part: "<type> <name>" or "<type> <name>[N]"
+    let type_and_name = parts[0].trim();
+
+    // Parse offset, size, signed from remaining parts.
+    let mut offset = None;
+    let mut size = None;
+    let mut signed = false;
+
+    for part in &parts[1..] {
+        let p = part.trim();
+        if let Some(rest) = p.strip_prefix("offset:") {
+            offset = rest.parse().ok();
+        } else if let Some(rest) = p.strip_prefix("size:") {
+            size = rest.parse().ok();
+        } else if let Some(rest) = p.strip_prefix("signed:") {
+            signed = rest.trim() == "1";
+        }
+    }
+
+    let offset = offset?;
+    let size = size?;
+
+    // Detect __data_loc dynamic fields (e.g. "__data_loc char[] name").
+    let is_dynamic = type_and_name.contains("__data_loc");
+
+    // Split type and name. The name is the last whitespace-separated token,
+    // but may have array brackets: `char name[16]` or `unsigned long addr`.
+    let (field_type, name) = split_type_and_name(type_and_name)?;
+
+    Some(TracepointField {
+        name,
+        field_type,
+        offset,
+        size,
+        signed,
+        is_dynamic,
+    })
+}
+
+/// Split `"unsigned int nr"` into `("unsigned int", "nr")`,
+/// `"char comm[16]"` into `("char[16]", "comm")`, or
+/// `"__data_loc char[] name"` into `("__data_loc char[]", "name")`.
+fn split_type_and_name(s: &str) -> Option<(String, String)> {
+    let s = s.trim();
+
+    if let Some(bracket_pos) = s.rfind('[') {
+        let close = s[bracket_pos..].find(']').map(|i| bracket_pos + i)?;
+        let after_bracket = s[close + 1..].trim();
+
+        if after_bracket.is_empty() {
+            // Brackets are on the name: "char prev_comm[16]"
+            // → type = "char[16]", name = "prev_comm"
+            let before_bracket = &s[..bracket_pos];
+            let array_suffix = &s[bracket_pos..];
+            let last_space = before_bracket.rfind(' ')?;
+            let name = before_bracket[last_space + 1..].trim().to_string();
+            let type_str = format!("{}{}", before_bracket[..last_space].trim(), array_suffix);
+            Some((type_str, name))
+        } else {
+            // Brackets are on the type: "__data_loc char[] name"
+            // → type = "__data_loc char[]", name = "name"
+            let type_str = s[..close + 1].trim().to_string();
+            let name = after_bracket.to_string();
+            Some((type_str, name))
+        }
+    } else {
+        // Simple: "unsigned int nr" → split on last space
+        let last_space = s.rfind(' ')?;
+        let field_type = s[..last_space].trim().to_string();
+        let name = s[last_space + 1..].trim().to_string();
+        Some((field_type, name))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Field value extraction
+// ---------------------------------------------------------------------------
+
+fn extract_field_value(bytes: &[u8], size: usize, signed: bool, field_type: &str) -> RawFieldValue {
+    // String fields: char[N]
+    if is_char_array(field_type) {
+        let s = nul_terminated_str(bytes);
+        return RawFieldValue::Str(s);
+    }
+
+    match (size, signed) {
+        (1, false) => RawFieldValue::U8(bytes[0]),
+        (1, true) => RawFieldValue::I8(bytes[0] as i8),
+        (2, false) => RawFieldValue::U16(u16::from_ne_bytes(bytes[..2].try_into().unwrap())),
+        (2, true) => RawFieldValue::I16(i16::from_ne_bytes(bytes[..2].try_into().unwrap())),
+        (4, false) => RawFieldValue::U32(u32::from_ne_bytes(bytes[..4].try_into().unwrap())),
+        (4, true) => RawFieldValue::I32(i32::from_ne_bytes(bytes[..4].try_into().unwrap())),
+        (8, false) => RawFieldValue::U64(u64::from_ne_bytes(bytes[..8].try_into().unwrap())),
+        (8, true) => RawFieldValue::I64(i64::from_ne_bytes(bytes[..8].try_into().unwrap())),
+        _ => RawFieldValue::Bytes(bytes.to_vec()),
+    }
+}
+
+fn is_char_array(field_type: &str) -> bool {
+    // Matches "char[N]" patterns
+    field_type.starts_with("char[") || field_type.starts_with("__kernel_char[")
+}
+
+/// Extract a NUL-terminated string from a fixed-size buffer.
+fn nul_terminated_str(bytes: &[u8]) -> String {
+    let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Kernel type → dial9-trace-format mapping
+// ---------------------------------------------------------------------------
+
+fn kernel_field_to_trace_format(field: &TracepointField) -> FieldDef {
+    let field_type = if field.is_dynamic {
+        FieldType::String
+    } else {
+        kernel_type_to_field_type(&field.field_type, field.size, field.signed)
+    };
+    FieldDef {
+        name: field.name.clone(),
+        field_type,
+    }
+}
+
+fn kernel_type_to_field_type(type_str: &str, size: usize, signed: bool) -> FieldType {
+    if is_char_array(type_str) {
+        return FieldType::String;
+    }
+
+    // FieldValue doesn't have U8/U16/U32 variants (they decode as Varint),
+    // so we map all unsigned integers to Varint for consistency.
+    match (size, signed) {
+        (1..=8, false) => FieldType::Varint,
+        (1..=8, true) => FieldType::I64,
+        _ => FieldType::Bytes,
+    }
+}
+
+fn raw_to_trace_format_value(raw: &RawFieldValue) -> FieldValue {
+    match raw {
+        RawFieldValue::U8(v) => FieldValue::Varint(*v as u64),
+        RawFieldValue::U16(v) => FieldValue::Varint(*v as u64),
+        RawFieldValue::U32(v) => FieldValue::Varint(*v as u64),
+        RawFieldValue::U64(v) => FieldValue::Varint(*v),
+        RawFieldValue::I8(v) => FieldValue::I64(*v as i64),
+        RawFieldValue::I16(v) => FieldValue::I64(*v as i64),
+        RawFieldValue::I32(v) => FieldValue::I64(*v as i64),
+        RawFieldValue::I64(v) => FieldValue::I64(*v),
+        RawFieldValue::Str(s) => FieldValue::String(s.clone()),
+        RawFieldValue::Bytes(b) => FieldValue::Bytes(b.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SCHED_SWITCH_FORMAT: &str = r#"name: sched_switch
+ID: 316
+format:
+	field:unsigned short common_type;	offset:0;	size:2;	signed:0;
+	field:unsigned char common_flags;	offset:2;	size:1;	signed:0;
+	field:unsigned char common_preempt_count;	offset:3;	size:1;	signed:0;
+	field:int common_pid;	offset:4;	size:4;	signed:1;
+
+	field:char prev_comm[16];	offset:8;	size:16;	signed:0;
+	field:pid_t prev_pid;	offset:24;	size:4;	signed:1;
+	field:int prev_prio;	offset:28;	size:4;	signed:1;
+	field:long prev_state;	offset:32;	size:8;	signed:1;
+	field:char next_comm[16];	offset:40;	size:16;	signed:0;
+	field:pid_t next_pid;	offset:56;	size:4;	signed:1;
+	field:int next_prio;	offset:60;	size:4;	signed:1;
+
+print fmt: "prev_comm=%s prev_pid=%d prev_prio=%d prev_state=%s%s ==> next_comm=%s next_pid=%d next_prio=%d", REC->prev_comm, REC->prev_pid, REC->prev_prio, (REC->prev_state & ((((0x0000 | 0x0001 | 0x0002 | 0x0004 | 0x0008 | 0x0010 | 0x0020 | 0x0040) + 1) << 1) - 1)) ? __print_flags(REC->prev_state & ((((0x0000 | 0x0001 | 0x0002 | 0x0004 | 0x0008 | 0x0010 | 0x0020 | 0x0040) + 1) << 1) - 1), "|", { 0x0001, "S" }, { 0x0002, "D" }) : "R", REC->prev_state & (((0x0000 | 0x0001 | 0x0002 | 0x0004 | 0x0008 | 0x0010 | 0x0020 | 0x0040) + 1) << 1) ? "+" : "", REC->next_comm, REC->next_pid, REC->next_prio
+"#;
+
+    #[test]
+    fn parse_sched_switch_format() {
+        let tp = TracepointDef::parse_format(SCHED_SWITCH_FORMAT).unwrap();
+        assert_eq!(tp.name, "sched_switch");
+        assert_eq!(tp.id, 316);
+        assert_eq!(tp.fields.len(), 7);
+
+        // Check first field
+        assert_eq!(tp.fields[0].name, "prev_comm");
+        assert_eq!(tp.fields[0].field_type, "char[16]");
+        assert_eq!(tp.fields[0].offset, 8);
+        assert_eq!(tp.fields[0].size, 16);
+        assert!(!tp.fields[0].signed);
+
+        // Check prev_pid
+        assert_eq!(tp.fields[1].name, "prev_pid");
+        assert_eq!(tp.fields[1].offset, 24);
+        assert_eq!(tp.fields[1].size, 4);
+        assert!(tp.fields[1].signed);
+
+        // Check prev_state (long, 8 bytes, signed)
+        assert_eq!(tp.fields[3].name, "prev_state");
+        assert_eq!(tp.fields[3].size, 8);
+        assert!(tp.fields[3].signed);
+
+        // Check next_prio (last field)
+        assert_eq!(tp.fields[6].name, "next_prio");
+        assert_eq!(tp.fields[6].offset, 60);
+        assert_eq!(tp.fields[6].size, 4);
+        assert!(tp.fields[6].signed);
+    }
+
+    #[test]
+    fn common_fields_are_excluded() {
+        let tp = TracepointDef::parse_format(SCHED_SWITCH_FORMAT).unwrap();
+        for field in &tp.fields {
+            assert!(
+                !field.name.starts_with("common_"),
+                "common field {} should be excluded",
+                field.name
+            );
+        }
+    }
+
+    #[test]
+    fn extract_fields_from_raw_data() {
+        let tp = TracepointDef::parse_format(SCHED_SWITCH_FORMAT).unwrap();
+
+        // Build fake raw data (64 bytes to cover all fields up to offset 60+4=64).
+        let mut raw = vec![0u8; 64];
+
+        // prev_comm at offset 8, size 16: "bash\0..."
+        raw[8..12].copy_from_slice(b"bash");
+
+        // prev_pid at offset 24, size 4, signed: 1234
+        raw[24..28].copy_from_slice(&1234i32.to_ne_bytes());
+
+        // prev_prio at offset 28, size 4, signed: 120
+        raw[28..32].copy_from_slice(&120i32.to_ne_bytes());
+
+        // prev_state at offset 32, size 8, signed: 1 (TASK_INTERRUPTIBLE)
+        raw[32..40].copy_from_slice(&1i64.to_ne_bytes());
+
+        // next_comm at offset 40, size 16: "tokio\0..."
+        raw[40..45].copy_from_slice(b"tokio");
+
+        // next_pid at offset 56, size 4, signed: 5678
+        raw[56..60].copy_from_slice(&5678i32.to_ne_bytes());
+
+        // next_prio at offset 60, size 4, signed: 120
+        raw[60..64].copy_from_slice(&120i32.to_ne_bytes());
+
+        let fields = tp.extract_fields(&raw).unwrap();
+        assert_eq!(fields.len(), 7);
+
+        assert_eq!(fields[0].0, "prev_comm");
+        assert_eq!(fields[0].1, RawFieldValue::Str("bash".to_string()));
+
+        assert_eq!(fields[1].0, "prev_pid");
+        assert_eq!(fields[1].1, RawFieldValue::I32(1234));
+
+        assert_eq!(fields[3].0, "prev_state");
+        assert_eq!(fields[3].1, RawFieldValue::I64(1));
+
+        assert_eq!(fields[4].0, "next_comm");
+        assert_eq!(fields[4].1, RawFieldValue::Str("tokio".to_string()));
+
+        assert_eq!(fields[5].0, "next_pid");
+        assert_eq!(fields[5].1, RawFieldValue::I32(5678));
+    }
+
+    #[test]
+    fn extract_fields_too_short_errors() {
+        let tp = TracepointDef::parse_format(SCHED_SWITCH_FORMAT).unwrap();
+        let raw = vec![0u8; 10]; // Way too short
+        assert!(tp.extract_fields(&raw).is_err());
+    }
+
+    #[test]
+    fn trace_format_field_mapping() {
+        let tp = TracepointDef::parse_format(SCHED_SWITCH_FORMAT).unwrap();
+        let defs = tp.to_trace_format_fields();
+        assert_eq!(defs.len(), 7);
+
+        // char[16] → String
+        assert_eq!(defs[0].name, "prev_comm");
+        assert_eq!(defs[0].field_type, FieldType::String);
+
+        // pid_t (4 bytes, signed) → I64
+        assert_eq!(defs[1].name, "prev_pid");
+        assert_eq!(defs[1].field_type, FieldType::I64);
+
+        // int (4 bytes, signed) → I64
+        assert_eq!(defs[2].name, "prev_prio");
+        assert_eq!(defs[2].field_type, FieldType::I64);
+
+        // long (8 bytes, signed) → I64
+        assert_eq!(defs[3].name, "prev_state");
+        assert_eq!(defs[3].field_type, FieldType::I64);
+    }
+
+    #[test]
+    fn trace_format_value_conversion() {
+        let tp = TracepointDef::parse_format(SCHED_SWITCH_FORMAT).unwrap();
+
+        let mut raw = vec![0u8; 64];
+        raw[8..12].copy_from_slice(b"bash");
+        raw[24..28].copy_from_slice(&42i32.to_ne_bytes());
+        raw[28..32].copy_from_slice(&120i32.to_ne_bytes());
+        raw[32..40].copy_from_slice(&1i64.to_ne_bytes());
+        raw[40..45].copy_from_slice(b"tokio");
+        raw[56..60].copy_from_slice(&99i32.to_ne_bytes());
+        raw[60..64].copy_from_slice(&120i32.to_ne_bytes());
+
+        let extracted = tp.extract_fields(&raw).unwrap();
+        let values = tp.to_trace_format_values(&extracted);
+
+        // prev_comm → String
+        assert_eq!(values[0], FieldValue::String("bash".to_string()));
+
+        // prev_pid → I64
+        assert_eq!(values[1], FieldValue::I64(42));
+
+        // prev_state → I64
+        assert_eq!(values[3], FieldValue::I64(1));
+    }
+
+    #[test]
+    fn trace_format_round_trip() {
+        use dial9_trace_format::decoder::{DecodedFrame, Decoder};
+        use dial9_trace_format::encoder::Encoder;
+
+        let tp = TracepointDef::parse_format(SCHED_SWITCH_FORMAT).unwrap();
+
+        // Register schema
+        let mut encoder = Encoder::new();
+        let fields = tp.to_trace_format_fields();
+        let type_id = encoder
+            .register_dynamic_schema(&tp.name, fields)
+            .unwrap();
+
+        // Build raw data and extract
+        let mut raw = vec![0u8; 64];
+        raw[8..12].copy_from_slice(b"bash");
+        raw[24..28].copy_from_slice(&42i32.to_ne_bytes());
+        raw[28..32].copy_from_slice(&120i32.to_ne_bytes());
+        raw[32..40].copy_from_slice(&(-1i64).to_ne_bytes());
+        raw[40..44].copy_from_slice(b"init");
+        raw[56..60].copy_from_slice(&1i32.to_ne_bytes());
+        raw[60..64].copy_from_slice(&120i32.to_ne_bytes());
+
+        let extracted = tp.extract_fields(&raw).unwrap();
+        let values = tp.to_trace_format_values(&extracted);
+
+        // Write event with timestamp as separate arg
+        encoder.write_dynamic_event(type_id, 5_000_000, &values).unwrap();
+
+        // Decode and verify
+        let bytes = encoder.finish();
+        let mut decoder = Decoder::new(&bytes).unwrap();
+        let frames = decoder.decode_all();
+
+        let mut found_schema = false;
+        let mut found_event = false;
+
+        for frame in frames {
+            match frame {
+                DecodedFrame::Schema(entry) => {
+                    assert_eq!(entry.name, "sched_switch");
+                    assert!(entry.has_timestamp);
+                    assert_eq!(entry.fields.len(), 7);
+                    assert_eq!(entry.fields[0].name, "prev_comm");
+                    found_schema = true;
+                }
+                DecodedFrame::Event {
+                    timestamp_ns,
+                    values,
+                    ..
+                } => {
+                    assert_eq!(timestamp_ns, Some(5_000_000));
+                    // prev_comm
+                    assert_eq!(values[0], FieldValue::String("bash".to_string()));
+                    // prev_pid
+                    assert_eq!(values[1], FieldValue::I64(42));
+                    // prev_state (negative)
+                    assert_eq!(values[3], FieldValue::I64(-1));
+                    // next_comm
+                    assert_eq!(values[4], FieldValue::String("init".to_string()));
+                    found_event = true;
+                }
+                _ => {}
+            }
+        }
+
+        assert!(found_schema, "schema frame should be present");
+        assert!(found_event, "event frame should be present");
+    }
+
+    // Minimal format for a simpler tracepoint
+    const KMALLOC_FORMAT: &str = r#"name: kmalloc
+ID: 404
+format:
+	field:unsigned short common_type;	offset:0;	size:2;	signed:0;
+	field:unsigned char common_flags;	offset:2;	size:1;	signed:0;
+	field:unsigned char common_preempt_count;	offset:3;	size:1;	signed:0;
+	field:int common_pid;	offset:4;	size:4;	signed:1;
+
+	field:unsigned long call_site;	offset:8;	size:8;	signed:0;
+	field:const void * ptr;	offset:16;	size:8;	signed:0;
+	field:size_t bytes_req;	offset:24;	size:8;	signed:0;
+	field:size_t bytes_alloc;	offset:32;	size:8;	signed:0;
+	field:unsigned int gfp_flags;	offset:40;	size:4;	signed:0;
+	field:int node;	offset:44;	size:4;	signed:1;
+"#;
+
+    #[test]
+    fn parse_kmalloc_format() {
+        let tp = TracepointDef::parse_format(KMALLOC_FORMAT).unwrap();
+        assert_eq!(tp.name, "kmalloc");
+        assert_eq!(tp.id, 404);
+        assert_eq!(tp.fields.len(), 6);
+
+        assert_eq!(tp.fields[0].name, "call_site");
+        assert_eq!(tp.fields[0].size, 8);
+        assert!(!tp.fields[0].signed);
+
+        // "const void *" is 8 bytes unsigned
+        assert_eq!(tp.fields[1].name, "ptr");
+        assert_eq!(tp.fields[1].size, 8);
+
+        assert_eq!(tp.fields[4].name, "gfp_flags");
+        assert_eq!(tp.fields[4].size, 4);
+        assert!(!tp.fields[4].signed);
+
+        assert_eq!(tp.fields[5].name, "node");
+        assert!(tp.fields[5].signed);
+    }
+
+    #[test]
+    fn type_mapping_unsigned_fields() {
+        assert_eq!(kernel_type_to_field_type("unsigned char", 1, false), FieldType::Varint);
+        assert_eq!(kernel_type_to_field_type("unsigned short", 2, false), FieldType::Varint);
+        assert_eq!(kernel_type_to_field_type("unsigned int", 4, false), FieldType::Varint);
+        assert_eq!(kernel_type_to_field_type("unsigned long", 8, false), FieldType::Varint);
+        assert_eq!(kernel_type_to_field_type("size_t", 8, false), FieldType::Varint);
+    }
+
+    #[test]
+    fn type_mapping_signed_fields() {
+        assert_eq!(kernel_type_to_field_type("int", 4, true), FieldType::I64);
+        assert_eq!(kernel_type_to_field_type("pid_t", 4, true), FieldType::I64);
+        assert_eq!(kernel_type_to_field_type("long", 8, true), FieldType::I64);
+    }
+
+    #[test]
+    fn type_mapping_char_array() {
+        assert_eq!(kernel_type_to_field_type("char[16]", 16, false), FieldType::String);
+    }
+
+    #[test]
+    fn split_type_name_simple() {
+        let (ty, name) = split_type_and_name("unsigned int nr").unwrap();
+        assert_eq!(ty, "unsigned int");
+        assert_eq!(name, "nr");
+    }
+
+    #[test]
+    fn split_type_name_array() {
+        let (ty, name) = split_type_and_name("char prev_comm[16]").unwrap();
+        assert_eq!(ty, "char[16]");
+        assert_eq!(name, "prev_comm");
+    }
+
+    #[test]
+    fn split_type_name_pointer() {
+        let (ty, name) = split_type_and_name("const void * ptr").unwrap();
+        assert_eq!(ty, "const void *");
+        assert_eq!(name, "ptr");
+    }
+
+    const NETIF_RX_FORMAT: &str = r#"name: netif_rx
+ID: 2691
+format:
+	field:unsigned short common_type;	offset:0;	size:2;	signed:0;
+	field:unsigned char common_flags;	offset:2;	size:1;	signed:0;
+	field:unsigned char common_preempt_count;	offset:3;	size:1;	signed:0;
+	field:int common_pid;	offset:4;	size:4;	signed:1;
+
+	field:void * skbaddr;	offset:8;	size:8;	signed:0;
+	field:unsigned int len;	offset:16;	size:4;	signed:0;
+	field:__data_loc char[] name;	offset:20;	size:4;	signed:0;
+"#;
+
+    #[test]
+    fn parse_data_loc_field() {
+        let tp = TracepointDef::parse_format(NETIF_RX_FORMAT).unwrap();
+        assert_eq!(tp.fields.len(), 3);
+
+        assert_eq!(tp.fields[2].name, "name");
+        assert!(tp.fields[2].is_dynamic);
+        assert_eq!(tp.fields[2].size, 4);
+
+        // Non-dynamic fields should not be marked dynamic
+        assert!(!tp.fields[0].is_dynamic);
+        assert!(!tp.fields[1].is_dynamic);
+    }
+
+    #[test]
+    fn extract_data_loc_field() {
+        let tp = TracepointDef::parse_format(NETIF_RX_FORMAT).unwrap();
+
+        // Build raw data: fixed part (24 bytes) + dynamic string appended after
+        let mut raw = vec![0u8; 32];
+
+        // skbaddr at offset 8, size 8
+        raw[8..16].copy_from_slice(&0xdeadbeef_u64.to_ne_bytes());
+        // len at offset 16, size 4
+        raw[16..20].copy_from_slice(&100_u32.to_ne_bytes());
+        // __data_loc at offset 20: string starts at byte 24, length 5 ("eth0\0")
+        let loc: u32 = (24 << 16) | 5;
+        raw[20..24].copy_from_slice(&loc.to_ne_bytes());
+        // Dynamic data at offset 24
+        raw[24..28].copy_from_slice(b"eth0");
+        raw[28] = 0; // NUL terminator
+
+        let fields = tp.extract_fields(&raw).unwrap();
+        assert_eq!(fields[2].0, "name");
+        assert_eq!(fields[2].1, RawFieldValue::Str("eth0".to_string()));
+    }
+
+    #[test]
+    fn data_loc_trace_format_mapping() {
+        let tp = TracepointDef::parse_format(NETIF_RX_FORMAT).unwrap();
+        let defs = tp.to_trace_format_fields();
+
+        // __data_loc char[] → String
+        assert_eq!(defs[2].name, "name");
+        assert_eq!(defs[2].field_type, FieldType::String);
+    }
+}

--- a/perf-self-profile/tests/tracepoint_e2e.rs
+++ b/perf-self-profile/tests/tracepoint_e2e.rs
@@ -1,0 +1,109 @@
+mod common;
+
+use dial9_perf_self_profile::tracepoint::TracepointDef;
+use dial9_perf_self_profile::{PerfSampler, SamplerConfig};
+use dial9_trace_format::decoder::{DecodedFrame, Decoder};
+use dial9_trace_format::encoder::Encoder;
+use dial9_trace_format::types::FieldValue;
+
+/// End-to-end test: subscribe to sched_switch tracepoint, capture real kernel
+/// events, parse raw sample data through TracepointDef, encode into
+/// dial9-trace-format, decode, and verify fields.
+#[test]
+fn tracepoint_sched_switch_e2e() {
+    if common::is_ci() {
+        eprintln!("skipping tracepoint e2e in CI");
+        return;
+    }
+
+    // 1. Parse the kernel format file (includes tracepoint ID)
+    let tp = match TracepointDef::from_event("sched", "sched_switch") {
+        Ok(tp) => tp,
+        Err(e) => {
+            eprintln!("skipping: cannot read sched_switch format: {}", e);
+            return;
+        }
+    };
+    eprintln!("parsed sched_switch: {} fields, id={}", tp.fields.len(), tp.id);
+
+    // 2. Open perf event using the TracepointDef's event source
+    let mut sampler = match PerfSampler::start(SamplerConfig {
+        frequency_hz: 1,
+        event_source: tp.event_source(),
+        include_kernel: false,
+    }) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("skipping: perf_event_open failed: {}", e);
+            return;
+        }
+    };
+
+    // 3. Generate context switches
+    for _ in 0..5 {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // 4. Collect samples
+    sampler.disable();
+    let samples = sampler.drain_samples();
+    eprintln!("collected {} samples", samples.len());
+    assert!(!samples.is_empty(), "expected at least one sched_switch sample");
+
+    // 5. Register schema + encode raw samples into trace-format
+    let mut encoder = Encoder::new();
+    let type_id = tp.register(&mut encoder).expect("register schema");
+
+    let mut encoded_count = 0;
+    for sample in &samples {
+        if let Some(raw) = &sample.raw {
+            match tp.encode_raw(&mut encoder, type_id, sample.time, raw) {
+                Ok(()) => {
+                    encoded_count += 1;
+                    if encoded_count <= 3 {
+                        // Print a few for debugging
+                        let extracted = tp.extract_fields(raw).unwrap();
+                        let values = tp.to_trace_format_values(&extracted);
+                        eprintln!("sample {} (tid={}):", encoded_count, sample.tid);
+                        for (field, val) in tp.fields.iter().zip(values.iter()) {
+                            eprintln!("  {} = {:?}", field.name, val);
+                        }
+                    }
+                }
+                Err(e) => eprintln!("warning: encode_raw failed: {}", e),
+            }
+        }
+    }
+    assert!(encoded_count > 0, "expected at least one encoded event");
+
+    // 6. Decode and verify round-trip
+    let bytes = encoder.finish();
+    let mut decoder = Decoder::new(&bytes).expect("decode");
+    let frames = decoder.decode_all();
+
+    let mut schema_count = 0;
+    let mut event_count = 0;
+
+    for frame in &frames {
+        match frame {
+            DecodedFrame::Schema(entry) => {
+                assert_eq!(entry.name, "sched_switch");
+                assert!(entry.has_timestamp);
+                assert_eq!(entry.fields.len(), tp.fields.len());
+                schema_count += 1;
+            }
+            DecodedFrame::Event { timestamp_ns, values, .. } => {
+                assert!(timestamp_ns.is_some());
+                assert_eq!(values.len(), tp.fields.len());
+                if values.iter().any(|v| matches!(v, FieldValue::String(s) if !s.is_empty())) {
+                    event_count += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(schema_count, 1);
+    assert!(event_count > 0, "expected decoded events with non-empty comm strings");
+    eprintln!("SUCCESS: {} events round-tripped ({} bytes)", event_count, bytes.len());
+}


### PR DESCRIPTION
## Summary

Adds comprehensive kernel tracepoint support to the perf-self-profile library, enabling collection and parsing of raw tracepoint data from perf events.

## Changes

### New Module: `perf-self-profile/src/tracepoint.rs`
- **`TracepointDef`**: Parses kernel tracepoint format files from tracefs
  - Reads from `/sys/kernel/debug/tracing/events/<subsystem>/<event>/format`
  - Extracts field definitions (name, type, offset, size, signedness)
  - Filters out common kernel bookkeeping fields
  - Supports both fixed-size and dynamic (`__data_loc`) fields

- **`TracepointField`**: Represents a single field with metadata
- **`RawFieldValue`**: Enum for typed field values (U8, U16, U32, U64, I8, I16, I32, I64, Str, Bytes)

### Key Functionality
- `extract_fields()`: Parse raw tracepoint data and return typed field values
- `to_trace_format_fields()`: Convert kernel field definitions to dial9-trace-format schema
- `encode_raw()`: Write extracted tracepoint events to trace format encoder
- Format file parsing with support for various kernel type annotations

### Updates to `perf-self-profile/src/sampler.rs`
- Add `EventSource::Tracepoint(u32)` variant for tracepoint-based sampling
- Update `Sample` struct with `raw: Option<Vec<u8>>` field for tracepoint data
- Set `PERF_SAMPLE_RAW` flag when sampling tracepoints
- Handle tracepoint event setup in `build_attr()`

### Updates to `dial9-trace-format/src/encoder.rs`
- Refactor schema storage from `Vec<(TypeId, WireTypeId)>` to `HashMap<SchemaKey, WireTypeId>`
- Add `SchemaKey` enum supporting both static (Rust `TypeId`) and dynamic (string name) schemas
- Add `register_dynamic_schema()`: Register runtime-defined schemas without requiring compile-time types
- Add `write_dynamic_event()`: Write events for dynamically registered schemas
- Refactor common event writing logic into `write_event_impl()` for code reuse
- Update tests for new dynamic schema functionality

### Cargo Dependencies
- Add `dial9-trace-format` dependency to perf-self-profile

## Testing
- 7 new unit tests for format parsing (sched_switch, kmalloc, netif_rx tracepoints)
- Tests for field extraction, type mapping, and trace format round-tripping
- End-to-end test: `perf-self-profile/tests/tracepoint_e2e.rs` (109 lines)
