### PR TITLE
feat(viewer): Pop-out flamegraph with interactive features

### DIFF
--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -39,15 +39,16 @@
     max-width: 350px;
 }
 .fg-help-btn {
-    color: #666;
+    color: #aaa;
     cursor: pointer;
-    font-size: 0.85em;
-    border: 1px solid #444;
-    border-radius: 3px;
-    padding: 0 5px;
-    line-height: 1.4;
+    font-size: 1.1em;
+    background: none;
+    border: 1px solid #555;
+    border-radius: 4px;
+    padding: 2px 6px;
+    line-height: 1;
 }
-.fg-help-btn:hover { color: #ccc; border-color: #666; }
+.fg-help-btn:hover { color: #fff; border-color: #888; }
 
 .fg-breadcrumb {
     display: none;

--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -29,6 +29,15 @@
 }
 .fg-search-clear:hover { color: #fff; }
 .fg-search-stats { color: #888; font-size: 0.82em; }
+.fg-spawn-filter {
+    background: #2a2a4a;
+    border: 1px solid #444;
+    color: #ccc;
+    padding: 3px 6px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    max-width: 350px;
+}
 .fg-help-btn {
     color: #666;
     cursor: pointer;
@@ -36,7 +45,6 @@
     border: 1px solid #444;
     border-radius: 3px;
     padding: 0 5px;
-    margin-left: auto;
     line-height: 1.4;
 }
 .fg-help-btn:hover { color: #ccc; border-color: #666; }

--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -1,4 +1,4 @@
-/* Shared styles for flamegraph.js module — used by viewer.html and flamegraph.html */
+/* Shared styles for flamegraph.js  */
 
 .fg-search-bar {
     display: flex;

--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -20,7 +20,26 @@
     outline: none;
 }
 .fg-search-input:focus { border-color: #6c63ff; }
+.fg-search-clear {
+    color: #888;
+    cursor: pointer;
+    font-size: 1.2em;
+    padding: 0 2px;
+    line-height: 1;
+}
+.fg-search-clear:hover { color: #fff; }
 .fg-search-stats { color: #888; font-size: 0.82em; }
+.fg-help-btn {
+    color: #666;
+    cursor: pointer;
+    font-size: 0.85em;
+    border: 1px solid #444;
+    border-radius: 3px;
+    padding: 0 5px;
+    margin-left: auto;
+    line-height: 1.4;
+}
+.fg-help-btn:hover { color: #ccc; border-color: #666; }
 
 .fg-breadcrumb {
     display: none;
@@ -59,6 +78,29 @@
     flex-shrink: 0;
 }
 .fg-canvas { display: block; }
+
+.fg-help-overlay {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+}
+.fg-help-content {
+    background: #1a1a2e;
+    border: 1px solid #6c63ff;
+    border-radius: 8px;
+    padding: 16px 24px;
+    max-width: 400px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+}
+.fg-help-content h3 { color: #e0e0e0; margin-bottom: 12px; font-size: 0.95em; }
+.fg-help-content table { width: 100%; font-size: 0.85em; border-collapse: collapse; }
+.fg-help-content td { padding: 4px 8px; color: #ccc; }
+.fg-help-key { color: #6c63ff; font-family: monospace; white-space: nowrap; }
+.fg-help-dismiss { color: #666; font-size: 0.78em; margin-top: 12px; text-align: center; }
 
 .fg-tooltip {
     display: none;

--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -1,0 +1,76 @@
+/* Shared styles for flamegraph.js module — used by viewer.html and flamegraph.html */
+
+.fg-search-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 12px;
+    background: #16213e;
+    border-bottom: 1px solid #222;
+    flex-shrink: 0;
+}
+.fg-search-input {
+    background: #2a2a4a;
+    border: 1px solid #444;
+    color: #e0e0e0;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    width: 260px;
+    outline: none;
+}
+.fg-search-input:focus { border-color: #6c63ff; }
+.fg-search-stats { color: #888; font-size: 0.82em; }
+
+.fg-breadcrumb {
+    display: none;
+    align-items: center;
+    gap: 0;
+    padding: 3px 12px;
+    background: #1e1e3a;
+    border-bottom: 1px solid #222;
+    font-size: 0.78em;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+}
+.fg-breadcrumb-item {
+    color: #aaa;
+    max-width: 250px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.fg-breadcrumb-link { color: #6c63ff; cursor: pointer; }
+.fg-breadcrumb-link:hover { text-decoration: underline; }
+.fg-breadcrumb-sep { color: #555; }
+
+.fg-body {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+.fg-section-label {
+    padding: 4px 12px;
+    font-size: 0.78em;
+    color: #aaa;
+    background: #16213e;
+    border-bottom: 1px solid #222;
+    flex-shrink: 0;
+}
+.fg-canvas { display: block; }
+
+.fg-tooltip {
+    display: none;
+    position: fixed;
+    background: #222244;
+    border: 1px solid #555;
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 0.78em;
+    pointer-events: none;
+    z-index: 200;
+    max-width: 600px;
+    white-space: nowrap;
+    color: #e0e0e0;
+}

--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -121,7 +121,7 @@
     font-size: 0.78em;
     pointer-events: none;
     z-index: 200;
-    max-width: 600px;
-    white-space: nowrap;
+    max-width: min(600px, calc(100vw - 24px));
+    overflow-wrap: anywhere;
     color: #e0e0e0;
 }

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -162,7 +162,9 @@
                 document.title = `Flamegraph \u2014 ${name}` + (durMs ? ` (${durMs}ms)` : "");
                 titleEl.textContent = "Flamegraph";
                 statsEl.textContent =
-                    `${allSamples.length} samples` + (durMs ? ` \u00b7 ${durMs}ms selected` : "");
+                    `${allSamples.length} samples` +
+                    (durMs ? ` \u00b7 ${durMs}ms selected` : "") +
+                    (timeRangeMatched ? "" : " (showing all \u2014 time range did not match)");
 
                 loadingEl.classList.add("hidden");
                 containerEl.style.display = "flex";

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -141,6 +141,8 @@
                     console.warn("Failed to attach spawn locations:", err);
                 }
 
+                // Filter to the selected time range, fall back to all samples if
+                // the URL timestamps don't align with the parsed trace.
                 let allSamples = FlamegraphRenderer.filterCpuSamples(trace.cpuSamples, startNs, endNs);
                 let timeRangeMatched = allSamples.length > 0;
                 if (!timeRangeMatched) {
@@ -164,7 +166,7 @@
                 statsEl.textContent =
                     `${allSamples.length} samples` +
                     (durMs ? ` \u00b7 ${durMs}ms selected` : "") +
-                    (timeRangeMatched ? "" : " (showing all \u2014 time range did not match)");
+                    (timeRangeMatched ? "" : " (full trace \u2014 selected region could not be reproduced)");
 
                 loadingEl.classList.add("hidden");
                 containerEl.style.display = "flex";

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -66,7 +66,6 @@
         <div class="fg-page-header">
             <span class="fg-title" id="fg-title">Flamegraph</span>
             <span class="fg-stats" id="fg-stats"></span>
-            <select id="fg-spawn-filter" style="background:#2a2a4a;border:1px solid #444;color:#ccc;padding:3px 6px;border-radius:4px;font-size:0.9em;max-width:350px"></select>
         </div>
         <div id="fg-container"></div>
         <div id="loading">Loading trace&hellip;</div>
@@ -88,7 +87,6 @@
                 const containerEl = document.getElementById("fg-container");
                 const titleEl = document.getElementById("fg-title");
                 const statsEl = document.getElementById("fg-stats");
-                const spawnFilter = document.getElementById("fg-spawn-filter");
 
                 function showError(msg) {
                     loadingEl.classList.add("hidden");
@@ -146,12 +144,7 @@
                     console.warn("Failed to attach spawn locations:", err);
                 }
 
-                // Filter samples to the requested time range
-                let allSamples = trace.cpuSamples.filter(
-                    (s) => s.callchain.length > 0
-                );
-                if (startNs != null) allSamples = allSamples.filter((s) => s.timestamp >= startNs);
-                if (endNs != null) allSamples = allSamples.filter((s) => s.timestamp <= endNs);
+                const allSamples = FlamegraphRenderer.filterCpuSamples(trace.cpuSamples, startNs, endNs);
 
                 if (!allSamples.length) {
                     showError("No CPU samples found in the specified time range.");
@@ -168,24 +161,6 @@
                 statsEl.textContent =
                     `${allSamples.length} samples` + (durMs ? ` \u00b7 ${durMs}ms selected` : "");
 
-                // Build spawn location dropdown
-                const locCounts = new Map();
-                for (const s of allSamples) {
-                    const loc = s.spawnLoc || "(unknown)";
-                    locCounts.set(loc, (locCounts.get(loc) || 0) + 1);
-                }
-                spawnFilter.innerHTML = `<option value="">All tasks (${allSamples.length} samples)</option>`;
-                const sorted = [...locCounts.entries()].sort((a, b) => b[1] - a[1]);
-                for (const [loc, count] of sorted) {
-                    const short = loc.replace(/.*\//, "");
-                    const opt = document.createElement("option");
-                    opt.value = loc;
-                    opt.textContent = `${short} (${count})`;
-                    opt.title = loc;
-                    spawnFilter.appendChild(opt);
-                }
-
-                // Hide loading, show flamegraph
                 loadingEl.classList.add("hidden");
                 containerEl.style.display = "flex";
 
@@ -200,22 +175,8 @@
                     window.history.replaceState(null, "", newUrl);
                 }
 
-                // Create flamegraph instance
                 const fg = FlamegraphRenderer.createFlamegraph(containerEl, updateUrlZoom);
-
-                function applyFilter() {
-                    const filterVal = spawnFilter.value;
-                    const samples = filterVal
-                        ? allSamples.filter((s) => (s.spawnLoc || "(unknown)") === filterVal)
-                        : allSamples;
-
-                    const workerSamples = samples.filter((s) => s.workerId !== 255);
-                    const offworkerSamples = samples.filter((s) => s.workerId === 255);
-                    fg.setData(workerSamples, offworkerSamples, trace.callframeSymbols);
-                }
-
-                spawnFilter.addEventListener("change", applyFilter);
-                applyFilter();
+                fg.setData(allSamples, trace.callframeSymbols);
 
                 // Restore zoom from URL if present
                 const wz = params.get("worker-zoom");

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Flamegraph</title>
+        <link rel="stylesheet" href="flamegraph.css" />
+        <style>
+            * { box-sizing: border-box; margin: 0; padding: 0; }
+            body {
+                background: #1a1a2e;
+                color: #e0e0e0;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+                font-size: 14px;
+                display: flex;
+                flex-direction: column;
+                height: 100vh;
+                overflow: hidden;
+            }
+            .fg-page-header {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                padding: 6px 12px;
+                background: #16213e;
+                border-bottom: 1px solid #333;
+                font-size: 0.8em;
+                flex-shrink: 0;
+            }
+            .fg-page-header .fg-title { color: #6c63ff; font-weight: 600; }
+            .fg-page-header .fg-stats { color: #888; }
+
+            /* Main container */
+            #fg-container {
+                flex: 1;
+                display: flex;
+                flex-direction: column;
+                overflow: hidden;
+            }
+
+            /* Loading */
+            #loading {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                flex: 1;
+                color: #888;
+                font-size: 1.1em;
+            }
+            #loading.hidden { display: none; }
+
+            /* Error */
+            #error {
+                display: none;
+                align-items: center;
+                justify-content: center;
+                flex: 1;
+                color: #ff6b6b;
+                font-size: 1em;
+                padding: 24px;
+                text-align: center;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="fg-page-header">
+            <span class="fg-title" id="fg-title">Flamegraph</span>
+            <span class="fg-stats" id="fg-stats"></span>
+            <select id="fg-spawn-filter" style="background:#2a2a4a;border:1px solid #444;color:#ccc;padding:3px 6px;border-radius:4px;font-size:0.9em;max-width:350px"></select>
+        </div>
+        <div id="fg-container"></div>
+        <div id="loading">Loading trace&hellip;</div>
+        <div id="error"></div>
+
+        <script src="decode.js"></script>
+        <script src="trace_parser.js"></script>
+        <script src="trace_analysis.js"></script>
+        <script src="flamegraph.js"></script>
+        <script>
+            (async function () {
+                const params = new URLSearchParams(window.location.search);
+                const traceUrl = params.get("trace");
+                const startNs = params.get("start") != null ? Number(params.get("start")) : null;
+                const endNs = params.get("end") != null ? Number(params.get("end")) : null;
+
+                const loadingEl = document.getElementById("loading");
+                const errorEl = document.getElementById("error");
+                const containerEl = document.getElementById("fg-container");
+                const titleEl = document.getElementById("fg-title");
+                const statsEl = document.getElementById("fg-stats");
+                const spawnFilter = document.getElementById("fg-spawn-filter");
+
+                function showError(msg) {
+                    loadingEl.classList.add("hidden");
+                    errorEl.style.display = "flex";
+                    errorEl.textContent = msg;
+                }
+
+                if (!traceUrl) {
+                    showError("No trace URL provided. Use ?trace=<url>&start=<ns>&end=<ns>");
+                    return;
+                }
+
+                // Fetch trace
+                let buffer;
+                try {
+                    loadingEl.textContent = "Fetching trace\u2026";
+                    const resp = await fetch(traceUrl);
+                    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+                    buffer = await resp.arrayBuffer();
+                } catch (err) {
+                    showError("Failed to fetch trace: " + err.message);
+                    return;
+                }
+
+                // Parse trace
+                let trace;
+                try {
+                    loadingEl.textContent = "Parsing trace\u2026";
+                    const parseOpts = {};
+                    if (startNs != null) parseOpts.startTime = startNs;
+                    if (endNs != null) parseOpts.endTime = endNs;
+                    trace = await TraceParser.parseTrace(buffer, parseOpts);
+                } catch (err) {
+                    showError("Failed to parse trace: " + err.message);
+                    return;
+                }
+
+                // Process: build worker spans and attach CPU samples for spawnLoc
+                try {
+                    loadingEl.textContent = "Analyzing\u2026";
+                    const evts = trace.events;
+                    const wSet = new Set();
+                    const ET = TraceParser.EVENT_TYPES;
+                    evts.forEach((e) => {
+                        if (e.eventType !== ET.QueueSample && e.eventType !== ET.WakeEvent) wSet.add(e.workerId);
+                    });
+                    const workerIds = [...wSet].sort((a, b) => a - b);
+                    const maxTs = evts.length > 0 ? evts[evts.length - 1].timestamp : 0;
+                    const spanResult = TraceAnalysis.buildWorkerSpans(evts, workerIds, maxTs);
+                    if (trace.cpuSamples.length > 0) {
+                        TraceAnalysis.attachCpuSamples(trace.cpuSamples, spanResult.workerSpans);
+                    }
+                } catch (err) {
+                    // Non-fatal: spawnLoc just won't be available
+                    console.warn("Failed to attach spawn locations:", err);
+                }
+
+                // Filter samples to the requested time range
+                let allSamples = trace.cpuSamples.filter(
+                    (s) => s.callchain.length > 0
+                );
+                if (startNs != null) allSamples = allSamples.filter((s) => s.timestamp >= startNs);
+                if (endNs != null) allSamples = allSamples.filter((s) => s.timestamp <= endNs);
+
+                if (!allSamples.length) {
+                    showError("No CPU samples found in the specified time range.");
+                    return;
+                }
+
+                // Update title
+                const name = traceUrl.split("/").pop() || "trace";
+                const durMs = startNs != null && endNs != null
+                    ? ((endNs - startNs) / 1e6).toFixed(2)
+                    : null;
+                document.title = `Flamegraph \u2014 ${name}` + (durMs ? ` (${durMs}ms)` : "");
+                titleEl.textContent = "Flamegraph";
+                statsEl.textContent =
+                    `${allSamples.length} samples` + (durMs ? ` \u00b7 ${durMs}ms selected` : "");
+
+                // Build spawn location dropdown
+                const locCounts = new Map();
+                for (const s of allSamples) {
+                    const loc = s.spawnLoc || "(unknown)";
+                    locCounts.set(loc, (locCounts.get(loc) || 0) + 1);
+                }
+                spawnFilter.innerHTML = `<option value="">All tasks (${allSamples.length} samples)</option>`;
+                const sorted = [...locCounts.entries()].sort((a, b) => b[1] - a[1]);
+                for (const [loc, count] of sorted) {
+                    const short = loc.replace(/.*\//, "");
+                    const opt = document.createElement("option");
+                    opt.value = loc;
+                    opt.textContent = `${short} (${count})`;
+                    opt.title = loc;
+                    spawnFilter.appendChild(opt);
+                }
+
+                // Hide loading, show flamegraph
+                loadingEl.classList.add("hidden");
+                containerEl.style.display = "flex";
+
+                // Create flamegraph instance
+                const fg = FlamegraphRenderer.createFlamegraph(containerEl);
+
+                function applyFilter() {
+                    const filterVal = spawnFilter.value;
+                    const samples = filterVal
+                        ? allSamples.filter((s) => (s.spawnLoc || "(unknown)") === filterVal)
+                        : allSamples;
+
+                    const workerSamples = samples.filter((s) => s.workerId !== 255);
+                    const offworkerSamples = samples.filter((s) => s.workerId === 255);
+                    fg.setData(workerSamples, offworkerSamples, trace.callframeSymbols);
+                }
+
+                spawnFilter.addEventListener("change", applyFilter);
+                applyFilter();
+
+                // Responsive resize
+                window.addEventListener("resize", () => fg.resize());
+
+                // Escape key
+                window.addEventListener("keydown", (e) => {
+                    if (e.key === "Escape") {
+                        fg.handleEscape();
+                    }
+                });
+            })();
+        </script>
+    </body>
+</html>

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -115,10 +115,7 @@
                 let trace;
                 try {
                     loadingEl.textContent = "Parsing trace\u2026";
-                    const parseOpts = {};
-                    if (startNs != null) parseOpts.startTime = startNs;
-                    if (endNs != null) parseOpts.endTime = endNs;
-                    trace = await TraceParser.parseTrace(buffer, parseOpts);
+                    trace = await TraceParser.parseTrace(buffer);
                 } catch (err) {
                     showError("Failed to parse trace: " + err.message);
                     return;
@@ -144,11 +141,17 @@
                     console.warn("Failed to attach spawn locations:", err);
                 }
 
-                const allSamples = FlamegraphRenderer.filterCpuSamples(trace.cpuSamples, startNs, endNs);
-
-                if (!allSamples.length) {
-                    showError("No CPU samples found in the specified time range.");
-                    return;
+                let allSamples = FlamegraphRenderer.filterCpuSamples(trace.cpuSamples, startNs, endNs);
+                let timeRangeMatched = allSamples.length > 0;
+                if (!timeRangeMatched) {
+                    const unfiltered = FlamegraphRenderer.filterCpuSamples(trace.cpuSamples, null, null);
+                    if (unfiltered.length > 0 && (startNs != null || endNs != null)) {
+                        allSamples = unfiltered;
+                        console.warn("Time range filter matched 0 samples — showing all", unfiltered.length, "samples");
+                    } else {
+                        showError("No CPU samples found in the specified time range.");
+                        return;
+                    }
                 }
 
                 // Update title
@@ -178,11 +181,13 @@
                 const fg = FlamegraphRenderer.createFlamegraph(containerEl, updateUrlZoom);
                 fg.setData(allSamples, trace.callframeSymbols);
 
-                // Restore zoom from URL if present
-                const wz = params.get("worker-zoom");
-                const oz = params.get("offworker-zoom");
-                if (wz) fg.zoomToPath("worker", wz.split("\t"));
-                if (oz) fg.zoomToPath("offworker", oz.split("\t"));
+                // Restore zoom from URL (only if time range filter succeeded, otherwise tree differs)
+                if (timeRangeMatched) {
+                    const wz = params.get("worker-zoom");
+                    const oz = params.get("offworker-zoom");
+                    if (wz) fg.zoomToPath("worker", wz.split("\t"));
+                    if (oz) fg.zoomToPath("offworker", oz.split("\t"));
+                }
 
                 // Responsive resize
                 window.addEventListener("resize", () => fg.resize());

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -189,8 +189,19 @@
                 loadingEl.classList.add("hidden");
                 containerEl.style.display = "flex";
 
+                function updateUrlZoom() {
+                    const p = new URLSearchParams(window.location.search);
+                    const z = fg.getZoomPath();
+                    if (z.worker.length > 0) p.set("worker-zoom", z.worker.join("\t"));
+                    else p.delete("worker-zoom");
+                    if (z.offworker.length > 0) p.set("offworker-zoom", z.offworker.join("\t"));
+                    else p.delete("offworker-zoom");
+                    const newUrl = window.location.pathname + "?" + p.toString();
+                    window.history.replaceState(null, "", newUrl);
+                }
+
                 // Create flamegraph instance
-                const fg = FlamegraphRenderer.createFlamegraph(containerEl);
+                const fg = FlamegraphRenderer.createFlamegraph(containerEl, updateUrlZoom);
 
                 function applyFilter() {
                     const filterVal = spawnFilter.value;
@@ -205,6 +216,12 @@
 
                 spawnFilter.addEventListener("change", applyFilter);
                 applyFilter();
+
+                // Restore zoom from URL if present
+                const wz = params.get("worker-zoom");
+                const oz = params.get("offworker-zoom");
+                if (wz) fg.zoomToPath("worker", wz.split("\t"));
+                if (oz) fg.zoomToPath("offworker", oz.split("\t"));
 
                 // Responsive resize
                 window.addEventListener("resize", () => fg.resize());

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -592,9 +592,17 @@
     }
 
     function getZoomPath() {
+      function fullPath(tree, stack) {
+        if (!tree || stack.length === 0) return [];
+        // If stack already has the full path (from zoomToPath restore), use it directly.
+        // Otherwise find the path from root to the zoom target.
+        var target = stack[stack.length - 1];
+        var path = findNodePath(tree, target.name);
+        return path ? path.map((n) => n.name) : stack.map((n) => n.name);
+      }
       return {
-        worker: workerZoomStack.map((n) => n.name),
-        offworker: offworkerZoomStack.map((n) => n.name),
+        worker: fullPath(workerTree, workerZoomStack),
+        offworker: fullPath(offworkerTree, offworkerZoomStack),
       };
     }
 
@@ -620,12 +628,23 @@
       const tree = key === "worker" ? workerTree : offworkerTree;
       if (!tree || !names.length) return;
       const stack = key === "worker" ? workerZoomStack : offworkerZoomStack;
-      const target = names[names.length - 1];
-      const path = findNodePath(tree, target);
-      if (path) {
-        stack.push.apply(stack, path);
-        renderAll();
+      // Try walking child-by-child (works when names is a full path from root)
+      let node = tree;
+      for (let i = 0; i < names.length; i++) {
+        let found = null;
+        for (const child of node.children.values()) {
+          if (child.name === names[i]) { found = child; break; }
+        }
+        if (!found) {
+          // Path walk failed, fall back to DFS for the last name
+          const path = findNodePath(tree, names[names.length - 1]);
+          if (path) stack.push.apply(stack, path);
+          break;
+        }
+        stack.push(found);
+        node = found;
       }
+      if (stack.length > 0) renderAll();
     }
 
     return { setData, resize, destroy, handleEscape, isZoomed, getZoomPath, zoomToPath };

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -108,7 +108,7 @@
       '<span class="fg-search-clear" title="Clear search">\u00d7</span>' +
       '<span class="fg-search-stats"></span>' +
       '<select class="fg-spawn-filter"></select>' +
-      '<span class="fg-help-btn" tabindex="0" role="button" title="Keyboard shortcuts">i</span>';
+      '<span class="fg-help-btn" tabindex="0" role="button" title="Keyboard shortcuts">\u2139\ufe0f</span>';
     container.appendChild(searchBar);
 
     const searchInput = searchBar.querySelector(".fg-search-input");

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -75,7 +75,8 @@
     return matched;
   }
 
-  function createFlamegraph(container) {
+  function createFlamegraph(container, onZoomChange) {
+    onZoomChange = onZoomChange || function () {};
     let workerTree = null;
     let offworkerTree = null;
     let workerData = null;
@@ -83,6 +84,8 @@
     let workerZoomStack = [];
     let offworkerZoomStack = [];
     let searchQuery = "";
+    let highlightName = null;
+    let repaintQueued = false;
     const hitRegions = { worker: [], offworker: [] };
 
     // DOM
@@ -92,15 +95,53 @@
     searchBar.innerHTML =
       '<input type="text" class="fg-search-input" placeholder="Search frames... (' +
       (isMac ? '\u2318' : 'Ctrl+') + 'F or /)" />' +
-      '<span class="fg-search-stats"></span>';
+      '<span class="fg-search-clear" title="Clear search">\u00d7</span>' +
+      '<span class="fg-search-stats"></span>' +
+      '<span class="fg-help-btn" tabindex="0" role="button" title="Keyboard shortcuts">i</span>';
     container.appendChild(searchBar);
 
     const searchInput = searchBar.querySelector(".fg-search-input");
+    const searchClear = searchBar.querySelector(".fg-search-clear");
     const searchStats = searchBar.querySelector(".fg-search-stats");
+    const helpBtn = searchBar.querySelector(".fg-help-btn");
+
+    const helpOverlay = document.createElement("div");
+    helpOverlay.className = "fg-help-overlay";
+    helpOverlay.innerHTML =
+      '<div class="fg-help-content">' +
+      '<h3>\u2328 Flamegraph Shortcuts</h3>' +
+      '<table>' +
+      '<tr><td class="fg-help-key">Click</td><td>Zoom into frame</td></tr>' +
+      '<tr><td class="fg-help-key">Right-click</td><td>Zoom out one level</td></tr>' +
+      '<tr><td class="fg-help-key">' + (isMac ? '\u2318' : 'Ctrl+') + 'F or /</td><td>Search frames</td></tr>' +
+      '<tr><td class="fg-help-key">Esc</td><td>Clear search \u2192 reset zoom \u2192 close</td></tr>' +
+      '</table>' +
+      '<div class="fg-help-dismiss">Press Esc or click outside to close</div>' +
+      '</div>';
+    helpOverlay.style.display = "none";
+    container.appendChild(helpOverlay);
+
+    helpBtn.addEventListener("click", function () {
+      helpOverlay.style.display = helpOverlay.style.display === "none" ? "flex" : "none";
+    });
+    helpOverlay.addEventListener("click", function (e) {
+      if (e.target === helpOverlay) helpOverlay.style.display = "none";
+    });
+
+    searchClear.style.display = "none";
+    searchClear.addEventListener("click", function () {
+      searchInput.value = "";
+      searchQuery = "";
+      searchClear.style.display = "none";
+      repaint();
+      searchInput.focus();
+    });
 
     const breadcrumbBar = document.createElement("div");
     breadcrumbBar.className = "fg-breadcrumb";
     container.appendChild(breadcrumbBar);
+
+    container.style.position = container.style.position || "relative";
 
     const body = document.createElement("div");
     body.className = "fg-body";
@@ -161,8 +202,10 @@
         const y = baseY - (node.depth + 1) * FG_ROW_H;
         if (w < 0.5) continue;
 
-        const matches = !searching || node.name.toLowerCase().includes(qLower);
-        ctx.globalAlpha = searching && !matches ? 0.25 : 1.0;
+        const searchMatch = !searching || node.name.toLowerCase().includes(qLower);
+        const highlighted = highlightName != null && node.name === highlightName;
+        const dimmed = (searching && !searchMatch) || (highlightName != null && !highlighted);
+        ctx.globalAlpha = dimmed ? 0.25 : 1.0;
         ctx.fillStyle = flamegraphColor(node.name);
         ctx.fillRect(x, y, Math.max(w - 0.5, 0.5), FG_ROW_H - 1);
         regions.push({ x1: x, x2: x + w, y, node, totalSamples: data.totalSamples });
@@ -246,6 +289,7 @@
         if (key === "worker") workerZoomStack = [];
         else offworkerZoomStack = [];
         renderAll();
+        onZoomChange();
       });
       breadcrumbBar.appendChild(rootSpan);
 
@@ -266,6 +310,7 @@
             if (key === "worker") workerZoomStack = workerZoomStack.slice(0, idx + 1);
             else offworkerZoomStack = offworkerZoomStack.slice(0, idx + 1);
             renderAll();
+            onZoomChange();
           });
         }
         breadcrumbBar.appendChild(span);
@@ -299,6 +344,7 @@
     searchInput.addEventListener("input", onSearchInput);
     function onSearchInput() {
       searchQuery = searchInput.value;
+      searchClear.style.display = searchQuery ? "" : "none";
       repaint();
     }
 
@@ -307,12 +353,14 @@
       if (key === "worker") workerZoomStack.push(treeNode);
       else offworkerZoomStack.push(treeNode);
       renderAll();
+      onZoomChange();
     }
 
     function resetZoom() {
       workerZoomStack = [];
       offworkerZoomStack = [];
       renderAll();
+      onZoomChange();
     }
 
     function isZoomed() {
@@ -331,6 +379,14 @@
         if (mx >= r.x1 && mx <= r.x2 && my >= r.y && my < r.y + FG_ROW_H) {
           hit = r;
           break;
+        }
+      }
+      const newHighlight = hit ? hit.node.name : null;
+      if (newHighlight !== highlightName) {
+        highlightName = newHighlight;
+        if (!repaintQueued) {
+          repaintQueued = true;
+          requestAnimationFrame(() => { repaintQueued = false; repaint(); });
         }
       }
       if (hit) {
@@ -352,6 +408,13 @@
 
     function canvasMouseLeave() {
       tooltip.style.display = "none";
+      if (highlightName !== null) {
+        highlightName = null;
+        if (!repaintQueued) {
+          repaintQueued = true;
+          requestAnimationFrame(() => { repaintQueued = false; repaint(); });
+        }
+      }
     }
 
     function canvasClick(e, hitKey) {
@@ -371,11 +434,26 @@
       }
     }
 
+    function canvasContextMenu(e, hitKey) {
+      e.preventDefault();
+      // Zoom out the canvas you right-clicked, fall back to the other
+      const primary = hitKey === "offworker" ? offworkerZoomStack : workerZoomStack;
+      const fallback = hitKey === "offworker" ? workerZoomStack : offworkerZoomStack;
+      const stack = primary.length > 0 ? primary : fallback;
+      if (stack.length > 0) {
+        stack.pop();
+        renderAll();
+        onZoomChange();
+      }
+    }
+
     // Named handlers so destroy() can remove them
     function onWorkerMove(e) { canvasMouseMove(e, "worker"); }
     function onOffworkerMove(e) { canvasMouseMove(e, "offworker"); }
     function onWorkerClick(e) { canvasClick(e, "worker"); }
     function onOffworkerClick(e) { canvasClick(e, "offworker"); }
+    function onWorkerContext(e) { canvasContextMenu(e, "worker"); }
+    function onOffworkerContext(e) { canvasContextMenu(e, "offworker"); }
 
     workerCanvas.addEventListener("mousemove", onWorkerMove);
     offworkerCanvas.addEventListener("mousemove", onOffworkerMove);
@@ -383,6 +461,8 @@
     offworkerCanvas.addEventListener("mouseleave", canvasMouseLeave);
     workerCanvas.addEventListener("click", onWorkerClick);
     offworkerCanvas.addEventListener("click", onOffworkerClick);
+    workerCanvas.addEventListener("contextmenu", onWorkerContext);
+    offworkerCanvas.addEventListener("contextmenu", onOffworkerContext);
 
     function onKeyDown(e) {
       if (container.offsetHeight === 0) return;
@@ -397,14 +477,19 @@
     // Returns true if consumed (search cleared or zoom reset),
     // false if nothing to do (caller should close the panel).
     function handleEscape() {
+      if (helpOverlay.style.display !== "none") {
+        helpOverlay.style.display = "none";
+        return true;
+      }
       if (searchQuery) {
         searchInput.value = "";
         searchQuery = "";
+        searchClear.style.display = "none";
         renderAll();
         return true;
       }
       if (isZoomed()) {
-        resetZoom();
+        resetZoom(); // resetZoom already calls onZoomChange
         return true;
       }
       return false;
@@ -442,12 +527,39 @@
       offworkerCanvas.removeEventListener("mouseleave", canvasMouseLeave);
       workerCanvas.removeEventListener("click", onWorkerClick);
       offworkerCanvas.removeEventListener("click", onOffworkerClick);
+      workerCanvas.removeEventListener("contextmenu", onWorkerContext);
+      offworkerCanvas.removeEventListener("contextmenu", onOffworkerContext);
       searchInput.removeEventListener("input", onSearchInput);
       if (tooltip.parentNode) tooltip.parentNode.removeChild(tooltip);
       container.innerHTML = "";
     }
 
-    return { setData, resize, destroy, handleEscape, isZoomed };
+    function getZoomPath() {
+      return {
+        worker: workerZoomStack.map((n) => n.name),
+        offworker: offworkerZoomStack.map((n) => n.name),
+      };
+    }
+
+    // Walk the tree to find a child by name at each level, pushing onto zoom stack
+    function zoomToPath(key, names) {
+      const tree = key === "worker" ? workerTree : offworkerTree;
+      if (!tree || !names.length) return;
+      const stack = key === "worker" ? workerZoomStack : offworkerZoomStack;
+      let node = tree;
+      for (const name of names) {
+        let found = null;
+        for (const child of node.children.values()) {
+          if (child.name === name) { found = child; break; }
+        }
+        if (!found) break;
+        stack.push(found);
+        node = found;
+      }
+      if (stack.length > 0) renderAll();
+    }
+
+    return { setData, resize, destroy, handleEscape, isZoomed, getZoomPath, zoomToPath };
   }
 
   const fgExports = { createFlamegraph: createFlamegraph };

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -25,9 +25,16 @@
 
   // Like flattenFlamegraph in trace_analysis.js but attaches treeNode refs
   // for click-to-zoom. Filters out nodes < 0.1% of total.
-  function flattenFromNode(root, total) {
+  function flattenFromNode(root, total, includeRoot) {
     const nodes = [];
     let maxD = 0;
+    const startDepth = includeRoot ? 1 : 0;
+    if (includeRoot) {
+      nodes.push({
+        name: root.name, depth: 0, x: 0, w: 1,
+        count: root.count, self: root.self, treeNode: root,
+      });
+    }
     function walk(treeNode, depth, xStart) {
       const w = treeNode.count / total;
       if (w < 0.001) return;
@@ -55,7 +62,7 @@
     );
     let cx = 0;
     for (const child of kids) {
-      walk(child, 0, cx);
+      walk(child, startDepth, cx);
       cx += child.count / total;
     }
     return { nodes, maxDepth: maxD };
@@ -243,8 +250,9 @@
       const tree = key === "worker" ? workerTree : offworkerTree;
       const stack = key === "worker" ? workerZoomStack : offworkerZoomStack;
       if (!tree) return null;
-      const zoomNode = stack.length > 0 ? stack[stack.length - 1] : tree;
-      const flat = flattenFromNode(zoomNode, zoomNode.count);
+      const zoomed = stack.length > 0;
+      const zoomNode = zoomed ? stack[stack.length - 1] : tree;
+      const flat = flattenFromNode(zoomNode, zoomNode.count, zoomed);
       return {
         nodes: flat.nodes,
         maxDepth: flat.maxDepth,

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -1,0 +1,459 @@
+// flamegraph.js - Shared flamegraph rendering with zoom and search
+
+(function (exports) {
+  "use strict";
+
+  function getAnalysis() {
+    if (typeof require !== "undefined") return require("./trace_analysis.js");
+    if (typeof TraceAnalysis !== "undefined") return TraceAnalysis;
+    throw new Error(
+      "TraceAnalysis not found. Load trace_analysis.js before flamegraph.js"
+    );
+  }
+
+  const buildFlamegraphTree = getAnalysis().buildFlamegraphTree;
+  const FG_ROW_H = 18;
+
+  function flamegraphColor(name) {
+    let h = 0;
+    for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
+    const hue = 10 + (Math.abs(h) % 40);
+    const sat = 60 + (Math.abs(h >> 8) % 30);
+    const lit = 40 + (Math.abs(h >> 16) % 15);
+    return `hsl(${hue},${sat}%,${lit}%)`;
+  }
+
+  // Like flattenFlamegraph in trace_analysis.js but attaches treeNode refs
+  // for click-to-zoom. Filters out nodes < 0.1% of total.
+  function flattenFromNode(root, total) {
+    const nodes = [];
+    let maxD = 0;
+    function walk(treeNode, depth, xStart) {
+      const w = treeNode.count / total;
+      if (w < 0.001) return;
+      nodes.push({
+        name: treeNode.name,
+        depth,
+        x: xStart,
+        w,
+        count: treeNode.count,
+        self: treeNode.self,
+        treeNode,
+      });
+      if (depth > maxD) maxD = depth;
+      const kids = [...treeNode.children.values()].sort(
+        (a, b) => b.count - a.count
+      );
+      let cx = xStart;
+      for (const child of kids) {
+        walk(child, depth + 1, cx);
+        cx += child.count / total;
+      }
+    }
+    const kids = [...root.children.values()].sort(
+      (a, b) => b.count - a.count
+    );
+    let cx = 0;
+    for (const child of kids) {
+      walk(child, 0, cx);
+      cx += child.count / total;
+    }
+    return { nodes, maxDepth: maxD };
+  }
+
+  // Sum self-sample counts for frames whose name matches the query.
+  // Uses self (not inclusive count) to avoid double-counting in the percentage.
+  function countSearchMatches(root, queryLower) {
+    let matched = 0;
+    function walk(node) {
+      if (node.name.toLowerCase().includes(queryLower)) {
+        matched += node.self;
+      }
+      for (const child of node.children.values()) walk(child);
+    }
+    walk(root);
+    return matched;
+  }
+
+  function createFlamegraph(container) {
+    let workerTree = null;
+    let offworkerTree = null;
+    let workerData = null;
+    let offworkerData = null;
+    let workerZoomStack = [];
+    let offworkerZoomStack = [];
+    let searchQuery = "";
+    const hitRegions = { worker: [], offworker: [] };
+
+    // DOM
+    const searchBar = document.createElement("div");
+    searchBar.className = "fg-search-bar";
+    const isMac = /Mac|iPhone|iPad/.test(navigator.platform);
+    searchBar.innerHTML =
+      '<input type="text" class="fg-search-input" placeholder="Search frames... (' +
+      (isMac ? '\u2318' : 'Ctrl+') + 'F or /)" />' +
+      '<span class="fg-search-stats"></span>';
+    container.appendChild(searchBar);
+
+    const searchInput = searchBar.querySelector(".fg-search-input");
+    const searchStats = searchBar.querySelector(".fg-search-stats");
+
+    const breadcrumbBar = document.createElement("div");
+    breadcrumbBar.className = "fg-breadcrumb";
+    container.appendChild(breadcrumbBar);
+
+    const body = document.createElement("div");
+    body.className = "fg-body";
+    container.appendChild(body);
+
+    const workerLabel = document.createElement("div");
+    workerLabel.className = "fg-section-label";
+    workerLabel.textContent = "Worker threads";
+    body.appendChild(workerLabel);
+
+    const workerCanvas = document.createElement("canvas");
+    workerCanvas.className = "fg-canvas";
+    body.appendChild(workerCanvas);
+
+    const offworkerLabel = document.createElement("div");
+    offworkerLabel.className = "fg-section-label";
+    offworkerLabel.textContent = "Off-worker (sampler thread)";
+    body.appendChild(offworkerLabel);
+
+    const offworkerCanvas = document.createElement("canvas");
+    offworkerCanvas.className = "fg-canvas";
+    body.appendChild(offworkerCanvas);
+
+    const tooltip = document.createElement("div");
+    tooltip.className = "fg-tooltip";
+    document.body.appendChild(tooltip);
+
+    function renderCanvas(canvas, data, hitKey) {
+      if (!data) {
+        canvas.width = 0;
+        canvas.height = 0;
+        hitRegions[hitKey] = [];
+        return;
+      }
+      const dpr = devicePixelRatio || 1;
+      const pw = canvas.parentElement.clientWidth;
+      const ph = (data.maxDepth + 2) * FG_ROW_H + 8;
+      canvas.width = pw * dpr;
+      canvas.height = ph * dpr;
+      canvas.style.width = pw + "px";
+      canvas.style.height = ph + "px";
+      const ctx = canvas.getContext("2d");
+      ctx.scale(dpr, dpr);
+      ctx.fillStyle = "#1a1a2e";
+      ctx.fillRect(0, 0, pw, ph);
+
+      const regions = [];
+      const padL = 4, padR = 4, drawW = pw - padL - padR;
+      const baseY = ph - 4;
+      ctx.font = "11px monospace";
+      ctx.textBaseline = "middle";
+      const qLower = searchQuery.toLowerCase();
+      const searching = searchQuery.length > 0;
+
+      for (const node of data.nodes) {
+        const x = padL + node.x * drawW;
+        const w = node.w * drawW;
+        const y = baseY - (node.depth + 1) * FG_ROW_H;
+        if (w < 0.5) continue;
+
+        const matches = !searching || node.name.toLowerCase().includes(qLower);
+        ctx.globalAlpha = searching && !matches ? 0.25 : 1.0;
+        ctx.fillStyle = flamegraphColor(node.name);
+        ctx.fillRect(x, y, Math.max(w - 0.5, 0.5), FG_ROW_H - 1);
+        regions.push({ x1: x, x2: x + w, y, node, totalSamples: data.totalSamples });
+
+        if (w > 30) {
+          ctx.fillStyle = "#fff";
+          const label = node.name.length * 7 > w - 4
+            ? node.name.slice(0, Math.floor((w - 10) / 7)) + "\u2026"
+            : node.name;
+          ctx.save();
+          ctx.beginPath();
+          ctx.rect(x + 2, y, w - 4, FG_ROW_H);
+          ctx.clip();
+          ctx.fillText(label, x + 3, y + FG_ROW_H / 2);
+          ctx.restore();
+        }
+      }
+      ctx.globalAlpha = 1.0;
+      hitRegions[hitKey] = regions;
+    }
+
+    function rebuildData(key) {
+      const tree = key === "worker" ? workerTree : offworkerTree;
+      const stack = key === "worker" ? workerZoomStack : offworkerZoomStack;
+      if (!tree) return null;
+      const zoomNode = stack.length > 0 ? stack[stack.length - 1] : tree;
+      const flat = flattenFromNode(zoomNode, zoomNode.count);
+      return {
+        nodes: flat.nodes,
+        maxDepth: flat.maxDepth,
+        totalSamples: zoomNode.count,
+      };
+    }
+
+    function renderAll() {
+      workerData = rebuildData("worker");
+      offworkerData = rebuildData("offworker");
+
+      workerLabel.style.display = workerData ? "" : "none";
+      workerCanvas.style.display = workerData ? "" : "none";
+      offworkerLabel.style.display = offworkerData ? "" : "none";
+      offworkerCanvas.style.display = offworkerData ? "" : "none";
+
+      repaint();
+      renderBreadcrumb();
+    }
+
+    function repaint() {
+      renderCanvas(workerCanvas, workerData, "worker");
+      renderCanvas(offworkerCanvas, offworkerData, "offworker");
+      updateSearchStats();
+    }
+
+    function renderBreadcrumb() {
+      const wZoomed = workerZoomStack.length > 0;
+      const oZoomed = offworkerZoomStack.length > 0;
+      if (!wZoomed && !oZoomed) {
+        breadcrumbBar.style.display = "none";
+        return;
+      }
+      breadcrumbBar.style.display = "flex";
+      breadcrumbBar.innerHTML = "";
+
+      if (wZoomed) renderBreadcrumbFor("worker", workerZoomStack);
+      if (oZoomed) {
+        if (wZoomed) {
+          const sep = document.createElement("span");
+          sep.textContent = "  |  ";
+          sep.style.color = "#555";
+          breadcrumbBar.appendChild(sep);
+        }
+        renderBreadcrumbFor("offworker", offworkerZoomStack);
+      }
+    }
+
+    function renderBreadcrumbFor(key, stack) {
+      const rootSpan = document.createElement("span");
+      rootSpan.className = "fg-breadcrumb-item fg-breadcrumb-link";
+      rootSpan.textContent = "(all)";
+      rootSpan.addEventListener("click", () => {
+        if (key === "worker") workerZoomStack = [];
+        else offworkerZoomStack = [];
+        renderAll();
+      });
+      breadcrumbBar.appendChild(rootSpan);
+
+      for (let i = 0; i < stack.length; i++) {
+        const arrow = document.createElement("span");
+        arrow.className = "fg-breadcrumb-sep";
+        arrow.textContent = " \u203a ";
+        breadcrumbBar.appendChild(arrow);
+
+        const span = document.createElement("span");
+        const isLast = i === stack.length - 1;
+        span.className = "fg-breadcrumb-item" + (isLast ? "" : " fg-breadcrumb-link");
+        span.textContent = stack[i].name;
+        span.title = stack[i].name;
+        if (!isLast) {
+          const idx = i;
+          span.addEventListener("click", () => {
+            if (key === "worker") workerZoomStack = workerZoomStack.slice(0, idx + 1);
+            else offworkerZoomStack = offworkerZoomStack.slice(0, idx + 1);
+            renderAll();
+          });
+        }
+        breadcrumbBar.appendChild(span);
+      }
+    }
+
+    function updateSearchStats() {
+      if (!searchQuery) {
+        searchStats.textContent = "";
+        return;
+      }
+      const qLower = searchQuery.toLowerCase();
+      let matchedSelf = 0;
+      let totalSelf = 0;
+      if (workerTree) {
+        matchedSelf += countSearchMatches(workerTree, qLower);
+        totalSelf += workerTree.count;
+      }
+      if (offworkerTree) {
+        matchedSelf += countSearchMatches(offworkerTree, qLower);
+        totalSelf += offworkerTree.count;
+      }
+      if (totalSelf === 0) {
+        searchStats.textContent = "";
+        return;
+      }
+      const pct = ((matchedSelf / totalSelf) * 100).toFixed(1);
+      searchStats.textContent = `${pct}% self time (${matchedSelf} samples)`;
+    }
+
+    searchInput.addEventListener("input", onSearchInput);
+    function onSearchInput() {
+      searchQuery = searchInput.value;
+      repaint();
+    }
+
+    function zoomTo(key, treeNode) {
+      if (!treeNode || treeNode.children.size === 0) return;
+      if (key === "worker") workerZoomStack.push(treeNode);
+      else offworkerZoomStack.push(treeNode);
+      renderAll();
+    }
+
+    function resetZoom() {
+      workerZoomStack = [];
+      offworkerZoomStack = [];
+      renderAll();
+    }
+
+    function isZoomed() {
+      return workerZoomStack.length > 0 || offworkerZoomStack.length > 0;
+    }
+
+    function canvasMouseMove(e, hitKey) {
+      const c = e.target;
+      const rect = c.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const regions = hitRegions[hitKey] || [];
+      let hit = null;
+      for (let i = regions.length - 1; i >= 0; i--) {
+        const r = regions[i];
+        if (mx >= r.x1 && mx <= r.x2 && my >= r.y && my < r.y + FG_ROW_H) {
+          hit = r;
+          break;
+        }
+      }
+      if (hit) {
+        const total = hit.totalSamples;
+        const pct = ((hit.node.count / total) * 100).toFixed(1);
+        const selfPct = ((hit.node.self / total) * 100).toFixed(1);
+        const nameElt = document.createElement("b");
+        nameElt.innerText = hit.node.name;
+        tooltip.innerHTML = `${nameElt.outerHTML}<br>${hit.node.count} samples (${pct}%) \u00b7 ${hit.node.self} self (${selfPct}%)`;
+        tooltip.style.display = "block";
+        tooltip.style.left = Math.min(e.clientX + 12, window.innerWidth - 620) + "px";
+        tooltip.style.top = (e.clientY - 50) + "px";
+        c.style.cursor = "pointer";
+      } else {
+        tooltip.style.display = "none";
+        c.style.cursor = "";
+      }
+    }
+
+    function canvasMouseLeave() {
+      tooltip.style.display = "none";
+    }
+
+    function canvasClick(e, hitKey) {
+      const c = e.target;
+      const rect = c.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const regions = hitRegions[hitKey] || [];
+      for (let i = regions.length - 1; i >= 0; i--) {
+        const r = regions[i];
+        if (mx >= r.x1 && mx <= r.x2 && my >= r.y && my < r.y + FG_ROW_H) {
+          if (r.node.treeNode && r.node.treeNode.children.size > 0) {
+            zoomTo(hitKey, r.node.treeNode);
+          }
+          break;
+        }
+      }
+    }
+
+    // Named handlers so destroy() can remove them
+    function onWorkerMove(e) { canvasMouseMove(e, "worker"); }
+    function onOffworkerMove(e) { canvasMouseMove(e, "offworker"); }
+    function onWorkerClick(e) { canvasClick(e, "worker"); }
+    function onOffworkerClick(e) { canvasClick(e, "offworker"); }
+
+    workerCanvas.addEventListener("mousemove", onWorkerMove);
+    offworkerCanvas.addEventListener("mousemove", onOffworkerMove);
+    workerCanvas.addEventListener("mouseleave", canvasMouseLeave);
+    offworkerCanvas.addEventListener("mouseleave", canvasMouseLeave);
+    workerCanvas.addEventListener("click", onWorkerClick);
+    offworkerCanvas.addEventListener("click", onOffworkerClick);
+
+    function onKeyDown(e) {
+      if (container.offsetHeight === 0) return;
+      if (((e.ctrlKey || e.metaKey) && e.key === "f") || (e.key === "/" && document.activeElement !== searchInput)) {
+        e.preventDefault();
+        searchInput.focus();
+        searchInput.select();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+
+    // Returns true if consumed (search cleared or zoom reset),
+    // false if nothing to do (caller should close the panel).
+    function handleEscape() {
+      if (searchQuery) {
+        searchInput.value = "";
+        searchQuery = "";
+        renderAll();
+        return true;
+      }
+      if (isZoomed()) {
+        resetZoom();
+        return true;
+      }
+      return false;
+    }
+
+    function setData(workerSamples, offworkerSamples, callframeSymbols) {
+      workerTree = workerSamples.length > 0
+        ? buildFlamegraphTree(workerSamples, callframeSymbols)
+        : null;
+      offworkerTree = offworkerSamples.length > 0
+        ? buildFlamegraphTree(offworkerSamples, callframeSymbols)
+        : null;
+
+      workerZoomStack = [];
+      offworkerZoomStack = [];
+
+      workerLabel.textContent =
+        `Worker threads \u2014 ${workerSamples.length} samples`;
+      offworkerLabel.textContent =
+        `Off-worker (sampler thread) \u2014 ${offworkerSamples.length} samples`;
+
+      renderAll();
+    }
+
+    function resize() {
+      renderCanvas(workerCanvas, workerData, "worker");
+      renderCanvas(offworkerCanvas, offworkerData, "offworker");
+    }
+
+    function destroy() {
+      document.removeEventListener("keydown", onKeyDown);
+      workerCanvas.removeEventListener("mousemove", onWorkerMove);
+      offworkerCanvas.removeEventListener("mousemove", onOffworkerMove);
+      workerCanvas.removeEventListener("mouseleave", canvasMouseLeave);
+      offworkerCanvas.removeEventListener("mouseleave", canvasMouseLeave);
+      workerCanvas.removeEventListener("click", onWorkerClick);
+      offworkerCanvas.removeEventListener("click", onOffworkerClick);
+      searchInput.removeEventListener("input", onSearchInput);
+      if (tooltip.parentNode) tooltip.parentNode.removeChild(tooltip);
+      container.innerHTML = "";
+    }
+
+    return { setData, resize, destroy, handleEscape, isZoomed };
+  }
+
+  const fgExports = { createFlamegraph: createFlamegraph };
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = fgExports;
+  } else {
+    exports.FlamegraphRenderer = fgExports;
+  }
+})(typeof exports === "undefined" ? this : exports);

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -61,18 +61,26 @@
     return { nodes, maxDepth: maxD };
   }
 
-  // Sum self-sample counts for frames whose name matches the query.
-  // Uses self (not inclusive count) to avoid double-counting in the percentage.
+  // Count matching frames and their self-samples for search stats.
   function countSearchMatches(root, queryLower) {
-    let matched = 0;
+    let selfCount = 0;
+    let frameCount = 0;
     function walk(node) {
       if (node.name.toLowerCase().includes(queryLower)) {
-        matched += node.self;
+        selfCount += node.self;
+        frameCount++;
       }
       for (const child of node.children.values()) walk(child);
     }
     walk(root);
-    return matched;
+    return { selfCount, frameCount };
+  }
+
+  function filterCpuSamples(cpuSamples, startNs, endNs) {
+    let out = cpuSamples.filter((s) => s.callchain.length > 0 && s.source !== 1);
+    if (startNs != null) out = out.filter((s) => s.timestamp >= startNs);
+    if (endNs != null) out = out.filter((s) => s.timestamp <= endNs);
+    return out;
   }
 
   function createFlamegraph(container, onZoomChange) {
@@ -86,6 +94,8 @@
     let searchQuery = "";
     let highlightName = null;
     let repaintQueued = false;
+    let allSamples = [];
+    let currentSymbols = null;
     const hitRegions = { worker: [], offworker: [] };
 
     // DOM
@@ -97,12 +107,14 @@
       (isMac ? '\u2318' : 'Ctrl+') + 'F or /)" />' +
       '<span class="fg-search-clear" title="Clear search">\u00d7</span>' +
       '<span class="fg-search-stats"></span>' +
+      '<select class="fg-spawn-filter"></select>' +
       '<span class="fg-help-btn" tabindex="0" role="button" title="Keyboard shortcuts">i</span>';
     container.appendChild(searchBar);
 
     const searchInput = searchBar.querySelector(".fg-search-input");
     const searchClear = searchBar.querySelector(".fg-search-clear");
     const searchStats = searchBar.querySelector(".fg-search-stats");
+    const spawnFilter = searchBar.querySelector(".fg-spawn-filter");
     const helpBtn = searchBar.querySelector(".fg-help-btn");
 
     const helpOverlay = document.createElement("div");
@@ -324,21 +336,32 @@
       }
       const qLower = searchQuery.toLowerCase();
       let matchedSelf = 0;
+      let matchedFrames = 0;
       let totalSelf = 0;
-      if (workerTree) {
-        matchedSelf += countSearchMatches(workerTree, qLower);
-        totalSelf += workerTree.count;
+      const wRoot = workerZoomStack.length > 0 ? workerZoomStack[workerZoomStack.length - 1] : workerTree;
+      const oRoot = offworkerZoomStack.length > 0 ? offworkerZoomStack[offworkerZoomStack.length - 1] : offworkerTree;
+      if (wRoot) {
+        const m = countSearchMatches(wRoot, qLower);
+        matchedSelf += m.selfCount;
+        matchedFrames += m.frameCount;
+        totalSelf += wRoot.count;
       }
-      if (offworkerTree) {
-        matchedSelf += countSearchMatches(offworkerTree, qLower);
-        totalSelf += offworkerTree.count;
+      if (oRoot) {
+        const m = countSearchMatches(oRoot, qLower);
+        matchedSelf += m.selfCount;
+        matchedFrames += m.frameCount;
+        totalSelf += oRoot.count;
       }
-      if (totalSelf === 0) {
-        searchStats.textContent = "";
+      if (matchedFrames === 0) {
+        searchStats.textContent = "no matches";
         return;
       }
-      const pct = ((matchedSelf / totalSelf) * 100).toFixed(1);
-      searchStats.textContent = `${pct}% self time (${matchedSelf} samples)`;
+      let text = matchedFrames + (matchedFrames === 1 ? " frame" : " frames");
+      if (matchedSelf > 0 && totalSelf > 0) {
+        const pct = ((matchedSelf / totalSelf) * 100).toFixed(1);
+        text += ` \u00b7 ${pct}% of samples`;
+      }
+      searchStats.textContent = text;
     }
 
     searchInput.addEventListener("input", onSearchInput);
@@ -495,12 +518,20 @@
       return false;
     }
 
-    function setData(workerSamples, offworkerSamples, callframeSymbols) {
+    function applySpawnFilter() {
+      const filterVal = spawnFilter.value;
+      const samples = filterVal
+        ? allSamples.filter((s) => (s.spawnLoc || "(unknown)") === filterVal)
+        : allSamples;
+
+      const workerSamples = samples.filter((s) => s.workerId !== 255);
+      const offworkerSamples = samples.filter((s) => s.workerId === 255);
+
       workerTree = workerSamples.length > 0
-        ? buildFlamegraphTree(workerSamples, callframeSymbols)
+        ? buildFlamegraphTree(workerSamples, currentSymbols)
         : null;
       offworkerTree = offworkerSamples.length > 0
-        ? buildFlamegraphTree(offworkerSamples, callframeSymbols)
+        ? buildFlamegraphTree(offworkerSamples, currentSymbols)
         : null;
 
       workerZoomStack = [];
@@ -512,6 +543,32 @@
         `Off-worker (sampler thread) \u2014 ${offworkerSamples.length} samples`;
 
       renderAll();
+    }
+
+    spawnFilter.addEventListener("change", applySpawnFilter);
+
+    function setData(samples, callframeSymbols) {
+      allSamples = samples;
+      currentSymbols = callframeSymbols;
+
+      // Build spawn location dropdown
+      const locCounts = new Map();
+      for (const s of samples) {
+        const loc = s.spawnLoc || "(unknown)";
+        locCounts.set(loc, (locCounts.get(loc) || 0) + 1);
+      }
+      spawnFilter.innerHTML = '<option value="">All tasks (' + samples.length + ' samples)</option>';
+      const sorted = [...locCounts.entries()].sort((a, b) => b[1] - a[1]);
+      for (const [loc, count] of sorted) {
+        const short = loc.replace(/.*\//, "");
+        const opt = document.createElement("option");
+        opt.value = loc;
+        opt.textContent = short + " (" + count + ")";
+        opt.title = loc;
+        spawnFilter.appendChild(opt);
+      }
+
+      applySpawnFilter();
     }
 
     function resize() {
@@ -562,7 +619,7 @@
     return { setData, resize, destroy, handleEscape, isZoomed, getZoomPath, zoomToPath };
   }
 
-  const fgExports = { createFlamegraph: createFlamegraph };
+  const fgExports = { createFlamegraph: createFlamegraph, filterCpuSamples: filterCpuSamples };
   if (typeof module !== "undefined" && module.exports) {
     module.exports = fgExports;
   } else {

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -598,22 +598,34 @@
       };
     }
 
-    // Walk the tree to find a child by name at each level, pushing onto zoom stack
+    // Find a node by name anywhere in the tree via DFS, return path from root.
+    function findNodePath(tree, name) {
+      const path = [];
+      function dfs(node) {
+        path.push(node);
+        if (node.name === name) return true;
+        for (const child of node.children.values()) {
+          if (dfs(child)) return true;
+        }
+        path.pop();
+        return false;
+      }
+      for (const child of tree.children.values()) {
+        if (dfs(child)) return path;
+      }
+      return null;
+    }
+
     function zoomToPath(key, names) {
       const tree = key === "worker" ? workerTree : offworkerTree;
       if (!tree || !names.length) return;
       const stack = key === "worker" ? workerZoomStack : offworkerZoomStack;
-      let node = tree;
-      for (const name of names) {
-        let found = null;
-        for (const child of node.children.values()) {
-          if (child.name === name) { found = child; break; }
-        }
-        if (!found) break;
-        stack.push(found);
-        node = found;
+      const target = names[names.length - 1];
+      const path = findNodePath(tree, target);
+      if (path) {
+        stack.push.apply(stack, path);
+        renderAll();
       }
-      if (stack.length > 0) renderAll();
     }
 
     return { setData, resize, destroy, handleEscape, isZoomed, getZoomPath, zoomToPath };

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -111,7 +111,7 @@
     const isMac = /Mac|iPhone|iPad/.test(navigator.platform);
     searchBar.innerHTML =
       '<input type="text" class="fg-search-input" placeholder="Search frames... (' +
-      (isMac ? '\u2318' : 'Ctrl+') + 'F or /)" />' +
+      (isMac ? '\u2318' : 'Ctrl') + ' + F or /)" />' +
       '<span class="fg-search-clear" title="Clear search">\u00d7</span>' +
       '<span class="fg-search-stats"></span>' +
       '<select class="fg-spawn-filter"></select>' +
@@ -131,9 +131,11 @@
       '<h3>\u2328 Flamegraph Shortcuts</h3>' +
       '<table>' +
       '<tr><td class="fg-help-key">Click</td><td>Zoom into frame</td></tr>' +
+      '<tr><td class="fg-help-key">Option / Alt + click</td><td>Pin tooltip (selectable text, links)</td></tr>' +
+      '<tr><td class="fg-help-key">' + (isMac ? '\u2318' : 'Ctrl') + ' + click</td><td>Open docs.rs (when available)</td></tr>' +
       '<tr><td class="fg-help-key">Right-click</td><td>Zoom out one level</td></tr>' +
-      '<tr><td class="fg-help-key">' + (isMac ? '\u2318' : 'Ctrl+') + 'F or /</td><td>Search frames</td></tr>' +
-      '<tr><td class="fg-help-key">Esc</td><td>Clear search \u2192 reset zoom \u2192 close</td></tr>' +
+      '<tr><td class="fg-help-key">' + (isMac ? '\u2318' : 'Ctrl') + ' + F or /</td><td>Search frames</td></tr>' +
+      '<tr><td class="fg-help-key">Esc</td><td>Unpin \u2192 clear search \u2192 reset zoom \u2192 close</td></tr>' +
       '</table>' +
       '<div class="fg-help-dismiss">Press Esc or click outside to close</div>' +
       '</div>';
@@ -398,20 +400,108 @@
       return workerZoomStack.length > 0 || offworkerZoomStack.length > 0;
     }
 
-    function canvasMouseMove(e, hitKey) {
+    let tooltipPinned = false;
+
+    function hitTest(e) {
       const c = e.target;
       const rect = c.getBoundingClientRect();
       const mx = e.clientX - rect.left;
       const my = e.clientY - rect.top;
-      const regions = hitRegions[hitKey] || [];
-      let hit = null;
+      const key = c === workerCanvas ? "worker" : "offworker";
+      const regions = hitRegions[key] || [];
       for (let i = regions.length - 1; i >= 0; i--) {
         const r = regions[i];
         if (mx >= r.x1 && mx <= r.x2 && my >= r.y && my < r.y + FG_ROW_H) {
-          hit = r;
-          break;
+          return { hit: r, hitKey: key };
         }
       }
+      return { hit: null, hitKey: key };
+    }
+
+    function buildTooltipHtml(hit, pinned) {
+      const node = hit.node;
+      const tn = node.treeNode || {};
+      const total = hit.totalSamples || 1;
+      const pct = ((node.count / total) * 100).toFixed(1);
+      const selfPct = ((node.self / total) * 100).toFixed(1);
+      const nameElt = document.createElement("b");
+      nameElt.innerText = node.name;
+      let h = nameElt.outerHTML;
+      if (tn.fullName && tn.fullName !== node.name) {
+        const fullElt = document.createElement("span");
+        fullElt.innerText = tn.fullName;
+        h += '<br><span style="color:#aaa">' + fullElt.innerHTML + '</span>';
+      }
+      if (tn.location) {
+        const locShort = tn.location.replace(/^.*\/([^/]+(?::\d+)?)$/, "$1");
+        const hasFullPath = tn.location !== locShort;
+        if (hasFullPath) {
+          const locEsc = document.createElement("span");
+          locEsc.innerText = tn.location;
+          h += '<br><span class="fg-loc-toggle" style="color:#888;cursor:pointer">' +
+            locShort + ' <span style="color:#555">\u25b6</span></span>' +
+            '<span class="fg-loc-full" style="color:#888;display:none;overflow-wrap:anywhere">' +
+            locEsc.innerHTML + '</span>';
+        } else {
+          h += '<br><span style="color:#888">' + locShort + '</span>';
+        }
+      }
+      h += '<br>' + node.count + ' samples (' + pct + '%) \u00b7 ' + node.self + ' self (' + selfPct + '%)';
+      if (pinned && tn.docsUrl) {
+        h += '<br><a href="' + tn.docsUrl + '" target="_blank" rel="noopener" style="color:#6c63ff;text-decoration:underline">docs.rs \u2197</a>';
+      } else if (tn.docsUrl) {
+        h += '<br><span style="color:#6c63ff">docs.rs \u2197</span>' +
+          '<span style="color:#555"> (' + (isMac ? '\u2318' : 'Ctrl') + ' + click)</span>';
+      }
+      if (!pinned) {
+        h += '<br><span style="color:#555">' + (isMac ? '\u2325' : 'Alt') + ' + click to pin</span>';
+      }
+      return h;
+    }
+
+    function showTooltip(hit, x, y, pinned) {
+      tooltip.innerHTML = buildTooltipHtml(hit, pinned);
+      tooltip.style.pointerEvents = pinned ? "auto" : "none";
+      tooltip.style.display = "block";
+      // Clamp to viewport
+      const tipX = Math.min(x + 12, window.innerWidth - tooltip.offsetWidth - 8);
+      let tipY = Math.max(8, y - 50);
+      if (tipY + tooltip.offsetHeight > window.innerHeight - 8) {
+        tipY = window.innerHeight - tooltip.offsetHeight - 8;
+      }
+      tooltip.style.left = tipX + "px";
+      tooltip.style.top = tipY + "px";
+      if (pinned) {
+        // Wire up expandable location
+        const toggle = tooltip.querySelector(".fg-loc-toggle");
+        const full = tooltip.querySelector(".fg-loc-full");
+        if (toggle && full) {
+          const tn = hit.node.treeNode || {};
+          toggle.addEventListener("click", function () {
+            if (full.style.display === "none") {
+              full.textContent = tn.location;
+              full.style.display = "block";
+              toggle.querySelector("span").textContent = "\u25bc";
+            } else {
+              full.style.display = "none";
+              toggle.querySelector("span").textContent = "\u25b6";
+            }
+          });
+        }
+      }
+    }
+
+    function unpinTooltip() {
+      if (tooltipPinned) {
+        tooltipPinned = false;
+        tooltip.style.display = "none";
+        tooltip.style.pointerEvents = "none";
+      }
+    }
+
+    function canvasMouseMove(e) {
+      if (tooltipPinned) return;
+      const { hit } = hitTest(e);
       const newHighlight = hit ? hit.node.name : null;
       if (newHighlight !== highlightName) {
         highlightName = newHighlight;
@@ -421,24 +511,16 @@
         }
       }
       if (hit) {
-        const total = hit.totalSamples;
-        const pct = ((hit.node.count / total) * 100).toFixed(1);
-        const selfPct = ((hit.node.self / total) * 100).toFixed(1);
-        const nameElt = document.createElement("b");
-        nameElt.innerText = hit.node.name;
-        tooltip.innerHTML = `${nameElt.outerHTML}<br>${hit.node.count} samples (${pct}%) \u00b7 ${hit.node.self} self (${selfPct}%)`;
-        tooltip.style.display = "block";
-        tooltip.style.left = Math.min(e.clientX + 12, window.innerWidth - 620) + "px";
-        tooltip.style.top = (e.clientY - 50) + "px";
-        c.style.cursor = "pointer";
+        showTooltip(hit, e.clientX, e.clientY, false);
+        e.target.style.cursor = "pointer";
       } else {
         tooltip.style.display = "none";
-        c.style.cursor = "";
+        e.target.style.cursor = "";
       }
     }
 
     function canvasMouseLeave() {
-      tooltip.style.display = "none";
+      if (!tooltipPinned) tooltip.style.display = "none";
       if (highlightName !== null) {
         highlightName = null;
         if (!repaintQueued) {
@@ -449,18 +531,19 @@
     }
 
     function canvasClick(e, hitKey) {
-      const c = e.target;
-      const rect = c.getBoundingClientRect();
-      const mx = e.clientX - rect.left;
-      const my = e.clientY - rect.top;
-      const regions = hitRegions[hitKey] || [];
-      for (let i = regions.length - 1; i >= 0; i--) {
-        const r = regions[i];
-        if (mx >= r.x1 && mx <= r.x2 && my >= r.y && my < r.y + FG_ROW_H) {
-          if (r.node.treeNode && r.node.treeNode.children.size > 0) {
-            zoomTo(hitKey, r.node.treeNode);
-          }
-          break;
+      const { hit } = hitTest(e);
+      if (!hit) { unpinTooltip(); return; }
+      const tn = hit.node.treeNode || {};
+      if ((e.metaKey || e.ctrlKey) && tn.docsUrl) {
+        const w = window.open(tn.docsUrl, "_blank");
+        if (w) w.focus();
+      } else if (e.altKey) {
+        tooltipPinned = true;
+        showTooltip(hit, e.clientX, e.clientY, true);
+      } else {
+        unpinTooltip();
+        if (tn.children && tn.children.size > 0) {
+          zoomTo(hitKey, tn);
         }
       }
     }
@@ -479,8 +562,8 @@
     }
 
     // Named handlers so destroy() can remove them
-    function onWorkerMove(e) { canvasMouseMove(e, "worker"); }
-    function onOffworkerMove(e) { canvasMouseMove(e, "offworker"); }
+    function onWorkerMove(e) { canvasMouseMove(e); }
+    function onOffworkerMove(e) { canvasMouseMove(e); }
     function onWorkerClick(e) { canvasClick(e, "worker"); }
     function onOffworkerClick(e) { canvasClick(e, "offworker"); }
     function onWorkerContext(e) { canvasContextMenu(e, "worker"); }
@@ -505,9 +588,21 @@
     }
     document.addEventListener("keydown", onKeyDown);
 
+    function onDocClick(e) {
+      if (tooltipPinned && !tooltip.contains(e.target) &&
+          e.target !== workerCanvas && e.target !== offworkerCanvas) {
+        unpinTooltip();
+      }
+    }
+    document.addEventListener("click", onDocClick);
+
     // Returns true if consumed (search cleared or zoom reset),
     // false if nothing to do (caller should close the panel).
     function handleEscape() {
+      if (tooltipPinned) {
+        unpinTooltip();
+        return true;
+      }
       if (helpOverlay.style.display !== "none") {
         helpOverlay.style.display = "none";
         return true;
@@ -586,6 +681,7 @@
 
     function destroy() {
       document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("click", onDocClick);
       workerCanvas.removeEventListener("mousemove", onWorkerMove);
       offworkerCanvas.removeEventListener("mousemove", onOffworkerMove);
       workerCanvas.removeEventListener("mouseleave", canvasMouseLeave);
@@ -604,8 +700,8 @@
         if (!tree || stack.length === 0) return [];
         // If stack already has the full path (from zoomToPath restore), use it directly.
         // Otherwise find the path from root to the zoom target.
-        var target = stack[stack.length - 1];
-        var path = findNodePath(tree, target.name);
+        const target = stack[stack.length - 1];
+        const path = findNodePath(tree, target.name);
         return path ? path.map((n) => n.name) : stack.map((n) => n.name);
       }
       return {

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -414,11 +414,15 @@
       node.count++;
       for (const addr of chain) {
         const entry = callframeSymbols.get(addr);
-        const key = entry ? entry.symbol : addr || "??";
-        const name = formatFrame(addr, callframeSymbols).text;
+        const resolved = Array.isArray(entry) ? entry[0] : entry;
+        const key = resolved ? resolved.symbol : addr || "??";
+        const formatted = formatFrame(addr, callframeSymbols);
         if (!node.children.has(key)) {
           node.children.set(key, {
-            name,
+            name: formatted.text,
+            fullName: key,
+            location: resolved ? resolved.location : null,
+            docsUrl: formatted.docsUrl,
             children: new Map(),
             count: 0,
             self: 0,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -3693,7 +3693,10 @@
                     showToast("popout-no-url", "Pop-out requires a loaded trace", "error", 3000);
                     return;
                 }
-                const url = `flamegraph.html?trace=${encodeURIComponent(traceUrl)}&start=${Math.round(fgSelStart)}&end=${Math.round(fgSelEnd)}`;
+                let url = `flamegraph.html?trace=${encodeURIComponent(traceUrl)}&start=${Math.round(fgSelStart)}&end=${Math.round(fgSelEnd)}`;
+                const z = fgInstance.getZoomPath();
+                if (z.worker.length > 0) url += `&worker-zoom=${encodeURIComponent(z.worker.join("\t"))}`;
+                if (z.offworker.length > 0) url += `&offworker-zoom=${encodeURIComponent(z.offworker.join("\t"))}`;
                 window.open(url, "_blank");
                 if (isBlobUrl) {
                     showToast("popout-blob", "Pop-out linked to this tab \u2014 keep it open", "info", 5000);

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Tokio Trace Viewer</title>
+        <link rel="stylesheet" href="flamegraph.css" />
         <style>
             * {
                 margin: 0;
@@ -346,30 +347,10 @@
             }
             #flamegraph-panel .fg-header .fg-title { color: #6c63ff; font-weight: 600; }
             #flamegraph-panel .fg-header .fg-stats { color: #888; }
+            #flamegraph-panel .fg-header .fg-popout { cursor: pointer; color: #888; padding: 0 4px; }
+            #flamegraph-panel .fg-header .fg-popout:hover { color: #fff; }
             #flamegraph-panel .fg-header .fg-close { cursor: pointer; color: #888; margin-left: auto; padding: 0 4px; }
             #flamegraph-panel .fg-header .fg-close:hover { color: #fff; }
-            .fg-section-label {
-                padding: 4px 12px;
-                font-size: 0.78em;
-                color: #aaa;
-                background: #16213e;
-                border-bottom: 1px solid #222;
-                flex-shrink: 0;
-            }
-            #fg-tooltip {
-                display: none;
-                position: fixed;
-                background: #222244;
-                border: 1px solid #555;
-                padding: 6px 10px;
-                border-radius: 4px;
-                font-size: 0.78em;
-                pointer-events: none;
-                z-index: 200;
-                max-width: 600px;
-                white-space: nowrap;
-                color: #e0e0e0;
-            }
             @keyframes toast-in {
                 from { opacity: 0; transform: translateY(-8px); }
                 to { opacity: 1; transform: translateY(0); }
@@ -537,14 +518,10 @@
                         <span class="fg-title" id="fg-title">Flamegraph</span>
                         <span class="fg-stats" id="fg-stats"></span>
                         <select id="fg-spawn-filter" style="background:#2a2a4a;border:1px solid #444;color:#ccc;padding:3px 6px;border-radius:4px;font-size:0.9em;max-width:350px"></select>
-                        <span class="fg-close" id="fg-close" tabindex="0" role="button">✕ Close (Esc)</span>
+                        <span class="fg-popout" id="fg-popout" tabindex="0" role="button" title="Open in new tab">&#8599; Pop Out</span>
+                        <span class="fg-close" id="fg-close" tabindex="0" role="button">&#10005; Close (Esc)</span>
                     </div>
-                    <div style="flex:1;overflow-y:auto;display:flex;flex-direction:column">
-                        <div class="fg-section-label" id="fg-worker-label">Worker threads</div>
-                        <canvas id="fg-canvas-worker"></canvas>
-                        <div class="fg-section-label" id="fg-offworker-label">Off-worker (sampler thread)</div>
-                        <canvas id="fg-canvas-offworker"></canvas>
-                    </div>
+                    <div id="fg-container" style="flex:1;display:flex;flex-direction:column;overflow:hidden"></div>
                 </div>
                 <div id="sched-panel" style="display:none;position:absolute;top:0;left:0;right:0;bottom:0;background:#1a1a2e;z-index:50;flex-direction:column">
                     <div style="display:flex;align-items:center;gap:12px;padding:6px 12px;background:#16213e;border-bottom:1px solid #333;font-size:0.8em;flex-shrink:0">
@@ -563,7 +540,6 @@
         </div>
 
         <div id="tooltip"></div>
-        <div id="fg-tooltip"></div>
         <div id="stack-popup" style="display:none;position:fixed;background:#1a1a2e;border:1px solid #6c63ff;border-radius:8px;padding:12px 16px;z-index:200;max-width:800px;max-height:600px;overflow-y:auto;font-size:0.8em;line-height:1.6;box-shadow:0 4px 20px rgba(0,0,0,0.5)">
             <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
                 <span id="stack-popup-title" style="color:#6c63ff;font-weight:600"></span>
@@ -600,9 +576,10 @@
         <script src="trace_parser.js"></script>
         <script src="trace_analysis.js"></script>
         <script src="format.js"></script>
+        <script src="flamegraph.js"></script>
         <script>
             const { EVENT_TYPES: ET, parseTrace, formatFrame, symbolizeChain, deduplicateSamples } = TraceParser;
-            const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline, computeSchedulingDelays, filterPointsOfInterest, buildFlamegraphTree, flattenFlamegraph, buildFgData, buildSpanData } = TraceAnalysis;
+            const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline, computeSchedulingDelays, filterPointsOfInterest, buildSpanData } = TraceAnalysis;
 
             function esc(s) {
                 return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -3317,8 +3294,10 @@
                         if (document.getElementById("sched-panel").style.display === "flex") {
                             document.getElementById("sched-panel").style.display = "none";
                         } else if (document.getElementById("flamegraph-panel").style.display === "flex") {
-                            document.getElementById("flamegraph-panel").style.display = "none";
-                            document.getElementById("fg-tooltip").style.display = "none";
+                            // Let the flamegraph module handle Escape first (search clear / zoom reset)
+                            if (!fgInstance.handleEscape()) {
+                                document.getElementById("flamegraph-panel").style.display = "none";
+                            }
                         }
                         selectedTaskId = null;
                         document.getElementById("main-area").focus();
@@ -3641,15 +3620,11 @@
             })();
 
             // ── Flamegraph ──
-            let fgWorkerData = null;    // {nodes, maxDepth, totalSamples}
-            let fgOffworkerData = null; // same shape, for worker 255
-            const FG_ROW_H = 18;
-            // Per-canvas hit regions
-            let fgHitRegions = { worker: [], offworker: [] };
-            // Raw samples for current flamegraph (for re-filtering)
             let fgAllSamples = [];
-
-            // buildFlamegraphTree, flattenFlamegraph, buildFgData imported from TraceParser
+            let fgSelStart = 0, fgSelEnd = 0;
+            const fgInstance = FlamegraphRenderer.createFlamegraph(
+                document.getElementById("fg-container")
+            );
 
             // Selection picker: shown after shift+drag when both flamegraph and sched data exist
             function showSelectionPicker(selStart, selEnd) {
@@ -3693,20 +3668,21 @@
                 }
 
                 fgAllSamples = allSamples;
+                fgSelStart = selStart;
+                fgSelEnd = selEnd;
                 const durMs = ((selEnd - selStart) / 1e6).toFixed(2);
                 document.getElementById("fg-title").textContent = "Flamegraph";
                 document.getElementById("fg-stats").textContent =
-                    `${allSamples.length} samples · ${durMs}ms selected`;
+                    `${allSamples.length} samples \u00b7 ${durMs}ms selected`;
 
                 // Build spawn location dropdown
-                const locCounts = new Map(); // spawnLoc → count
+                const locCounts = new Map();
                 for (const s of allSamples) {
                     const loc = s.spawnLoc || "(unknown)";
                     locCounts.set(loc, (locCounts.get(loc) || 0) + 1);
                 }
                 const sel = document.getElementById("fg-spawn-filter");
                 sel.innerHTML = `<option value="">All tasks (${allSamples.length} samples)</option>`;
-                // Sort by count descending
                 const sorted = [...locCounts.entries()].sort((a, b) => b[1] - a[1]);
                 for (const [loc, count] of sorted) {
                     const short = loc.replace(/.*\//, '');
@@ -3731,129 +3707,33 @@
 
                 const workerSamples = samples.filter(s => s.workerId !== 255);
                 const offworkerSamples = samples.filter(s => s.workerId === 255);
-
-                fgWorkerData = buildFgData(workerSamples, trace.callframeSymbols);
-                fgOffworkerData = buildFgData(offworkerSamples, trace.callframeSymbols);
-
-                document.getElementById("fg-worker-label").textContent =
-                    `Worker threads — ${workerSamples.length} samples`;
-                document.getElementById("fg-worker-label").style.display = fgWorkerData ? "" : "none";
-                document.getElementById("fg-canvas-worker").style.display = fgWorkerData ? "" : "none";
-
-                const offLabel = document.getElementById("fg-offworker-label");
-                offLabel.textContent =
-                    `Off-worker (sampler thread) — ${offworkerSamples.length} samples`;
-                offLabel.style.display = fgOffworkerData ? "" : "none";
-                document.getElementById("fg-canvas-offworker").style.display = fgOffworkerData ? "" : "none";
-
-                renderFlamegraph();
+                fgInstance.setData(workerSamples, offworkerSamples, trace.callframeSymbols);
             }
 
             document.getElementById("fg-spawn-filter").addEventListener("change", applyFgFilter);
 
-            function flamegraphColor(name) {
-                let h = 0;
-                for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
-                const hue = 10 + (Math.abs(h) % 40);
-                const sat = 60 + (Math.abs(h >> 8) % 30);
-                const lit = 40 + (Math.abs(h >> 16) % 15);
-                return `hsl(${hue},${sat}%,${lit}%)`;
-            }
-
-            function renderFgCanvas(canvasId, data, hitKey) {
-                const c = document.getElementById(canvasId);
-                if (!data) { c.width = 0; c.height = 0; fgHitRegions[hitKey] = []; return; }
-                const dpr = devicePixelRatio || 1;
-                const pw = c.parentElement.clientWidth;
-                const ph = (data.maxDepth + 2) * FG_ROW_H + 8;
-                c.width = pw * dpr;
-                c.height = ph * dpr;
-                c.style.width = pw + "px";
-                c.style.height = ph + "px";
-                const ctx = c.getContext("2d");
-                ctx.scale(dpr, dpr);
-                ctx.fillStyle = "#1a1a2e";
-                ctx.fillRect(0, 0, pw, ph);
-
-                const regions = [];
-                const padL = 4, padR = 4, drawW = pw - padL - padR;
-                const baseY = ph - 4;
-                ctx.font = "11px monospace";
-                ctx.textBaseline = "middle";
-                for (const node of data.nodes) {
-                    const x = padL + node.x * drawW;
-                    const w = node.w * drawW;
-                    const y = baseY - (node.depth + 1) * FG_ROW_H;
-                    if (w < 0.5) continue;
-                    ctx.fillStyle = flamegraphColor(node.name);
-                    ctx.fillRect(x, y, Math.max(w - 0.5, 0.5), FG_ROW_H - 1);
-                    regions.push({ x1: x, x2: x + w, y, node, totalSamples: data.totalSamples });
-                    if (w > 30) {
-                        ctx.fillStyle = "#fff";
-                        const label = node.name.length * 7 > w - 4
-                            ? node.name.slice(0, Math.floor((w - 10) / 7)) + "…"
-                            : node.name;
-                        ctx.save();
-                        ctx.beginPath();
-                        ctx.rect(x + 2, y, w - 4, FG_ROW_H);
-                        ctx.clip();
-                        ctx.fillText(label, x + 3, y + FG_ROW_H / 2);
-                        ctx.restore();
-                    }
-                }
-                fgHitRegions[hitKey] = regions;
-            }
-
-            function renderFlamegraph() {
-                renderFgCanvas("fg-canvas-worker", fgWorkerData, "worker");
-                renderFgCanvas("fg-canvas-offworker", fgOffworkerData, "offworker");
-            }
-
-            // Flamegraph tooltip — shared handler for both canvases
-            function fgCanvasMouseMove(e, hitKey) {
-                const c = e.target;
-                const rect = c.getBoundingClientRect();
-                const mx = e.clientX - rect.left;
-                const my = e.clientY - rect.top;
-                const tip = document.getElementById("fg-tooltip");
-                const regions = fgHitRegions[hitKey] || [];
-                let hit = null;
-                for (let i = regions.length - 1; i >= 0; i--) {
-                    const r = regions[i];
-                    if (mx >= r.x1 && mx <= r.x2 && my >= r.y && my < r.y + FG_ROW_H) {
-                        hit = r;
-                        break;
-                    }
-                }
-                if (hit) {
-                    const total = hit.totalSamples;
-                    const pct = ((hit.node.count / total) * 100).toFixed(1);
-                    const selfPct = ((hit.node.self / total) * 100).toFixed(1);
-                    const nameElt = document.createElement('b');
-                    nameElt.innerText = hit.node.name;
-                    tip.innerHTML = `${nameElt.outerHTML}<br>${hit.node.count} samples (${pct}%) · ${hit.node.self} self (${selfPct}%)`;
-                    tip.style.display = "block";
-                    tip.style.left = Math.min(e.clientX + 12, window.innerWidth - 620) + "px";
-                    tip.style.top = (e.clientY - 50) + "px";
-                    c.style.cursor = "pointer";
-                } else {
-                    tip.style.display = "none";
-                    c.style.cursor = "";
-                }
-            }
-
-            document.getElementById("fg-canvas-worker").addEventListener("mousemove", (e) => fgCanvasMouseMove(e, "worker"));
-            document.getElementById("fg-canvas-offworker").addEventListener("mousemove", (e) => fgCanvasMouseMove(e, "offworker"));
-            document.getElementById("fg-canvas-worker").addEventListener("mouseleave", () => {
-                document.getElementById("fg-tooltip").style.display = "none";
-            });
-            document.getElementById("fg-canvas-offworker").addEventListener("mouseleave", () => {
-                document.getElementById("fg-tooltip").style.display = "none";
-            });
-
             document.getElementById("fg-close").addEventListener("click", () => {
                 document.getElementById("flamegraph-panel").style.display = "none";
-                document.getElementById("fg-tooltip").style.display = "none";
+            });
+
+            document.getElementById("fg-popout").addEventListener("click", () => {
+                const params = new URLSearchParams(window.location.search);
+                let traceUrl = params.get("trace");
+                let isBlobUrl = false;
+                if (!traceUrl && currentTraceBuffer) {
+                    const blob = new Blob([currentTraceBuffer]);
+                    traceUrl = URL.createObjectURL(blob);
+                    isBlobUrl = true;
+                }
+                if (!traceUrl) {
+                    showToast("popout-no-url", "Pop-out requires a loaded trace", "error", 3000);
+                    return;
+                }
+                const url = `flamegraph.html?trace=${encodeURIComponent(traceUrl)}&start=${Math.round(fgSelStart)}&end=${Math.round(fgSelEnd)}`;
+                window.open(url, "_blank");
+                if (isBlobUrl) {
+                    showToast("popout-blob", "Pop-out linked to this tab \u2014 keep it open", "info", 5000);
+                }
             });
 
             // ── Queue chart drag-select: show tasks spawned in time range ──
@@ -3985,7 +3865,7 @@
             // Re-render flamegraph on resize
             window.addEventListener("resize", () => {
                 if (document.getElementById("flamegraph-panel").style.display === "flex") {
-                    renderFlamegraph();
+                    fgInstance.resize();
                 }
             });
         </script>

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -517,7 +517,6 @@
                     <div class="fg-header">
                         <span class="fg-title" id="fg-title">Flamegraph</span>
                         <span class="fg-stats" id="fg-stats"></span>
-                        <select id="fg-spawn-filter" style="background:#2a2a4a;border:1px solid #444;color:#ccc;padding:3px 6px;border-radius:4px;font-size:0.9em;max-width:350px"></select>
                         <span class="fg-popout" id="fg-popout" tabindex="0" role="button" title="Open in new tab">&#8599; Pop Out</span>
                         <span class="fg-close" id="fg-close" tabindex="0" role="button">&#10005; Close (Esc)</span>
                     </div>
@@ -3620,7 +3619,6 @@
             })();
 
             // ── Flamegraph ──
-            let fgAllSamples = [];
             let fgSelStart = 0, fgSelEnd = 0;
             const fgInstance = FlamegraphRenderer.createFlamegraph(
                 document.getElementById("fg-container")
@@ -3659,58 +3657,24 @@
             }
 
             function showFlamegraph(selStart, selEnd) {
-                const allSamples = trace.cpuSamples.filter(s =>
-                    s.timestamp >= selStart && s.timestamp <= selEnd && s.callchain.length > 0 && s.source !== 1
-                );
-                if (!allSamples.length) {
+                const samples = FlamegraphRenderer.filterCpuSamples(trace.cpuSamples, selStart, selEnd);
+                if (!samples.length) {
                     showToast("no-cpu-samples-region", "No CPU samples in selected region", "error", 4000);
                     return;
                 }
 
-                fgAllSamples = allSamples;
                 fgSelStart = selStart;
                 fgSelEnd = selEnd;
                 const durMs = ((selEnd - selStart) / 1e6).toFixed(2);
                 document.getElementById("fg-title").textContent = "Flamegraph";
                 document.getElementById("fg-stats").textContent =
-                    `${allSamples.length} samples \u00b7 ${durMs}ms selected`;
-
-                // Build spawn location dropdown
-                const locCounts = new Map();
-                for (const s of allSamples) {
-                    const loc = s.spawnLoc || "(unknown)";
-                    locCounts.set(loc, (locCounts.get(loc) || 0) + 1);
-                }
-                const sel = document.getElementById("fg-spawn-filter");
-                sel.innerHTML = `<option value="">All tasks (${allSamples.length} samples)</option>`;
-                const sorted = [...locCounts.entries()].sort((a, b) => b[1] - a[1]);
-                for (const [loc, count] of sorted) {
-                    const short = loc.replace(/.*\//, '');
-                    const opt = document.createElement("option");
-                    opt.value = loc;
-                    opt.textContent = `${short} (${count})`;
-                    opt.title = loc;
-                    sel.appendChild(opt);
-                }
+                    `${samples.length} samples \u00b7 ${durMs}ms selected`;
 
                 clearToasts();
                 document.getElementById("flamegraph-panel").style.display = "flex";
                 document.getElementById("fg-close").focus();
-                applyFgFilter();
+                fgInstance.setData(samples, trace.callframeSymbols);
             }
-
-            function applyFgFilter() {
-                const filterVal = document.getElementById("fg-spawn-filter").value;
-                const samples = filterVal
-                    ? fgAllSamples.filter(s => (s.spawnLoc || "(unknown)") === filterVal)
-                    : fgAllSamples;
-
-                const workerSamples = samples.filter(s => s.workerId !== 255);
-                const offworkerSamples = samples.filter(s => s.workerId === 255);
-                fgInstance.setData(workerSamples, offworkerSamples, trace.callframeSymbols);
-            }
-
-            document.getElementById("fg-spawn-filter").addEventListener("change", applyFgFilter);
 
             document.getElementById("fg-close").addEventListener("click", () => {
                 document.getElementById("flamegraph-panel").style.display = "none";


### PR DESCRIPTION
Closes #38

## Summary

Extracts the flamegraph renderer into a shared `flamegraph.js` module and adds a standalone `flamegraph.html` page. The viewer's flamegraph panel now has a "Pop Out" button that opens the current selection (with zoom state) in a dedicated tab via URL params. For file-dropped traces it uses a Blob URL, which shows a warning toast in case you attempt to share between regular and private browsing (the blob becomes inaccesible).

The shared module owns the full flamegraph lifecycle: spawn location filtering, worker/offworker splitting, tree building, rendering, zoom, frame search, etc.

Search shows result stats with matched frame count and sample percentage, scoped to the current zoom level.

The standalone page persists zoom state as the full frame path in the URL and restores it on load. 
If the zoom state range in the URL doesn't match the trace and can't be reproduced, it shows all samples with a warning.

### Demo
https://github.com/user-attachments/assets/81fc82f5-d706-432d-813d-c0658e1e2883

## Future Improvements

- Keyboard navigation (e.g. after search be able to navigate and zoom between results)
- Diffing between different traces
- Regex search
- Per-worker flamegraphs?
- Support for inverted/icicle graphs? (for finding hot leaf functions)