### PR TITLE
draft / RFC: Add support for application defined events

### DIFF
--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -107,6 +107,39 @@ runtime.block_on(async {
 
 For frameworks like Axum where you don't control the spawn call, you need to wrap the accept loop. See [`examples/metrics-service/src/axum_traced.rs`](/examples/metrics-service/src/axum_traced.rs) for a working example that wraps both the accept loop and per-connection futures.
 
+## Custom events
+
+You can emit your own application-level events into the trace alongside the built-in runtime events. Define a struct with `#[derive(TraceEvent)]` and call `record_event`:
+
+```rust,no_run
+# fn main() {
+use dial9_trace_format::TraceEvent;
+use dial9_tokio_telemetry::telemetry::{record_event, clock_monotonic_ns, TelemetryHandle};
+
+#[derive(TraceEvent)]
+struct RequestCompleted {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    status_code: u32,
+    latency_us: u64,
+}
+
+# let handle: TelemetryHandle = todo!();
+record_event(
+    RequestCompleted {
+        timestamp_ns: clock_monotonic_ns(),
+        status_code: 200,
+        latency_us: 1500,
+    },
+    &handle,
+);
+# }
+```
+
+For events with repeated string values (HTTP methods, endpoint paths, etc.), implement `Encodable` manually to use string interning — see [`examples/custom_events.rs`](/dial9-tokio-telemetry/examples/custom_events.rs) for a complete example showing both patterns.
+
+Custom events are encoded into the same thread-local buffer as built-in events (~100–200 ns per call) and appear in the trace viewer alongside poll/park/wake events.
+
 ## Platform support
 
 Core telemetry (poll timing, park/unpark, queue depth, wake events) works on all platforms.

--- a/dial9-tokio-telemetry/examples/custom_events.rs
+++ b/dial9-tokio-telemetry/examples/custom_events.rs
@@ -1,0 +1,125 @@
+//! Example: emitting custom events into a dial9 trace.
+//!
+//! Shows two patterns:
+//! 1. **Simple** — `#[derive(TraceEvent)]` struct passed directly to `record_event`
+//! 2. **Advanced** — manual `Encodable` impl with string interning for repeated values
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example custom_events
+//! ```
+
+use dial9_tokio_telemetry::telemetry::{
+    Encodable, RotatingWriter, ThreadLocalEncoder, TracedRuntime, clock_monotonic_ns, record_event,
+};
+use dial9_trace_format::{InternedString, TraceEvent};
+use std::time::Duration;
+
+// ── Simple: derive-only, no interning ───────────────────────────────────────
+
+/// A custom event with only primitive fields. The blanket `Encodable` impl
+/// handles encoding automatically — just pass it to `record_event`.
+#[derive(TraceEvent)]
+struct RequestCompleted {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    status_code: u32,
+    latency_us: u64,
+}
+
+// ── Advanced: manual Encodable with string interning ────────────────────────
+
+/// Application-level event with a string field we want to intern.
+struct HttpRequest {
+    timestamp_ns: u64,
+    method: String,
+    status: u32,
+}
+
+/// Wire-format struct with the interned string handle.
+#[derive(TraceEvent)]
+struct HttpRequestWire {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    method: InternedString,
+    status: u32,
+}
+
+impl Encodable for HttpRequest {
+    fn encode(&self, enc: &mut ThreadLocalEncoder<'_>) {
+        let method = enc.intern_string(&self.method);
+        enc.encode(&HttpRequestWire {
+            timestamp_ns: self.timestamp_ns,
+            method,
+            status: self.status,
+        });
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let trace_path = dir.path().join("trace.bin");
+
+    let writer = RotatingWriter::single_file(&trace_path)?;
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let (runtime, guard) = TracedRuntime::build_and_start(builder, writer)?;
+    let handle = guard.handle();
+
+    runtime.block_on(async {
+        // Simple: derive-only events
+        for i in 0..10 {
+            record_event(
+                RequestCompleted {
+                    timestamp_ns: clock_monotonic_ns(),
+                    status_code: 200,
+                    latency_us: 100 + i,
+                },
+                &handle,
+            );
+        }
+
+        // Advanced: manual Encodable with interning
+        // "GET" is interned once and reused across all events in the batch.
+        for _ in 0..10 {
+            record_event(
+                HttpRequest {
+                    timestamp_ns: clock_monotonic_ns(),
+                    method: "GET".into(),
+                    status: 200,
+                },
+                &handle,
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    // Verify: decode the trace and count our custom events
+    let sealed = dir.path().join("trace.0.bin");
+    let data = std::fs::read(&sealed)?;
+    let mut decoder = dial9_trace_format::decoder::Decoder::new(&data)
+        .ok_or_else(|| std::io::Error::other("invalid trace"))?;
+
+    let mut request_completed = 0u32;
+    let mut http_request = 0u32;
+    decoder
+        .for_each_event(|ev| match ev.name {
+            "RequestCompleted" => request_completed += 1,
+            "HttpRequestWire" => http_request += 1,
+            _ => {}
+        })
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    println!("RequestCompleted events: {request_completed}");
+    println!("HttpRequestWire events:  {http_request}");
+    assert_eq!(request_completed, 10);
+    assert_eq!(http_request, 10);
+    println!("✓ All custom events recorded successfully");
+
+    Ok(())
+}

--- a/dial9-tokio-telemetry/src/telemetry/buffer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/buffer.rs
@@ -48,6 +48,9 @@ impl ThreadLocalEncoder<'_> {
     }
 
     /// Encode a [`TraceEvent`](dial9_trace_format::TraceEvent) struct into the buffer.
+    ///
+    /// The `'static` bound is required because the encoder uses [`TypeId`](std::any::TypeId)
+    /// to cache schema registrations per concrete type.
     pub fn encode(&mut self, event: &(impl dial9_trace_format::TraceEvent + 'static)) {
         self.encoder.write_infallible(event);
     }
@@ -102,8 +105,20 @@ impl ThreadLocalEncoder<'_> {
 ///     }
 /// }
 /// ```
+///
+/// # Wire event naming
+///
+/// The event name in the trace comes from the struct passed to
+/// [`ThreadLocalEncoder::encode`], not from the type implementing `Encodable`.
+/// In the example above, the trace will contain events named `"HttpRequestWire"`,
+/// not `"HttpRequest"`.
 pub trait Encodable {
     /// Encode this event into the thread-local trace buffer.
+    ///
+    /// Implementations should call [`ThreadLocalEncoder::encode`] exactly once.
+    /// Each `encode` call is counted as one event for buffer flush decisions;
+    /// calling `encode` multiple times will produce multiple wire events but
+    /// only one event will be counted.
     fn encode(&self, encoder: &mut ThreadLocalEncoder<'_>);
 }
 
@@ -372,37 +387,7 @@ pub(crate) fn record_event(
     collector: &Arc<CentralCollector>,
     drain_epoch: &AtomicU64,
 ) -> Option<TlBufferHandle> {
-    BUFFER.with(|arc| {
-        // Poisoning requires a panic while the lock is held. Since the only code
-        // under the lock is the encoder (which should never panic), this should be
-        // unreachable. If it does happen, the encoder's internal buffer may be
-        // corrupt, so drop the event rather than writing into garbage state.
-        // The mutex stays poisoned, so this thread silently stops recording.
-        let mut buf = match arc.lock() {
-            Ok(guard) => guard,
-            Err(_) => {
-                crate::rate_limit::rate_limited!(Duration::from_secs(60), {
-                    tracing::error!("dial9: thread-local buffer mutex poisoned in record_event; dropping events for this thread");
-                });
-                return None;
-            }
-        };
-        let first_call = buf.set_collector(collector);
-        buf.record_encodable(&event);
-        let current_epoch = drain_epoch.load(Ordering::Relaxed);
-        if buf.should_flush() || buf.flush_epoch.load() < current_epoch {
-            buf.flush_epoch.store(current_epoch);
-            collector.accept_flush(buf.flush());
-        }
-        if first_call {
-            Some(TlBufferHandle {
-                buffer: Arc::downgrade(arc),
-                flush_epoch: buf.flush_epoch.clone(),
-            })
-        } else {
-            None
-        }
-    })
+    record_encodable_event(&event, collector, drain_epoch)
 }
 
 /// Drain the current thread's buffer into `collector`, even if not full.

--- a/dial9-tokio-telemetry/src/telemetry/buffer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/buffer.rs
@@ -17,6 +17,209 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+// ── Public API types ────────────────────────────────────────────────────────
+
+/// Scoped encoder for writing events into the thread-local trace buffer.
+///
+/// Provides access to string interning and event encoding. The borrow lifetime
+/// ensures that [`InternedString`] handles created via [`intern_string`](Self::intern_string)
+/// are used within the same batch — they become invalid after the buffer flushes.
+///
+/// You don't construct this directly; it's passed to [`Encodable::encode`].
+pub struct ThreadLocalEncoder<'a> {
+    encoder: &'a mut Encoder<Vec<u8>>,
+    location_cache: &'a mut HashMap<&'static Location<'static>, String>,
+}
+
+impl std::fmt::Debug for ThreadLocalEncoder<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ThreadLocalEncoder").finish_non_exhaustive()
+    }
+}
+
+impl ThreadLocalEncoder<'_> {
+    /// Intern a string into the trace's string pool, returning a compact handle.
+    ///
+    /// If the string was already interned in this batch, returns the existing handle
+    /// (no duplicate wire data). The returned [`InternedString`] is only valid for
+    /// encoding within this same [`Encodable::encode`] call.
+    pub fn intern_string(&mut self, s: &str) -> InternedString {
+        self.encoder.intern_string_infallible(s)
+    }
+
+    /// Encode a [`TraceEvent`](dial9_trace_format::TraceEvent) struct into the buffer.
+    pub fn encode(&mut self, event: &(impl dial9_trace_format::TraceEvent + 'static)) {
+        self.encoder.write_infallible(event);
+    }
+
+    /// Intern a `&'static Location` (caching the `to_string()` result).
+    pub(crate) fn intern_location(
+        &mut self,
+        location: &'static Location<'static>,
+    ) -> InternedString {
+        let s = self
+            .location_cache
+            .entry(location)
+            .or_insert_with(|| location.to_string());
+        self.encoder.intern_string_infallible(s)
+    }
+}
+
+/// Trait for types that can be encoded into a dial9 trace.
+///
+/// # Simple case — `#[derive(TraceEvent)]`
+///
+/// Any type implementing [`TraceEvent`](dial9_trace_format::TraceEvent) automatically
+/// implements `Encodable` via a blanket impl, so you can pass it directly to
+/// [`record_event`](crate::telemetry::record_event):
+///
+/// ```ignore
+/// #[derive(TraceEvent)]
+/// struct MyEvent {
+///     #[traceevent(timestamp)]
+///     timestamp_ns: u64,
+///     request_count: u32,
+/// }
+/// record_event(MyEvent { timestamp_ns: now, request_count: 42 }, &handle);
+/// ```
+///
+/// # Advanced case — string interning
+///
+/// Implement `Encodable` manually when you need [`InternedString`] fields
+/// for efficient repeated-string encoding:
+///
+/// ```ignore
+/// struct HttpRequest { timestamp_ns: u64, method: String, status: u32 }
+///
+/// impl Encodable for HttpRequest {
+///     fn encode(&self, enc: &mut ThreadLocalEncoder<'_>) {
+///         let method = enc.intern_string(&self.method);
+///         enc.encode(&HttpRequestWire {
+///             timestamp_ns: self.timestamp_ns,
+///             method,
+///             status: self.status,
+///         });
+///     }
+/// }
+/// ```
+pub trait Encodable {
+    /// Encode this event into the thread-local trace buffer.
+    fn encode(&self, encoder: &mut ThreadLocalEncoder<'_>);
+}
+
+impl<T: dial9_trace_format::TraceEvent + 'static> Encodable for T {
+    fn encode(&self, encoder: &mut ThreadLocalEncoder<'_>) {
+        encoder.encode(self);
+    }
+}
+
+impl Encodable for RawEvent {
+    fn encode(&self, enc: &mut ThreadLocalEncoder<'_>) {
+        match self {
+            RawEvent::PollStart {
+                timestamp_nanos,
+                worker_id,
+                worker_local_queue_depth,
+                task_id,
+                location,
+            } => {
+                let spawn_loc = enc.intern_location(location);
+                enc.encode(&PollStartEvent {
+                    timestamp_ns: *timestamp_nanos,
+                    worker_id: *worker_id,
+                    local_queue: *worker_local_queue_depth as u8,
+                    task_id: *task_id,
+                    spawn_loc,
+                });
+            }
+            RawEvent::PollEnd {
+                timestamp_nanos,
+                worker_id,
+            } => enc.encode(&PollEndEvent {
+                timestamp_ns: *timestamp_nanos,
+                worker_id: *worker_id,
+            }),
+            RawEvent::WorkerPark {
+                timestamp_nanos,
+                worker_id,
+                worker_local_queue_depth,
+                cpu_time_nanos,
+            } => enc.encode(&WorkerParkEvent {
+                timestamp_ns: *timestamp_nanos,
+                worker_id: *worker_id,
+                local_queue: *worker_local_queue_depth as u8,
+                cpu_time_ns: *cpu_time_nanos,
+            }),
+            RawEvent::WorkerUnpark {
+                timestamp_nanos,
+                worker_id,
+                worker_local_queue_depth,
+                cpu_time_nanos,
+                sched_wait_delta_nanos,
+            } => enc.encode(&WorkerUnparkEvent {
+                timestamp_ns: *timestamp_nanos,
+                worker_id: *worker_id,
+                local_queue: *worker_local_queue_depth as u8,
+                cpu_time_ns: *cpu_time_nanos,
+                sched_wait_ns: *sched_wait_delta_nanos,
+            }),
+            RawEvent::QueueSample {
+                timestamp_nanos,
+                global_queue_depth,
+            } => enc.encode(&QueueSampleEvent {
+                timestamp_ns: *timestamp_nanos,
+                global_queue: *global_queue_depth as u8,
+            }),
+            RawEvent::TaskSpawn {
+                timestamp_nanos,
+                task_id,
+                location,
+            } => {
+                let spawn_loc = enc.intern_location(location);
+                enc.encode(&TaskSpawnEvent {
+                    timestamp_ns: *timestamp_nanos,
+                    task_id: *task_id,
+                    spawn_loc,
+                });
+            }
+            RawEvent::TaskTerminate {
+                timestamp_nanos,
+                task_id,
+            } => enc.encode(&TaskTerminateEvent {
+                timestamp_ns: *timestamp_nanos,
+                task_id: *task_id,
+            }),
+            RawEvent::WakeEvent {
+                timestamp_nanos,
+                waker_task_id,
+                woken_task_id,
+                target_worker,
+            } => enc.encode(&WakeEventEvent {
+                timestamp_ns: *timestamp_nanos,
+                waker_task_id: *waker_task_id,
+                woken_task_id: *woken_task_id,
+                target_worker: *target_worker,
+            }),
+            RawEvent::CpuSample(data) => {
+                let thread_name = match &data.thread_name {
+                    Some(name) => enc.intern_string(name.as_str()),
+                    None => enc.intern_string("<no thread name>"),
+                };
+                enc.encode(&CpuSampleEvent {
+                    timestamp_ns: data.timestamp_nanos,
+                    worker_id: data.worker_id,
+                    tid: data.tid,
+                    source: data.source,
+                    thread_name,
+                    callchain: dial9_trace_format::StackFrames(data.callchain.clone()),
+                });
+            }
+        }
+    }
+}
+
+// ── Thread-local buffer internals ───────────────────────────────────────────
+
 /// Tracks the last drain epoch at which a particular thread-local buffer
 /// was flushed. The flush thread reads this (relaxed) to skip buffers
 /// that have self-flushed recently, avoiding contention with busy workers.
@@ -89,119 +292,15 @@ impl ThreadLocalBuffer {
         false
     }
 
-    fn encode_event(&mut self, event: &RawEvent) {
-        match event {
-            RawEvent::PollStart {
-                timestamp_nanos,
-                worker_id,
-                worker_local_queue_depth,
-                task_id,
-                location,
-            } => {
-                let spawn_loc = self.intern_location(location);
-                self.encoder.write_infallible(&PollStartEvent {
-                    timestamp_ns: *timestamp_nanos,
-                    worker_id: *worker_id,
-                    local_queue: *worker_local_queue_depth as u8,
-                    task_id: *task_id,
-                    spawn_loc,
-                });
-            }
-            RawEvent::PollEnd {
-                timestamp_nanos,
-                worker_id,
-            } => self.encoder.write_infallible(&PollEndEvent {
-                timestamp_ns: *timestamp_nanos,
-                worker_id: *worker_id,
-            }),
-            RawEvent::WorkerPark {
-                timestamp_nanos,
-                worker_id,
-                worker_local_queue_depth,
-                cpu_time_nanos,
-            } => self.encoder.write_infallible(&WorkerParkEvent {
-                timestamp_ns: *timestamp_nanos,
-                worker_id: *worker_id,
-                local_queue: *worker_local_queue_depth as u8,
-                cpu_time_ns: *cpu_time_nanos,
-            }),
-            RawEvent::WorkerUnpark {
-                timestamp_nanos,
-                worker_id,
-                worker_local_queue_depth,
-                cpu_time_nanos,
-                sched_wait_delta_nanos,
-            } => self.encoder.write_infallible(&WorkerUnparkEvent {
-                timestamp_ns: *timestamp_nanos,
-                worker_id: *worker_id,
-                local_queue: *worker_local_queue_depth as u8,
-                cpu_time_ns: *cpu_time_nanos,
-                sched_wait_ns: *sched_wait_delta_nanos,
-            }),
-            RawEvent::QueueSample {
-                timestamp_nanos,
-                global_queue_depth,
-            } => self.encoder.write_infallible(&QueueSampleEvent {
-                timestamp_ns: *timestamp_nanos,
-                global_queue: *global_queue_depth as u8,
-            }),
-            RawEvent::TaskSpawn {
-                timestamp_nanos,
-                task_id,
-                location,
-            } => {
-                let spawn_loc = self.intern_location(location);
-                self.encoder.write_infallible(&TaskSpawnEvent {
-                    timestamp_ns: *timestamp_nanos,
-                    task_id: *task_id,
-                    spawn_loc,
-                });
-            }
-            RawEvent::TaskTerminate {
-                timestamp_nanos,
-                task_id,
-            } => self.encoder.write_infallible(&TaskTerminateEvent {
-                timestamp_ns: *timestamp_nanos,
-                task_id: *task_id,
-            }),
-            RawEvent::WakeEvent {
-                timestamp_nanos,
-                waker_task_id,
-                woken_task_id,
-                target_worker,
-            } => self.encoder.write_infallible(&WakeEventEvent {
-                timestamp_ns: *timestamp_nanos,
-                waker_task_id: *waker_task_id,
-                woken_task_id: *woken_task_id,
-                target_worker: *target_worker,
-            }),
-            RawEvent::CpuSample(data) => {
-                let thread_name = match &data.thread_name {
-                    Some(name) => self.encoder.intern_string_infallible(name.as_str()),
-                    None => self.encoder.intern_string_infallible("<no thread name>"),
-                };
-                self.encoder.write_infallible(&CpuSampleEvent {
-                    timestamp_ns: data.timestamp_nanos,
-                    worker_id: data.worker_id,
-                    tid: data.tid,
-                    source: data.source,
-                    thread_name,
-                    callchain: dial9_trace_format::StackFrames(data.callchain.clone()),
-                });
-            }
+    fn thread_local_encoder(&mut self) -> ThreadLocalEncoder<'_> {
+        ThreadLocalEncoder {
+            encoder: &mut self.encoder,
+            location_cache: &mut self.location_cache,
         }
     }
 
-    fn intern_location(&mut self, location: &'static Location<'static>) -> InternedString {
-        let s = self
-            .location_cache
-            .entry(location)
-            .or_insert_with(|| location.to_string());
-        self.encoder.intern_string_infallible(s)
-    }
-
-    fn record_event(&mut self, event: &RawEvent) {
-        self.encode_event(event);
+    fn record_encodable(&mut self, event: &dyn Encodable) {
+        event.encode(&mut self.thread_local_encoder());
         self.event_count += 1;
     }
 
@@ -210,7 +309,7 @@ impl ThreadLocalBuffer {
     #[cfg(test)]
     pub(crate) fn encode_single(event: &RawEvent) -> Vec<u8> {
         let mut buf = Self::with_batch_size(1024);
-        buf.encode_event(event);
+        buf.record_encodable(event);
         buf.flush().encoded_bytes
     }
 
@@ -289,7 +388,7 @@ pub(crate) fn record_event(
             }
         };
         let first_call = buf.set_collector(collector);
-        buf.record_event(&event);
+        buf.record_encodable(&event);
         let current_epoch = drain_epoch.load(Ordering::Relaxed);
         if buf.should_flush() || buf.flush_epoch.load() < current_epoch {
             buf.flush_epoch.store(current_epoch);
@@ -325,6 +424,43 @@ pub(crate) fn drain_to_collector(collector: &CentralCollector) {
     });
 }
 
+/// Record a user-defined event into the thread-local trace buffer.
+///
+/// Like [`record_event`] but accepts any [`Encodable`] type, including
+/// user-defined `#[derive(TraceEvent)]` structs.
+pub(crate) fn record_encodable_event(
+    event: &dyn Encodable,
+    collector: &Arc<CentralCollector>,
+    drain_epoch: &AtomicU64,
+) -> Option<TlBufferHandle> {
+    BUFFER.with(|arc| {
+        let mut buf = match arc.lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                crate::rate_limit::rate_limited!(Duration::from_secs(60), {
+                    tracing::error!("dial9: thread-local buffer mutex poisoned in record_encodable_event; dropping events for this thread");
+                });
+                return None;
+            }
+        };
+        let first_call = buf.set_collector(collector);
+        buf.record_encodable(event);
+        let current_epoch = drain_epoch.load(Ordering::Relaxed);
+        if buf.should_flush() || buf.flush_epoch.load() < current_epoch {
+            buf.flush_epoch.store(current_epoch);
+            collector.accept_flush(buf.flush());
+        }
+        if first_call {
+            Some(TlBufferHandle {
+                buffer: Arc::downgrade(arc),
+                flush_epoch: buf.flush_epoch.clone(),
+            })
+        } else {
+            None
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -345,7 +481,7 @@ mod tests {
     #[test]
     fn test_record_event() {
         let mut buffer = ThreadLocalBuffer::new();
-        buffer.record_event(&poll_end_event());
+        buffer.record_encodable(&poll_end_event());
         assert_eq!(buffer.event_count, 1);
         assert!(buffer.encoder.bytes_written() > 0);
     }
@@ -355,7 +491,7 @@ mod tests {
         // Use a tiny batch size so a single event triggers flush.
         let mut buffer = ThreadLocalBuffer::with_batch_size(1);
         assert!(!buffer.should_flush());
-        buffer.record_event(&poll_end_event());
+        buffer.record_encodable(&poll_end_event());
         assert!(buffer.should_flush());
     }
 
@@ -363,7 +499,7 @@ mod tests {
     fn test_should_flush_default_batch_size() {
         let mut buffer = ThreadLocalBuffer::new();
         assert!(!buffer.should_flush());
-        buffer.record_event(&poll_end_event());
+        buffer.record_encodable(&poll_end_event());
         // A single small event should not exceed 1 MB.
         assert!(!buffer.should_flush());
     }
@@ -371,7 +507,7 @@ mod tests {
     #[test]
     fn test_flush() {
         let mut buffer = ThreadLocalBuffer::new();
-        buffer.record_event(&poll_end_event());
+        buffer.record_encodable(&poll_end_event());
         let batch = buffer.flush();
         assert!(!batch.encoded_bytes.is_empty());
         assert_eq!(buffer.event_count, 0);
@@ -405,7 +541,7 @@ mod tests {
         // logic directly: flush + stamp.
         let mut buffer = ThreadLocalBuffer::with_batch_size(1);
         buffer.set_collector(&collector);
-        buffer.record_event(&poll_end_event());
+        buffer.record_encodable(&poll_end_event());
         assert!(buffer.should_flush());
         buffer
             .flush_epoch
@@ -421,7 +557,7 @@ mod tests {
         // Write an event from a different thread.
         let handle = std::thread::spawn(move || {
             let mut guard = buf_clone.lock().unwrap();
-            guard.record_event(&poll_end_event());
+            guard.record_encodable(&poll_end_event());
             assert_eq!(guard.event_count, 1);
         });
         handle.join().unwrap();

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod recorder;
 pub(crate) mod task_metadata;
 pub(crate) mod writer;
 
+pub use buffer::{Encodable, ThreadLocalEncoder};
 pub use events::{CpuSampleSource, TelemetryEvent, clock_monotonic_ns};
 pub use format::{
     PollEndEvent, PollStartEvent, TaskSpawnEvent, WakeEventEvent, WorkerId, WorkerParkEvent,
@@ -26,3 +27,38 @@ pub use recorder::{
 };
 pub use task_metadata::{TaskId, UNKNOWN_TASK_ID};
 pub use writer::{NullWriter, RotatingWriter, TraceWriter};
+
+/// Record a custom event into the trace.
+///
+/// Events are encoded into a thread-local buffer and flushed to disk by the
+/// background flush thread. This function is very cheap (~100–200 ns) and
+/// safe to call on hot paths.
+///
+/// Any type implementing [`dial9_trace_format::TraceEvent`] (typically via
+/// `#[derive(TraceEvent)]`) automatically implements [`Encodable`] and can
+/// be passed directly. For events that need string interning, implement
+/// [`Encodable`] manually.
+///
+/// Does nothing if telemetry is disabled on the handle.
+///
+/// # Example
+///
+/// ```ignore
+/// use dial9_trace_format::TraceEvent;
+/// use dial9_tokio_telemetry::telemetry::{record_event, clock_monotonic_ns};
+///
+/// #[derive(TraceEvent)]
+/// struct HttpRequest {
+///     #[traceevent(timestamp)]
+///     timestamp_ns: u64,
+///     status_code: u32,
+/// }
+///
+/// record_event(
+///     HttpRequest { timestamp_ns: clock_monotonic_ns(), status_code: 200 },
+///     &handle,
+/// );
+/// ```
+pub fn record_event(event: impl Encodable, handle: &TelemetryHandle) {
+    handle.record_encodable_event(&event);
+}

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -245,6 +245,11 @@ impl TelemetryHandle {
         }
     }
 
+    /// Record a user-defined [`Encodable`](crate::telemetry::buffer::Encodable) event.
+    pub(crate) fn record_encodable_event(&self, event: &dyn crate::telemetry::buffer::Encodable) {
+        self.shared.record_encodable_event(event);
+    }
+
     /// Spawn a future wrapped with wake-event tracking.
     #[track_caller]
     pub fn spawn<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -100,6 +100,18 @@ impl SharedState {
         }
     }
 
+    /// Record a user-defined [`Encodable`](crate::telemetry::buffer::Encodable) event.
+    pub(crate) fn record_encodable_event(&self, event: &dyn buffer::Encodable) {
+        if !self.enabled.load(Ordering::Relaxed) {
+            return;
+        }
+        if let Some(handle) =
+            buffer::record_encodable_event(event, &self.collector, &self.drain_epoch)
+        {
+            self.tl_buffers.lock().unwrap().push(handle);
+        }
+    }
+
     /// Bump the drain epoch and flush all idle/silent thread-local buffers.
     ///
     /// Buffers whose `FlushEpoch` matches the current epoch are skipped

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -92,12 +92,7 @@ impl SharedState {
     }
 
     pub(crate) fn record_event(&self, event: RawEvent) {
-        if !self.enabled.load(Ordering::Relaxed) {
-            return;
-        }
-        if let Some(handle) = buffer::record_event(event, &self.collector, &self.drain_epoch) {
-            self.tl_buffers.lock().unwrap().push(handle);
-        }
+        self.record_encodable_event(&event);
     }
 
     /// Record a user-defined [`Encodable`](crate::telemetry::buffer::Encodable) event.

--- a/dial9-tokio-telemetry/tests/end_to_end.rs
+++ b/dial9-tokio-telemetry/tests/end_to_end.rs
@@ -143,3 +143,56 @@ fn task_terminate_events_are_captured() {
         "expected at least {N} TaskTerminate events, got {terminate_count}"
     );
 }
+
+#[test]
+fn custom_event_appears_in_trace() {
+    use dial9_trace_format::TraceEvent as TraceEventDerive;
+
+    #[derive(TraceEventDerive)]
+    struct MyCustomEvent {
+        #[traceevent(timestamp)]
+        timestamp_ns: u64,
+        request_count: u32,
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let trace_path = dir.path().join("trace.bin");
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let writer = RotatingWriter::single_file(&trace_path).unwrap();
+    let (runtime, guard) = TracedRuntime::build_and_start(builder, writer).unwrap();
+
+    let handle = guard.handle();
+    runtime.block_on(async {
+        for i in 0..5 {
+            dial9_tokio_telemetry::telemetry::record_event(
+                MyCustomEvent {
+                    timestamp_ns: dial9_tokio_telemetry::telemetry::clock_monotonic_ns(),
+                    request_count: i,
+                },
+                &handle,
+            );
+        }
+        // Wait for flush cycle
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    // Decode at the trace-format level to find our custom event
+    let sealed_path = dir.path().join("trace.0.bin");
+    let data = std::fs::read(&sealed_path).unwrap();
+    let mut decoder = dial9_trace_format::decoder::Decoder::new(&data).unwrap();
+    let mut custom_count = 0u32;
+    decoder
+        .for_each_event(|ev| {
+            if ev.name == "MyCustomEvent" {
+                custom_count += 1;
+            }
+        })
+        .unwrap();
+    assert_eq!(custom_count, 5, "expected 5 MyCustomEvent events in trace");
+}


### PR DESCRIPTION
The main challenge is access to string interning which I solved by introducing `Encodable`. A side benefit is that `Encodeable` is dyn Safe which is convenient.