### PR TITLE
ci: set kptr_restrict=0 to fix kallsyms test in CI

### DIFF
--- a/.github/actions/rust-build/action.yml
+++ b/.github/actions/rust-build/action.yml
@@ -21,11 +21,11 @@ runs:
                   rm -fv Cargo.lock
               fi
               cargo build
-        - name: Enable perf_event_open for tests
+        - name: Enable perf_event_open and kallsyms for tests
           shell: bash
           run: |
               sudo sysctl kernel.perf_event_paranoid=1
-              cat /proc/sys/kernel/perf_event_paranoid
+              sudo sysctl kernel.kptr_restrict=0
         - name: Run tests
           shell: bash
           env:


### PR DESCRIPTION
The `resolve_kernel_symbol_returns_name` test reads `/proc/kallsyms` to look up the address of `schedule`, but `kptr_restrict=1` (the default on Ubuntu) zeros out all kernel addresses, causing the test to fail.

This adds `sudo sysctl kernel.kptr_restrict=0` to the CI workflow alongside the existing `perf_event_paranoid` setting.