### PR TITLE
Make worker lanes scrollable in viewer

### DIFF
--- a/dial9-tokio-telemetry/examples/many_workers.rs
+++ b/dial9-tokio-telemetry/examples/many_workers.rs
@@ -1,0 +1,57 @@
+//! Generate a trace with 48 workers for testing the viewer with many lanes.
+//!
+//! Usage:
+//!   cargo run --example many_workers
+//!
+//! Then open the trace in the viewer:
+//!   cargo run -p dial9-viewer -- serve --local-dir .
+
+use std::time::Duration;
+
+use dial9_tokio_telemetry::config::{Dial9Config, Dial9ConfigBuilder};
+use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+
+fn my_config() -> Dial9Config {
+    Dial9ConfigBuilder::new(
+        "many_workers_trace.bin",
+        64 * 1024 * 1024,
+        256 * 1024 * 1024,
+    )
+    .with_tokio(|t| {
+        t.worker_threads(48);
+    })
+    .with_runtime(|r| r.with_task_tracking(true))
+    .build()
+}
+
+#[dial9_tokio_telemetry::main(config = my_config)]
+async fn main() {
+    println!("Running workload with 48 workers...");
+
+    let handle = TelemetryHandle::current();
+    let tasks: Vec<_> = (0..500)
+        .map(|i| {
+            handle.spawn(async move {
+                for _ in 0..5 {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    // Small CPU work to generate poll events
+                    let mut v = 0u64;
+                    for j in 0..50_000u64 {
+                        v = v.wrapping_add(j.wrapping_mul(j));
+                    }
+                    std::hint::black_box(v);
+                    tokio::task::yield_now().await;
+                }
+                if i % 100 == 0 {
+                    println!("Task {i} done");
+                }
+            })
+        })
+        .collect();
+
+    for task in tasks {
+        let _ = task.await;
+    }
+
+    println!("Trace written to many_workers_trace.*.bin");
+}

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -551,7 +551,8 @@
             <div id="help-content">
                 <h3>🖱 Mouse</h3>
                 <table>
-                    <tr><td>Scroll wheel</td><td>Zoom in/out (centered on cursor)</td></tr>
+                    <tr><td>Scroll wheel</td><td>Scroll worker lanes vertically</td></tr>
+                    <tr><td>⌘/Ctrl + scroll</td><td>Zoom in/out (centered on cursor)</td></tr>
                     <tr><td>Drag</td><td>Pan left/right</td></tr>
                     <tr><td>Click poll</td><td>Select task &amp; show wake timeline</td></tr>
                     <tr><td>⇧ Shift+drag</td><td>Select region → flamegraph / blocking calls</td></tr>
@@ -2671,21 +2672,29 @@
                 renderAll();
             }
 
-            // Mouse wheel zoom on main area
+            // Mouse wheel: Ctrl/Cmd+wheel zooms timeline, plain wheel scrolls worker lanes
             document.getElementById("main-area").addEventListener(
                 "wheel",
                 (e) => {
                     if (document.getElementById("flamegraph-panel").style.display === "flex") return;
-                    e.preventDefault();
-                    const rect = lanesContainer.getBoundingClientRect();
-                    const mouseX = e.clientX - rect.left - LABEL_W;
-                    const drawW = rect.width - LABEL_W;
-                    const frac = Math.max(0, Math.min(1, mouseX / drawW));
-                    const factor = e.deltaY > 0 ? 1.3 : 1 / 1.3;
-                    zoom(factor, frac);
+                    if (e.ctrlKey || e.metaKey) {
+                        e.preventDefault();
+                        const rect = lanesContainer.getBoundingClientRect();
+                        const mouseX = e.clientX - rect.left - LABEL_W;
+                        const drawW = rect.width - LABEL_W;
+                        const frac = Math.max(0, Math.min(1, mouseX / drawW));
+                        const factor = e.deltaY > 0 ? 1.3 : 1 / 1.3;
+                        zoom(factor, frac);
+                    }
+                    // Plain wheel: let the browser scroll #lanes-container naturally
                 },
                 { passive: false },
             );
+
+            // Re-render crosshair when lanes are scrolled so it stays aligned
+            lanesContainer.addEventListener("scroll", () => {
+                renderCrosshair();
+            });
 
             // Pan with mouse drag (normal) or region select (shift+drag)
             let dragging = false,


### PR DESCRIPTION
Plain scroll wheel now scrolls worker lanes vertically instead of zooming. Ctrl/Cmd+scroll zooms the timeline. This allows viewing traces with many workers (e.g. 48) without lanes being clipped.

Also adds a many_workers example that generates a 48-worker trace for testing.