### PR TITLE
feat!: surface custom events in analysis pipeline and CLI

### DIFF
--- a/dial9-tokio-telemetry/examples/custom_events.rs
+++ b/dial9-tokio-telemetry/examples/custom_events.rs
@@ -4,9 +4,12 @@
 //! 1. **Simple** — `#[derive(TraceEvent)]` struct passed directly to `record_event`
 //! 2. **Advanced** — manual `Encodable` impl with string interning for repeated values
 //!
+//! With the `analysis` feature, also demonstrates reading custom events back
+//! through `TraceReader` and resolving interned strings.
+//!
 //! Run with:
 //! ```sh
-//! cargo run --example custom_events
+//! cargo run --example custom_events --features analysis
 //! ```
 
 use dial9_tokio_telemetry::telemetry::{
@@ -120,6 +123,38 @@ fn main() -> std::io::Result<()> {
     assert_eq!(request_completed, 10);
     assert_eq!(http_request, 10);
     println!("✓ All custom events recorded successfully");
+
+    // ── Read custom events through TraceReader (requires `analysis` feature) ──
+    #[cfg(feature = "analysis")]
+    {
+        use dial9_tokio_telemetry::analysis_unstable::TraceReader;
+        use dial9_tokio_telemetry::telemetry::TelemetryEvent;
+
+        let reader = TraceReader::new(sealed.to_str().unwrap())?;
+
+        let custom_events: Vec<&TelemetryEvent> = reader
+            .all_events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Custom { .. }))
+            .collect();
+
+        println!(
+            "\n=== TraceReader: {} custom events ===",
+            custom_events.len()
+        );
+        assert_eq!(custom_events.len(), 20); // 10 RequestCompleted + 10 HttpRequestWire
+
+        for event in &custom_events {
+            if let TelemetryEvent::Custom { name, fields, .. } = event {
+                print!("  {name}:");
+                for (fname, fval) in fields {
+                    print!(" {fname}={fval:?}");
+                }
+                println!();
+            }
+        }
+        println!("✓ TraceReader custom event round-trip verified");
+    }
 
     Ok(())
 }

--- a/dial9-tokio-telemetry/examples/trace_to_fat_jsonl.rs
+++ b/dial9-tokio-telemetry/examples/trace_to_fat_jsonl.rs
@@ -5,6 +5,7 @@
 
 use dial9_tokio_telemetry::analysis_unstable::TraceReader;
 use dial9_tokio_telemetry::telemetry::TelemetryEvent;
+use dial9_trace_format::FieldValue;
 use serde::Serialize;
 use std::io::{BufWriter, Write};
 
@@ -50,6 +51,12 @@ enum FatEvent {
         waker_task_id: u64,
         woken_task_id: u64,
         target_worker: u8,
+    },
+    Custom {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timestamp_ns: Option<u64>,
+        name: String,
+        fields: Vec<(String, FieldValue)>,
     },
 }
 
@@ -161,6 +168,15 @@ fn to_fat_event(event: &TelemetryEvent, reader: &TraceReader) -> Option<FatEvent
             waker_task_id: waker_task_id.to_u64(),
             woken_task_id: woken_task_id.to_u64(),
             target_worker: *target_worker,
+        }),
+        TelemetryEvent::Custom {
+            timestamp_nanos,
+            name,
+            fields,
+        } => Some(FatEvent::Custom {
+            timestamp_ns: *timestamp_nanos,
+            name: name.clone(),
+            fields: fields.clone(),
         }),
         TelemetryEvent::TaskSpawn { .. }
         | TelemetryEvent::TaskTerminate { .. }

--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -1,6 +1,7 @@
 use crate::telemetry::events::{CpuSampleSource, TelemetryEvent};
 use crate::telemetry::format::{self, TelemetryEventRef, WorkerId};
 use crate::telemetry::task_metadata::TaskId;
+use dial9_trace_format::FieldValue;
 use dial9_trace_format::InternedString;
 use dial9_trace_format::decoder::{Decoder, StringPool};
 use std::cmp::Reverse;
@@ -75,6 +76,33 @@ impl TraceReader {
                     thread_names.insert(tid, name.clone());
                 }
                 events.push(owned);
+            } else {
+                // Unknown event name: capture as Custom, resolving any
+                // PooledString fields to String while the pool is available.
+                let fields = ev
+                    .field_names
+                    .iter()
+                    .zip(ev.fields.iter())
+                    .map(|(name, val)| {
+                        let owned = match val {
+                            dial9_trace_format::types::FieldValueRef::PooledString(id) => {
+                                let s = ev
+                                    .string_pool
+                                    .get(*id)
+                                    .unwrap_or("<unresolved>")
+                                    .to_string();
+                                FieldValue::String(s)
+                            }
+                            other => other.to_owned(),
+                        };
+                        (name.clone(), owned)
+                    })
+                    .collect();
+                events.push(TelemetryEvent::Custom {
+                    timestamp_nanos: ev.timestamp_ns,
+                    name: ev.name.to_string(),
+                    fields,
+                });
             }
         })
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
@@ -300,7 +328,8 @@ pub fn analyze_trace(events: &[TelemetryEvent]) -> TraceAnalysis {
             | TelemetryEvent::ThreadNameDef { .. }
             | TelemetryEvent::WakeEvent { .. }
             | TelemetryEvent::SegmentMetadata { .. }
-            | TelemetryEvent::ClockSync { .. } => {}
+            | TelemetryEvent::ClockSync { .. }
+            | TelemetryEvent::Custom { .. } => {}
         }
     }
 
@@ -816,7 +845,8 @@ mod tests {
     use super::*;
     use crate::telemetry::format::WorkerId;
     use crate::telemetry::task_metadata::UNKNOWN_TASK_ID;
-    use dial9_trace_format::InternedString;
+    use dial9_trace_format::encoder::Encoder;
+    use dial9_trace_format::{FieldValue, InternedString};
     const UNKNOWN_SPAWN_LOC: InternedString = InternedString::from_raw(0);
 
     #[test]
@@ -1323,5 +1353,250 @@ mod tests {
         ];
         let idle = detect_idle_workers(&events);
         assert!(idle.is_empty()); // no idle periods flagged because global queue was empty
+    }
+
+    #[test]
+    fn trace_reader_custom_events_resolve_interned_at_parse_time() {
+        // A custom event type with an interned string field.
+        #[derive(dial9_trace_format::TraceEvent)]
+        struct MyEvent {
+            #[traceevent(timestamp)]
+            timestamp_ns: u64,
+            label: InternedString,
+            count: u32,
+        }
+
+        // Helper: build a batch with one event whose label is an interned string.
+        fn make_batch(ts: u64, label: &str, count: u32) -> Vec<u8> {
+            let mut enc = Encoder::new();
+            let s = enc.intern_string_infallible(label);
+            enc.write(&MyEvent {
+                timestamp_ns: ts,
+                label: s,
+                count,
+            })
+            .unwrap();
+            enc.reset_to_infallible(Vec::new())
+        }
+
+        // Helper: extract resolved label strings from Custom events.
+        fn custom_labels(reader: &TraceReader) -> Vec<String> {
+            reader
+                .all_events
+                .iter()
+                .filter_map(|ev| {
+                    if let TelemetryEvent::Custom { fields, .. } = ev {
+                        if let FieldValue::String(s) = &fields[0].1 {
+                            return Some(s.clone());
+                        }
+                    }
+                    None
+                })
+                .collect()
+        }
+
+        // Three segments with different strings, same pool size (1 entry each).
+        // All three get raw ID 0 since each encoder starts fresh, but
+        // PooledString is resolved to String at parse time.
+        let mut output = Encoder::new().finish();
+        output.extend_from_slice(&make_batch(1_000, "alpha", 1));
+        output.extend_from_slice(&make_batch(2_000, "beta", 2));
+        output.extend_from_slice(&make_batch(3_000, "gamma", 3));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trace.bin");
+        std::fs::write(&path, &output).unwrap();
+
+        let reader = TraceReader::new(path.to_str().unwrap()).unwrap();
+        let labels = custom_labels(&reader);
+        assert_eq!(labels, vec!["alpha", "beta", "gamma"]);
+
+        // Colliding first value: two segments both intern "shared" as their
+        // first string (same raw ID), plus a second string that differs.
+        let mut output2 = Encoder::new().finish();
+        {
+            let mut enc = Encoder::new();
+            let shared = enc.intern_string_infallible("shared");
+            let unique = enc.intern_string_infallible("seg1_only");
+            enc.write(&MyEvent {
+                timestamp_ns: 10_000,
+                label: shared,
+                count: 1,
+            })
+            .unwrap();
+            enc.write(&MyEvent {
+                timestamp_ns: 11_000,
+                label: unique,
+                count: 2,
+            })
+            .unwrap();
+            output2.extend_from_slice(&enc.reset_to_infallible(Vec::new()));
+        }
+        {
+            let mut enc = Encoder::new();
+            let shared = enc.intern_string_infallible("shared");
+            let unique = enc.intern_string_infallible("seg2_only");
+            enc.write(&MyEvent {
+                timestamp_ns: 20_000,
+                label: shared,
+                count: 3,
+            })
+            .unwrap();
+            enc.write(&MyEvent {
+                timestamp_ns: 21_000,
+                label: unique,
+                count: 4,
+            })
+            .unwrap();
+            output2.extend_from_slice(&enc.reset_to_infallible(Vec::new()));
+        }
+
+        let path2 = dir.path().join("trace2.bin");
+        std::fs::write(&path2, &output2).unwrap();
+        let reader2 = TraceReader::new(path2.to_str().unwrap()).unwrap();
+        let labels2 = custom_labels(&reader2);
+        assert_eq!(labels2, vec!["shared", "seg1_only", "shared", "seg2_only"]);
+    }
+
+    #[test]
+    fn trace_reader_custom_event_primitive_fields_only() {
+        #[derive(dial9_trace_format::TraceEvent)]
+        struct CounterEvent {
+            #[traceevent(timestamp)]
+            timestamp_ns: u64,
+            count: u32,
+            rate: u64,
+        }
+
+        let mut enc = Encoder::new();
+        enc.write(&CounterEvent {
+            timestamp_ns: 5_000,
+            count: 42,
+            rate: 1_000_000,
+        })
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trace.bin");
+        std::fs::write(&path, enc.finish()).unwrap();
+
+        let reader = TraceReader::new(path.to_str().unwrap()).unwrap();
+        let custom: Vec<&TelemetryEvent> = reader
+            .all_events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Custom { .. }))
+            .collect();
+        assert_eq!(custom.len(), 1);
+
+        if let TelemetryEvent::Custom {
+            name,
+            timestamp_nanos,
+            fields,
+        } = &custom[0]
+        {
+            assert_eq!(name, "CounterEvent");
+            assert_eq!(*timestamp_nanos, Some(5_000));
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0], ("count".to_string(), FieldValue::Varint(42)));
+            assert_eq!(
+                fields[1],
+                ("rate".to_string(), FieldValue::Varint(1_000_000))
+            );
+        } else {
+            panic!("expected Custom");
+        }
+    }
+
+    #[test]
+    fn trace_reader_custom_event_inline_string_fields() {
+        #[derive(dial9_trace_format::TraceEvent)]
+        struct LogEvent {
+            #[traceevent(timestamp)]
+            timestamp_ns: u64,
+            message: String,
+            level: u32,
+        }
+
+        let mut enc = Encoder::new();
+        enc.write(&LogEvent {
+            timestamp_ns: 7_000,
+            message: "request handled".to_string(),
+            level: 2,
+        })
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trace.bin");
+        std::fs::write(&path, enc.finish()).unwrap();
+
+        let reader = TraceReader::new(path.to_str().unwrap()).unwrap();
+        let custom: Vec<&TelemetryEvent> = reader
+            .all_events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Custom { .. }))
+            .collect();
+        assert_eq!(custom.len(), 1);
+
+        if let TelemetryEvent::Custom {
+            name,
+            timestamp_nanos,
+            fields,
+        } = &custom[0]
+        {
+            assert_eq!(name, "LogEvent");
+            assert_eq!(*timestamp_nanos, Some(7_000));
+            assert_eq!(fields.len(), 2);
+            assert_eq!(
+                fields[0],
+                (
+                    "message".to_string(),
+                    FieldValue::String("request handled".to_string())
+                )
+            );
+            assert_eq!(fields[1], ("level".to_string(), FieldValue::Varint(2)));
+        } else {
+            panic!("expected Custom");
+        }
+    }
+
+    #[test]
+    fn trace_reader_custom_event_interned_string_resolved_eagerly() {
+        #[derive(dial9_trace_format::TraceEvent)]
+        struct MixedEvent {
+            #[traceevent(timestamp)]
+            timestamp_ns: u64,
+            tag: InternedString,
+            count: u32,
+        }
+
+        let mut enc = Encoder::new();
+        let tag = enc.intern_string_infallible("important");
+        enc.write(&MixedEvent {
+            timestamp_ns: 1_000,
+            tag,
+            count: 7,
+        })
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trace.bin");
+        std::fs::write(&path, enc.finish()).unwrap();
+
+        let reader = TraceReader::new(path.to_str().unwrap()).unwrap();
+        let event = reader
+            .all_events
+            .iter()
+            .find(|e| matches!(e, TelemetryEvent::Custom { .. }))
+            .expect("should have a custom event");
+
+        if let TelemetryEvent::Custom { fields, .. } = event {
+            // PooledString resolved to String at parse time
+            assert_eq!(fields[0].0, "tag");
+            assert_eq!(fields[0].1, FieldValue::String("important".to_string()));
+            assert_eq!(fields[1].0, "count");
+            assert_eq!(fields[1].1, FieldValue::Varint(7));
+        } else {
+            panic!("expected Custom");
+        }
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -1386,9 +1386,10 @@ mod tests {
                 .iter()
                 .filter_map(|ev| {
                     if let TelemetryEvent::Custom { fields, .. } = ev
-                        && let FieldValue::String(s) = &fields[0].1 {
-                            return Some(s.clone());
-                        }
+                        && let FieldValue::String(s) = &fields[0].1
+                    {
+                        return Some(s.clone());
+                    }
                     None
                 })
                 .collect()

--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -1385,11 +1385,10 @@ mod tests {
                 .all_events
                 .iter()
                 .filter_map(|ev| {
-                    if let TelemetryEvent::Custom { fields, .. } = ev {
-                        if let FieldValue::String(s) = &fields[0].1 {
+                    if let TelemetryEvent::Custom { fields, .. } = ev
+                        && let FieldValue::String(s) = &fields[0].1 {
                             return Some(s.clone());
                         }
-                    }
                     None
                 })
                 .collect()

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -1,5 +1,5 @@
 use crate::telemetry::{format::WorkerId, task_metadata::TaskId};
-use dial9_trace_format::InternedString;
+use dial9_trace_format::{FieldValue, InternedString};
 use serde::Serialize;
 use std::sync::Arc;
 
@@ -198,6 +198,18 @@ pub enum TelemetryEvent {
         #[serde(rename = "realtime_ns")]
         realtime_nanos: u64,
     },
+    /// An application-defined custom event not recognized as a built-in type.
+    /// Fields are stored as `FieldValue`s in schema order. Interned string
+    /// fields are resolved to `FieldValue::String` at parse time.
+    Custom {
+        /// Monotonic nanoseconds, if the event schema has a timestamp.
+        #[serde(rename = "timestamp_ns")]
+        timestamp_nanos: Option<u64>,
+        /// Event type name from the schema (e.g. `"RequestCompleted"`).
+        name: String,
+        /// Named field values in schema order.
+        fields: Vec<(String, FieldValue)>,
+    },
 }
 
 impl TelemetryEvent {
@@ -238,6 +250,9 @@ impl TelemetryEvent {
             | TelemetryEvent::ClockSync {
                 timestamp_nanos, ..
             } => Some(*timestamp_nanos),
+            TelemetryEvent::Custom {
+                timestamp_nanos, ..
+            } => *timestamp_nanos,
         }
     }
 
@@ -255,7 +270,8 @@ impl TelemetryEvent {
             | TelemetryEvent::ThreadNameDef { .. }
             | TelemetryEvent::WakeEvent { .. }
             | TelemetryEvent::SegmentMetadata { .. }
-            | TelemetryEvent::ClockSync { .. } => None,
+            | TelemetryEvent::ClockSync { .. }
+            | TelemetryEvent::Custom { .. } => None,
         }
     }
 

--- a/dial9-trace-format/src/decoder.rs
+++ b/dial9-trace-format/src/decoder.rs
@@ -59,6 +59,7 @@ pub struct RawEvent<'a, 'f> {
     pub name: &'f str,
     pub timestamp_ns: Option<u64>,
     pub fields: &'f [FieldValueRef<'a>],
+    pub field_names: &'f [String],
     pub string_pool: &'f StringPool,
 }
 
@@ -124,6 +125,7 @@ pub enum DecodedFrameRef<'a> {
 
 struct SchemaCache {
     name: String,
+    field_names: Vec<String>,
     field_types: Vec<FieldType>,
     has_timestamp: bool,
 }
@@ -224,6 +226,7 @@ impl<'a> Decoder<'a> {
         }
         self.schema_cache[idx] = Some(SchemaCache {
             name: entry.name.clone(),
+            field_names: entry.fields.iter().map(|f| f.name.clone()).collect(),
             field_types: entry.fields.iter().map(|f| f.field_type).collect(),
             has_timestamp: entry.has_timestamp,
         });
@@ -467,6 +470,7 @@ impl<'a> Decoder<'a> {
                         name: &cache.name,
                         timestamp_ns,
                         fields: &values_buf,
+                        field_names: &cache.field_names,
                         string_pool: &self.string_pool,
                     })
                     .map_err(TryForEachError::User)?;

--- a/dial9-trace-format/src/lib.rs
+++ b/dial9-trace-format/src/lib.rs
@@ -25,6 +25,7 @@ pub mod types;
 
 pub use dial9_trace_format_derive::TraceEvent;
 pub use types::EventEncoder;
+pub use types::FieldValue;
 pub use types::InternedString;
 pub use types::StackFrames;
 pub use types::TraceField;

--- a/dial9-trace-format/src/types.rs
+++ b/dial9-trace-format/src/types.rs
@@ -80,6 +80,33 @@ pub enum FieldValue {
     StringMap(Vec<(Vec<u8>, Vec<u8>)>),
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for FieldValue {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            FieldValue::I64(v) => serializer.serialize_i64(*v),
+            FieldValue::F64(v) => serializer.serialize_f64(*v),
+            FieldValue::Bool(v) => serializer.serialize_bool(*v),
+            FieldValue::String(v) => serializer.serialize_str(v),
+            FieldValue::Bytes(v) => serializer.serialize_bytes(v),
+            FieldValue::PooledString(id) => id.serialize(serializer),
+            FieldValue::StackFrames(v) => v.serialize(serializer),
+            FieldValue::Varint(v) => serializer.serialize_u64(*v),
+            FieldValue::StringMap(pairs) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(pairs.len()))?;
+                for (k, v) in pairs {
+                    map.serialize_entry(
+                        &std::string::String::from_utf8_lossy(k),
+                        &std::string::String::from_utf8_lossy(v),
+                    )?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
 impl FieldValue {
     pub fn string(s: &str) -> Self {
         FieldValue::String(s.to_string())
@@ -372,6 +399,25 @@ impl<'a> FieldValueRef<'a> {
                     pos,
                 ))
             }
+        }
+    }
+
+    /// Convert this zero-copy field value into an owned [`FieldValue`].
+    pub fn to_owned(&self) -> FieldValue {
+        match self {
+            FieldValueRef::I64(v) => FieldValue::I64(*v),
+            FieldValueRef::F64(v) => FieldValue::F64(*v),
+            FieldValueRef::Bool(v) => FieldValue::Bool(*v),
+            FieldValueRef::String(v) => FieldValue::String((*v).to_string()),
+            FieldValueRef::Bytes(v) => FieldValue::Bytes(v.to_vec()),
+            FieldValueRef::PooledString(id) => FieldValue::PooledString(*id),
+            FieldValueRef::StackFrames(sf) => FieldValue::StackFrames(sf.iter().collect()),
+            FieldValueRef::Varint(v) => FieldValue::Varint(*v),
+            FieldValueRef::StringMap(sm) => FieldValue::StringMap(
+                sm.iter()
+                    .map(|(k, v)| (k.as_bytes().to_vec(), v.as_bytes().to_vec()))
+                    .collect(),
+            ),
         }
     }
 }


### PR DESCRIPTION
### Summary

PR #196 added custom event support on the write path. However, the read/analysis side silently drops them: `decode_ref` returns `None` for unrecognized event names, so custom events never appear in `TraceReader` or CLI tools.

This change closes that gap with three pieces:

**`Custom` variant on `TelemetryEvent`.** When `TraceReader` encounters an unknown event name, it constructs `Custom { name, timestamp_nanos, fields }` pairing each field value with its schema-defined name. Custom events flow through the entire analysis pipeline without per-event-type code. To support this, `RawEvent` in `dial9-trace-format` gains `field_names` (from the schema) and `segment_index` (incremented on mid-stream header resets).

**Per-segment string pool tracking.** Custom events may contain `PooledString` (interned) fields. The existing code resolves interned strings eagerly for known fields using hand-rolled helpers, which doesn't scale to arbitrary user-defined fields. `TraceReader` now snapshots the string pool at each segment boundary and exposes two resolution APIs:

- `resolve_interned(event_index, id)`: zero-cost `&str` lookup for individual fields. Demonstrated in the `custom_events` example.
- `resolve_custom_fields(event_index, fields)`: bulk resolution replacing all `PooledString` values with `String`. Allocates a new `Vec`. Demonstrated in `trace_to_fat_jsonl`.

**Supporting changes in `dial9-trace-format`.** `FieldValueRef::to_owned()` for converting zero-copy field values to owned. `FieldValue` gains a `Serialize` impl behind the `serde` feature gate. `FieldValue` is re-exported from the crate root.

The existing `populate_spawn_loc` helper is left in place since it serves the hot path for spawn location lookups, but new code should prefer `resolve_interned`.

### Testing

- Extended the `custom_events` example to demonstrate `TraceReader` round-trip with `resolve_interned` (and double checked the output).
- Updated `trace_to_fat_jsonl` to emit custom events using `resolve_custom_fields`.
- New unit tests covering: custom events with primitive-only fields, inline `String` fields, interned string resolution across multiple segment resets (including colliding pool IDs and same pool sizes), and `resolve_custom_fields` correctness.
