### PR TITLE
Test/improve testing cpu profiling fallback

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,6 +43,9 @@ jobs:
           - name: overhead_bench
             adapter: json
             command: cargo bench --bench overhead_bench -- --bmf 10
+          - name: overhead_bench_ctimer
+            adapter: json
+            command: DIAL9_FORCE_CTIMER=1 cargo bench --bench overhead_bench -- --bmf 10
           - name: e2e_workload
             adapter: json
             command: cargo bench --bench e2e_workload -- --bmf 10
@@ -90,6 +93,9 @@ jobs:
           - name: overhead_bench
             adapter: json
             command: cargo bench --bench overhead_bench -- --bmf 10
+          - name: overhead_bench_ctimer
+            adapter: json
+            command: DIAL9_FORCE_CTIMER=1 cargo bench --bench overhead_bench -- --bmf 10
           - name: e2e_workload
             adapter: json
             command: cargo bench --bench e2e_workload -- --bmf 10

--- a/perf-self-profile/src/sys/linux/ctimer_sampler.rs
+++ b/perf-self-profile/src/sys/linux/ctimer_sampler.rs
@@ -130,7 +130,7 @@ impl SamplerBackend for CtimerSampler {
 
 impl Drop for CtimerSampler {
     fn drop(&mut self) {
-        ctimer::disable_permanent();
+        ctimer::disarm_all_timers();
         CTIMER_ACTIVE.store(false, Ordering::Release);
     }
 }
@@ -142,7 +142,7 @@ extern "C" fn sigprof_handler(
     ucontext: *mut libc::c_void,
 ) {
     if !ctimer::is_running() {
-        if ctimer::is_permanently_stopped()
+        if ctimer::is_disarm_requested()
             && let Some(t) = ctimer::current_thread_timer_id()
         {
             // Self-disarm so the timer doesn't keep firing for the rest of the

--- a/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
@@ -12,6 +12,16 @@
 //!
 //! ctimer avoids both by binding each timer to a specific tid (`SIGEV_THREAD_ID`)
 //! and charging against per-thread CPU time.
+//!
+//! # Lifecycle                                                                                                                                                                                       
+//!                                                                                   
+//! 1. Call `start(interval_ns)` once in the main thread to install the SIGPROF handler.
+//! 2. Each thread calls `register_thread` from its own context to arm a per-thread
+//! timer, and `unregister_thread` (same thread) to tear it down.
+//! 3. `disable` and `enable` pause sampling without disarming the timers, so resuming doesn't
+//! require re-registration.
+//! Teardown: `disarm_all_timers` disarms timers globally (called automatically on `CtimerSampler` drop)
+//! A subsequent `start` is required to sample again.
 
 use std::cell::Cell;
 use std::io;

--- a/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
@@ -12,19 +12,6 @@
 //!
 //! ctimer avoids both by binding each timer to a specific tid (`SIGEV_THREAD_ID`)
 //! and charging against per-thread CPU time.
-//!
-//! # Lifecycle
-//!
-//! 1. Call `start(interval_ns)` once from the main thread. This installs the
-//!    SIGPROF handler.
-//! 2. Each thread that wants to be profiled calls `register_thread()` from
-//!    its own context. This creates the per-thread timer and arms it.
-//! 3. On thread exit, call `unregister_thread()` to delete the timer.
-//! 4. Pause/resume: `disable()` clears RUNNING but leaves timers armed, so
-//!    `enable()` can re-enable sampling.
-//! 5. Teardown: `disable_permanent()` (called from `CtimerSampler::drop`) sets
-//!    a permanent-stop flag, each thread's next SIGPROF self-disarms its
-//!    timer.
 
 use std::cell::Cell;
 use std::io;
@@ -38,7 +25,7 @@ static INTERVAL_NS: AtomicI64 = AtomicI64::new(0);
 /// Whether sampling is currently enabled. Toggled by `disable`/`enable`.
 static RUNNING: AtomicBool = AtomicBool::new(false);
 /// One-way flag to tell the signal handler to self-disarm each thread's timer.
-static PERMANENTLY_STOPPED: AtomicBool = AtomicBool::new(false);
+static DISARM_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 thread_local! {
     static THREAD_TIMER: Cell<Option<libc::timer_t>> = const { Cell::new(None) };
@@ -77,7 +64,7 @@ pub unsafe fn start(
     }
 
     INTERVAL_NS.store(interval_ns, Ordering::Release);
-    PERMANENTLY_STOPPED.store(false, Ordering::Release);
+    DISARM_REQUESTED.store(false, Ordering::Release);
     RUNNING.store(true, Ordering::Release);
     Ok(())
 }
@@ -93,11 +80,13 @@ pub fn enable() {
     RUNNING.store(true, Ordering::Release);
 }
 
-/// Permanently disable sampling. Sets both flags so the handler self-disarms
-/// each thread's timer on its next tick. Not reversible; a subsequent `start`
-/// is required to sample again.
-pub fn disable_permanent() {
-    PERMANENTLY_STOPPED.store(true, Ordering::Release);
+/// Request per-thread timer disarm. Sets the flag and pauses sampling; each
+/// thread's SIGPROF handler observes the flag on its next tick and calls
+/// `timer_delete` on its own timer, so disarm completes within one sample
+/// interval per thread. Not reversible — a subsequent `start` is required
+/// to sample again. Called from `CtimerSampler::drop`.
+pub fn disarm_all_timers() {
+    DISARM_REQUESTED.store(true, Ordering::Release);
     RUNNING.store(false, Ordering::Release);
 }
 
@@ -105,8 +94,8 @@ pub fn is_running() -> bool {
     RUNNING.load(Ordering::Acquire)
 }
 
-pub fn is_permanently_stopped() -> bool {
-    PERMANENTLY_STOPPED.load(Ordering::Acquire)
+pub fn is_disarm_requested() -> bool {
+    DISARM_REQUESTED.load(Ordering::Acquire)
 }
 
 pub fn interval_ns() -> i64 {
@@ -182,6 +171,8 @@ pub fn register_thread() -> Result<(), io::Error> {
     Ok(())
 }
 
+/// Disarm and delete the calling thread's timer. Must run on the thread being
+/// unregistered. No-op if never registered.
 pub fn unregister_thread() {
     THREAD_TIMER.with(|c| {
         if let Some(t) = c.take() {

--- a/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
@@ -197,6 +197,12 @@ pub fn unregister_thread() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicU64;
+
+    // Serializes tests touching process-global state: RUNNING,
+    // DISARM_REQUESTED, INTERVAL_NS, and the SIGPROF handler.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     extern "C" fn dummy_handler(_: libc::c_int, _: *mut libc::siginfo_t, _: *mut libc::c_void) {}
 
@@ -214,6 +220,7 @@ mod tests {
 
     #[test]
     fn register_thread_fails_when_not_running() {
+        let _g = TEST_LOCK.lock().unwrap();
         RUNNING.store(false, Ordering::Release);
         let err = register_thread().unwrap_err();
         assert!(err.to_string().contains("not running"));
@@ -224,5 +231,57 @@ mod tests {
         THREAD_TIMER.with(|c| c.set(None));
         unregister_thread();
         assert!(THREAD_TIMER.with(|c| c.get()).is_none());
+    }
+
+    static SAMPLE_COUNT: AtomicU64 = AtomicU64::new(0);
+
+    extern "C" fn counting_handler(_: libc::c_int, _: *mut libc::siginfo_t, _: *mut libc::c_void) {
+        SAMPLE_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn thread_cpu_time_ns() -> u64 {
+        let mut ts = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut ts) };
+        ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
+    }
+
+    fn burn_cpu(duration_ns: u64) {
+        let deadline = thread_cpu_time_ns() + duration_ns;
+        let mut acc: u64 = 0;
+        while thread_cpu_time_ns() < deadline {
+            for i in 0..10_000u64 {
+                acc = acc.wrapping_add(i);
+            }
+        }
+        std::hint::black_box(acc);
+    }
+
+    #[test]
+    fn register_thread_fires_samples_under_cpu_load() {
+        let _g = TEST_LOCK.lock().unwrap();
+        SAMPLE_COUNT.store(0, Ordering::Relaxed);
+
+        // ~1000 samples/sec.
+        unsafe { start(1_000_000, counting_handler) }.expect("start");
+        register_thread().expect("should register thread");
+
+        // 200ms of CPU => expect ~200 samples.
+        burn_cpu(200_000_000);
+
+        let count = SAMPLE_COUNT.load(Ordering::Relaxed);
+
+        unregister_thread();
+
+        RUNNING.store(false, Ordering::Release);
+        DISARM_REQUESTED.store(false, Ordering::Release);
+
+        // lower threshold to account for noise
+        assert!(
+            count >= 150,
+            "expected >=150 samples from 200ms of CPU at 1kHz, got {count}"
+        );
     }
 }

--- a/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
@@ -13,15 +13,15 @@
 //! ctimer avoids both by binding each timer to a specific tid (`SIGEV_THREAD_ID`)
 //! and charging against per-thread CPU time.
 //!
-//! # Lifecycle                                                                                                                                                                                       
-//!                                                                                   
+//! # Lifecycle
+//!
 //! 1. Call `start(interval_ns)` once in the main thread to install the SIGPROF handler.
 //! 2. Each thread calls `register_thread` from its own context to arm a per-thread
-//! timer, and `unregister_thread` (same thread) to tear it down.
-//! 3. `disable` and `enable` pause sampling without disarming the timers, so resuming doesn't
-//! require re-registration.
-//! Teardown: `disarm_all_timers` disarms timers globally (called automatically on `CtimerSampler` drop)
-//! A subsequent `start` is required to sample again.
+//!    timer, and `unregister_thread` (same thread) to tear it down.
+//! 3. `disable` and `enable` pause sampling without disarming the timers, so resuming
+//!    doesn't require re-registration.
+//! 4. Teardown: `disarm_all_timers` disarms timers globally (called automatically on
+//!    `CtimerSampler` drop). A subsequent `start` is required to sample again.
 
 use std::cell::Cell;
 use std::io;

--- a/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/ctimer.rs
@@ -80,11 +80,8 @@ pub fn enable() {
     RUNNING.store(true, Ordering::Release);
 }
 
-/// Request per-thread timer disarm. Sets the flag and pauses sampling; each
-/// thread's SIGPROF handler observes the flag on its next tick and calls
-/// `timer_delete` on its own timer, so disarm completes within one sample
-/// interval per thread. Not reversible — a subsequent `start` is required
-/// to sample again. Called from `CtimerSampler::drop`.
+/// Requests that all timers are disarmed.
+/// A subsequent `start` is required to sample again.
 pub fn disarm_all_timers() {
     DISARM_REQUESTED.store(true, Ordering::Release);
     RUNNING.store(false, Ordering::Release);

--- a/perf-self-profile/src/sys/linux/fp_profiler/sample_buffer.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/sample_buffer.rs
@@ -494,11 +494,16 @@ mod tests {
         }
         assert_eq!(BUFFER.tail.load(Ordering::Relaxed), BUFFER_CAP);
 
+        // Claim while full, tail should stay at BUFFER_CAP.
+        let overflow = unsafe { claim_slot() };
+        assert!(overflow.is_none(), "buffer full: claim must fail");
+        drop(overflow);
         assert_eq!(
             BUFFER.tail.load(Ordering::Relaxed),
             BUFFER_CAP,
-            "tail must not advance on failed claims",
+            "tail must not advance on a failed claim",
         );
+        let _ = take_dropped_count();
 
         // Drain the first batch.
         let mut first_drained = 0;

--- a/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
@@ -274,10 +274,11 @@ mod tests {
         let mut out = [0u64; MAX_FRAMES];
         let n = unsafe { unwind(0x40_0000, fp, fp, &mut out) };
 
+        // Unmap before the asserts so a panic doesn't leak the mapping.
+        assert_eq!(unsafe { libc::munmap(guard, ps) }, 0);
+
         assert_eq!(n, 1, "unwind must stop when saved_fp load faults");
         assert_eq!(out[0], 0x40_0000);
-
-        assert_eq!(unsafe { libc::munmap(guard, ps) }, 0);
     }
 
     #[test]
@@ -311,9 +312,10 @@ mod tests {
         let mut out = [0u64; MAX_FRAMES];
         let n = unsafe { unwind(0x40_0000, fp, fp, &mut out) };
 
+        // Unmap before the asserts so a panic doesn't leak the mapping.
+        assert_eq!(unsafe { libc::munmap(region, 2 * ps) }, 0);
+
         assert_eq!(n, 1, "unwind must stop when ret_addr load faults");
         assert_eq!(out[0], 0x40_0000);
-
-        assert_eq!(unsafe { libc::munmap(region, 2 * ps) }, 0);
     }
 }

--- a/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
@@ -245,4 +245,75 @@ mod tests {
         assert_eq!(n, 1);
         assert_eq!(out[0], 0x40_0000);
     }
+
+    fn page_size() -> usize {
+        let ps = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        assert!(ps > 0, "sysconf(_SC_PAGESIZE) must return a positive value");
+        ps as usize
+    }
+
+    #[test]
+    fn stops_when_saved_fp_load_faults() {
+        install();
+        let ps = page_size();
+        // Guard page, any load faults.
+        let guard = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                ps,
+                libc::PROT_NONE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(guard, libc::MAP_FAILED);
+        let fp = guard as usize;
+
+        // sp = fp keeps fp in range, page-aligned.
+        let mut out = [0u64; MAX_FRAMES];
+        let n = unsafe { unwind(0x40_0000, fp, fp, &mut out) };
+
+        assert_eq!(n, 1, "unwind must stop when saved_fp load faults");
+        assert_eq!(out[0], 0x40_0000);
+
+        assert_eq!(unsafe { libc::munmap(guard, ps) }, 0);
+    }
+
+    #[test]
+    fn stops_when_ret_addr_load_faults() {
+        install();
+        let ps = page_size();
+        // Two pages: first writable, second PROT_NONE. fp at last usize of
+        // first page => *fp succeeds, *(fp+8) crosses into guard and faults.
+        let region = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                2 * ps,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(region, libc::MAP_FAILED);
+        let guard = unsafe { (region as *mut u8).add(ps) };
+        assert_eq!(
+            unsafe { libc::mprotect(guard as *mut _, ps, libc::PROT_NONE) },
+            0,
+        );
+
+        let sz = std::mem::size_of::<usize>();
+        let fp = unsafe { (region as *mut u8).add(ps - sz) } as usize;
+        // Ensure saved_fp load succeeds so the walk reaches ret_addr load.
+        unsafe { (fp as *mut usize).write(fp + 16) };
+
+        let mut out = [0u64; MAX_FRAMES];
+        let n = unsafe { unwind(0x40_0000, fp, fp, &mut out) };
+
+        assert_eq!(n, 1, "unwind must stop when ret_addr load faults");
+        assert_eq!(out[0], 0x40_0000);
+
+        assert_eq!(unsafe { libc::munmap(region, 2 * ps) }, 0);
+    }
 }

--- a/perf-self-profile/src/sys/linux/perf_sampler.rs
+++ b/perf-self-profile/src/sys/linux/perf_sampler.rs
@@ -255,9 +255,8 @@ impl PerfSamplerImpl {
                 0
             };
 
-        // Use CLOCK_MONOTONIC so perf timestamps are in the same clock domain
-        // as Rust's `Instant::now()`. Without this, perf defaults to
-        // CLOCK_MONOTONIC_RAW which drifts relative to CLOCK_MONOTONIC.
+        // Stamp samples with CLOCK_MONOTONIC so they share a clock with ctimer
+        // samples and `telemetry::events::clock_monotonic_ns()`.
         attr.set_use_clockid(1);
         attr.clockid = libc::CLOCK_MONOTONIC;
 

--- a/perf-self-profile/src/sys/linux/perf_sampler.rs
+++ b/perf-self-profile/src/sys/linux/perf_sampler.rs
@@ -56,20 +56,7 @@ fn open_perf_event(attr: &mut perf_event_attr, pid: i32, cpu: i32) -> io::Result
         )
     };
     if fd < 0 {
-        let err = io::Error::last_os_error();
-        if err.kind() == io::ErrorKind::PermissionDenied {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!(
-                    "perf_event_open denied ({}); for context-switch sampling \
-                     /proc/sys/kernel/perf_event_paranoid must be <= 1 \
-                     (current value can be checked with: \
-                     cat /proc/sys/kernel/perf_event_paranoid)",
-                    err
-                ),
-            ));
-        }
-        return Err(err);
+        return Err(io::Error::last_os_error());
     }
 
     let base = unsafe {

--- a/perf-self-profile/tests/fallback_detection.rs
+++ b/perf-self-profile/tests/fallback_detection.rs
@@ -1,0 +1,132 @@
+#![cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+
+use dial9_perf_self_profile::{
+    EventSource, PerfSampler, SamplerConfig, SamplingMode, is_ctimer_active,
+};
+
+// libc doesn't re-export AUDIT_ARCH_*, see include/uapi/linux/audit.h.
+#[cfg(target_arch = "x86_64")]
+const AUDIT_ARCH: u32 = 0xC000_003E;
+#[cfg(target_arch = "aarch64")]
+const AUDIT_ARCH: u32 = 0xC000_00B7;
+
+fn stmt(code: u16, k: u32) -> libc::sock_filter {
+    libc::sock_filter {
+        code,
+        jt: 0,
+        jf: 0,
+        k,
+    }
+}
+fn jump(code: u16, k: u32, jt: u8, jf: u8) -> libc::sock_filter {
+    libc::sock_filter { code, jt, jf, k }
+}
+
+// Seccomp BPF: return EACCES for perf_event_open, allow everything else.
+// PR_SET_NO_NEW_PRIVS lets us install the filter without CAP_SYS_ADMIN.
+fn install_seccomp_blocking_perf_event_open() {
+    let ld_abs = (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16;
+    let jeq = (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16;
+    let ret = (libc::BPF_RET | libc::BPF_K) as u16;
+
+    // seccomp_data offsets: nr @ 0, arch @ 4.
+    let filter = [
+        stmt(ld_abs, 4),
+        jump(jeq, AUDIT_ARCH, 0, 3),
+        stmt(ld_abs, 0),
+        jump(jeq, libc::SYS_perf_event_open as u32, 0, 1),
+        stmt(ret, libc::SECCOMP_RET_ERRNO | libc::EACCES as u32),
+        stmt(ret, libc::SECCOMP_RET_ALLOW),
+    ];
+    let prog = libc::sock_fprog {
+        len: filter.len() as u16,
+        filter: filter.as_ptr() as *mut _,
+    };
+
+    unsafe {
+        assert_eq!(libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0), 0);
+        assert_eq!(
+            libc::prctl(
+                libc::PR_SET_SECCOMP,
+                libc::SECCOMP_MODE_FILTER as libc::c_ulong,
+                &prog as *const _ as libc::c_ulong,
+                0,
+                0,
+            ),
+            0
+        );
+    }
+}
+
+/// Raw self-profile probe. Returns true if the kernel lets us open a
+/// minimal perf event on the calling task.
+fn perf_event_open_works() -> bool {
+    // perf_event_attr: type=PERF_TYPE_SOFTWARE (1), size=128,
+    // config=PERF_COUNT_SW_CPU_CLOCK (0). Rest zeroed.
+    let mut attr: [u8; 128] = [0; 128];
+    attr[0] = 1;
+    attr[4..8].copy_from_slice(&128u32.to_le_bytes());
+    let fd = unsafe {
+        libc::syscall(
+            libc::SYS_perf_event_open,
+            attr.as_ptr(),
+            0i32,  // pid = self
+            0i32,  // cpu = 0
+            -1i32, // group_fd
+            0u64,  // flags
+        )
+    };
+    if fd >= 0 {
+        unsafe { libc::close(fd as i32) };
+        true
+    } else {
+        false
+    }
+}
+
+#[test]
+fn uses_perf_path_when_available() {
+    if !perf_event_open_works() {
+        eprintln!("skipping: perf_event_open blocked in this env");
+        return;
+    }
+
+    let _sampler = PerfSampler::start(
+        SamplerConfig::default()
+            .event_source(EventSource::SwCpuClock)
+            .sampling(SamplingMode::FrequencyHz(999)),
+    )
+    .expect("PerfSampler::start should succeed when perf is available");
+
+    assert!(
+        !is_ctimer_active(),
+        "dispatcher routed to ctimer despite perf being available"
+    );
+}
+
+// Fork so the seccomp filter (sticky) stays isolated from the rest of
+// the test run.
+#[test]
+fn falls_back_to_ctimer_when_perf_event_open_blocked() {
+    let pid = unsafe { libc::fork() };
+    assert!(pid >= 0, "fork failed");
+
+    if pid == 0 {
+        install_seccomp_blocking_perf_event_open();
+        let sampler = PerfSampler::start(
+            SamplerConfig::default()
+                .event_source(EventSource::SwCpuClock)
+                .sampling(SamplingMode::FrequencyHz(999)),
+        );
+        let ok = sampler.is_ok() && is_ctimer_active();
+        unsafe { libc::_exit(!ok as i32) };
+    }
+
+    let mut status = 0;
+    assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+    assert!(libc::WIFEXITED(status), "child did not exit normally");
+    assert_eq!(libc::WEXITSTATUS(status), 0, "fallback did not trigger");
+}


### PR DESCRIPTION
Follow-up to #250 (new CPU profiling fallback), this PR does some minor clean up and adds a few tests:

- Tests around the new pieces: sigsegv trap path, and ctimer sample firing under cpu load. 
- Adds fallback path to the bencher overhead tracking.
- One regression fix: `open_perf_event` was wrapping `PermissionDenied` errors via `io::Error::new`, which dropped `raw_os_error` and broke `is_perf_blocked`. Added a fallback detection [test to catch this](perf-self-profile/tests/fallback_detection.rs). 

Will follow up with another one improving the ECS simulation, current check is probably not enough or exactly what ECS restricts.