### PR TITLE
Fix packing for viewer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,29 @@ jobs:
           sudo sysctl kernel.kptr_restrict=0
       - run: scripts/e2e-trace-tests.sh
 
+  package:
+    name: Cargo package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.STABLE_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Verify all publishable crates package cleanly
+        env:
+          RUSTFLAGS: "--cfg tokio_unstable"
+        run: |
+          for crate in dial9-trace-format-derive dial9-trace-format dial9-perf-self-profile dial9-macro dial9-tokio-telemetry dial9-viewer; do
+            echo "::group::cargo package -p $crate"
+            cargo package -p "$crate"
+            echo "::endgroup::"
+          done
+
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, build, check-docs, trace-integrity]
+    needs: [fmt, clippy, build, check-docs, trace-integrity, package]
     if: always()
     steps:
       - run: |

--- a/dial9-viewer/README_TELEMETRY.md
+++ b/dial9-viewer/README_TELEMETRY.md
@@ -1,0 +1,1 @@
+../dial9-tokio-telemetry/README.md

--- a/dial9-viewer/build.rs
+++ b/dial9-viewer/build.rs
@@ -19,7 +19,7 @@ fn main() {
     println!("cargo::rerun-if-changed=toolkit");
     println!("cargo::rerun-if-changed=skills");
     println!("cargo::rerun-if-changed=ui");
-    println!("cargo::rerun-if-changed=../dial9-tokio-telemetry/README.md");
+    println!("cargo::rerun-if-changed=README_TELEMETRY.md");
 
     generate_toolkit(&manifest_dir, &out_dir);
     generate_setup_from_readme(&manifest_dir, &out_dir);
@@ -137,7 +137,7 @@ const SETUP_SECTIONS: &[&str] = &[
 /// skills directory. This keeps the README as the single source of truth for
 /// instrumentation docs.
 fn generate_setup_from_readme(manifest_dir: &str, out_dir: &str) {
-    let readme_path = Path::new(manifest_dir).join("../dial9-tokio-telemetry/README.md");
+    let readme_path = Path::new(manifest_dir).join("README_TELEMETRY.md");
     let readme = fs::read_to_string(&readme_path)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", readme_path.display()));
 


### PR DESCRIPTION
Packaging for the viewer was failing because it included the README but the file MUST be present in the directory. This adds a symlink to pull it in + a new CI test