### PR TITLE
Breaking: builder-ize SamplerConfig + CpuProfilingConfig

### DIFF
--- a/dial9-tokio-telemetry/examples/blocking_pool_tracking.rs
+++ b/dial9-tokio-telemetry/examples/blocking_pool_tracking.rs
@@ -29,10 +29,7 @@ fn main() {
     let writer = RotatingWriter::single_file("blocking_pool_trace.bin").unwrap();
     let (runtime, _guard) = TracedRuntime::builder()
         .with_task_tracking(true)
-        .with_cpu_profiling(CpuProfilingConfig {
-            frequency_hz: 999,
-            ..Default::default()
-        })
+        .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
         .build_and_start(builder, writer)
         .unwrap();
 

--- a/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
+++ b/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
@@ -21,12 +21,9 @@ pub(crate) fn read_thread_name(tid: u32) -> Option<String> {
 /// Configuration for CPU profiling integration.
 #[derive(Debug, Clone)]
 pub struct CpuProfilingConfig {
-    /// Sampling frequency in Hz. Default: 99 (low overhead).
-    pub frequency_hz: u64,
-    /// Which perf event source to use.
-    pub event_source: EventSource,
-    /// Whether to include kernel stack frames.
-    pub include_kernel: bool,
+    frequency_hz: u64,
+    event_source: EventSource,
+    include_kernel: bool,
 }
 
 impl Default for CpuProfilingConfig {
@@ -36,6 +33,26 @@ impl Default for CpuProfilingConfig {
             event_source: EventSource::SwCpuClock,
             include_kernel: false,
         }
+    }
+}
+
+impl CpuProfilingConfig {
+    /// Sampling frequency in Hz. Default: 99 (low overhead).
+    pub fn frequency_hz(mut self, hz: u64) -> Self {
+        self.frequency_hz = hz;
+        self
+    }
+
+    /// Which perf event source to use.
+    pub fn event_source(mut self, source: EventSource) -> Self {
+        self.event_source = source;
+        self
+    }
+
+    /// Whether to include kernel stack frames.
+    pub fn include_kernel(mut self, yes: bool) -> Self {
+        self.include_kernel = yes;
+        self
     }
 }
 
@@ -82,11 +99,12 @@ pub(crate) struct CpuProfiler {
 
 impl CpuProfiler {
     pub(crate) fn start(config: CpuProfilingConfig) -> io::Result<Self> {
-        let sampler = PerfSampler::start(SamplerConfig {
-            event_source: config.event_source,
-            sampling: SamplingMode::FrequencyHz(config.frequency_hz),
-            include_kernel: config.include_kernel,
-        })?;
+        let sampler = PerfSampler::start(
+            SamplerConfig::default()
+                .event_source(config.event_source)
+                .sampling(SamplingMode::FrequencyHz(config.frequency_hz))
+                .include_kernel(config.include_kernel),
+        )?;
         Ok(Self {
             sampler,
             pid: std::process::id(),
@@ -130,11 +148,12 @@ pub(crate) struct SchedProfiler {
 
 impl SchedProfiler {
     pub(crate) fn new(config: SchedEventConfig) -> io::Result<Self> {
-        let sampler = PerfSampler::new_per_thread(SamplerConfig {
-            event_source: EventSource::SwContextSwitches,
-            sampling: SamplingMode::Period(config.sampling_interval.unwrap_or(1)),
-            include_kernel: config.include_kernel,
-        })?;
+        let sampler = PerfSampler::new_per_thread(
+            SamplerConfig::default()
+                .event_source(EventSource::SwContextSwitches)
+                .sampling(SamplingMode::Period(config.sampling_interval.unwrap_or(1)))
+                .include_kernel(config.include_kernel),
+        )?;
         Ok(Self { sampler })
     }
 

--- a/dial9-tokio-telemetry/tests/background_symbolization.rs
+++ b/dial9-tokio-telemetry/tests/background_symbolization.rs
@@ -41,10 +41,7 @@ fn background_symbolization_produces_symbol_table_entries() {
     builder.worker_threads(2).enable_all();
 
     let (runtime, guard) = TracedRuntime::builder()
-        .with_cpu_profiling(CpuProfilingConfig {
-            frequency_hz: 999,
-            ..Default::default()
-        })
+        .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
         .with_trace_path(&trace_path)
         .with_worker_poll_interval(std::time::Duration::from_millis(50))
         .build_and_start(builder, writer)

--- a/dial9-tokio-telemetry/tests/cpu_sample_clock_alignment.rs
+++ b/dial9-tokio-telemetry/tests/cpu_sample_clock_alignment.rs
@@ -33,10 +33,7 @@ fn cpu_sample_timestamps_align_with_wall_clock() {
     builder.worker_threads(num_workers).enable_all();
 
     let (runtime, guard) = TracedRuntime::builder()
-        .with_cpu_profiling(CpuProfilingConfig {
-            frequency_hz: 999,
-            ..Default::default()
-        })
+        .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
         .build_and_start(builder, writer)
         .unwrap();
 
@@ -274,10 +271,7 @@ fn thread_name_attribution_for_external_and_blocking_threads() {
         .enable_all();
 
     let (runtime, guard) = TracedRuntime::builder()
-        .with_cpu_profiling(CpuProfilingConfig {
-            frequency_hz: 999,
-            ..Default::default()
-        })
+        .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
         .build_and_start(builder, writer)
         .unwrap();
 

--- a/perf-self-profile/examples/basic.rs
+++ b/perf-self-profile/examples/basic.rs
@@ -13,11 +13,11 @@ use std::collections::HashMap;
 
 fn main() {
     // --- Start the sampler ---
-    let mut sampler = match PerfSampler::start(SamplerConfig {
-        sampling: SamplingMode::FrequencyHz(999),
-        event_source: EventSource::SwCpuClock,
-        include_kernel: false,
-    }) {
+    let mut sampler = match PerfSampler::start(
+        SamplerConfig::default()
+            .event_source(EventSource::SwCpuClock)
+            .sampling(SamplingMode::FrequencyHz(999)),
+    ) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("Failed to start sampler: {e}");

--- a/perf-self-profile/examples/debug_cs.rs
+++ b/perf-self-profile/examples/debug_cs.rs
@@ -6,11 +6,12 @@ use std::thread;
 
 fn main() {
     let sampler = Arc::new(Mutex::new(
-        PerfSampler::new_per_thread(SamplerConfig {
-            sampling: SamplingMode::Period(1),
-            event_source: EventSource::SwContextSwitches,
-            include_kernel: false,
-        })
+        PerfSampler::new_per_thread(
+            SamplerConfig::default()
+                .event_source(EventSource::SwContextSwitches)
+                .sampling(SamplingMode::Period(1))
+                .include_kernel(false),
+        )
         .unwrap(),
     ));
     sampler.lock().unwrap().track_current_thread().unwrap();

--- a/perf-self-profile/examples/multithread.rs
+++ b/perf-self-profile/examples/multithread.rs
@@ -12,11 +12,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 fn main() {
-    let mut sampler = match PerfSampler::start(SamplerConfig {
-        sampling: SamplingMode::FrequencyHz(999),
-        event_source: EventSource::SwCpuClock,
-        include_kernel: false,
-    }) {
+    let mut sampler = match PerfSampler::start(
+        SamplerConfig::default()
+            .event_source(EventSource::SwCpuClock)
+            .include_kernel(false)
+            .sampling(SamplingMode::FrequencyHz(999)),
+    ) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("Failed to start sampler: {e}");

--- a/perf-self-profile/examples/test_sleep.rs
+++ b/perf-self-profile/examples/test_sleep.rs
@@ -16,11 +16,11 @@ fn main() {
     }
 
     let sampler = Arc::new(Mutex::new(
-        PerfSampler::new_per_thread(SamplerConfig {
-            sampling: SamplingMode::Period(1),
-            event_source: EventSource::SwContextSwitches,
-            include_kernel: false,
-        })
+        PerfSampler::new_per_thread(
+            SamplerConfig::default()
+                .event_source(EventSource::SwContextSwitches)
+                .sampling(SamplingMode::Period(1)),
+        )
         .unwrap(),
     ));
     sampler.lock().unwrap().track_current_thread().unwrap();

--- a/perf-self-profile/src/lib.rs
+++ b/perf-self-profile/src/lib.rs
@@ -23,11 +23,11 @@
 //! ```no_run
 //! use dial9_perf_self_profile::{PerfSampler, SamplerConfig, SamplingMode, EventSource, Sample};
 //!
-//! let mut sampler = PerfSampler::start(SamplerConfig {
-//!     event_source: EventSource::SwCpuClock,
-//!     sampling: SamplingMode::FrequencyHz(999),
-//!     include_kernel: false,
-//! }).expect("failed to start sampler");
+//! let mut sampler = PerfSampler::start(
+//!     SamplerConfig::default()
+//!         .event_source(EventSource::SwCpuClock)
+//!         .sampling(SamplingMode::FrequencyHz(999)),
+//! ).expect("failed to start sampler");
 //!
 //! // ... do work ...
 //!

--- a/perf-self-profile/src/sampler.rs
+++ b/perf-self-profile/src/sampler.rs
@@ -4,6 +4,7 @@
 // TODO: these variants are currently Linux-specific (perf_event_open constants),
 // consider cfg-gating individual variants when adding other platform backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EventSource {
     /// `PERF_COUNT_HW_CPU_CYCLES` — hardware CPU cycle counter.
     /// Most precise, but may fail in VMs or containers without PMU access.
@@ -26,6 +27,7 @@ pub enum EventSource {
 
 /// The sampling mode to use.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum SamplingMode {
     /// Sample at this frequency in Hz (e.g., 999 or 4000).
     FrequencyHz(u64),
@@ -36,13 +38,9 @@ pub enum SamplingMode {
 /// Configuration for the sampler.
 #[derive(Debug, Clone)]
 pub struct SamplerConfig {
-    /// Which event to sample on.
-    pub event_source: EventSource,
-    /// What type of sampling to use.
-    pub sampling: SamplingMode,
-    /// Whether to include kernel stack frames.
-    /// Requires `perf_event_paranoid` <= 1 (or CAP_PERFMON).
-    pub include_kernel: bool,
+    pub(crate) event_source: EventSource,
+    pub(crate) sampling: SamplingMode,
+    pub(crate) include_kernel: bool,
 }
 
 impl Default for SamplerConfig {
@@ -55,8 +53,30 @@ impl Default for SamplerConfig {
     }
 }
 
+impl SamplerConfig {
+    /// Set the event source to sample on.
+    pub fn event_source(mut self, source: EventSource) -> Self {
+        self.event_source = source;
+        self
+    }
+
+    /// Set the sampling mode (frequency or fixed period).
+    pub fn sampling(mut self, mode: SamplingMode) -> Self {
+        self.sampling = mode;
+        self
+    }
+
+    /// Whether to include kernel stack frames.
+    /// Requires `perf_event_paranoid` <= 1 (or CAP_PERFMON).
+    pub fn include_kernel(mut self, yes: bool) -> Self {
+        self.include_kernel = yes;
+        self
+    }
+}
+
 /// A single sample captured from perf events.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Sample {
     /// Instruction pointer at the time of the sample.
     pub ip: u64,

--- a/perf-self-profile/tests/multithread.rs
+++ b/perf-self-profile/tests/multithread.rs
@@ -19,11 +19,11 @@ fn burn_cpu(stop: &AtomicBool) {
 
 #[test]
 fn profiles_spawned_threads() {
-    let mut sampler = PerfSampler::start(SamplerConfig {
-        sampling: SamplingMode::FrequencyHz(999),
-        event_source: EventSource::SwCpuClock,
-        include_kernel: false,
-    })
+    let mut sampler = PerfSampler::start(
+        SamplerConfig::default()
+            .event_source(EventSource::SwCpuClock)
+            .sampling(SamplingMode::FrequencyHz(999)),
+    )
     .expect("failed to start sampler");
 
     let stop = Arc::new(AtomicBool::new(false));

--- a/perf-self-profile/tests/sched_triggers.rs
+++ b/perf-self-profile/tests/sched_triggers.rs
@@ -20,11 +20,12 @@ fn do_sleep() {
 fn captures_lock_acquisition_stack() {
     unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 1) };
     let sampler = Arc::new(Mutex::new(
-        PerfSampler::new_per_thread(SamplerConfig {
-            event_source: EventSource::SwContextSwitches,
-            sampling: SamplingMode::Period(1),
-            include_kernel: false,
-        })
+        PerfSampler::new_per_thread(
+            SamplerConfig::default()
+                .event_source(EventSource::SwContextSwitches)
+                .sampling(SamplingMode::Period(1))
+                .include_kernel(false),
+        )
         .expect("failed to create sampler"),
     ));
 
@@ -82,11 +83,12 @@ fn captures_lock_acquisition_stack() {
 fn captures_sleep_stack() {
     unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 1) };
     let sampler = Arc::new(Mutex::new(
-        PerfSampler::new_per_thread(SamplerConfig {
-            event_source: EventSource::SwContextSwitches,
-            sampling: SamplingMode::Period(1),
-            include_kernel: false,
-        })
+        PerfSampler::new_per_thread(
+            SamplerConfig::default()
+                .event_source(EventSource::SwContextSwitches)
+                .include_kernel(false)
+                .sampling(SamplingMode::Period(1)),
+        )
         .expect("failed to create sampler"),
     ));
 
@@ -141,11 +143,12 @@ fn sampling_interval_controls_ratio() {
 
     let run = |period: u64| -> usize {
         let sampler = Arc::new(Mutex::new(
-            PerfSampler::new_per_thread(SamplerConfig {
-                event_source: EventSource::SwContextSwitches,
-                sampling: SamplingMode::Period(period),
-                include_kernel: false,
-            })
+            PerfSampler::new_per_thread(
+                SamplerConfig::default()
+                    .event_source(EventSource::SwContextSwitches)
+                    .include_kernel(false)
+                    .sampling(SamplingMode::Period(period)),
+            )
             .expect("failed to create sampler"),
         ));
         sampler.lock().unwrap().track_current_thread().unwrap();
@@ -166,11 +169,12 @@ fn sampling_interval_controls_ratio() {
 
 #[test]
 fn rejects_zero_period() {
-    let err = match PerfSampler::new_per_thread(SamplerConfig {
-        event_source: EventSource::SwContextSwitches,
-        sampling: SamplingMode::Period(0),
-        include_kernel: false,
-    }) {
+    let err = match PerfSampler::new_per_thread(
+        SamplerConfig::default()
+            .event_source(EventSource::SwContextSwitches)
+            .include_kernel(false)
+            .sampling(SamplingMode::Period(0)),
+    ) {
         Err(e) => e,
         Ok(_) => panic!("Period(0) must be rejected"),
     };

--- a/perf-self-profile/tests/tracepoint_e2e.rs
+++ b/perf-self-profile/tests/tracepoint_e2e.rs
@@ -26,11 +26,12 @@ fn tracepoint_sched_switch_e2e() {
     );
 
     // 2. Open perf event using the TracepointDef's event source
-    let mut sampler = match PerfSampler::start(SamplerConfig {
-        sampling: SamplingMode::Period(1),
-        event_source: tp.event_source(),
-        include_kernel: false,
-    }) {
+    let mut sampler = match PerfSampler::start(
+        SamplerConfig::default()
+            .event_source(tp.event_source())
+            .sampling(SamplingMode::Period(1))
+            .include_kernel(false),
+    ) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("skipping: perf_event_open failed: {}", e);


### PR DESCRIPTION
Builder-ize `SamplerConfig` and `CpuProfilingConfig`.
                                                                        
Makes it consistent with `SchedEventConfig`, makes some upcoming work additive instead of forcing another semver-major.
  
**Breaking**: external callers using struct-literal construction need to migrate to using the builders