### PR TITLE
refactor(trace-parser): consolidate per-branch cap checks into early continue

### DIFF
--- a/dial9-tokio-telemetry/trace_viewer/trace_parser.js
+++ b/dial9-tokio-telemetry/trace_viewer/trace_parser.js
@@ -46,7 +46,11 @@
         const threadNames = new Map();
 
         const capped = () => events.length >= maxEvents;
-        const META_FRAMES = new Set([
+        // Frames processed regardless of event cap:
+        // - SymbolTableEntry: symbol tables are needed to resolve addresses in all other frames
+        // - TaskSpawnEvent/TaskTerminateEvent: task lifecycle tracking for the task list view
+        // - CpuSampleEvent: CPU samples feed the flame graph, which should reflect the full trace
+        const UNCAPPED_FRAMES = new Set([
             'TaskSpawnEvent', 'TaskTerminateEvent',
             'CpuSampleEvent', 'SymbolTableEntry',
         ]);
@@ -56,7 +60,7 @@
             const v = frame.values;
             const ts = num(frame.timestamp_ns);
 
-            if (capped() && !META_FRAMES.has(frame.name)) continue;
+            if (capped() && !UNCAPPED_FRAMES.has(frame.name)) continue;
 
             switch (frame.name) {
                 case 'PollStartEvent': {


### PR DESCRIPTION
# refactor(trace-parser): consolidate per-branch cap checks into early continue

Follow-up to https://github.com/dial9-rs/dial9-tokio-telemetry/pull/98#discussion_r2957135279

### Summary

PR #98 added per-branch `if (!capped())` guards to each event-type case in the `parseTrace` switch statement, so that metadata frames (symbols, task spawn/terminate, CPU samples) would still be processed past the event cap. rcoh noted it would be cleaner to hoist the check: skip non-metadata frames early with a single `if (capped() && !META_FRAMES.has(frame.name)) continue` before the switch, then let each branch push unconditionally.

This commit does that. A `META_FRAMES` set defines the frame types that should always be processed regardless of cap (`TaskSpawnEvent`, `TaskTerminateEvent`, `CpuSampleEvent`, `SymbolTableEntry`). Non-meta frames are skipped entirely when capped.

One minor behavioral change: `PollStartEvent` previously populated `spawnLocations`/`taskSpawnLocs` even when capped (the metadata work happened before the per-branch guard). Now those frames are skipped entirely. This is fine because `TaskSpawnEvent` (which is in `META_FRAMES`) is the primary source for those maps, and the poll events for capped tasks won't appear in the output anyway.

### Testing

Both existing JS parser test suites pass (`dial9-tokio-telemetry::js_parser` and `dial9-trace-format::js_parser`), including the `test_js_parser_resolves_symbols_past_event_cap` test that specifically validates metadata frames are processed past the event cap.
