### PR TITLE
feat(viewer): replace stack trace popup with right sidebar panel

### DIFF
--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -98,6 +98,61 @@
                 overflow: hidden;
             }
 
+            #viewer-body {
+                display: flex;
+                flex-direction: row;
+                flex: 1;
+                min-height: 0;
+                overflow: hidden;
+            }
+
+            #stack-sidebar {
+                width: 400px;
+                min-width: 300px;
+                max-width: 50vw;
+                background: #1a1a2e;
+                border-left: 1px solid #6c63ff;
+                display: none;
+                flex-direction: column;
+                flex-shrink: 0;
+                font-size: 0.8em;
+                line-height: 1.6;
+                z-index: 5;
+            }
+            #stack-sidebar .sidebar-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                padding: 8px 12px;
+                background: #16213e;
+                border-bottom: 1px solid #333;
+                flex-shrink: 0;
+            }
+            #stack-sidebar .sidebar-title {
+                color: #6c63ff;
+                font-weight: 600;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+            #stack-sidebar .sidebar-close {
+                cursor: pointer;
+                color: #888;
+                font-size: 1.2em;
+                padding: 0 4px;
+                flex-shrink: 0;
+            }
+            #stack-sidebar .sidebar-close:hover {
+                color: #fff;
+            }
+            #stack-sidebar .sidebar-body {
+                flex: 1;
+                overflow-y: auto;
+                padding: 10px 12px;
+                font-family: monospace;
+                font-size: 0.9em;
+            }
+
             #toolbar {
                 display: flex;
                 align-items: center;
@@ -193,6 +248,7 @@
 
             #main-area {
                 flex: 1;
+                min-width: 0;
                 display: flex;
                 flex-direction: column;
                 overflow: hidden;
@@ -472,6 +528,7 @@
                 <button id="btn-tz-mode" title="Toggle between UTC and local timezone for absolute timestamps" style="display:none">TZ: UTC</button>
                 <button id="btn-reset">New File</button>
             </div>
+            <div id="viewer-body">
             <div id="main-area" tabindex="0" role="application" aria-label="Trace timeline">
                 <div id="selection-overlay"></div>
                 <canvas id="crosshair-overlay" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:10"></canvas>
@@ -536,16 +593,17 @@
                     <div id="sched-panel-body" style="flex:1;overflow-y:auto;padding:8px 12px;font-family:monospace;font-size:0.82em;line-height:1.5"></div>
                 </div>
             </div>
+            <div id="stack-sidebar">
+                <div class="sidebar-header">
+                    <span class="sidebar-title" id="stack-sidebar-title"></span>
+                    <span class="sidebar-close" id="stack-sidebar-close">&times;</span>
+                </div>
+                <div class="sidebar-body" id="stack-sidebar-body"></div>
+            </div>
+            </div>
         </div>
 
         <div id="tooltip"></div>
-        <div id="stack-popup" style="display:none;position:fixed;background:#1a1a2e;border:1px solid #6c63ff;border-radius:8px;padding:12px 16px;z-index:200;max-width:800px;max-height:600px;overflow-y:auto;font-size:0.8em;line-height:1.6;box-shadow:0 4px 20px rgba(0,0,0,0.5)">
-            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
-                <span id="stack-popup-title" style="color:#6c63ff;font-weight:600"></span>
-                <span id="stack-popup-close" style="cursor:pointer;color:#888;font-size:1.2em;padding:0 4px">&times;</span>
-            </div>
-            <div id="stack-popup-body" style="font-family:monospace;font-size:0.9em"></div>
-        </div>
 
         <div id="help-overlay" role="dialog" aria-label="Keyboard and mouse shortcuts">
             <div id="help-content">
@@ -2958,9 +3016,9 @@
             });
 
             function showStackPopup(poll, x, y) {
-                const popup = document.getElementById("stack-popup");
-                const title = document.getElementById("stack-popup-title");
-                const body = document.getElementById("stack-popup-body");
+                const sidebar = document.getElementById("stack-sidebar");
+                const title = document.getElementById("stack-sidebar-title");
+                const body = document.getElementById("stack-sidebar-body");
                 const durStr = formatHumanDuration(poll.end - poll.start);
                 const cpuCount = poll.cpuSamples ? poll.cpuSamples.length : 0;
                 const schedCount = poll.schedSamples ? poll.schedSamples.length : 0;
@@ -2978,23 +3036,23 @@
                         const pct = ((g.count / schedCount) * 100).toFixed(0);
                         const barW = Math.max(2, (g.count / schedCount) * 200);
                         html += `<div style="margin-bottom:10px;border-left:3px solid #ff4444;padding-left:8px">`;
-                        html += `<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">`;
+                        html += `<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;flex-wrap:wrap">`;
                         html += `<span style="color:#ff4444;font-weight:600;font-size:1.1em">${g.count}×</span>`;
-                        html += `<span style="color:#fff;font-weight:600">${g.leaf}</span>`;
+                        html += `<span style="color:#fff;font-weight:600;word-break:break-all">${g.leaf}</span>`;
                         html += `<span style="color:#888">(${pct}%)</span>`;
                         html += `<span style="display:inline-block;height:8px;width:${barW}px;background:#ff4444;border-radius:2px;opacity:0.6"></span>`;
                         html += `</div>`;
                         // Show abbreviated context: leaf + first interesting caller
                         const ctx = g.frames.slice(0, 3);
                         for (let i = 0; i < ctx.length; i++) {
-                            html += `<div style="color:${i === 0 ? '#ff8a65' : '#777'};padding-left:${i * 8}px;font-size:0.9em">${renderFrame(ctx[i])}</div>`;
+                            html += `<div style="color:${i === 0 ? '#ff8a65' : '#777'};padding-left:${i * 8}px;font-size:0.9em;word-break:break-all">${renderFrame(ctx[i])}</div>`;
                         }
                         if (g.frames.length > 3) {
                             const id = 'sched-expand-' + Math.random().toString(36).slice(2);
                             html += `<div id="${id}-toggle" style="color:#6c63ff;cursor:pointer;font-size:0.85em;padding-left:16px" onclick="document.getElementById('${id}').style.display=document.getElementById('${id}').style.display==='none'?'block':'none';this.textContent=this.textContent.startsWith('▶')?'▼ collapse':'▶ ${g.frames.length - 3} more frames'">▶ ${g.frames.length - 3} more frames</div>`;
                             html += `<div id="${id}" style="display:none">`;
                             for (let i = 3; i < g.frames.length; i++) {
-                                html += `<div style="color:#666;padding-left:24px;font-size:0.85em">${renderFrame(g.frames[i])}</div>`;
+                                html += `<div style="color:#666;padding-left:24px;font-size:0.85em;word-break:break-all">${renderFrame(g.frames[i])}</div>`;
                             }
                             html += `</div>`;
                         }
@@ -3012,18 +3070,18 @@
                         const pct = ((g.count / cpuCount) * 100).toFixed(0);
                         html += `<div style="margin-bottom:8px;border-left:2px solid #333;padding-left:8px">`;
                         html += `<span style="color:#ff8c00">${g.count}×</span> `;
-                        html += `<span style="color:#fff">${g.leaf}</span> `;
+                        html += `<span style="color:#fff;word-break:break-all">${g.leaf}</span> `;
                         html += `<span style="color:#888">(${pct}%)</span>`;
                         const ctx = g.frames.slice(1, 3);
                         for (const f of ctx) {
-                            html += `<div style="color:#777;padding-left:8px;font-size:0.9em">${renderFrame(f)}</div>`;
+                            html += `<div style="color:#777;padding-left:8px;font-size:0.9em;word-break:break-all">${renderFrame(f)}</div>`;
                         }
                         if (g.frames.length > 3) {
                             const id = 'cpu-expand-' + Math.random().toString(36).slice(2);
                             html += `<div id="${id}-toggle" style="color:#6c63ff;cursor:pointer;font-size:0.85em;padding-left:8px" onclick="document.getElementById('${id}').style.display=document.getElementById('${id}').style.display==='none'?'block':'none';this.textContent=this.textContent.startsWith('▶')?'▼ collapse':'▶ ${g.frames.length - 3} more frames'">▶ ${g.frames.length - 3} more frames</div>`;
                             html += `<div id="${id}" style="display:none">`;
                             for (let i = 3; i < g.frames.length; i++) {
-                                html += `<div style="color:#666;padding-left:16px;font-size:0.85em">${renderFrame(g.frames[i])}</div>`;
+                                html += `<div style="color:#666;padding-left:16px;font-size:0.85em;word-break:break-all">${renderFrame(g.frames[i])}</div>`;
                             }
                             html += `</div>`;
                         }
@@ -3032,25 +3090,20 @@
                 }
 
                 body.innerHTML = html;
-                popup.style.display = "block";
-                popup.style.left = Math.min(x + 12, window.innerWidth - 820) + "px";
-                popup.style.top = Math.min(y - 20, window.innerHeight - 620) + "px";
+                const wasHidden = sidebar.style.display !== "flex";
+                sidebar.style.display = "flex";
+                if (wasHidden && trace) requestAnimationFrame(renderAll);
             }
 
             function hideStackPopup() {
-                document.getElementById("stack-popup").style.display = "none";
+                const sidebar = document.getElementById("stack-sidebar");
+                const wasVisible = sidebar.style.display === "flex";
+                sidebar.style.display = "none";
                 selOverlay.style.display = "none";
+                if (wasVisible && trace) requestAnimationFrame(renderAll);
             }
 
-            document.getElementById("stack-popup-close").addEventListener("click", hideStackPopup);
-            // Close popup when clicking outside it
-            document.addEventListener("click", (e) => {
-                const popup = document.getElementById("stack-popup");
-                if (popup.style.display !== "none" && !popup.contains(e.target) &&
-                    !e.target.closest("#main-area")) {
-                    hideStackPopup();
-                }
-            });
+            document.getElementById("stack-sidebar-close").addEventListener("click", hideStackPopup);
 
             // ── Sched Events Panel (global view of all blocking operations) ──
             let schedPanelTimeRange = null; // {start, end} or null for full trace
@@ -3289,8 +3342,9 @@
                             break;
                         }
                         clearToasts();
-                        hideStackPopup();
-                        if (document.getElementById("sched-panel").style.display === "flex") {
+                        if (document.getElementById("stack-sidebar").style.display === "flex") {
+                            hideStackPopup();
+                        } else if (document.getElementById("sched-panel").style.display === "flex") {
                             document.getElementById("sched-panel").style.display = "none";
                         } else if (document.getElementById("flamegraph-panel").style.display === "flex") {
                             // Let the flamegraph module handle Escape first (search clear / zoom reset)
@@ -3628,29 +3682,28 @@
             function showSelectionPicker(selStart, selEnd) {
                 const durMs = ((selEnd - selStart) / 1e6).toFixed(2);
                 const schedCount = collectSchedSamples({ start: selStart, end: selEnd }).length;
-                const popup = document.getElementById("stack-popup");
-                const title = document.getElementById("stack-popup-title");
-                const body = document.getElementById("stack-popup-body");
+                const sidebar = document.getElementById("stack-sidebar");
+                const title = document.getElementById("stack-sidebar-title");
+                const body = document.getElementById("stack-sidebar-body");
                 title.textContent = `${durMs}ms selected`;
                 body.innerHTML = `
-                    <div style="display:flex;flex-direction:column;gap:8px;min-width:250px">
+                    <div style="display:flex;flex-direction:column;gap:8px">
                         <div style="padding:8px 12px;background:#2a2a4a;border:1px solid #444;border-radius:6px;cursor:pointer;transition:background 0.15s"
                              onmouseover="this.style.background='#3a3a5a'" onmouseout="this.style.background='#2a2a4a'"
                              id="pick-flamegraph" tabindex="0" role="button">
-                            <div style="color:#ff8c00;font-weight:600">🔥 CPU Flamegraph</div>
+                            <div style="color:#ff8c00;font-weight:600">CPU Flamegraph</div>
                             <div style="color:#888;font-size:0.9em">Profile where CPU time is spent</div>
                         </div>
                         <div style="padding:8px 12px;background:#2a2a4a;border:1px solid #444;border-radius:6px;cursor:pointer;transition:background 0.15s"
                              onmouseover="this.style.background='#3a3a5a'" onmouseout="this.style.background='#2a2a4a'"
                              id="pick-sched" tabindex="0" role="button">
-                            <div style="color:#ff4444;font-weight:600">⚠ Blocking Calls <span style="color:#888;font-weight:400">(${schedCount})</span></div>
+                            <div style="color:#ff4444;font-weight:600">Blocking Calls <span style="color:#888;font-weight:400">(${schedCount})</span></div>
                             <div style="color:#888;font-size:0.9em">Analyze what's blocking the runtime</div>
                         </div>
                     </div>`;
-                popup.style.display = "block";
-                // Center it roughly
-                popup.style.left = (window.innerWidth / 2 - 150) + "px";
-                popup.style.top = (window.innerHeight / 2 - 80) + "px";
+                const wasHidden = sidebar.style.display !== "flex";
+                sidebar.style.display = "flex";
+                if (wasHidden && trace) requestAnimationFrame(renderAll);
                 document.getElementById("pick-flamegraph").onclick = () => { hideStackPopup(); showFlamegraph(selStart, selEnd); };
                 document.getElementById("pick-sched").onclick = () => { hideStackPopup(); showSchedPanel(selStart, selEnd); };
                 document.getElementById("pick-flamegraph").focus();
@@ -3794,9 +3847,9 @@
                 const sorted = [...groups.entries()].sort((a, b) => b[1].length - a[1].length);
 
                 const durMs = ((selEnd - selStart) / 1e6).toFixed(2);
-                const popup = document.getElementById("stack-popup");
-                const title = document.getElementById("stack-popup-title");
-                const body = document.getElementById("stack-popup-body");
+                const sidebar = document.getElementById("stack-sidebar");
+                const title = document.getElementById("stack-sidebar-title");
+                const body = document.getElementById("stack-sidebar-body");
                 title.textContent = `${tasks.length} tasks spawned in ${durMs}ms`;
 
                 let html = "";
@@ -3804,19 +3857,19 @@
                     const short = loc.replace(/.*\//, '');
                     html += `<div style="margin-bottom:10px;border-left:3px solid #81c784;padding-left:8px">`;
                     html += `<div style="color:#81c784;font-weight:600">${taskList.length}× <span style="color:#fff">${esc(short)}</span></div>`;
-                    if (short !== loc) html += `<div style="color:#666;font-size:0.85em">${esc(loc)}</div>`;
+                    if (short !== loc) html += `<div style="color:#666;font-size:0.85em;word-break:break-all">${esc(loc)}</div>`;
                     // Show first few tasks as clickable links
                     const show = taskList.slice(0, 5);
                     for (const t of show) {
                         html += `<div style="margin-left:8px"><span class="spawned-task-link" style="color:#6c63ff;cursor:pointer;text-decoration:underline" data-task-id="${t.taskId}">0x${t.taskId.toString(16)}</span> <span style="color:#888">@ ${fmtTs(t.firstPoll)}</span></div>`;
                     }
-                    if (taskList.length > 5) html += `<div style="color:#888;margin-left:8px;font-size:0.9em">… ${taskList.length - 5} more</div>`;
+                    if (taskList.length > 5) html += `<div style="color:#888;margin-left:8px;font-size:0.9em">... ${taskList.length - 5} more</div>`;
                     html += `</div>`;
                 }
                 body.innerHTML = html;
-                popup.style.display = "block";
-                popup.style.left = (window.innerWidth / 2 - 200) + "px";
-                popup.style.top = (window.innerHeight / 2 - 150) + "px";
+                const wasHidden = sidebar.style.display !== "flex";
+                sidebar.style.display = "flex";
+                if (wasHidden && trace) requestAnimationFrame(renderAll);
 
                 // Wire up task links to select and focus
                 body.querySelectorAll('.spawned-task-link').forEach(el => {


### PR DESCRIPTION
Show stack traces, selection picker, and spawned tasks in a persistent sidebar instead of a floating popup dialog for better usability.

After
<img width="1511" height="793" alt="SCR-20260422-ohbh" src="https://github.com/user-attachments/assets/1994e0c4-52f4-4c8f-8e72-07b82cd5f781" />

Before
<img width="1511" height="783" alt="SCR-20260422-ogws" src="https://github.com/user-attachments/assets/2405c18e-1ed2-43cc-a000-1deb7c228966" />
