### PR TITLE
feat: include boot_id in default S3 key layout (#225)

### DIFF
--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -339,7 +339,7 @@ runtime.block_on(async {
 # fn main() {}
 ```
 
-By default (customizable via `S3Config::builder().key_fn(...)`), objects land at `s3://{bucket}/{prefix}/{YYYY-MM-DD}/{HHMM}/{service_name}/{instance_path}/{epoch_secs}-{index}.bin.gz`. The time bucket is the first key component after the prefix, enabling efficient incident correlation: `aws s3 ls s3://bucket/traces/2026-03-07/2030/` lists all traces from all services during that minute.
+By default (customizable via `S3Config::builder().key_fn(...)`), objects land at `s3://{bucket}/{prefix}/{YYYY-MM-DD}/{HHMM}/{service_name}/{instance_path}/{boot_id}/{epoch_secs}-{index}.bin.gz`. The time bucket is the first key component after the prefix, enabling efficient incident correlation: `aws s3 ls s3://bucket/traces/2026-03-07/2030/` lists all traces from all services during that minute. The `boot_id` (4 lowercase alpha chars by default, regenerated per process start) disambiguates segments across application restarts so segment indices from different runs never collide.
 
 The worker requires `s3:PutObject` and `s3:HeadBucket` permissions.
 

--- a/dial9-tokio-telemetry/design/s3-worker-design.md
+++ b/dial9-tokio-telemetry/design/s3-worker-design.md
@@ -287,12 +287,13 @@ Pipeline stage metrics are prefixed with the processor name automatically.
 ## S3 Object Layout
 
 ```
-s3://{bucket}/{prefix}/{date-time}/{service}/{instance}/{epoch_secs}-{index}.bin.gz
+s3://{bucket}/{prefix}/{date-time}/{service}/{instance}/{boot_id}/{epoch_secs}-{index}.bin.gz
 ```
 
 - `{date-time}`: `2026-03-07/2030` — 1-minute bucket (enables time-range queries across all services)
 - `{service}`: user-provided service name
 - `{instance}`: `us-east-1/i-0abc123` or `dc-west/rack4-host7` (opaque string)
+- `{boot_id}`: 4 lowercase alpha chars generated per process start (disambiguates segment indices across restarts — see issue #225)
 - `{epoch_secs}`: Unix epoch seconds (parsed from `SegmentMetadata` header, falls back to file mtime)
 - `{index}`: segment index from RotatingWriter
 

--- a/dial9-tokio-telemetry/src/background_task/s3.rs
+++ b/dial9-tokio-telemetry/src/background_task/s3.rs
@@ -45,7 +45,7 @@ pub struct SegmentInfo {
 /// Trait for custom S3 object key generation.
 ///
 /// Implement this to control the S3 key layout. The default key layout is
-/// `{prefix}/{date}/{HHMM}/{service}/{instance}/{epoch}-{index}.bin.gz`.
+/// `{prefix}/{date}/{HHMM}/{service}/{instance}/{boot_id}/{epoch}-{index}.bin.gz`.
 pub trait S3KeyFn: Send + Sync {
     /// Generate the S3 object key for the given segment.
     fn object_key(&self, segment: &SegmentInfo) -> String;

--- a/dial9-tokio-telemetry/src/background_task/s3.rs
+++ b/dial9-tokio-telemetry/src/background_task/s3.rs
@@ -67,7 +67,7 @@ where
 /// sensible defaults:
 ///
 /// - `instance_path`: system hostname
-/// - `boot_id`: `{pid}-{timestamp_nanos}` (unique per process start)
+/// - `boot_id`: `{4 alpha derived from timestamp}-{pid}` (unique per process start)
 /// - `prefix`: none (keys start at the time bucket)
 /// - `region`: auto-detected via `HeadBucket`
 /// - `key_fn`: built-in time-first layout

--- a/dial9-tokio-telemetry/src/background_task/s3.rs
+++ b/dial9-tokio-telemetry/src/background_task/s3.rs
@@ -10,13 +10,23 @@ use aws_sdk_s3_transfer_manager::Client;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Generate a per-process identifier from PID and current timestamp.
+/// Generate a short boot identifier (4 lowercase alpha chars).
+///
+/// Derived from the current system time nanoseconds. Different process
+/// restarts pick different values, letting you disambiguate segments
+/// from successive runs of the same service on the same host.
 fn default_boot_id() -> String {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    format!("{}-{}", std::process::id(), nanos)
+    let mut v = nanos as u64;
+    let mut s = String::with_capacity(4);
+    for _ in 0..4 {
+        s.push((b'a' + (v % 26) as u8) as char);
+        v /= 26;
+    }
+    s
 }
 
 /// Metadata about a sealed trace segment, passed to custom key functions.
@@ -27,6 +37,9 @@ pub struct SegmentInfo {
     pub index: u32,
     /// Segment creation time as seconds since the Unix epoch.
     pub epoch_secs: u64,
+    /// Identifier for this process lifetime. A new value each application
+    /// start, so segment indices from different runs do not collide.
+    pub boot_id: String,
 }
 
 /// Trait for custom S3 object key generation.
@@ -61,8 +74,12 @@ where
 /// # Default key layout
 ///
 /// ```text
-/// {prefix}/{YYYY-MM-DD}/{HHMM}/{service_name}/{instance_path}/{epoch_secs}-{index}.bin.gz
+/// {prefix}/{YYYY-MM-DD}/{HHMM}/{service_name}/{instance_path}/{boot_id}/{epoch_secs}-{index}.bin.gz
 /// ```
+///
+/// The `boot_id` segment disambiguates segment indices across process
+/// restarts — without it, a service that restarts will produce colliding
+/// `{epoch_secs}-{index}` names.
 ///
 /// Override with [`key_fn`](S3ConfigBuilder::key_fn) for a custom layout.
 #[derive(Clone, bon::Builder)]
@@ -73,11 +90,12 @@ pub struct S3Config {
     /// Instance identifier for S3 key paths. Defaults to the system hostname.
     #[builder(into, default = InstanceIdentity::from_hostname())]
     instance_path: InstanceIdentity,
-    /// Identifies this process lifetime. Stored as S3 object metadata to
-    /// correlate segments from the same application run. A new value each
-    /// time the application restarts lets you group or filter by run.
+    /// Identifies this process lifetime. Included as both S3 object
+    /// metadata and in the default key path. A new value each application
+    /// start disambiguates segments (and segment indices) from different
+    /// runs of the same service on the same host.
     ///
-    /// Defaults to `{pid}-{timestamp_nanos}`.
+    /// Defaults to 4 random lowercase alpha characters.
     #[builder(default = default_boot_id())]
     boot_id: String,
     /// Optional key prefix. When `None`, keys start at the time bucket.
@@ -115,7 +133,7 @@ impl S3Config {
     ///
     /// If a custom `key_fn` is set, delegates to it. Otherwise uses the
     /// default time-first layout:
-    /// `{prefix}/{date}/{HHMM}/{service}/{instance}/{epoch_secs}-{index}.bin.gz`
+    /// `{prefix}/{date}/{HHMM}/{service}/{instance}/{boot_id}/{epoch_secs}-{index}.bin.gz`
     pub(crate) fn object_key(
         &self,
         segment: &SealedSegment,
@@ -130,6 +148,7 @@ impl S3Config {
             let info = SegmentInfo {
                 index: segment.index,
                 epoch_secs,
+                boot_id: self.boot_id.clone(),
             };
             return key_fn.object_key(&info);
         }
@@ -146,10 +165,11 @@ impl S3Config {
         };
 
         let suffix = format!(
-            "{}/{}/{}/{}-{}{}",
+            "{}/{}/{}/{}/{}-{}{}",
             date_hour,
             self.service_name,
             self.instance_path.as_str(),
+            self.boot_id,
             ts,
             segment.index,
             extension,
@@ -363,7 +383,7 @@ mod tests {
         let metadata = make_metadata(1741209000);
         let key = config.object_key(&segment, &metadata);
         check!(
-            key == "traces/2025-03-05/2110/checkout-api/us-east-1/i-0abc123/1741209000-3.bin.gz"
+            key == "traces/2025-03-05/2110/checkout-api/us-east-1/i-0abc123/test-boot-id/1741209000-3.bin.gz"
         );
     }
 
@@ -378,7 +398,9 @@ mod tests {
         let segment = make_segment("/tmp/trace.0.bin", 0);
         let metadata = make_metadata(1741209000);
         let key = config.object_key(&segment, &metadata);
-        check!(key == "2025-03-05/2110/checkout-api/us-east-1/i-0abc123/1741209000-0.bin.gz");
+        check!(
+            key == "2025-03-05/2110/checkout-api/us-east-1/i-0abc123/test-boot-id/1741209000-0.bin.gz"
+        );
     }
 
     #[test]
@@ -387,7 +409,16 @@ mod tests {
         let segment = make_segment("/tmp/trace.0.bin", 0);
         let metadata = HashMap::from([("epoch_secs".into(), "1741209000".into())]);
         let key = config.object_key(&segment, &metadata);
-        check!(key == "traces/2025-03-05/2110/checkout-api/us-east-1/i-0abc123/1741209000-0.bin");
+        check!(
+            key == "traces/2025-03-05/2110/checkout-api/us-east-1/i-0abc123/test-boot-id/1741209000-0.bin"
+        );
+    }
+
+    #[test]
+    fn default_boot_id_is_four_lowercase_alpha_chars() {
+        let id = default_boot_id();
+        check!(id.len() == 4);
+        check!(id.chars().all(|c| c.is_ascii_lowercase()));
     }
 
     #[test]
@@ -497,7 +528,7 @@ mod tests {
             .unwrap();
 
         check!(
-            key == "traces/2025-03-05/2110/checkout-api/us-east-1/i-0abc123/1741209000-0.bin.gz"
+            key == "traces/2025-03-05/2110/checkout-api/us-east-1/i-0abc123/test-boot-id/1741209000-0.bin.gz"
         );
 
         // Local file should be deleted

--- a/dial9-tokio-telemetry/src/background_task/s3.rs
+++ b/dial9-tokio-telemetry/src/background_task/s3.rs
@@ -26,6 +26,7 @@ fn default_boot_id() -> String {
         s.push((b'a' + (v % 26) as u8) as char);
         v /= 26;
     }
+    s.push_str(&format!("-{}", std::process::id()));
     s
 }
 
@@ -415,10 +416,11 @@ mod tests {
     }
 
     #[test]
-    fn default_boot_id_is_four_lowercase_alpha_chars() {
+    fn default_boot_id_is_alpha_timestamp_and_pid() {
         let id = default_boot_id();
-        check!(id.len() == 4);
-        check!(id.chars().all(|c| c.is_ascii_lowercase()));
+        let (ts, pid) = id.split_once("-").unwrap();
+        assert_eq!(ts.len(), 4);
+        pid.parse::<u64>().unwrap();
     }
 
     #[test]

--- a/dial9-viewer/README.md
+++ b/dial9-viewer/README.md
@@ -76,7 +76,7 @@ The trace endpoint returns raw binary data (`application/octet-stream`) suitable
 The viewer expects the [time-first key layout](../dial9-tokio-telemetry/design/s3-worker-design.md) used by `dial9-tokio-telemetry`'s S3 worker:
 
 ```
-{prefix}/{YYYY-MM-DD}/{HHMM}/{service}/{instance}/{epoch}-{index}.bin.gz
+{prefix}/{YYYY-MM-DD}/{HHMM}/{service}/{instance}/{boot_id}/{epoch}-{index}.bin.gz
 ```
 
 Search by entering prefixes that match this structure, e.g.:

--- a/dial9-viewer/src/bin/dev_server.rs
+++ b/dial9-viewer/src/bin/dev_server.rs
@@ -47,12 +47,12 @@ async fn main() -> anyhow::Result<()> {
         client
             .put_object()
             .bucket(bucket)
-            .key("traces/2026-04-09/1900/demo-service/local/host-0/1744224000-0.bin.gz")
+            .key("traces/2026-04-09/1900/demo-service/local/host-0/abcd/1744224000-0.bin.gz")
             .body(full_compressed.into())
             .send()
             .await?;
         tracing::info!(
-            key = "traces/2026-04-09/1900/demo-service/local/host-0/1744224000-0.bin.gz",
+            key = "traces/2026-04-09/1900/demo-service/local/host-0/abcd/1744224000-0.bin.gz",
             size = demo_data.len(),
             "seeded full demo trace"
         );
@@ -61,8 +61,9 @@ async fn main() -> anyhow::Result<()> {
         for i in 0..5 {
             let data = format!("synthetic trace segment {i}");
             let compressed = gzip_bytes(data.as_bytes());
-            let key =
-                format!("traces/2026-04-09/191{i}/test-svc/us-east-1/host-1/1744224{i}00-0.bin.gz");
+            let key = format!(
+                "traces/2026-04-09/191{i}/test-svc/us-east-1/host-1/xyzw/1744224{i}00-0.bin.gz"
+            );
             client
                 .put_object()
                 .bucket(bucket)

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -172,6 +172,7 @@
                             <th style="width:30px"><input type="checkbox" id="raw-select-all" /></th>
                             <th data-sort="service">Service</th>
                             <th data-sort="host">Host</th>
+                            <th data-sort="bootId">Boot</th>
                             <th data-sort="traceStart">Trace Start</th>
                             <th data-sort="segIndex">Seg #</th>
                             <th data-sort="size">Size</th>
@@ -349,23 +350,58 @@
     }
 
     function parseKey(key) {
+        // Default layout (as of issue #225):
+        //   {prefix}/{YYYY-MM-DD}/{HHMM}/{service}/{instance}/{boot_id}/{epoch}-{index}.bin[.gz]
+        // Legacy layout (pre-#225):
+        //   {prefix}/{YYYY-MM-DD}/{HHMM}/{service}/{instance}/{epoch}-{index}.bin[.gz]
+        // We find the date-shaped segment and count components between it
+        // and the filename to distinguish. Custom instance paths containing
+        // slashes will fall back to best-effort positional parsing.
         const parts = key.split('/');
-        if (parts.length >= 5) {
-            const file = parts[parts.length - 1];
-            const match = file.match(/^(\d+)-(\d+)\.bin/);
-            let epoch = 0, segIndex = '';
-            if (match) {
-                epoch = parseInt(match[1], 10);
-                segIndex = match[2];
+        const dateRe = /^\d{4}-\d{2}-\d{2}$/;
+        let dateIdx = -1;
+        for (let i = parts.length - 1; i >= 0; i--) {
+            if (dateRe.test(parts[i])) { dateIdx = i; break; }
+        }
+        const file = parts[parts.length - 1];
+        const match = file.match(/^(\d+)-(\d+)\.bin/);
+        let epoch = 0, segIndex = '';
+        if (match) {
+            epoch = parseInt(match[1], 10);
+            segIndex = match[2];
+        }
+        if (dateIdx >= 0) {
+            const below = parts.length - 1 - dateIdx; // count after date, not including date itself
+            if (below === 5) {
+                return {
+                    service: parts[dateIdx + 2],
+                    host: parts[dateIdx + 3],
+                    bootId: parts[dateIdx + 4],
+                    epoch, segIndex,
+                    get traceStart() { return formatEpoch(epoch); },
+                };
             }
+            if (below === 4) {
+                return {
+                    service: parts[dateIdx + 2],
+                    host: parts[dateIdx + 3],
+                    bootId: '',
+                    epoch, segIndex,
+                    get traceStart() { return formatEpoch(epoch); },
+                };
+            }
+        }
+        // Fallback — positional, best-effort.
+        if (parts.length >= 5) {
             return {
                 service: parts[parts.length - 3],
                 host: parts[parts.length - 2],
+                bootId: '',
                 epoch, segIndex,
                 get traceStart() { return formatEpoch(epoch); },
             };
         }
-        return { service: '', host: key, epoch: 0, segIndex: '', get traceStart() { return ''; } };
+        return { service: '', host: key, bootId: '', epoch: 0, segIndex: '', get traceStart() { return ''; } };
     }
 
     function toLocalDatetime(d) {
@@ -506,12 +542,16 @@
                 return;
             }
 
-            // Group by service/host
+            // Group by service/host[/boot]. A new boot_id indicates a
+            // separate process run — keeping runs distinct prevents
+            // segment-index duplicates when a service restarts.
             hostGroups = {};
             for (const obj of allObjects) {
                 const p = parseKey(obj.key);
-                const groupKey = p.service + '/' + p.host;
-                if (!hostGroups[groupKey]) hostGroups[groupKey] = { service: p.service, host: p.host, objects: [] };
+                const groupKey = p.bootId
+                    ? p.service + '/' + p.host + '/' + p.bootId
+                    : p.service + '/' + p.host;
+                if (!hostGroups[groupKey]) hostGroups[groupKey] = { service: p.service, host: p.host, bootId: p.bootId, objects: [] };
                 hostGroups[groupKey].objects.push(obj);
             }
 
@@ -531,7 +571,7 @@
         selectedHost = null;
 
         const groups = Object.values(hostGroups).sort((a, b) =>
-            (a.service + a.host).localeCompare(b.service + b.host));
+            ((a.service + a.host + (a.bootId || '')).localeCompare(b.service + b.host + (b.bootId || ''))));
 
         for (const g of groups) {
             const epochs = g.objects.map(o => parseKey(o.key).epoch).filter(e => e > 0);
@@ -540,17 +580,20 @@
             const maxEnd = endTimes.length ? Math.max(...endTimes) : 0;
             const totalSize = g.objects.reduce((s, o) => s + o.size, 0);
 
+            const bootLine = g.bootId ? `<div class="meta" style="font-size:0.75em;color:#7a7ab0">boot ${esc(g.bootId)}</div>` : '';
             const card = document.createElement('div');
             card.className = 'host-card';
             card.innerHTML = `
                 <div class="svc">${esc(g.service)}</div>
                 <div class="hostname">${esc(g.host)}</div>
+                ${bootLine}
                 <div class="meta">
                     ${g.objects.length} segment${g.objects.length !== 1 ? 's' : ''} · ${formatSize(totalSize)}<br>
                     ${formatEpoch(minEpoch)}${maxEnd ? ' → ' + formatEpoch(maxEnd) : ''}
                 </div>
             `;
-            card.addEventListener('click', () => showSegments(g.service + '/' + g.host));
+            const gk = g.bootId ? g.service + '/' + g.host + '/' + g.bootId : g.service + '/' + g.host;
+            card.addEventListener('click', () => showSegments(gk));
             hostGrid.appendChild(card);
         }
     }
@@ -569,7 +612,7 @@
 
         segmentPanel.innerHTML = `
             <span class="back-link" onclick="renderHostGrid()">← Back to hosts</span>
-            <h3>${esc(g.service)} / ${esc(g.host)}</h3>
+            <h3>${esc(g.service)} / ${esc(g.host)}${g.bootId ? ' <span style="color:#7a7ab0;font-weight:400;font-size:0.85em">(boot ' + esc(g.bootId) + ')</span>' : ''}</h3>
             <div style="margin-bottom:8px;display:flex;gap:8px;align-items:center">
                 <button onclick="segSelectAll(true)">Select All</button>
                 <button onclick="segSelectAll(false)">Deselect All</button>
@@ -697,6 +740,7 @@
                 <td><input type="checkbox" class="raw-cb" data-key="${esc(row.key)}" /></td>
                 <td class="service">${esc(p.service)}</td>
                 <td class="host">${esc(p.host)}</td>
+                <td class="host">${esc(p.bootId || '')}</td>
                 <td>${esc(p.traceStart)}</td>
                 <td>${esc(p.segIndex)}</td>
                 <td class="size">${formatSize(row.size)}</td>

--- a/dial9-viewer/ui/test_parse_key.js
+++ b/dial9-viewer/ui/test_parse_key.js
@@ -9,36 +9,45 @@ const vm = require("vm");
 
 const html = fs.readFileSync(path.join(__dirname, "index.html"), "utf8");
 const m = html.match(/function parseKey\([\s\S]*?\n    \}\n/);
-if (!m) { console.error("could not locate parseKey() in index.html"); process.exit(1); }
+if (!m) {
+    console.error("could not locate parseKey() in index.html");
+    process.exit(1);
+}
 
 // parseKey depends on formatEpoch/formatDate — stub them out.
-const sandbox = { parseKey: null, formatEpoch: () => "", };
+const sandbox = { parseKey: null, formatEpoch: () => "" };
 vm.createContext(sandbox);
 vm.runInContext(m[0] + "\nthis.parseKey = parseKey;", sandbox);
 const parseKey = sandbox.parseKey;
 
 function assertEq(actual, expected, label) {
-  if (actual !== expected) {
-    console.error(`✗ ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
-    process.exit(1);
-  } else {
-    console.log(`✓ ${label}`);
-  }
+    if (actual !== expected) {
+        console.error(
+            `✗ ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+        );
+        process.exit(1);
+    } else {
+        console.log(`✓ ${label}`);
+    }
 }
 
 // New layout with prefix
-let p = parseKey("traces/2026-04-09/1910/checkout-api/us-east-1/abcd/1744224000-3.bin.gz");
+let p = parseKey(
+    "traces/2026-04-09/1910/checkout-api/us-east-1/abcd-123213/1744224000-3.bin.gz",
+);
 assertEq(p.service, "checkout-api", "new layout: service");
 assertEq(p.host, "us-east-1", "new layout: host");
-assertEq(p.bootId, "abcd", "new layout: bootId");
+assertEq(p.bootId, "abcd-123213", "new layout: bootId");
 assertEq(p.epoch, 1744224000, "new layout: epoch");
 assertEq(p.segIndex, "3", "new layout: segIndex");
 
 // New layout without prefix
-p = parseKey("2026-04-09/1910/checkout-api/us-east-1/xyzw/1744224000-0.bin.gz");
+p = parseKey(
+    "2026-04-09/1910/checkout-api/us-east-1/xyzw-asdfasdf/1744224000-0.bin.gz",
+);
 assertEq(p.service, "checkout-api", "new no-prefix: service");
 assertEq(p.host, "us-east-1", "new no-prefix: host");
-assertEq(p.bootId, "xyzw", "new no-prefix: bootId");
+assertEq(p.bootId, "xyzw-asdfasdf", "new no-prefix: bootId");
 
 // Legacy layout with prefix — unchanged behavior
 p = parseKey("traces/2026-04-09/1910/checkout-api/host1/1744224000-2.bin.gz");
@@ -52,8 +61,13 @@ assertEq(p.segIndex, "2", "legacy: segIndex");
 // cannot be reliably distinguished from the new boot_id layout on
 // path-component count alone, so the parser falls back to the positional
 // heuristic. We just sanity-check that parsing does not throw.
-p = parseKey("traces/2026-04-09/1910/checkout-api/us-east-1/i-0abc123/1744224000-0.bin.gz");
-if (!p || typeof p !== "object") { console.error("compound-instance: must return object"); process.exit(1); }
+p = parseKey(
+    "traces/2026-04-09/1910/checkout-api/us-east-1/i-0abc123/1744224000-0.bin.gz",
+);
+if (!p || typeof p !== "object") {
+    console.error("compound-instance: must return object");
+    process.exit(1);
+}
 console.log("✓ compound-instance: returns object (best-effort)");
 
 console.log("\nAll parseKey tests passed");

--- a/dial9-viewer/ui/test_parse_key.js
+++ b/dial9-viewer/ui/test_parse_key.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Verify parseKey() in index.html understands both the new boot_id layout
+// and the legacy (pre-#225) layout.
+
+"use strict";
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const html = fs.readFileSync(path.join(__dirname, "index.html"), "utf8");
+const m = html.match(/function parseKey\([\s\S]*?\n    \}\n/);
+if (!m) { console.error("could not locate parseKey() in index.html"); process.exit(1); }
+
+// parseKey depends on formatEpoch/formatDate — stub them out.
+const sandbox = { parseKey: null, formatEpoch: () => "", };
+vm.createContext(sandbox);
+vm.runInContext(m[0] + "\nthis.parseKey = parseKey;", sandbox);
+const parseKey = sandbox.parseKey;
+
+function assertEq(actual, expected, label) {
+  if (actual !== expected) {
+    console.error(`✗ ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    process.exit(1);
+  } else {
+    console.log(`✓ ${label}`);
+  }
+}
+
+// New layout with prefix
+let p = parseKey("traces/2026-04-09/1910/checkout-api/us-east-1/abcd/1744224000-3.bin.gz");
+assertEq(p.service, "checkout-api", "new layout: service");
+assertEq(p.host, "us-east-1", "new layout: host");
+assertEq(p.bootId, "abcd", "new layout: bootId");
+assertEq(p.epoch, 1744224000, "new layout: epoch");
+assertEq(p.segIndex, "3", "new layout: segIndex");
+
+// New layout without prefix
+p = parseKey("2026-04-09/1910/checkout-api/us-east-1/xyzw/1744224000-0.bin.gz");
+assertEq(p.service, "checkout-api", "new no-prefix: service");
+assertEq(p.host, "us-east-1", "new no-prefix: host");
+assertEq(p.bootId, "xyzw", "new no-prefix: bootId");
+
+// Legacy layout with prefix — unchanged behavior
+p = parseKey("traces/2026-04-09/1910/checkout-api/host1/1744224000-2.bin.gz");
+assertEq(p.service, "checkout-api", "legacy: service");
+assertEq(p.host, "host1", "legacy: host");
+assertEq(p.bootId, "", "legacy: bootId empty");
+assertEq(p.epoch, 1744224000, "legacy: epoch");
+assertEq(p.segIndex, "2", "legacy: segIndex");
+
+// Instance path with embedded slash is a best-effort legacy case —
+// cannot be reliably distinguished from the new boot_id layout on
+// path-component count alone, so the parser falls back to the positional
+// heuristic. We just sanity-check that parsing does not throw.
+p = parseKey("traces/2026-04-09/1910/checkout-api/us-east-1/i-0abc123/1744224000-0.bin.gz");
+if (!p || typeof p !== "object") { console.error("compound-instance: must return object"); process.exit(1); }
+console.log("✓ compound-instance: returns object (best-effort)");
+
+console.log("\nAll parseKey tests passed");


### PR DESCRIPTION
Closes #225.

## Problem

When a service restarts, segment indices reset to 0 — producing duplicate
`{epoch_secs}-{index}` keys across successive runs. In the trace browser this
shows up as overlapping segments on the same host.

## Change

Inject a boot identifier into the default S3 key layout, before the filename:

\`\`\`
{prefix}/{YYYY-MM-DD}/{HHMM}/{service}/{instance}/{boot_id}/{epoch_secs}-{index}.bin.gz
\`\`\`

- Default \`boot_id\` is 4 lowercase alpha chars derived from the current system
  time nanoseconds, regenerated per process start.
- Existing \`S3ConfigBuilder::boot_id()\` callers see their value appear in the
  path *and* in the \`x-amz-meta-boot-id\` header (previously metadata only).

## Viewer

- \`parseKey()\` locates the \`YYYY-MM-DD\` segment and counts components to
  recognise both the new layout and the pre-#225 layout.
- Browse mode groups host cards by \`(service, host, boot_id)\` so distinct
  process runs are no longer blended together — segment-index duplicates
  are gone.
- New \`boot\` badge on host cards; new \`Boot\` column in raw search.
- \`test_parse_key.js\` covers both layouts.

## Tests

- New \`default_boot_id_is_four_lowercase_alpha_chars\`
- Updated key-format assertions in \`background_task::s3::tests\`
- Updated \`upload_and_delete_writes_to_s3_and_removes_local_file\` integration test
- Node \`test_parse_key.js\` for the viewer parser

\`cargo nextest run --workspace --all-features\`: 381 passed.
\`cargo nextest run --workspace --all-features --stress-duration 20s\`: passed.
\`cargo clippy --all-targets --all-features\`: clean.
\`cargo fmt --check\`: clean.