### PR TITLE
chore: fix clippy warnings across workspace

### DIFF
--- a/dial9-tokio-telemetry/examples/cancelled_task.rs
+++ b/dial9-tokio-telemetry/examples/cancelled_task.rs
@@ -4,7 +4,7 @@ use tokio::time::Duration;
 #[tokio::main]
 async fn main() {
     let (tracker, mut handle) = LongPollTracker::new();
-    let _tracker_task = tracker.spawn();
+    tracker.spawn();
 
     let sleep_future = tokio::time::sleep(Duration::from_secs(20));
     let wrapped = DetectLongWait::new(sleep_future, handle.sentinel_tx.clone());

--- a/dial9-tokio-telemetry/examples/completing_task.rs
+++ b/dial9-tokio-telemetry/examples/completing_task.rs
@@ -4,7 +4,7 @@ use tokio::time::Duration;
 #[tokio::main]
 async fn main() {
     let (tracker, mut handle) = LongPollTracker::new();
-    let _tracker_task = tracker.spawn();
+    tracker.spawn();
 
     println!("Starting short sleep (2s) that completes before threshold...");
     let sleep_future = tokio::time::sleep(Duration::from_secs(2));

--- a/dial9-tokio-telemetry/examples/long_sleep.rs
+++ b/dial9-tokio-telemetry/examples/long_sleep.rs
@@ -4,7 +4,7 @@ use tokio::time::Duration;
 #[tokio::main]
 async fn main() {
     let (tracker, mut handle) = LongPollTracker::new();
-    let _tracker_task = tracker.spawn();
+    tracker.spawn();
 
     let sleep_future = tokio::time::sleep(Duration::from_secs(10));
     let wrapped = DetectLongWait::new(sleep_future, handle.sentinel_tx.clone());

--- a/dial9-tokio-telemetry/src/task_dump.rs
+++ b/dial9-tokio-telemetry/src/task_dump.rs
@@ -441,7 +441,7 @@ mod tests {
 
         // Drain any traces that were sent before completion
         let mut trace_count = 0;
-        while let Some(_) = handle.rx.recv().await {
+        while handle.rx.recv().await.is_some() {
             trace_count += 1;
         }
 

--- a/dial9-tokio-telemetry/tests/fake_s3/mod.rs
+++ b/dial9-tokio-telemetry/tests/fake_s3/mod.rs
@@ -151,7 +151,7 @@ impl<S> FlakyS3<S> {
         let n = self
             .fail_counter
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        if n % self.fail_every_n == 0 {
+        if n.is_multiple_of(self.fail_every_n) {
             return Err(s3s::S3Error::with_message(
                 s3s::S3ErrorCode::InternalError,
                 "injected failure",

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -522,12 +522,7 @@ fn stress_test_all_segments_uploaded_and_valid() {
     let entries = inspector.entries();
     let successes: Vec<_> = entries
         .iter()
-        .filter(|e| {
-            e.metrics
-                .contains_key("Success")
-                .then(|| e.metrics["Success"] == true)
-                .unwrap_or(false)
-        })
+        .filter(|e| e.metrics.get("Success").is_some_and(|v| *v == true))
         .collect();
     assert_eq!(
         successes.len(),

--- a/dial9-trace-format/tests/derive_round_trip.rs
+++ b/dial9-trace-format/tests/derive_round_trip.rs
@@ -60,6 +60,7 @@ struct MultiPool {
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 /// Decode all ref frames, returning only events as (type_id, values) pairs.
+#[allow(clippy::type_complexity)]
 fn decode_events(data: &[u8]) -> (Decoder<'_>, Vec<(Option<u64>, Vec<FieldValueRef<'_>>)>) {
     let mut dec = Decoder::new(data).unwrap();
     let mut events = Vec::new();

--- a/perf-self-profile/src/offline_symbolize.rs
+++ b/perf-self-profile/src/offline_symbolize.rs
@@ -475,7 +475,7 @@ mod tests {
             "expected '[symbolize-failed] 0x1000' in string pool, got: {:?}",
             pool_strings
         );
-        let has_source_file = pool_strings.iter().any(|s| *s == fake_path);
+        let has_source_file = pool_strings.contains(&fake_path);
         assert!(
             has_source_file,
             "expected source file '{}' in string pool, got: {:?}",


### PR DESCRIPTION
Fix all clippy warnings across the workspace:

- `contains()` instead of `iter().any()` in offline_symbolize.rs
- `is_some()` instead of `while let Some(_)` in task_dump.rs
- `is_multiple_of()` instead of manual modulo check in fake_s3
- Simplify obfuscated if/else chain in s3_integration.rs
- Remove unit let bindings in examples
- Allow complex type in test helper (derive_round_trip.rs)

All tests pass (283 passed, 6 skipped).