### PR TITLE
perf: use FxHash for intern_location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,13 @@ jobs:
         env:
           RUSTFLAGS: "--cfg tokio_unstable"
         run: |
-          for crate in dial9-trace-format-derive dial9-trace-format dial9-perf-self-profile dial9-macro dial9-tokio-telemetry dial9-viewer; do
-            echo "::group::cargo package -p $crate"
-            cargo package -p "$crate"
-            echo "::endgroup::"
-          done
+          cargo package \
+            -p dial9-trace-format-derive \
+            -p dial9-trace-format \
+            -p dial9-perf-self-profile \
+            -p dial9-macro \
+            -p dial9-tokio-telemetry \
+            -p dial9-viewer
 
   ci-pass:
     name: CI Pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/dial9-rs/dial9-tokio-telemetry/compare/dial9-tokio-telemetry-v0.3.4...dial9-tokio-telemetry-v0.3.5) - 2026-04-24
+
+### Added
+
+- *(viewer)* resizable sidebar and slightly improved ux ([#290](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/290))
+
+### Fixed
+
+- *(ci)* use single cargo package invocation for cross-crate verification
+
+### Other
+
+- lower expected sample threshold in ctimer cpu load test ([#292](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/292))
+- Restore collect_files safety limits lost by merge-queue bug ([#276](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/276)) ([#295](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/295))
+- restore ([#286](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/286))
+- Fix stack overflow on large profiles ([#285](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/285))
+
 ## [0.3.4](https://github.com/dial9-rs/dial9-tokio-telemetry/compare/dial9-tokio-telemetry-v0.3.3...dial9-tokio-telemetry-v0.3.4) - 2026-04-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-macro"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "insta",
  "prettyplease",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-perf-self-profile"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "blazesym",
  "crossbeam-utils",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-tokio-telemetry"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "arc-swap",
  "assert2",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-trace-format"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "criterion",
  "dial9-trace-format-derive",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-trace-format-derive"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "insta",
  "prettyplease",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-viewer"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "assert2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ repository = "https://github.com/dial9-rs/dial9-tokio-telemetry"
 
 [workspace.dependencies]
 libc = "0.2"
-dial9-perf-self-profile = { version = "0.3.4", path = "perf-self-profile" }
-dial9-trace-format = { version = "0.3.4", path = "dial9-trace-format" }
-dial9-trace-format-derive = { version = "0.3.4", path = "dial9-trace-format-derive" }
-dial9-macro = { version = "0.3.4", path = "dial9-macro" }
+dial9-perf-self-profile = { version = "0.3.5", path = "perf-self-profile" }
+dial9-trace-format = { version = "0.3.5", path = "dial9-trace-format" }
+dial9-trace-format-derive = { version = "0.3.5", path = "dial9-trace-format-derive" }
+dial9-macro = { version = "0.3.5", path = "dial9-macro" }
 assert2 = "0.4"
 
 [profile.release]

--- a/dial9-macro/Cargo.toml
+++ b/dial9-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-macro"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-tokio-telemetry"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dial9-tokio-telemetry/src/telemetry/buffer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/buffer.rs
@@ -10,8 +10,7 @@ use crate::telemetry::collector::CentralCollector;
 use crate::telemetry::events::RawEvent;
 use crate::telemetry::format::*;
 use dial9_trace_format::InternedString;
-use dial9_trace_format::encoder::Encoder;
-use std::collections::HashMap;
+use dial9_trace_format::encoder::{Encoder, FxHashMap};
 use std::panic::Location;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -28,7 +27,7 @@ use std::time::Duration;
 /// You don't construct this directly; it's passed to [`Encodable::encode`].
 pub struct ThreadLocalEncoder<'a> {
     encoder: &'a mut Encoder<Vec<u8>>,
-    location_cache: &'a mut HashMap<&'static Location<'static>, String>,
+    location_cache: &'a mut FxHashMap<&'static Location<'static>, String>,
 }
 
 impl std::fmt::Debug for ThreadLocalEncoder<'_> {
@@ -295,7 +294,7 @@ pub(crate) struct ThreadLocalBuffer {
     /// Caches `Location::to_string()` to avoid re-formatting on every event.
     /// Bounded by the number of `#[track_caller]` call sites in the program,
     /// which is fixed at compile time, so this does not grow unboundedly.
-    location_cache: HashMap<&'static Location<'static>, String>,
+    location_cache: FxHashMap<&'static Location<'static>, String>,
     /// Last drain epoch at which this buffer was flushed. Shared with the
     /// flush thread via `TlBufferHandle` so it can skip busy workers.
     pub(crate) flush_epoch: FlushEpoch,
@@ -320,7 +319,7 @@ impl ThreadLocalBuffer {
             event_count: 0,
             batch_size,
             collector: None,
-            location_cache: HashMap::new(),
+            location_cache: FxHashMap::default(),
             flush_epoch: FlushEpoch::new(),
         }
     }

--- a/dial9-trace-format-derive/Cargo.toml
+++ b/dial9-trace-format-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-trace-format-derive"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dial9-trace-format/Cargo.toml
+++ b/dial9-trace-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-trace-format"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 ///
 /// For HashMap keys that are already well-distributed (TypeId, Arc<str>), this
 /// avoids hash collisions.
+#[doc(hidden)]
 #[derive(Default)]
 pub struct FxHasher(u64);
 
@@ -61,7 +62,9 @@ impl Hasher for FxHasher {
     }
 }
 
+#[doc(hidden)]
 pub type FxBuildHasher = BuildHasherDefault<FxHasher>;
+#[doc(hidden)]
 pub type FxHashMap<K, V> = HashMap<K, V, FxBuildHasher>;
 
 /// A schema handle returned by [`Encoder::register_schema`] or created via

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 /// For HashMap keys that are already well-distributed (TypeId, Arc<str>), this
 /// avoids hash collisions.
 #[derive(Default)]
-pub(crate) struct FxHasher(u64);
+pub struct FxHasher(u64);
 
 impl Hasher for FxHasher {
     #[inline]
@@ -61,8 +61,8 @@ impl Hasher for FxHasher {
     }
 }
 
-pub(crate) type FxBuildHasher = BuildHasherDefault<FxHasher>;
-pub(crate) type FxHashMap<K, V> = HashMap<K, V, FxBuildHasher>;
+pub type FxBuildHasher = BuildHasherDefault<FxHasher>;
+pub type FxHashMap<K, V> = HashMap<K, V, FxBuildHasher>;
 
 /// A schema handle returned by [`Encoder::register_schema`] or created via
 /// [`Schema::new`].

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-viewer"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/perf-self-profile/Cargo.toml
+++ b/perf-self-profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-perf-self-profile"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 repository.workspace = true
 description = "Minimal self-profiling via Linux perf_event_open with frame-pointer-based stack traces"


### PR DESCRIPTION
closes #245 

Swap `std::collections::HashMap` for `FxHashMap` (reusing the in-tree `FxHasher` already defined in `dial9-trace-format`)

