### PR TITLE
refactor: log sealing at debug

### DIFF
--- a/dial9-tokio-telemetry/src/telemetry/writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/writer.rs
@@ -368,7 +368,7 @@ impl RotatingWriter {
         self.next_rotation_time =
             Self::next_boundary(time_source().system_time().as_std(), self.rotation_period);
 
-        tracing::info!(
+        tracing::debug!(
             segment_index = self.next_index - 1,
             "rotated to new trace segment"
         );


### PR DESCRIPTION
The "rotated to new trace segment" log fires on every segment rotation, which is a routine internal operation.

At `info` level this adds noise for consumers who aren't actively debugging the writer.

Downgraded it to `debug` so it's still available when needed but stays out of the way in normal operation.