### PR TITLE
refactor(ci): drop shared-key, keep save-if for simpler per-job caches

### DIFF
--- a/.github/actions/rust-build/action.yml
+++ b/.github/actions/rust-build/action.yml
@@ -4,10 +4,6 @@ inputs:
     toolchain:
         required: true
         description: "the Rust toolchain to use"
-    shared-key:
-        required: false
-        description: "shared cache key for Swatinem/rust-cache"
-        default: ""
     save-if:
         required: false
         description: "whether to save the cache (e.g. only on main)"
@@ -21,7 +17,6 @@ runs:
               toolchain: ${{ inputs.toolchain }}
         - uses: Swatinem/rust-cache@v2
           with:
-              shared-key: ${{ inputs.shared-key }}
               save-if: ${{ inputs.save-if }}
         - name: Enable perf_event_open and kallsyms for tests
           if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: nightly-ubuntu
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt --all -- --check
 
@@ -37,7 +36,6 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: stable-ubuntu
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run clippy check
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -58,7 +56,6 @@ jobs:
       - uses: ./.github/actions/rust-build
         with:
           toolchain: ${{ matrix.toolchain }}
-          shared-key: ${{ matrix.toolchain }}-${{ matrix.os }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
   check-docs:
@@ -77,7 +74,6 @@ jobs:
           components: rust-docs
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: nightly-ubuntu
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: sudo apt-get update && sudo apt-get install -y jq
       - run: cargo install cargo-docs-rs
@@ -98,7 +94,6 @@ jobs:
           toolchain: ${{ env.STABLE_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: stable-ubuntu
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@v4
         with:
@@ -125,7 +120,6 @@ jobs:
           toolchain: ${{ env.STABLE_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: stable-ubuntu
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Verify all publishable crates package cleanly
         env:


### PR DESCRIPTION
### Summary

Drops `shared-key` from all `Swatinem/rust-cache` usages. The default auto-generated key (job name + toolchain + Cargo.lock hash) gives each job its own isolated cache slot, which is simpler and avoids unrelated jobs overwriting each other's cached artifacts. They broadly have little in common with each other.

`save-if` alone is sufficient for merge queue cache hits. The gap for us was that we weren't writing to `cache` on push, which #266 already fixed.