### PR TITLE
Enable perf_event_open & kallsyms for E2E CI

### DIFF
--- a/.github/workflows/e2e-trace-integrity-and-analysis.yml
+++ b/.github/workflows/e2e-trace-integrity-and-analysis.yml
@@ -21,5 +21,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: Enable perf_event_open and kallsyms for tests
+        shell: bash
+        run: |
+          sudo sysctl kernel.perf_event_paranoid=1
+          sudo sysctl kernel.kptr_restrict=0
       - name: E2E trace tests
         run: scripts/e2e-trace-tests.sh


### PR DESCRIPTION
Fixes malformed demo trace generation, without CPU samples due to `kernel.perf_event_paranoid` & `kernel.kptr_restrict` not being set