### PR TITLE
(viewer) Move flamegraph into sidebar instead of full-screen overlay

### DIFF
--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -629,19 +629,6 @@
                 <div id="flamegraph-panel">
                     <div id="fg-container" style="flex:1;display:flex;flex-direction:column;overflow:hidden"></div>
                 </div>
-                <div id="sched-panel" style="display:none;position:absolute;top:0;left:0;right:0;bottom:0;background:#1a1a2e;z-index:50;flex-direction:column">
-                    <div style="display:flex;align-items:center;gap:12px;padding:6px 12px;background:#16213e;border-bottom:1px solid #333;font-size:0.8em;flex-shrink:0">
-                        <span style="color:#ff4444;font-weight:600" id="sched-panel-title">⚠ Scheduling Events</span>
-                        <span style="color:#888" id="sched-panel-stats"></span>
-                        <select id="sched-group-by" style="background:#2a2a4a;border:1px solid #444;color:#ccc;padding:3px 6px;border-radius:4px;font-size:0.9em">
-                            <option value="leaf">Group by blocking call</option>
-                            <option value="full">Group by full stack</option>
-                        </select>
-                        <span style="flex:1"></span>
-                        <span id="sched-panel-close" style="cursor:pointer;color:#888;padding:0 4px" tabindex="0" role="button">✕ Close (Esc)</span>
-                    </div>
-                    <div id="sched-panel-body" style="flex:1;overflow-y:auto;padding:8px 12px;font-family:monospace;font-size:0.82em;line-height:1.5"></div>
-                </div>
             </div>
             <div id="stack-sidebar">
                 <div class="sidebar-resize" id="sidebar-resize-handle"></div>
@@ -3167,6 +3154,7 @@
                     fgActive = false;
                     document.getElementById("flamegraph-panel").appendChild(fgContainer);
                 }
+                schedActive = false;
                 const sidebar = document.getElementById("stack-sidebar");
                 const body = document.getElementById("stack-sidebar-body");
                 const wasVisible = sidebar.style.display === "flex";
@@ -3227,6 +3215,7 @@
 
             // ── Sched Events Panel (global view of all blocking operations) ──
             let schedPanelTimeRange = null; // {start, end} or null for full trace
+            let schedActive = false;
 
             function showSchedPanel(startNs, endNs) {
                 schedPanelTimeRange = (startNs != null && endNs != null) ? { start: startNs, end: endNs } : null;
@@ -3235,10 +3224,19 @@
                     showToast("no-sched-events", "No scheduling events found" + (schedPanelTimeRange ? " in selected range" : " in trace"), "error", 4000);
                     return;
                 }
+                schedActive = true;
+                const sidebar = document.getElementById("stack-sidebar");
+                const title = document.getElementById("stack-sidebar-title");
+                const rangeLabel = schedPanelTimeRange
+                    ? ` in ${formatHumanDuration(schedPanelTimeRange.end - schedPanelTimeRange.start)}`
+                    : "";
+                title.textContent = `Blocking Calls \u00b7 ${allSched.length} events${rangeLabel}`;
+
                 renderSchedPanel(allSched);
                 clearToasts();
-                document.getElementById("sched-panel").style.display = "flex";
-                document.getElementById("sched-panel-close").focus();
+                const wasHidden = sidebar.style.display !== "flex";
+                sidebar.style.display = "flex";
+                if (wasHidden && trace) requestAnimationFrame(renderAll);
             }
 
             function collectSchedSamples(range) {
@@ -3257,14 +3255,11 @@
             }
 
             function renderSchedPanel(allSched) {
-                const groupBy = document.getElementById("sched-group-by").value;
-                const body = document.getElementById("sched-panel-body");
+                const groupBy = schedActive
+                    ? (document.getElementById("sched-group-by-sb") || {}).value || "leaf"
+                    : "leaf";
+                const body = document.getElementById("stack-sidebar-body");
                 const total = allSched.length;
-                const rangeLabel = schedPanelTimeRange
-                    ? ` in ${formatHumanDuration(schedPanelTimeRange.end - schedPanelTimeRange.start)} selection`
-                    : " (full trace)";
-                document.getElementById("sched-panel-stats").textContent =
-                    `${total} events across ${workerIds.length} workers${rangeLabel}`;
 
                 // Group by leaf frame or full stack
                 const groups = new Map();
@@ -3289,9 +3284,14 @@
 
                 const sorted = [...groups.values()].sort((a, b) => b.count - a.count);
 
-                let html = `<div style="margin-bottom:12px;color:#aaa;font-size:0.9em">
+                let html = `<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+                    <select id="sched-group-by-sb" style="background:#2a2a4a;border:1px solid #444;color:#ccc;padding:3px 6px;border-radius:4px;font-size:0.9em">
+                        <option value="leaf"${groupBy === "leaf" ? " selected" : ""}>Group by blocking call</option>
+                        <option value="full"${groupBy === "full" ? " selected" : ""}>Group by full stack</option>
+                    </select>
+                </div>`;
+                html += `<div style="margin-bottom:10px;color:#aaa;font-size:0.9em">
                     Blocking calls that caused the kernel to deschedule a tokio worker thread during a poll.
-                    These indicate synchronous/blocking operations on the async runtime.
                 </div>`;
 
                 // Summary bar chart
@@ -3321,14 +3321,14 @@
                     const gid = 'sg-' + Math.random().toString(36).slice(2);
 
                     html += `<div style="border:1px solid #333;border-radius:6px;margin-bottom:8px;overflow:hidden">`;
-                    html += `<div style="padding:8px 12px;background:#16213e;display:flex;align-items:center;gap:8px;cursor:pointer" onclick="document.getElementById('${gid}').style.display=document.getElementById('${gid}').style.display==='none'?'block':'none'">`;
+                    html += `<div style="padding:8px 12px;background:#16213e;display:flex;align-items:center;gap:8px;cursor:pointer" onclick="var d=document.getElementById('${gid}');d.style.display=d.style.display==='none'?'block':'none';this.querySelector('.sg-toggle').textContent=d.style.display==='none'?'▶ details':'▼ collapse'">`;
                     html += `<span style="color:${color};font-weight:700;font-size:1.1em">${g.count}×</span>`;
                     html += `<span style="color:#fff;font-weight:600">${g.leaf}</span>`;
                     html += `<span style="color:#888">(${pct}% of all sched events)</span>`;
-                    html += `<span style="color:#6c63ff;margin-left:auto;font-size:0.9em">▼ details</span>`;
+                    html += `<span class="sg-toggle" style="color:#6c63ff;margin-left:auto;font-size:0.9em">▼ collapse</span>`;
                     html += `</div>`;
 
-                    html += `<div id="${gid}" style="display:none;padding:8px 12px">`;
+                    html += `<div id="${gid}" style="padding:8px 12px">`;
 
                     // Show unique stacks within this group
                     const subStacks = [...g.stacks.values()].sort((a, b) => b.count - a.count);
@@ -3365,6 +3365,15 @@
 
                 body.innerHTML = html;
 
+                // Wire up group-by dropdown
+                const groupByEl = document.getElementById("sched-group-by-sb");
+                if (groupByEl) {
+                    groupByEl.addEventListener("change", () => {
+                        const allSched = collectSchedSamples(schedPanelTimeRange);
+                        renderSchedPanel(allSched);
+                    });
+                }
+
                 // Wire up jump-to-poll links
                 body.querySelectorAll('.sched-jump').forEach(el => {
                     el.addEventListener('click', (e) => {
@@ -3375,7 +3384,7 @@
                         const pad = Math.max(dur * 5, 1e6);
                         viewStart = Math.max(minTs, t - pad * 0.3);
                         viewEnd = Math.min(maxTs, viewStart + pad);
-                        document.getElementById("sched-panel").style.display = "none";
+                        hideStackPopup();
                         // Scroll to worker lane
                         const laneIdx = workerIds.indexOf(w);
                         if (laneIdx >= 0) lanesContainer.scrollTop = laneIdx * LANE_H;
@@ -3383,15 +3392,6 @@
                     });
                 });
             }
-
-            document.getElementById("sched-group-by").addEventListener("change", () => {
-                const allSched = collectSchedSamples(schedPanelTimeRange);
-                renderSchedPanel(allSched);
-            });
-
-            document.getElementById("sched-panel-close").addEventListener("click", () => {
-                document.getElementById("sched-panel").style.display = "none";
-            });
 
             // Enter activates role="button" elements and toggles checkboxes
             document.addEventListener("keydown", (e) => {
@@ -3468,8 +3468,6 @@
                                 break;
                             }
                             hideStackPopup();
-                        } else if (document.getElementById("sched-panel").style.display === "flex") {
-                            document.getElementById("sched-panel").style.display = "none";
                         }
                         selectedTaskId = null;
                         document.getElementById("main-area").focus();

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -660,6 +660,7 @@
                     <span class="sidebar-close" id="stack-sidebar-close">&times;</span>
                 </div>
                 <div class="sidebar-tabs" id="sidebar-tabs" style="display:none">
+                    <span class="tab" id="tab-poll-detail" data-tab="poll-detail" style="display:none">Poll Detail</span>
                     <span class="tab" id="tab-flamegraph" data-tab="flamegraph">Flamegraph</span>
                     <span class="tab" id="tab-blocking" data-tab="blocking">Blocking Calls</span>
                 </div>
@@ -3165,12 +3166,11 @@
                 }
 
                 body.innerHTML = html;
+                showSidebarTabs("poll-detail");
                 const wasHidden = sidebar.style.display !== "flex";
                 sidebar.style.display = "flex";
                 if (wasHidden && trace) requestAnimationFrame(renderAll);
             }
-
-            // Track the current selection range for tab switching
             let sidebarSelStart = 0, sidebarSelEnd = 0;
 
             function hideStackPopup() {
@@ -3195,12 +3195,27 @@
 
             document.getElementById("stack-sidebar-close").addEventListener("click", hideStackPopup);
 
-            // ── Sidebar view tabs (flamegraph <-> blocking calls) ──
+            // ── Sidebar view tabs (poll-detail | flamegraph <-> blocking calls) ──
             function showSidebarTabs(activeTab) {
                 const tabs = document.getElementById("sidebar-tabs");
                 tabs.style.display = "flex";
-                tabs.querySelector("#tab-flamegraph").classList.toggle("active", activeTab === "flamegraph");
-                tabs.querySelector("#tab-blocking").classList.toggle("active", activeTab === "blocking");
+                const pollDetail = tabs.querySelector("#tab-poll-detail");
+                const flamegraph = tabs.querySelector("#tab-flamegraph");
+                const blocking = tabs.querySelector("#tab-blocking");
+
+                if (activeTab === "poll-detail") {
+                    pollDetail.style.display = "";
+                    flamegraph.style.display = "none";
+                    blocking.style.display = "none";
+                } else {
+                    pollDetail.style.display = "none";
+                    flamegraph.style.display = "";
+                    blocking.style.display = "";
+                }
+
+                pollDetail.classList.toggle("active", activeTab === "poll-detail");
+                flamegraph.classList.toggle("active", activeTab === "flamegraph");
+                blocking.classList.toggle("active", activeTab === "blocking");
             }
 
             document.getElementById("tab-flamegraph").addEventListener("click", () => {

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -167,6 +167,29 @@
                 font-family: monospace;
                 font-size: 0.9em;
             }
+            #stack-sidebar .sidebar-tabs {
+                display: flex;
+                gap: 0;
+                padding: 0 12px;
+                background: #16213e;
+                flex-shrink: 0;
+                border-bottom: 1px solid #333;
+            }
+            #stack-sidebar .sidebar-tabs .tab {
+                padding: 6px 14px;
+                font-size: 0.85em;
+                cursor: pointer;
+                color: #888;
+                border-bottom: 2px solid transparent;
+                transition: color 0.15s, border-color 0.15s;
+            }
+            #stack-sidebar .sidebar-tabs .tab:hover {
+                color: #ccc;
+            }
+            #stack-sidebar .sidebar-tabs .tab.active {
+                color: #fff;
+                border-bottom-color: #6c63ff;
+            }
 
             #toolbar {
                 display: flex;
@@ -635,6 +658,10 @@
                 <div class="sidebar-header">
                     <span class="sidebar-title" id="stack-sidebar-title"></span>
                     <span class="sidebar-close" id="stack-sidebar-close">&times;</span>
+                </div>
+                <div class="sidebar-tabs" id="sidebar-tabs" style="display:none">
+                    <span class="tab" id="tab-flamegraph" data-tab="flamegraph">Flamegraph</span>
+                    <span class="tab" id="tab-blocking" data-tab="blocking">Blocking Calls</span>
                 </div>
                 <div class="sidebar-body" id="stack-sidebar-body"></div>
             </div>
@@ -2920,8 +2947,6 @@
                     );
                     if (hasSched && !hasCpu) {
                         showSchedPanel(selStart, selEnd);
-                    } else if (hasSched) {
-                        showSelectionPicker(selStart, selEnd);
                     } else {
                         showFlamegraph(selStart, selEnd);
                     }
@@ -2986,9 +3011,6 @@
                             if (hasSched && !hasCpu) {
                                 selOverlay.style.display = "none";
                                 showSchedPanel(selStart, selEnd);
-                            } else if (hasSched) {
-                                // Keep overlay visible while picker is shown
-                                showSelectionPicker(selStart, selEnd);
                             } else {
                                 selOverlay.style.display = "none";
                                 showFlamegraph(selStart, selEnd);
@@ -3148,6 +3170,9 @@
                 if (wasHidden && trace) requestAnimationFrame(renderAll);
             }
 
+            // Track the current selection range for tab switching
+            let sidebarSelStart = 0, sidebarSelEnd = 0;
+
             function hideStackPopup() {
                 // If flamegraph was in the sidebar, move its container back
                 if (fgActive) {
@@ -3155,10 +3180,13 @@
                     document.getElementById("flamegraph-panel").appendChild(fgContainer);
                 }
                 schedActive = false;
+                sidebarSelStart = 0;
+                sidebarSelEnd = 0;
                 const sidebar = document.getElementById("stack-sidebar");
                 const body = document.getElementById("stack-sidebar-body");
                 const wasVisible = sidebar.style.display === "flex";
                 sidebar.style.display = "none";
+                document.getElementById("sidebar-tabs").style.display = "none";
                 body.style.display = "";
                 body.style.flexDirection = "";
                 selOverlay.style.display = "none";
@@ -3166,6 +3194,30 @@
             }
 
             document.getElementById("stack-sidebar-close").addEventListener("click", hideStackPopup);
+
+            // ── Sidebar view tabs (flamegraph <-> blocking calls) ──
+            function showSidebarTabs(activeTab) {
+                const tabs = document.getElementById("sidebar-tabs");
+                tabs.style.display = "flex";
+                tabs.querySelector("#tab-flamegraph").classList.toggle("active", activeTab === "flamegraph");
+                tabs.querySelector("#tab-blocking").classList.toggle("active", activeTab === "blocking");
+            }
+
+            document.getElementById("tab-flamegraph").addEventListener("click", () => {
+                if (fgActive) return; // already showing
+                // Clean up current view before switching
+                schedActive = false;
+                showFlamegraph(sidebarSelStart, sidebarSelEnd);
+            });
+            document.getElementById("tab-blocking").addEventListener("click", () => {
+                if (schedActive) return; // already showing
+                // Clean up flamegraph before switching
+                if (fgActive) {
+                    fgActive = false;
+                    document.getElementById("flamegraph-panel").appendChild(fgContainer);
+                }
+                showSchedPanel(sidebarSelStart, sidebarSelEnd);
+            });
 
             // ── Sidebar resize drag ──
             (function initSidebarResize() {
@@ -3224,13 +3276,36 @@
                     showToast("no-sched-events", "No scheduling events found" + (schedPanelTimeRange ? " in selected range" : " in trace"), "error", 4000);
                     return;
                 }
+                // Clean up flamegraph if switching from it
+                if (fgActive) {
+                    fgActive = false;
+                    document.getElementById("flamegraph-panel").appendChild(fgContainer);
+                }
                 schedActive = true;
                 const sidebar = document.getElementById("stack-sidebar");
                 const title = document.getElementById("stack-sidebar-title");
-                const rangeLabel = schedPanelTimeRange
-                    ? ` in ${formatHumanDuration(schedPanelTimeRange.end - schedPanelTimeRange.start)}`
-                    : "";
-                title.textContent = `Blocking Calls \u00b7 ${allSched.length} events${rangeLabel}`;
+                const body = document.getElementById("stack-sidebar-body");
+                body.style.display = "";
+                body.style.flexDirection = "";
+
+                if (startNs != null && endNs != null) {
+                    sidebarSelStart = startNs;
+                    sidebarSelEnd = endNs;
+                    const durMs = ((endNs - startNs) / 1e6).toFixed(2);
+                    title.textContent = `${durMs}ms selected`;
+                    // Show tabs if CPU samples exist in range
+                    const hasCpu = trace.cpuSamples.some(s =>
+                        s.timestamp >= startNs && s.timestamp <= endNs && s.callchain.length > 0 && s.source !== 1
+                    );
+                    if (hasCpu) {
+                        showSidebarTabs("blocking");
+                    } else {
+                        document.getElementById("sidebar-tabs").style.display = "none";
+                    }
+                } else {
+                    title.textContent = `Blocking Calls \u00b7 ${allSched.length} events`;
+                    document.getElementById("sidebar-tabs").style.display = "none";
+                }
 
                 renderSchedPanel(allSched);
                 clearToasts();
@@ -3813,37 +3888,6 @@
             const fgContainer = document.getElementById("fg-container");
             const fgInstance = FlamegraphRenderer.createFlamegraph(fgContainer);
 
-            // Selection picker: shown after shift+drag when both flamegraph and sched data exist
-            function showSelectionPicker(selStart, selEnd) {
-                const durMs = ((selEnd - selStart) / 1e6).toFixed(2);
-                const schedCount = collectSchedSamples({ start: selStart, end: selEnd }).length;
-                const sidebar = document.getElementById("stack-sidebar");
-                const title = document.getElementById("stack-sidebar-title");
-                const body = document.getElementById("stack-sidebar-body");
-                title.textContent = `${durMs}ms selected`;
-                body.innerHTML = `
-                    <div style="display:flex;flex-direction:column;gap:8px">
-                        <div style="padding:8px 12px;background:#2a2a4a;border:1px solid #444;border-radius:6px;cursor:pointer;transition:background 0.15s"
-                             onmouseover="this.style.background='#3a3a5a'" onmouseout="this.style.background='#2a2a4a'"
-                             id="pick-flamegraph" tabindex="0" role="button">
-                            <div style="color:#ff8c00;font-weight:600">CPU Flamegraph</div>
-                            <div style="color:#888;font-size:0.9em">Profile where CPU time is spent</div>
-                        </div>
-                        <div style="padding:8px 12px;background:#2a2a4a;border:1px solid #444;border-radius:6px;cursor:pointer;transition:background 0.15s"
-                             onmouseover="this.style.background='#3a3a5a'" onmouseout="this.style.background='#2a2a4a'"
-                             id="pick-sched" tabindex="0" role="button">
-                            <div style="color:#ff4444;font-weight:600">Blocking Calls <span style="color:#888;font-weight:400">(${schedCount})</span></div>
-                            <div style="color:#888;font-size:0.9em">Analyze what's blocking the runtime</div>
-                        </div>
-                    </div>`;
-                const wasHidden = sidebar.style.display !== "flex";
-                sidebar.style.display = "flex";
-                if (wasHidden && trace) requestAnimationFrame(renderAll);
-                document.getElementById("pick-flamegraph").onclick = () => { hideStackPopup(); showFlamegraph(selStart, selEnd); };
-                document.getElementById("pick-sched").onclick = () => { hideStackPopup(); showSchedPanel(selStart, selEnd); };
-                document.getElementById("pick-flamegraph").focus();
-            }
-
             function showFlamegraph(selStart, selEnd) {
                 const samples = FlamegraphRenderer.filterCpuSamples(trace.cpuSamples, selStart, selEnd);
                 if (!samples.length) {
@@ -3854,20 +3898,31 @@
                 fgSelStart = selStart;
                 fgSelEnd = selEnd;
                 fgActive = true;
+                schedActive = false;
+                sidebarSelStart = selStart;
+                sidebarSelEnd = selEnd;
                 const durMs = ((selEnd - selStart) / 1e6).toFixed(2);
 
                 const sidebar = document.getElementById("stack-sidebar");
                 const title = document.getElementById("stack-sidebar-title");
                 const body = document.getElementById("stack-sidebar-body");
-                title.textContent = `Flamegraph \u00b7 ${samples.length} samples \u00b7 ${durMs}ms`;
+                title.textContent = `${durMs}ms selected`;
+
+                // Show tabs if both data types exist
+                const hasSched = collectSchedSamples({ start: selStart, end: selEnd }).length > 0;
+                if (hasSched) {
+                    showSidebarTabs("flamegraph");
+                } else {
+                    document.getElementById("sidebar-tabs").style.display = "none";
+                }
 
                 body.innerHTML = "";
                 body.style.display = "flex";
                 body.style.flexDirection = "column";
                 // Add pop-out button above the flamegraph
                 const actions = document.createElement("div");
-                actions.style.cssText = "display:flex;gap:8px;margin-bottom:6px;flex-shrink:0";
-                actions.innerHTML = `<span id="fg-popout-sb" tabindex="0" role="button" title="Open in new tab" style="cursor:pointer;color:#6c63ff;font-size:0.9em">&#8599; Pop Out</span>`;
+                actions.style.cssText = "display:flex;gap:8px;margin-bottom:6px;flex-shrink:0;align-items:center";
+                actions.innerHTML = `<span style="color:#888;font-size:0.85em">${samples.length} samples</span><span id="fg-popout-sb" tabindex="0" role="button" title="Open in new tab" style="cursor:pointer;color:#6c63ff;font-size:0.9em">&#8599; Pop Out</span>`;
                 body.appendChild(actions);
                 // Move fg-container into sidebar body
                 fgContainer.style.flex = "1";

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -446,31 +446,7 @@
 
             #flamegraph-panel {
                 display: none;
-                position: absolute;
-                top: 0;
-                left: 0;
-                right: 0;
-                bottom: 0;
-                background: #1a1a2e;
-                z-index: 50;
-                flex-direction: column;
             }
-            #flamegraph-panel .fg-header {
-                display: flex;
-                align-items: center;
-                gap: 12px;
-                padding: 6px 12px;
-                background: #16213e;
-                border-bottom: 1px solid #333;
-                font-size: 0.8em;
-                flex-shrink: 0;
-            }
-            #flamegraph-panel .fg-header .fg-title { color: #6c63ff; font-weight: 600; }
-            #flamegraph-panel .fg-header .fg-stats { color: #888; }
-            #flamegraph-panel .fg-header .fg-popout { cursor: pointer; color: #888; padding: 0 4px; }
-            #flamegraph-panel .fg-header .fg-popout:hover { color: #fff; }
-            #flamegraph-panel .fg-header .fg-close { cursor: pointer; color: #888; margin-left: auto; padding: 0 4px; }
-            #flamegraph-panel .fg-header .fg-close:hover { color: #fff; }
             @keyframes toast-in {
                 from { opacity: 0; transform: translateY(-8px); }
                 to { opacity: 1; transform: translateY(0); }
@@ -651,12 +627,6 @@
                     <canvas id="queue-canvas"></canvas>
                 </div>
                 <div id="flamegraph-panel">
-                    <div class="fg-header">
-                        <span class="fg-title" id="fg-title">Flamegraph</span>
-                        <span class="fg-stats" id="fg-stats"></span>
-                        <span class="fg-popout" id="fg-popout" tabindex="0" role="button" title="Open in new tab">&#8599; Pop Out</span>
-                        <span class="fg-close" id="fg-close" tabindex="0" role="button">&#10005; Close (Esc)</span>
-                    </div>
                     <div id="fg-container" style="flex:1;display:flex;flex-direction:column;overflow:hidden"></div>
                 </div>
                 <div id="sched-panel" style="display:none;position:absolute;top:0;left:0;right:0;bottom:0;background:#1a1a2e;z-index:50;flex-direction:column">
@@ -984,7 +954,6 @@
             const dragOverlay = document.getElementById("drag-overlay");
             const fileInput = document.getElementById("file-input");
             const viewer = document.getElementById("viewer");
-            const fgPanel = document.getElementById("flamegraph-panel");
             const taskDetailPanel = document.getElementById("task-detail");
             const clearRangeBtn = document.getElementById("btn-clear-range");
             const tooltip = document.getElementById("tooltip");
@@ -1055,7 +1024,7 @@
             function resetTraceState({ clearUrlRange } = {}) {
                 selectedTaskId = null;
                 hoveredWakerTaskId = null;
-                fgPanel.style.display = "none";
+                hideStackPopup();
                 taskDetailPanel.style.display = "none";
                 schedPanelTimeRange = null;
 
@@ -2823,7 +2792,6 @@
             document.getElementById("main-area").addEventListener(
                 "wheel",
                 (e) => {
-                    if (document.getElementById("flamegraph-panel").style.display === "flex") return;
                     if (e.ctrlKey || e.metaKey) {
                         e.preventDefault();
                         const rect = lanesContainer.getBoundingClientRect();
@@ -3194,9 +3162,17 @@
             }
 
             function hideStackPopup() {
+                // If flamegraph was in the sidebar, move its container back
+                if (fgActive) {
+                    fgActive = false;
+                    document.getElementById("flamegraph-panel").appendChild(fgContainer);
+                }
                 const sidebar = document.getElementById("stack-sidebar");
+                const body = document.getElementById("stack-sidebar-body");
                 const wasVisible = sidebar.style.display === "flex";
                 sidebar.style.display = "none";
+                body.style.display = "";
+                body.style.flexDirection = "";
                 selOverlay.style.display = "none";
                 if (wasVisible && trace) requestAnimationFrame(renderAll);
             }
@@ -3244,6 +3220,7 @@
                     handle.classList.remove("active");
                     document.body.style.cursor = "";
                     document.body.style.userSelect = "";
+                    if (fgActive) fgInstance.resize();
                     if (trace) requestAnimationFrame(renderAll);
                 });
             })();
@@ -3486,14 +3463,13 @@
                         }
                         clearToasts();
                         if (document.getElementById("stack-sidebar").style.display === "flex") {
+                            // If flamegraph is in the sidebar, let it handle Escape first
+                            if (fgActive && fgInstance.handleEscape()) {
+                                break;
+                            }
                             hideStackPopup();
                         } else if (document.getElementById("sched-panel").style.display === "flex") {
                             document.getElementById("sched-panel").style.display = "none";
-                        } else if (document.getElementById("flamegraph-panel").style.display === "flex") {
-                            // Let the flamegraph module handle Escape first (search clear / zoom reset)
-                            if (!fgInstance.handleEscape()) {
-                                document.getElementById("flamegraph-panel").style.display = "none";
-                            }
                         }
                         selectedTaskId = null;
                         document.getElementById("main-area").focus();
@@ -3550,12 +3526,6 @@
                     }
                     // Don't override span panel tooltip
                     if (e.target.closest && e.target.closest("#span-panel")) {
-                        mouseNs = null;
-                        lanesContainer.style.cursor = "";
-                        return;
-                    }
-                    if (document.getElementById("flamegraph-panel").style.display === "flex") {
-                        tooltip.style.display = "none";
                         mouseNs = null;
                         lanesContainer.style.cursor = "";
                         return;
@@ -3841,9 +3811,9 @@
 
             // ── Flamegraph ──
             let fgSelStart = 0, fgSelEnd = 0;
-            const fgInstance = FlamegraphRenderer.createFlamegraph(
-                document.getElementById("fg-container")
-            );
+            let fgActive = false;
+            const fgContainer = document.getElementById("fg-container");
+            const fgInstance = FlamegraphRenderer.createFlamegraph(fgContainer);
 
             // Selection picker: shown after shift+drag when both flamegraph and sched data exist
             function showSelectionPicker(selStart, selEnd) {
@@ -3885,22 +3855,43 @@
 
                 fgSelStart = selStart;
                 fgSelEnd = selEnd;
+                fgActive = true;
                 const durMs = ((selEnd - selStart) / 1e6).toFixed(2);
-                document.getElementById("fg-title").textContent = "Flamegraph";
-                document.getElementById("fg-stats").textContent =
-                    `${samples.length} samples \u00b7 ${durMs}ms selected`;
+
+                const sidebar = document.getElementById("stack-sidebar");
+                const title = document.getElementById("stack-sidebar-title");
+                const body = document.getElementById("stack-sidebar-body");
+                title.textContent = `Flamegraph \u00b7 ${samples.length} samples \u00b7 ${durMs}ms`;
+
+                body.innerHTML = "";
+                body.style.display = "flex";
+                body.style.flexDirection = "column";
+                // Add pop-out button above the flamegraph
+                const actions = document.createElement("div");
+                actions.style.cssText = "display:flex;gap:8px;margin-bottom:6px;flex-shrink:0";
+                actions.innerHTML = `<span id="fg-popout-sb" tabindex="0" role="button" title="Open in new tab" style="cursor:pointer;color:#6c63ff;font-size:0.9em">&#8599; Pop Out</span>`;
+                body.appendChild(actions);
+                // Move fg-container into sidebar body
+                fgContainer.style.flex = "1";
+                fgContainer.style.minHeight = "0";
+                body.appendChild(fgContainer);
 
                 clearToasts();
-                document.getElementById("flamegraph-panel").style.display = "flex";
-                document.getElementById("fg-close").focus();
-                fgInstance.setData(samples, trace.callframeSymbols);
+                const wasHidden = sidebar.style.display !== "flex";
+                sidebar.style.display = "flex";
+                if (wasHidden && trace) requestAnimationFrame(renderAll);
+
+                // Give the container a frame to get its layout, then render
+                requestAnimationFrame(() => {
+                    fgInstance.setData(samples, trace.callframeSymbols);
+                    fgInstance.resize();
+                });
+
+                // Wire pop-out
+                document.getElementById("fg-popout-sb").onclick = handleFgPopout;
             }
 
-            document.getElementById("fg-close").addEventListener("click", () => {
-                document.getElementById("flamegraph-panel").style.display = "none";
-            });
-
-            document.getElementById("fg-popout").addEventListener("click", () => {
+            function handleFgPopout() {
                 const params = new URLSearchParams(window.location.search);
                 let traceUrl = params.get("trace");
                 let isBlobUrl = false;
@@ -3921,7 +3912,7 @@
                 if (isBlobUrl) {
                     showToast("popout-blob", "Pop-out linked to this tab \u2014 keep it open", "info", 5000);
                 }
-            });
+            }
 
             // ── Queue chart drag-select: show tasks spawned in time range ──
             let qcDragging = false, qcDragStartX = 0, qcDragStartNs = 0, qcDragEndNs = 0, qcDragMoved = false;
@@ -4051,7 +4042,7 @@
 
             // Re-render flamegraph on resize
             window.addEventListener("resize", () => {
-                if (document.getElementById("flamegraph-panel").style.display === "flex") {
+                if (fgActive) {
                     fgInstance.resize();
                 }
             });


### PR DESCRIPTION
The full-screen overlay was disruptive -- clicking a flamegraph or
viewing blocking calls would hide the entire timeline, making it
impossible to correlate profiling data with what was happening on
the workers. By rendering the flamegraph in the sidebar, the timeline
stays visible and interactive while inspecting CPU profiles.

The pop-out button is preserved for opening in a dedicated tab. Escape
still clears the flamegraph (after letting the flamegraph module handle
search/zoom reset first).

<img width="1511" height="794" alt="SCR-20260424-bsdq" src="https://github.com/user-attachments/assets/bf0bbd6b-6371-499f-98d5-18b042b02cdc" />

[this is a draft until #290 is merged]