### PR TITLE
Escape stack frame names in flame graph tooltip

### DIFF
--- a/dial9-tokio-telemetry/trace_viewer/index.html
+++ b/dial9-tokio-telemetry/trace_viewer/index.html
@@ -3206,7 +3206,9 @@
                     const total = hit.totalSamples;
                     const pct = ((hit.node.count / total) * 100).toFixed(1);
                     const selfPct = ((hit.node.self / total) * 100).toFixed(1);
-                    tip.innerHTML = `<b>${hit.node.name}</b><br>${hit.node.count} samples (${pct}%) · ${hit.node.self} self (${selfPct}%)`;
+                    const nameElt = document.createElement('b');
+                    nameElt.innerText = hit.node.name;
+                    tip.innerHTML = `${nameElt.outerHTML}<br>${hit.node.count} samples (${pct}%) · ${hit.node.self} self (${selfPct}%)`;
                     tip.style.display = "block";
                     tip.style.left = Math.min(e.clientX + 12, window.innerWidth - 620) + "px";
                     tip.style.top = (e.clientY - 50) + "px";


### PR DESCRIPTION
If you have a type parameter called `Input` in the name of a stack trace entry, then quite entertainingly it will render a text box in the tooltip:

<img width="1246" height="724" alt="unescaped-tooltip" src="https://github.com/user-attachments/assets/8cdac14b-ab0e-4586-90a7-d45d624b5541" />

This is a fix which escapes the text first so this doesn't happen.