### PR TITLE
Fix clippy warnings across workspace

### DIFF
--- a/dial9-tokio-telemetry/examples/analyze_trace.rs
+++ b/dial9-tokio-telemetry/examples/analyze_trace.rs
@@ -101,7 +101,7 @@ fn main() {
             }
         }
         let mut top_unresolved: Vec<_> = unresolved_ids.into_iter().collect();
-        top_unresolved.sort_by(|a, b| b.1.cmp(&a.1));
+        top_unresolved.sort_by_key(|b| std::cmp::Reverse(b.1));
         println!("  Top unresolved waker IDs:");
         for (id, count) in top_unresolved.iter().take(5) {
             let raw = id.to_u64();
@@ -136,7 +136,7 @@ fn main() {
             );
         }
         let mut by_count: Vec<_> = wakes_by_loc.into_iter().collect();
-        by_count.sort_by(|a, b| b.1.cmp(&a.1));
+        by_count.sort_by_key(|b| std::cmp::Reverse(b.1));
         for (loc, count) in &by_count {
             let name = loc.unwrap_or("<unknown>");
             println!("  {:>8} wakes from {}", count, name);

--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -3,6 +3,7 @@ use crate::telemetry::format::{self, TelemetryEventRef, WorkerId};
 use crate::telemetry::task_metadata::TaskId;
 use dial9_trace_format::InternedString;
 use dial9_trace_format::decoder::{Decoder, StringPool};
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::io::{Read as _, Result};
 
@@ -460,7 +461,7 @@ pub fn print_analysis(analysis: &TraceAnalysis, spawn_locations: &HashMap<Intern
     if !analysis.spawn_location_stats.is_empty() {
         println!("\n=== Spawn Locations (by poll count) ===");
         let mut locs: Vec<_> = analysis.spawn_location_stats.iter().collect();
-        locs.sort_by(|a, b| b.1.poll_count.cmp(&a.1.poll_count));
+        locs.sort_by_key(|b| Reverse(b.1.poll_count));
         for (id, stats) in locs {
             let name = spawn_locations
                 .get(id)

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1468,10 +1468,10 @@ mod tests {
                 crate::telemetry::events::TelemetryEvent::PollStart { worker_id, .. }
                 | crate::telemetry::events::TelemetryEvent::PollEnd { worker_id, .. }
                 | crate::telemetry::events::TelemetryEvent::WorkerPark { worker_id, .. }
-                | crate::telemetry::events::TelemetryEvent::WorkerUnpark { worker_id, .. } => {
-                    if *worker_id != WorkerId::UNKNOWN {
-                        worker_ids.insert(worker_id.as_u64());
-                    }
+                | crate::telemetry::events::TelemetryEvent::WorkerUnpark { worker_id, .. }
+                    if *worker_id != WorkerId::UNKNOWN =>
+                {
+                    worker_ids.insert(worker_id.as_u64());
                 }
                 _ => {}
             }

--- a/dial9-trace-format/examples/format_comparison.rs
+++ b/dial9-trace-format/examples/format_comparison.rs
@@ -721,7 +721,7 @@ fn main() {
         *counts.entry(name).or_insert(0usize) += 1;
     }
     let mut sorted: Vec<_> = counts.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
     for (name, count) in &sorted {
         println!("  {name}: {count}");
     }

--- a/perf-self-profile/examples/basic.rs
+++ b/perf-self-profile/examples/basic.rs
@@ -68,7 +68,7 @@ fn main() {
     }
 
     let mut sorted: Vec<_> = counts.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     let total = samples.len() as f64;
     for (name, count) in sorted.iter().take(15) {
@@ -92,7 +92,7 @@ fn main() {
     }
 
     let mut sorted: Vec<_> = inclusive.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (name, count) in sorted.iter().take(15) {
         let pct = (*count as f64 / total) * 100.0;

--- a/perf-self-profile/examples/multithread.rs
+++ b/perf-self-profile/examples/multithread.rs
@@ -67,7 +67,7 @@ fn main() {
         *by_tid.entry(s.tid).or_default() += 1;
     }
     let mut tids: Vec<_> = by_tid.into_iter().collect();
-    tids.sort_by(|a, b| b.1.cmp(&a.1));
+    tids.sort_by_key(|b| std::cmp::Reverse(b.1));
     for (tid, count) in &tids {
         eprintln!("  tid={tid}: {count} samples");
     }


### PR DESCRIPTION
## Summary

Fix all clippy warnings in the workspace:

- **`unnecessary_sort_by`**: Replace `sort_by(|a, b| b.cmp(&a))` with `sort_by_key(|b| Reverse(b))` in 6 files across 3 crates
- **`collapsible_match`**: Collapse nested `if` into a match guard in `recorder/mod.rs`

## Files changed

- `dial9-tokio-telemetry/src/telemetry/analysis.rs` — sort_by_key
- `dial9-tokio-telemetry/src/telemetry/recorder/mod.rs` — collapsible match guard
- `dial9-tokio-telemetry/examples/analyze_trace.rs` — sort_by_key (2 sites)
- `dial9-trace-format/examples/format_comparison.rs` — sort_by_key
- `perf-self-profile/examples/basic.rs` — sort_by_key (2 sites)
- `perf-self-profile/examples/multithread.rs` — sort_by_key

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features` — zero warnings
- `cargo nextest run --stress-duration 20s` — 365 tests × 3 iterations, all pass