### PR TITLE
Add telemetry added latency metric.

### DIFF
--- a/dial9-tokio-telemetry/benches/overhead_bench.rs
+++ b/dial9-tokio-telemetry/benches/overhead_bench.rs
@@ -252,6 +252,7 @@ fn main() {
 
     if is_bmf {
         let mut report = bmf::Report::new();
+        let mut results = std::collections::HashMap::new();
         for mode in ["baseline", "telemetry", "noop"] {
             let r = run_bench(mode, duration_secs);
             let rps = r.hist.len() as f64 / r.wall.as_secs_f64();
@@ -269,7 +270,14 @@ fn main() {
                 format!("{p}::p99_9_lat_ns"),
                 bmf::Metric::latency(r.hist.value_at_percentile(99.9) as f64),
             );
+            results.insert(mode, r);
         }
+        let baseline_p99 = results["baseline"].hist.value_at_percentile(99.0);
+        let telemetry_p99 = results["telemetry"].hist.value_at_percentile(99.0);
+        report.insert(
+            "overhead::telemetry_p99_added_latency_ns".to_string(),
+            bmf::Metric::latency((telemetry_p99 - baseline_p99) as f64),
+        );
         println!("{}", serde_json::to_string_pretty(&report).unwrap());
         return;
     }


### PR DESCRIPTION
send new metric `overhead::telemetry_p99_added_latency_ns`, which is the delta of telemetry and baseline p99, this tracks the extra latency telemetry adds.

if the metric goes up, there's regression.