### PR TITLE
fix(viewer): discard open polls at trace end (#194)

### DIFF
--- a/dial9-viewer/ui/test_trace_analysis.js
+++ b/dial9-viewer/ui/test_trace_analysis.js
@@ -367,9 +367,28 @@ async function main() {
     pass("buildFgData returns null for empty samples");
   }
 
+  // ── Regression: open PollStart at trace end must not create phantom poll (#194) ──
+
+  function testOpenPollStartDiscarded() {
+    // Simulate a rotated segment where PollStart is the last event (no PollEnd).
+    const syntheticEvents = [
+      { eventType: EVENT_TYPES.PollStart, timestamp: 1000, workerId: 0, taskId: 1, spawnLocId: null, spawnLoc: null, localQueue: 0 },
+      { eventType: EVENT_TYPES.PollEnd,   timestamp: 2000, workerId: 0 },
+      // This PollStart has no matching PollEnd — file rotated
+      { eventType: EVENT_TYPES.PollStart, timestamp: 3000, workerId: 0, taskId: 2, spawnLocId: null, spawnLoc: null, localQueue: 0 },
+    ];
+    const syntheticMaxTs = 1_000_000; // 1ms later — would create a huge phantom poll
+    const result = buildWorkerSpans(syntheticEvents, [0], syntheticMaxTs);
+    const polls = result.workerSpans[0].polls;
+    if (polls.length !== 1) fail(`Expected 1 poll, got ${polls.length} — open PollStart was not discarded`);
+    if (polls[0].start !== 1000 || polls[0].end !== 2000) fail(`Unexpected poll range`);
+    pass("Open PollStart at trace end is discarded (no phantom long poll)");
+  }
+
   // ── Run all tests ──
 
   console.log("\nbuildWorkerSpans:");
+  testOpenPollStartDiscarded();
   testPollsHaveValidRange();
   testNoOverlappingPolls();
   testActiveRatiosInRange();

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -145,10 +145,10 @@
       }
     }
 
-    // Close any open spans at trace end
+    // Close any open park spans at trace end.
+    // Open polls are discarded: a PollStart without a matching PollEnd
+    // means the segment rotated mid-poll, not that the poll was long (#194).
     for (const w of workerIds) {
-      if (openPoll[w] != null)
-        workerSpans[w].polls.push({ start: openPoll[w], end: maxTs });
       if (openPark[w] != null)
         workerSpans[w].parks.push({ start: openPark[w], end: maxTs });
     }


### PR DESCRIPTION
## Summary

When a trace segment rotates with `PollStart` as the last event (no matching `PollEnd`), the viewer was closing the open poll span at `maxTs`, creating a phantom long poll. Now open polls are simply discarded.

Fixes #194

## Changes

- **`trace_analysis.js`**: Removed the code that closes open poll spans at trace end. Open parks are still closed (correct behavior).
- **`test_trace_analysis.js`**: Added `testOpenPollStartDiscarded` regression test with synthetic events.

## What was verified

- New unit test passes (Red→Green TDD)
- All existing JS viewer tests pass
- `cargo clippy --all-targets --all-features` clean
- `cargo nextest run` — 356 tests pass
- `cargo nextest run --stress-duration 20s` — 4 iterations, all pass
- Rust `detect_long_polls` was already correct (only creates entries with matching `PollEnd`)