### PR TITLE
feat: add cargo binstall support

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,77 @@
+# Builds cross-platform binaries and uploads to GitHub Releases.
+# Binaries are discoverable by cargo-binstall (https://github.com/cargo-bins/cargo-binstall).
+# Triggered automatically when release-plz publishes a dial9-viewer release.
+name: Build Binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    if: startsWith(github.event.release.tag_name, 'dial9-viewer-v')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - run: cargo build --release --target ${{ matrix.target }} -p dial9-viewer
+        env:
+          RUSTFLAGS: "--cfg tokio_unstable"
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          # Strip package name prefix (e.g. "dial9-viewer-v0.3.1" -> "v0.3.1")
+          VERSION="${TAG##*-v}"
+          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Package (Unix)
+        if: ${{ matrix.archive == 'tar.gz' }}
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar -czvf ../../../dial9-viewer-${{ matrix.target }}-${{ steps.version.outputs.version }}.tar.gz dial9-viewer
+
+      - name: Package (Windows)
+        if: ${{ matrix.archive == 'zip' }}
+        shell: pwsh
+        run: |
+          cd target/${{ matrix.target }}/release
+          Compress-Archive -Path dial9-viewer.exe -DestinationPath ../../../dial9-viewer-${{ matrix.target }}-${{ steps.version.outputs.version }}.zip
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dial9-viewer-${{ matrix.target }}-${{ steps.version.outputs.version }}.${{ matrix.archive }}

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 description = "CLI trace viewer and S3 browser for dial9-tokio-telemetry"
 default-run = "dial9-viewer"
+exclude = ["src/bin/dev_server.rs"]
 
 [features]
 dev-server = ["dep:s3s", "dep:s3s-fs", "dep:s3s-aws", "dep:tempfile"]

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -8,6 +8,9 @@ description = "CLI trace viewer and S3 browser for dial9-tokio-telemetry"
 default-run = "dial9-viewer"
 exclude = ["src/bin/dev_server.rs"]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
+
 [features]
 dev-server = ["dep:s3s", "dep:s3s-fs", "dep:s3s-aws", "dep:tempfile"]
 

--- a/dial9-viewer/README.md
+++ b/dial9-viewer/README.md
@@ -2,6 +2,18 @@
 
 CLI tool that serves a web UI for browsing and viewing [dial9-tokio-telemetry](../dial9-tokio-telemetry) trace files stored in S3 or on the local filesystem.
 
+## Installation
+
+Pre-built binaries are available from [GitHub Releases](https://github.com/dial9-rs/dial9-tokio-telemetry/releases) for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64).
+
+```bash
+# From source via crates.io
+cargo install --locked dial9-viewer
+
+# Or with cargo-binstall (downloads a pre-built binary, faster)
+cargo binstall dial9-viewer
+```
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
(also fixes #249)

### Summary

Adds pre-built release binaries and `cargo-binstall` support for `dial9-viewer`. Previously, installing the viewer required compiling from source (`cargo install dial9-viewer`), which is slow due to the large dependency tree (AWS SDK, axum, etc.).

A new `build-binaries.yml` workflow triggers on `dial9-viewer-v*` releases (created by release-plz) and cross-compiles for five targets: Linux x86_64/aarch64, macOS x86_64/aarch64, and Windows x86_64. The asset naming convention follows the `cargo-binstall` default discovery pattern, configured via `[package.metadata.binstall]` in Cargo.toml.

The workflow also supports `workflow_dispatch` for manual builds without a release (uploads as artifacts instead of release assets).

Also excludes `dev-server` from the published crate (#249). The `dev-server` binary is a local development tool (fake S3 server) that shouldn't ship to end users. Adding `exclude = ["src/bin/dev_server.rs"]` to `[package]` keeps it out of the tarball while preserving it for local development.

### Testing

Verified `cargo package -p dial9-viewer` succeeds and the tarball no longer contains `dev_server.rs`. The workflow itself can only be fully validated once a release tag is pushed; the `workflow_dispatch` path can be used to test the build matrix before that.
