### PR TITLE
Fix: add explicit monotonic <-> realtime clock sync to trace format

### DIFF
--- a/dial9-tokio-telemetry/examples/trace_to_fat_jsonl.rs
+++ b/dial9-tokio-telemetry/examples/trace_to_fat_jsonl.rs
@@ -165,6 +165,7 @@ fn to_fat_event(event: &TelemetryEvent, reader: &TraceReader) -> Option<FatEvent
         TelemetryEvent::TaskSpawn { .. }
         | TelemetryEvent::TaskTerminate { .. }
         | TelemetryEvent::ThreadNameDef { .. }
-        | TelemetryEvent::SegmentMetadata { .. } => None,
+        | TelemetryEvent::SegmentMetadata { .. }
+        | TelemetryEvent::ClockSync { .. } => None,
     }
 }

--- a/dial9-tokio-telemetry/src/background_task/sealed.rs
+++ b/dial9-tokio-telemetry/src/background_task/sealed.rs
@@ -12,9 +12,9 @@ pub(crate) struct SealedSegment {
     pub(crate) index: u32,
 }
 
-/// Segment creation time as epoch seconds, parsed from SegmentMetadata header.
-/// Returns `(epoch_secs, true)` if the header was valid, or falls back to
-/// file mtime / current time with `(epoch_secs, false)`.
+/// Segment creation time as epoch seconds, parsed from the first clock
+/// anchor in the trace. Returns `(secs, true)` on a successful parse, or
+/// falls back to file mtime / current time with `(secs, false)`.
 pub(crate) fn creation_epoch_secs(data: &[u8], path: &Path) -> (u64, bool) {
     match parse_segment_timestamp(data) {
         Ok(ts) => return (ts / 1_000_000_000, true),
@@ -40,17 +40,32 @@ pub(crate) fn creation_epoch_secs(data: &[u8], path: &Path) -> (u64, bool) {
     (secs, false)
 }
 
-/// Parse the timestamp (nanos) from the first SegmentMetadata event in a trace segment.
+/// Legacy epoch-vs-monotonic discriminator for ambiguous
+/// `SegmentMetadataEvent.timestamp_ns` values.
+///
+/// Pre-clock-sync traces may store epoch nanoseconds there, while new traces
+/// use monotonic nanoseconds. Epoch timestamps are ~1e18, while monotonic uptime is much smaller.
+/// So we use `2020-01-01` ns as a floor, monotonic would need decades
+/// of continuous runtime to reach that range.
+///
+/// Keep in sync with `LEGACY_EPOCH_NS_FLOOR` in `dial9-viewer/ui/trace_parser.js`.
+pub(crate) const LEGACY_EPOCH_NS_FLOOR: u64 = 1_577_836_800_000_000_000;
+
+/// Parse wall-clock creation time from the first `ClockSyncEvent`,
+/// or from a legacy `SegmentMetadataEvent.timestamp_ns` that predates clock-sync support.
 fn parse_segment_timestamp(data: &[u8]) -> Result<u64, ParseTimestampError> {
     use dial9_trace_format::decoder::{DecodedFrameRef, Decoder};
+    use dial9_trace_format::types::FieldValueRef;
 
     let mut dec = Decoder::new(data).ok_or(ParseTimestampError::InvalidHeader)?;
     let mut events_seen = 0;
+    let mut legacy_fallback: Option<u64> = None;
     loop {
         match dec.next_frame_ref() {
             Ok(Some(DecodedFrameRef::Event {
                 type_id,
                 timestamp_ns,
+                values,
                 ..
             })) => {
                 events_seen += 1;
@@ -59,16 +74,25 @@ fn parse_segment_timestamp(data: &[u8]) -> Result<u64, ParseTimestampError> {
                     .get(type_id)
                     .map(|s| s.name.as_str())
                     .ok_or(ParseTimestampError::UnknownTypeId(type_id.0))?;
-                if name == "SegmentMetadataEvent" {
-                    return timestamp_ns.ok_or(ParseTimestampError::MissingTimestamp);
+                if name == "ClockSyncEvent" {
+                    return match values.first() {
+                        Some(FieldValueRef::Varint(v)) => Ok(*v),
+                        _ => Err(ParseTimestampError::MissingRealtimeField),
+                    };
+                }
+                if name == "SegmentMetadataEvent"
+                    && let Some(ts) = timestamp_ns
+                    && ts >= LEGACY_EPOCH_NS_FLOOR
+                {
+                    legacy_fallback = Some(ts);
                 }
                 if events_seen >= 10 {
-                    return Err(ParseTimestampError::NotFoundInFirst10Events);
+                    return legacy_fallback.ok_or(ParseTimestampError::NoAnchorInFirst10Events);
                 }
             }
             Ok(Some(_)) => {} // schema/pool frame, keep going
             Ok(None) => {
-                return Err(ParseTimestampError::EndOfStream { events_seen });
+                return legacy_fallback.ok_or(ParseTimestampError::EndOfStream { events_seen });
             }
             Err(e) => {
                 return Err(ParseTimestampError::DecodeError(e.to_string()));
@@ -81,8 +105,8 @@ fn parse_segment_timestamp(data: &[u8]) -> Result<u64, ParseTimestampError> {
 enum ParseTimestampError {
     InvalidHeader,
     UnknownTypeId(u16),
-    MissingTimestamp,
-    NotFoundInFirst10Events,
+    MissingRealtimeField,
+    NoAnchorInFirst10Events,
     EndOfStream { events_seen: u32 },
     DecodeError(String),
 }
@@ -92,13 +116,14 @@ impl std::fmt::Display for ParseTimestampError {
         match self {
             Self::InvalidHeader => write!(f, "invalid trace header"),
             Self::UnknownTypeId(id) => write!(f, "unknown type_id {id} not in registry"),
-            Self::MissingTimestamp => write!(f, "SegmentMetadataEvent had no timestamp"),
-            Self::NotFoundInFirst10Events => {
-                write!(f, "SegmentMetadataEvent not found in first 10 events")
-            }
+            Self::MissingRealtimeField => write!(f, "ClockSyncEvent had no realtime_ns field"),
+            Self::NoAnchorInFirst10Events => write!(
+                f,
+                "no ClockSyncEvent or legacy wall-clock SegmentMetadataEvent in first 10 events"
+            ),
             Self::EndOfStream { events_seen } => write!(
                 f,
-                "end of stream after {events_seen} events without SegmentMetadataEvent"
+                "end of stream after {events_seen} events without a clock anchor"
             ),
             Self::DecodeError(e) => write!(f, "decode error: {e}"),
         }
@@ -326,6 +351,63 @@ mod tests {
             .unwrap()
             .as_nanos() as u64;
         check!(now_nanos.abs_diff(ts) < 60_000_000_000);
+    }
+
+    fn legacy_segment_metadata_trace(timestamp_ns: u64) -> Vec<u8> {
+        use crate::telemetry::format::{SegmentMetadataEvent, WorkerParkEvent};
+        use dial9_trace_format::encoder::Encoder;
+
+        let mut enc = Encoder::new_to(Vec::new()).unwrap();
+        enc.write(&SegmentMetadataEvent {
+            timestamp_ns,
+            entries: vec![("k".into(), "v".into())],
+        })
+        .unwrap();
+        enc.write_infallible(&WorkerParkEvent {
+            timestamp_ns: 1_000_000_000,
+            worker_id: crate::telemetry::format::WorkerId::from(0usize),
+            local_queue: 0,
+            cpu_time_ns: 0,
+        });
+        enc.into_inner()
+    }
+
+    /// Legacy pre-clock-sync files stored wall clock in `SegmentMetadataEvent.timestamp_ns`,
+    /// parser fallback should recover it.
+    #[test]
+    fn test_parse_segment_timestamp_legacy_segment_metadata_fallback() {
+        // 2024-06-01T00:00:00Z: comfortably epoch-scale.
+        const LEGACY_WALL_NS: u64 = 1_717_200_000_000_000_000;
+        let data = legacy_segment_metadata_trace(LEGACY_WALL_NS);
+
+        let parsed = parse_segment_timestamp(&data).unwrap();
+        check!(parsed == LEGACY_WALL_NS);
+    }
+
+    #[test]
+    fn test_creation_epoch_secs_uses_legacy_segment_metadata_fallback() {
+        const LEGACY_WALL_NS: u64 = 1_717_200_000_000_000_000;
+        let data = legacy_segment_metadata_trace(LEGACY_WALL_NS);
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("legacy.0.bin");
+        std::fs::write(&path, &data).unwrap();
+        let (epoch_secs, header_valid) = creation_epoch_secs(&data, &path);
+        check!(header_valid);
+        check!(epoch_secs == LEGACY_WALL_NS / 1_000_000_000);
+    }
+
+    /// A small (monotonic-looking) SegmentMeta.timestamp_ns must NOT be
+    /// mistaken for a legacy wall-clock value.
+    #[test]
+    fn test_parse_segment_timestamp_monotonic_segment_metadata_is_not_legacy() {
+        let data = legacy_segment_metadata_trace(12_345);
+
+        let result = parse_segment_timestamp(&data);
+        check!(matches!(
+            result,
+            Err(ParseTimestampError::EndOfStream { .. })
+                | Err(ParseTimestampError::NoAnchorInFirst10Events)
+        ));
     }
 
     #[test]

--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -88,6 +88,7 @@ impl TraceReader {
                     TelemetryEvent::TaskSpawn { .. }
                         | TelemetryEvent::ThreadNameDef { .. }
                         | TelemetryEvent::SegmentMetadata { .. }
+                        | TelemetryEvent::ClockSync { .. }
                 )
             })
             .cloned()
@@ -297,7 +298,8 @@ pub fn analyze_trace(events: &[TelemetryEvent]) -> TraceAnalysis {
             | TelemetryEvent::CpuSample { .. }
             | TelemetryEvent::ThreadNameDef { .. }
             | TelemetryEvent::WakeEvent { .. }
-            | TelemetryEvent::SegmentMetadata { .. } => {}
+            | TelemetryEvent::SegmentMetadata { .. }
+            | TelemetryEvent::ClockSync { .. } => {}
         }
     }
 

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -188,6 +188,16 @@ pub enum TelemetryEvent {
         /// Key-value metadata pairs.
         entries: Vec<(String, String)>,
     },
+    /// Clock-correlation anchor pairing a monotonic timestamp with the
+    /// wall-clock value captured at the same instant.
+    ClockSync {
+        /// Monotonic nanoseconds.
+        #[serde(rename = "timestamp_ns")]
+        timestamp_nanos: u64,
+        /// Nanoseconds since the Unix epoch.
+        #[serde(rename = "realtime_ns")]
+        realtime_nanos: u64,
+    },
 }
 
 impl TelemetryEvent {
@@ -224,6 +234,9 @@ impl TelemetryEvent {
             TelemetryEvent::ThreadNameDef { .. } => None,
             TelemetryEvent::SegmentMetadata {
                 timestamp_nanos, ..
+            }
+            | TelemetryEvent::ClockSync {
+                timestamp_nanos, ..
             } => Some(*timestamp_nanos),
         }
     }
@@ -241,7 +254,8 @@ impl TelemetryEvent {
             | TelemetryEvent::TaskTerminate { .. }
             | TelemetryEvent::ThreadNameDef { .. }
             | TelemetryEvent::WakeEvent { .. }
-            | TelemetryEvent::SegmentMetadata { .. } => None,
+            | TelemetryEvent::SegmentMetadata { .. }
+            | TelemetryEvent::ClockSync { .. } => None,
         }
     }
 
@@ -367,13 +381,49 @@ pub fn clock_monotonic_ns() -> u64 {
     ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
 }
 
+/// `CLOCK_MONOTONIC` in nanoseconds. Non-Linux fallback: elapsed time
+/// since the first call on this process via `Instant`.
 #[cfg(not(target_os = "linux"))]
 pub fn clock_monotonic_ns() -> u64 {
-    // Fallback: use Instant. This is fine for non-Linux where perf isn't available.
     use std::sync::OnceLock;
     use std::time::Instant;
     static EPOCH: OnceLock<Instant> = OnceLock::new();
     EPOCH.get_or_init(Instant::now).elapsed().as_nanos() as u64
+}
+
+/// `CLOCK_REALTIME` in nanoseconds since the Unix epoch. Only for
+/// clock-correlation anchors — never as an event time source, since
+/// realtime jumps under NTP/suspend/manual edits.
+#[cfg(target_os = "linux")]
+pub(crate) fn clock_realtime_ns() -> u64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    unsafe {
+        libc::clock_gettime(libc::CLOCK_REALTIME, &mut ts);
+    }
+    ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn clock_realtime_ns() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}
+
+/// Snapshot `(monotonic_ns, realtime_ns)` as close together as possible.
+/// Reads M₁ → R → M₂ and pairs `R` with the midpoint of M₁ and M₂ so
+/// the correlation error is half the `clock_gettime` interval.
+pub(crate) fn clock_pair() -> (u64, u64) {
+    let m1 = clock_monotonic_ns();
+    let r = clock_realtime_ns();
+    let m2 = clock_monotonic_ns();
+    let mono = m1 + m2.saturating_sub(m1) / 2;
+    (mono, r)
 }
 
 /// Per-thread scheduler stats from `/proc/<pid>/task/<tid>/schedstat`.

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -391,9 +391,7 @@ pub fn clock_monotonic_ns() -> u64 {
     EPOCH.get_or_init(Instant::now).elapsed().as_nanos() as u64
 }
 
-/// `CLOCK_REALTIME` in nanoseconds since the Unix epoch. Only for
-/// clock-correlation anchors — never as an event time source, since
-/// realtime jumps under NTP/suspend/manual edits.
+/// `CLOCK_REALTIME` in nanoseconds since the Unix epoch.
 #[cfg(target_os = "linux")]
 pub(crate) fn clock_realtime_ns() -> u64 {
     let mut ts = libc::timespec {
@@ -416,7 +414,7 @@ pub(crate) fn clock_realtime_ns() -> u64 {
 }
 
 /// Snapshot `(monotonic_ns, realtime_ns)` as close together as possible.
-/// Reads M₁ → R → M₂ and pairs `R` with the midpoint of M₁ and M₂ so
+/// Reads M₁ -> R -> M₂ and pairs `R` with the midpoint of M₁ and M₂ so
 /// the correlation error is half the `clock_gettime` interval.
 pub(crate) fn clock_pair() -> (u64, u64) {
     let m1 = clock_monotonic_ns();

--- a/dial9-tokio-telemetry/src/telemetry/format.rs
+++ b/dial9-tokio-telemetry/src/telemetry/format.rs
@@ -215,6 +215,19 @@ pub(crate) struct SegmentMetadataEvent {
     pub entries: Vec<(String, String)>,
 }
 
+/// Clock-correlation anchor. `timestamp_ns` (monotonic) and `realtime_ns`
+/// (nanoseconds since Unix epoch) are captured at the same instant via
+/// [`clock_pair`], so offline consumers can recover wall clock from the
+/// monotonic event stream.
+///
+/// [`clock_pair`]: crate::telemetry::events::clock_pair
+#[derive(TraceEvent)]
+pub(crate) struct ClockSyncEvent {
+    #[traceevent(timestamp)]
+    pub timestamp_ns: u64,
+    pub realtime_ns: u64,
+}
+
 // ── dial9-trace-format: decode ──────────────────────────────────────────────
 
 /// Decode all events from a `dial9-trace-format` byte slice into `TelemetryEvent`s.
@@ -254,6 +267,7 @@ pub(crate) enum TelemetryEventRef<'a> {
     CpuSample(CpuSampleEventRef<'a>),
     WakeEvent(WakeEventEventRef<'a>),
     SegmentMetadata(SegmentMetadataEventRef<'a>),
+    ClockSync(ClockSyncEventRef<'a>),
 }
 
 #[cfg(any(feature = "analysis", test))]
@@ -272,6 +286,7 @@ impl<'a> TelemetryEventRef<'a> {
             Self::CpuSample(e) => Some(e.timestamp_ns),
             Self::WakeEvent(e) => Some(e.timestamp_ns),
             Self::SegmentMetadata(e) => Some(e.timestamp_ns),
+            Self::ClockSync(e) => Some(e.timestamp_ns),
         }
     }
 }
@@ -313,6 +328,9 @@ pub(crate) fn decode_ref<'a>(
         }
         "SegmentMetadataEvent" => {
             TelemetryEventRef::SegmentMetadata(SegmentMetadataEvent::decode(timestamp_ns, fields)?)
+        }
+        "ClockSyncEvent" => {
+            TelemetryEventRef::ClockSync(ClockSyncEvent::decode(timestamp_ns, fields)?)
         }
         _ => return None,
     })
@@ -391,6 +409,10 @@ pub(crate) fn to_owned_event(r: TelemetryEventRef<'_>, pool: &StringPool) -> Tel
                 .iter()
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
                 .collect(),
+        },
+        TelemetryEventRef::ClockSync(e) => TelemetryEvent::ClockSync {
+            timestamp_nanos: e.timestamp_ns,
+            realtime_nanos: e.realtime_ns,
         },
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/writer.rs
@@ -1,7 +1,8 @@
 use dial9_trace_format::encoder::{Encoder, RawEncoder};
 
 use crate::telemetry::collector::Batch;
-use crate::telemetry::format::SegmentMetadataEvent;
+use crate::telemetry::events::{clock_monotonic_ns, clock_pair};
+use crate::telemetry::format::{ClockSyncEvent, SegmentMetadataEvent};
 use std::collections::VecDeque;
 use std::fs::{self, File};
 use std::io::BufWriter;
@@ -266,43 +267,43 @@ impl RotatingWriter {
         &self.active_path
     }
 
-    /// Create an encoder, write the file header and segment metadata, then
-    /// convert to a [`RawEncoder`] for the remainder of the file's lifetime.
+    /// Create an encoder, write the file header, segment metadata, and a
+    /// clock-sync anchor, then convert to a [`RawEncoder`] for the
+    /// remainder of the file's lifetime.
     fn write_header_and_metadata(
         writer: BufWriter<File>,
         segment_metadata: &[(String, String)],
     ) -> std::io::Result<RawEncoder<BufWriter<File>>> {
         let mut encoder = Encoder::new_to(writer)?;
         let entries = segment_metadata.to_vec();
-        let timestamp_ns = time_source()
-            .system_time()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as u64;
         encoder.write(&SegmentMetadataEvent {
-            timestamp_ns,
+            timestamp_ns: clock_monotonic_ns(),
             entries,
+        })?;
+        let (mono, real) = clock_pair();
+        encoder.write(&ClockSyncEvent {
+            timestamp_ns: mono,
+            realtime_ns: real,
         })?;
         Ok(encoder.into_raw_encoder())
     }
 
-    /// Write a `SegmentMetadataEvent` into the current active segment.
-    /// Used by `write_current_segment_metadata` to flush runtime metadata
-    /// before finalize.
+    /// Write a `SegmentMetadataEvent` and a fresh `ClockSyncEvent` into
+    /// the current active segment.
     fn write_segment_metadata(&mut self) -> std::io::Result<()> {
         let WriterState::Active(raw) = &mut self.state else {
             return Ok(());
         };
         let entries = self.segment_metadata.clone();
-        let timestamp_ns = time_source()
-            .system_time()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as u64;
         let mut enc = Encoder::new();
         enc.write(&SegmentMetadataEvent {
-            timestamp_ns,
+            timestamp_ns: clock_monotonic_ns(),
             entries,
+        })?;
+        let (mono, real) = clock_pair();
+        enc.write(&ClockSyncEvent {
+            timestamp_ns: mono,
+            realtime_ns: real,
         })?;
         raw.write_raw(&enc.finish())?;
         Ok(())
@@ -579,7 +580,12 @@ mod tests {
         format::decode_events(&data)
             .unwrap()
             .into_iter()
-            .filter(|e| !matches!(e, TelemetryEvent::SegmentMetadata { .. }))
+            .filter(|e| {
+                !matches!(
+                    e,
+                    TelemetryEvent::SegmentMetadata { .. } | TelemetryEvent::ClockSync { .. }
+                )
+            })
             .collect()
     }
 
@@ -1550,5 +1556,222 @@ mod tests {
 
         let events = read_trace_events(&rotating_file(&base, 0));
         assert_eq!(events.len(), 2, "both events should be in segment 0");
+    }
+
+    #[test]
+    fn test_clock_sync_precedes_first_data_event() {
+        use crate::background_task::sealed::LEGACY_EPOCH_NS_FLOOR;
+
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("trace");
+        let mut writer = RotatingWriter::builder()
+            .base_path(&base)
+            .max_file_size(100_000)
+            .max_total_size(100_000)
+            .build()
+            .unwrap();
+        writer.write_encoded_batch(&test_batch()).unwrap();
+        writer.flush().unwrap();
+        writer.finalize().unwrap();
+
+        let data = std::fs::read(rotating_file(&base, 0)).unwrap();
+        let all = format::decode_events(&data).unwrap();
+
+        // ClockSync must precede the first data event so a streaming
+        // decoder never sees a data timestamp without an anchor.
+        let first_data_idx = all
+            .iter()
+            .position(|e| {
+                !matches!(
+                    e,
+                    TelemetryEvent::SegmentMetadata { .. } | TelemetryEvent::ClockSync { .. }
+                )
+            })
+            .expect("expected at least one data event");
+        let first_clock_sync_idx = all
+            .iter()
+            .position(|e| matches!(e, TelemetryEvent::ClockSync { .. }))
+            .expect("expected a ClockSyncEvent in the file");
+        assert!(first_clock_sync_idx < first_data_idx);
+
+        match &all[first_clock_sync_idx] {
+            TelemetryEvent::ClockSync { realtime_nanos, .. } => {
+                assert!(*realtime_nanos >= LEGACY_EPOCH_NS_FLOOR);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn test_segment_metadata_timestamp_is_monotonic_scale() {
+        use crate::background_task::sealed::LEGACY_EPOCH_NS_FLOOR;
+
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("trace");
+        let mut writer = RotatingWriter::builder()
+            .base_path(&base)
+            .max_file_size(100_000)
+            .max_total_size(100_000)
+            .build()
+            .unwrap();
+        writer.write_encoded_batch(&test_batch()).unwrap();
+        writer.flush().unwrap();
+        writer.finalize().unwrap();
+
+        let data = std::fs::read(rotating_file(&base, 0)).unwrap();
+        let all = format::decode_events(&data).unwrap();
+
+        // SegmentMetadata.timestamp_ns should remain monotonic-scale,
+        // not epoch wall-clock.
+        let seg_ts = all
+            .iter()
+            .find_map(|e| match e {
+                TelemetryEvent::SegmentMetadata {
+                    timestamp_nanos, ..
+                } => Some(*timestamp_nanos),
+                _ => None,
+            })
+            .expect("SegmentMetadata");
+        assert!(
+            seg_ts < LEGACY_EPOCH_NS_FLOOR,
+            "SegmentMetadata.timestamp_nanos ({seg_ts}) should be monotonic-scale"
+        );
+    }
+
+    #[test]
+    fn test_clock_sync_written_in_every_rotated_file() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("trace");
+        let one_event = single_event_file_size();
+        let mut writer = RotatingWriter::builder()
+            .base_path(&base)
+            .max_file_size(one_event)
+            .max_total_size(100_000)
+            .build()
+            .unwrap();
+
+        for _ in 0..5 {
+            writer.write_encoded_batch(&test_batch()).unwrap();
+        }
+        writer.flush().unwrap();
+        writer.finalize().unwrap();
+
+        let mut files: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "bin"))
+            .collect();
+        files.sort();
+        assert!(files.len() >= 2, "expected at least 2 files from rotation");
+
+        for file in &files {
+            let all = format::decode_events(&std::fs::read(file).unwrap()).unwrap();
+            let has_clock_sync = all
+                .iter()
+                .any(|e| matches!(e, TelemetryEvent::ClockSync { .. }));
+            assert!(
+                has_clock_sync,
+                "{}: expected ClockSyncEvent",
+                file.display()
+            );
+        }
+    }
+
+    /// A hand-built legacy-shaped buffer (SegmentMetadata + WorkerPark,
+    /// no ClockSyncEvent) must still round-trip through the decoder.
+    #[test]
+    fn test_legacy_trace_without_clock_sync_still_decodes() {
+        let mut enc = Encoder::new_to(Vec::new()).unwrap();
+        enc.write(&SegmentMetadataEvent {
+            timestamp_ns: 1,
+            entries: vec![("k".into(), "v".into())],
+        })
+        .unwrap();
+        enc.write_infallible(&WorkerParkEvent {
+            timestamp_ns: 1000,
+            worker_id: crate::telemetry::format::WorkerId::from(0usize),
+            local_queue: 0,
+            cpu_time_ns: 0,
+        });
+        let buf = enc.into_inner();
+
+        let all = format::decode_events(&buf).unwrap();
+        assert!(
+            all.iter()
+                .any(|e| matches!(e, TelemetryEvent::WorkerPark { .. })),
+            "expected WorkerPark to decode"
+        );
+        assert!(
+            !all.iter()
+                .any(|e| matches!(e, TelemetryEvent::ClockSync { .. })),
+            "legacy trace must not contain ClockSync"
+        );
+    }
+
+    #[test]
+    fn test_clock_sync_offset_recovers_wall_clock_for_recent_event() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("trace");
+        let mut writer = RotatingWriter::builder()
+            .base_path(&base)
+            .max_file_size(100_000)
+            .max_total_size(100_000)
+            .build()
+            .unwrap();
+
+        // Use a real monotonic reading so reconstruction lands near now.
+        let park_ts = crate::telemetry::events::clock_monotonic_ns();
+        let mut enc = Encoder::new_to(Vec::new()).unwrap();
+        enc.write_infallible(&WorkerParkEvent {
+            timestamp_ns: park_ts,
+            worker_id: crate::telemetry::format::WorkerId::from(0usize),
+            local_queue: 0,
+            cpu_time_ns: 0,
+        });
+        writer
+            .write_encoded_batch(&Batch {
+                encoded_bytes: enc.into_inner(),
+                event_count: 1,
+            })
+            .unwrap();
+        writer.flush().unwrap();
+        writer.finalize().unwrap();
+
+        let all = format::decode_events(&std::fs::read(rotating_file(&base, 0)).unwrap()).unwrap();
+
+        let (sync_mono, sync_real) = all
+            .iter()
+            .find_map(|e| match e {
+                TelemetryEvent::ClockSync {
+                    timestamp_nanos,
+                    realtime_nanos,
+                } => Some((*timestamp_nanos, *realtime_nanos)),
+                _ => None,
+            })
+            .expect("ClockSync");
+        let park_from_file = all
+            .iter()
+            .find_map(|e| match e {
+                TelemetryEvent::WorkerPark {
+                    timestamp_nanos, ..
+                } => Some(*timestamp_nanos),
+                _ => None,
+            })
+            .expect("WorkerPark");
+
+        let offset = sync_real as i128 - sync_mono as i128;
+        let reconstructed_wall_ns = park_from_file as i128 + offset;
+        let now_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i128;
+        let diff = (reconstructed_wall_ns - now_ns).abs();
+        assert!(
+            diff < 5_000_000_000,
+            "reconstructed wall clock {reconstructed_wall_ns} diverges from now {now_ns} by {diff}ns"
+        );
     }
 }

--- a/dial9-viewer/ui/test_trace_integrity.js
+++ b/dial9-viewer/ui/test_trace_integrity.js
@@ -296,6 +296,39 @@ async function main() {
     pass("WakeEvent targetWorker within valid range");
   }
 
+  function testClockSyncRecoversWallClock() {
+    if (trace.clockSyncAnchors.length === 0) {
+      fail("No clock-sync anchors (real or legacy-synthesized)");
+    }
+    if (trace.clockOffsetNs == null) {
+      fail("clockOffsetNs not derived from anchors");
+    }
+  
+    const a0 = trace.clockSyncAnchors[0];
+    const reconstructedAnchorWall = a0.monotonicNs + trace.clockOffsetNs;
+  
+    if (!(a0.realtimeNs > a0.monotonicNs)) {
+      fail(
+        `anchor values look wrong: realtimeNs=${a0.realtimeNs} monotonicNs=${a0.monotonicNs}`
+      );
+    }
+
+    // Offset must map anchor mono -> anchor wall.
+    if (Math.abs(reconstructedAnchorWall - a0.realtimeNs) > 1_000_000) {
+      fail("clockOffsetNs does not match first anchor");
+    }
+  
+    // epoch-scale vs monotonic-scale sanity check
+    const MIN_PLAUSIBLE_WALL_CLOCK_MS = 1_577_836_800_000; // 2020-01-01
+    if (reconstructedAnchorWall / 1e6 < MIN_PLAUSIBLE_WALL_CLOCK_MS) {
+      fail(
+        `reconstructed wall clock ${reconstructedAnchorWall} is implausibly old`
+      );
+    }
+  
+    pass(`Clock offset reconstructs plausible wall clock`);
+  }
+
   function testAllPollStartsHaveTaskId() {
     const pollStarts = trace.events.filter(
       (e) => e.eventType === EVENT_TYPES.PollStart
@@ -341,6 +374,9 @@ async function main() {
   testWakeEventReferencesKnownTasks();
   testWakeEventTargetWorkerInRange();
   testAllPollStartsHaveTaskId();
+
+  console.log("\nClock-sync:");
+  testClockSyncRecoversWallClock();
 
   console.log("\n✓ All checks passed!");
 }

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -136,24 +136,45 @@
     const cpuSamples = [];
     const threadNames = new Map();
     const runtimeWorkers = new Map(); // runtime name → [workerId, ...]
+    // { monotonicNs, realtimeNs } anchors used to recover wall clock.
+    const clockSyncAnchors = [];
+    // Legacy classifier: epoch ns are ~1e18, monotonic ns are much smaller.
+    // 2020 is a practical floor that separates those ranges.
+    const LEGACY_EPOCH_FLOOR_MS = 1_577_836_800_000; // 2020-01-01
+    let legacySegmentMetaWallNs = null;
+    // Smallest monotonic ts seen across all event frames.
+    // Used as the monotonic timestamp for the legacy synthesized anchor.
+    let minMonoTs = null;
 
     const capped = () => events.length >= maxEvents;
     // Frames processed regardless of event cap:
     // - SymbolTableEntry: symbol tables are needed to resolve addresses in all other frames
     // - TaskSpawnEvent/TaskTerminateEvent: task lifecycle tracking for the task list view
     // - CpuSampleEvent: CPU samples feed the flame graph, which should reflect the full trace
+    // - ClockSyncEvent: to convert any timestamp to wall clock
     const UNCAPPED_FRAMES = new Set([
       "TaskSpawnEvent",
       "TaskTerminateEvent",
       "CpuSampleEvent",
       "SymbolTableEntry",
       "SegmentMetadataEvent",
+      "ClockSyncEvent",
     ]);
 
     for (const frame of frames) {
       if (frame.type !== "event") continue;
       const v = frame.values;
       const ts = num(frame.timestamp_ns);
+      // Track smallest monotonic ts for legacy anchor synthesis.
+      // Skip SegmentMetadata (legacy wall clock) and SymbolTableEntry.
+      if (
+        ts != null &&
+        frame.name !== "SegmentMetadataEvent" &&
+        frame.name !== "SymbolTableEntry" &&
+        (minMonoTs == null || ts < minMonoTs)
+      ) {
+        minMonoTs = ts;
+      }
 
       if (capped() && !UNCAPPED_FRAMES.has(frame.name)) continue;
 
@@ -280,7 +301,22 @@
           }
           break;
         }
+        case "ClockSyncEvent": {
+          const real = num(v.realtime_ns);
+          if (real > 0) {
+            clockSyncAnchors.push({ monotonicNs: ts, realtimeNs: real });
+          }
+          break;
+        }
         case "SegmentMetadataEvent": {
+          // If this looks epoch-scale, treat it as legacy wall clock.
+          if (
+            legacySegmentMetaWallNs == null &&
+            ts != null &&
+            ts / 1e6 >= LEGACY_EPOCH_FLOOR_MS
+          ) {
+            legacySegmentMetaWallNs = ts;
+          }
           const entries = v.entries || {};
           for (const [key, val] of Object.entries(entries)) {
             if (key.startsWith("runtime.")) {
@@ -323,6 +359,31 @@
       }
     }
 
+    // Legacy fallback: synthesize an anchor from legacy SegmentMetadata wall
+    // time + earliest monotonic event timestamp. This is best-effort only.
+    if (
+      clockSyncAnchors.length === 0 &&
+      legacySegmentMetaWallNs != null &&
+      minMonoTs != null
+    ) {
+      clockSyncAnchors.push({
+        monotonicNs: minMonoTs,
+        realtimeNs: legacySegmentMetaWallNs,
+      });
+    }
+
+    clockSyncAnchors.sort((a, b) => {
+      if (a.monotonicNs < b.monotonicNs) return -1;
+      if (a.monotonicNs > b.monotonicNs) return 1;
+      return 0;
+    });
+
+    let clockOffsetNs = null;
+    if (clockSyncAnchors.length > 0) {
+      const a0 = clockSyncAnchors[0];
+      clockOffsetNs = a0.realtimeNs - a0.monotonicNs;
+    }
+
     return {
       magic: "D9TF",
       version: dec.version,
@@ -339,6 +400,8 @@
       threadNames,
       taskTerminateTimes,
       runtimeWorkers,
+      clockSyncAnchors,
+      clockOffsetNs,
     };
   }
 

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -154,11 +154,6 @@
     let minMonoTs = null;
 
     const capped = () => events.length >= maxEvents;
-    // Frames processed regardless of event cap:
-    // - SymbolTableEntry: symbol tables are needed to resolve addresses in all other frames
-    // - TaskSpawnEvent/TaskTerminateEvent: task lifecycle tracking for the task list view
-    // - CpuSampleEvent: CPU samples feed the flame graph, which should reflect the full trace
-    // - ClockSyncEvent: to convert any timestamp to wall clock
     const UNCAPPED_FRAMES = new Set([
       "TaskSpawnEvent",
       "TaskTerminateEvent",

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -576,7 +576,13 @@
             }
 
             function fmtWallClock(ns) {
-                const ms = ns / 1e6;
+                // Apply the clock-sync offset to render as wall clock. Fall back to
+                // relative time if the trace has no anchors.
+                if (!trace || trace.clockOffsetNs == null) {
+                    return fmtDuration(ns - minTs);
+                }
+                const wallNs = ns + trace.clockOffsetNs;
+                const ms = wallNs / 1e6;
                 const d = new Date(ms);
                 const pad2 = n => String(n).padStart(2, "0");
                 if (useLocalTz) {

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -575,13 +575,46 @@
                 return prefix + v.toFixed(0) + "ns";
             }
 
+            function clockOffsetForTimestamp(ns) {
+                if (!trace) return null;
+                const anchors = trace.clockSyncAnchors || [];
+                if (anchors.length === 0) return trace.clockOffsetNs ?? null;
+                if (anchors.length === 1) {
+                    const a = anchors[0];
+                    return a.realtimeNs - a.monotonicNs;
+                }
+
+                // Nearest-anchor lookup on sorted monotonic timestamps.
+                let lo = 0, hi = anchors.length;
+                while (lo < hi) {
+                    const mid = (lo + hi) >> 1;
+                    if (anchors[mid].monotonicNs < ns) lo = mid + 1;
+                    else hi = mid;
+                }
+                if (lo === 0) {
+                    const a = anchors[0];
+                    return a.realtimeNs - a.monotonicNs;
+                }
+                if (lo >= anchors.length) {
+                    const a = anchors[anchors.length - 1];
+                    return a.realtimeNs - a.monotonicNs;
+                }
+                const prev = anchors[lo - 1];
+                const next = anchors[lo];
+                const pick = Math.abs(ns - prev.monotonicNs) <= Math.abs(next.monotonicNs - ns)
+                    ? prev
+                    : next;
+                return pick.realtimeNs - pick.monotonicNs;
+            }
+
             function fmtWallClock(ns) {
-                // Apply the clock-sync offset to render as wall clock. Fall back to
-                // relative time if the trace has no anchors.
-                if (!trace || trace.clockOffsetNs == null) {
+                // Apply the nearest clock-sync anchor to render wall clock.
+                // Fall back to relative time if the trace has no anchors.
+                const offsetNs = clockOffsetForTimestamp(ns);
+                if (offsetNs == null) {
                     return fmtDuration(ns - minTs);
                 }
-                const wallNs = ns + trace.clockOffsetNs;
+                const wallNs = ns + offsetNs;
                 const ms = wallNs / 1e6;
                 const d = new Date(ms);
                 const pad2 = n => String(n).padStart(2, "0");


### PR DESCRIPTION
closes #202

## Summary

Event timestamps are `CLOCK_MONOTONIC` nanoseconds since boot, but the viewer was feeding them directly to `new Date()`, so absolute-time mode rendered 1970-ish timestamps (e.g. ~00:00 in the viewer).

This change records explicit monotonic-to-realtime anchors in the trace and uses them in the viewer to recover wall clock correctly. New traces now show accurate absolute time without changing event timestamp semantics. Older traces work through a compatibility fallback. 

I went for this approach rather than directly switching event timestamps to `CLOCK_REALTIME`, because as I understand it clock jumps/slew (NTP), suspend/resume, or manual clock edits could break duration math.

## Details

Adds `ClockSyncEvent { timestamp_ns, realtime_ns }` wire type. Both values come from `clock_pair()`, which reads monotonic -> realtime -> monotonic back-to-back and pairs realtime with the midpoint monotonic sample, so correlation error is roughly half a `clock_gettime` interval. The writer emits anchors at file open and on rotation. The viewer picks the nearest anchor for each timestamp, computes `realtime - monotonic` at that anchor, and applies that offset in `fmtWallClock`.

I kept this as a new event type instead of extending SegmentMetadataEvent for compatibility, AFAIK in our typed decode path, missing fields on older traces can make that event decode to None and get skipped.

This also changes something I found confusing: `SegmentMetadataEvent.timestamp_ns` used wall clock while being a `#[traceevent(timestamp)]` field, and other timestamp fields are monotic. This now matches the rest of events, and wall clock is explicit in `ClockSyncEvent.realtime_ns`.
For new files, `sealed.rs` reads segment creation time from `ClockSyncEvent`. For older files, both `sealed.rs` and the viewer fall back to legacy `SegmentMetadata.timestamp_ns` when it looks epoch-scale, and reconstruct wall clock as an approximation.

The behavioral break is only for any external consumers that treated `SegmentMetadataEvent.timestamp_ns` as wall clock. If any those consumers should migrate to `ClockSyncEvent.realtime_ns` (or apply the same `LEGACY_EPOCH_NS_FLOOR` fallback for old traces).

If we'd rather not change `SegmentMetadataEvent.timestamp_ns`, I'm happy to revert but perhaps semantics should change in some other way.

## Future improvements

If needed, we could add interpolation between neighboring anchors (instead of nearest-anchor offset). Perhaps that could help on very long traces, or something like during gradual clock drift? 