### PR TITLE
fix: set default-run in dial9-viewer

### DIFF
--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "CLI trace viewer and S3 browser for dial9-tokio-telemetry"
+default-run = "dial9-viewer"
 
 [features]
 dev-server = ["dep:s3s", "dep:s3s-fs", "dep:s3s-aws", "dep:tempfile"]


### PR DESCRIPTION
Without `default-run`, `cargo run -p dial9-viewer` is ambiguous between the `dial9-viewer` and `dev-server` binaries and may try to launch the dev server (which requires the `dev-server` feature).

Adds `default-run = "dial9-viewer"` to `dial9-viewer/Cargo.toml`.

Closes #203