### PR TITLE
fix overhead_bench telemetry and baseline p99

### DIFF
--- a/dial9-tokio-telemetry/benches/overhead_bench.rs
+++ b/dial9-tokio-telemetry/benches/overhead_bench.rs
@@ -253,6 +253,9 @@ fn main() {
     if is_bmf {
         let mut report = bmf::Report::new();
         let mut results = std::collections::HashMap::new();
+        // Discarded warmup run so the first measured mode doesn't pay
+        // cold-process costs (CPU freq ramp, allocator/page faults).
+        let _ = run_bench("baseline", WARMUP_SECS);
         for mode in ["baseline", "telemetry", "noop"] {
             let r = run_bench(mode, duration_secs);
             let rps = r.hist.len() as f64 / r.wall.as_secs_f64();

--- a/dial9-tokio-telemetry/benches/overhead_bench.rs
+++ b/dial9-tokio-telemetry/benches/overhead_bench.rs
@@ -30,7 +30,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
 const NUM_CLIENTS: usize = 50;
-const DEFAULT_DURATION_SECS: u64 = 30;
+const DEFAULT_DURATION_SECS: u64 = 60;
 const WARMUP_SECS: u64 = 3;
 
 // ── Echo server (runs on the traced runtime) ─────────────────────────────────

--- a/dial9-tokio-telemetry/benches/overhead_bench.rs
+++ b/dial9-tokio-telemetry/benches/overhead_bench.rs
@@ -276,7 +276,7 @@ fn main() {
         let telemetry_p99 = results["telemetry"].hist.value_at_percentile(99.0);
         report.insert(
             "overhead::telemetry_p99_added_latency_ns".to_string(),
-            bmf::Metric::latency((telemetry_p99 - baseline_p99) as f64),
+            bmf::Metric::latency((telemetry_p99 as i64 - baseline_p99 as i64) as f64),
         );
         println!("{}", serde_json::to_string_pretty(&report).unwrap());
         return;


### PR DESCRIPTION
`overhead::telemetry::p99_lat_ns` was being faster than  `overhead::baseline::p99_lat_ns`, which shouldnt really happen.

implements:
doubled the default measurement time to tighten the estimate. 
added warmup before measurement. 
fixed underflow error.

tested on fork