### PR TITLE
Restore collect_files safety limits lost by merge-queue bug (#276)

### DIFF
--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -220,7 +220,7 @@ impl StorageBackend for LocalBackend {
             let prefix2 = prefix.clone();
             tokio::task::spawn_blocking(move || {
                 let mut objects = Vec::new();
-                collect_files(&root, &root, &prefix2, &mut objects)?;
+                collect_files(&root, &root, &prefix2, &mut objects, 0, &mut 0)?;
                 objects.sort_by(|a, b| a.key.cmp(&b.key));
                 Ok(objects)
             })
@@ -313,18 +313,49 @@ impl StorageBackend for LocalBackend {
     }
 }
 
+/// Maximum directory depth to recurse into when listing local files.
+const MAX_COLLECT_DEPTH: u32 = 10;
+
+/// Maximum number of files to return from a local directory listing.
+const MAX_COLLECT_FILES: usize = 50;
+
+/// Maximum number of directory entries to visit (files + dirs) across the
+/// entire recursive walk. This bounds the number of syscalls (`canonicalize`,
+/// `metadata`) so a huge directory tree cannot hang the listing.
+const MAX_ENTRIES_VISITED: usize = 500;
+
+/// Directory names to skip during recursive file collection.
+fn is_skipped_dir(name: &str) -> bool {
+    name.starts_with('.') || matches!(name, "target" | "node_modules")
+}
+
 fn collect_files(
     root: &Path,
     dir: &Path,
     prefix: &str,
     out: &mut Vec<ObjectInfo>,
+    depth: u32,
+    visited: &mut usize,
 ) -> Result<(), StorageError> {
+    if depth > MAX_COLLECT_DEPTH
+        || out.len() >= MAX_COLLECT_FILES
+        || *visited >= MAX_ENTRIES_VISITED
+    {
+        return Ok(());
+    }
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            return Err(StorageError::Other("permission denied".into()));
+        }
         Err(e) => return Err(StorageError::Other(e.to_string())),
     };
     for entry in entries {
+        *visited += 1;
+        if out.len() >= MAX_COLLECT_FILES || *visited >= MAX_ENTRIES_VISITED {
+            break;
+        }
         let entry = entry.map_err(|e| StorageError::Other(e.to_string()))?;
         let path = entry.path();
         // Resolve symlinks and verify the target stays within root.
@@ -333,7 +364,11 @@ fn collect_files(
             _ => continue,
         };
         if canonical.is_dir() {
-            collect_files(root, &canonical, prefix, out)?;
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !is_skipped_dir(&name) {
+                collect_files(root, &canonical, prefix, out, depth + 1, visited)?;
+            }
         } else if canonical.is_file() {
             let key = path
                 .strip_prefix(root)
@@ -356,4 +391,32 @@ fn collect_files(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_files_caps_entries_visited() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create more files than MAX_ENTRIES_VISITED to prove we stop early.
+        let n = MAX_ENTRIES_VISITED + 500;
+        for i in 0..n {
+            std::fs::write(dir.path().join(format!("file_{i:05}.bin")), b"x").unwrap();
+        }
+        let mut out = Vec::new();
+        let mut visited = 0;
+        collect_files(dir.path(), dir.path(), "", &mut out, 0, &mut visited).unwrap();
+        // visited must be capped — we should NOT have iterated all n files.
+        assert!(
+            visited <= MAX_ENTRIES_VISITED,
+            "visited {visited} entries, expected at most {MAX_ENTRIES_VISITED}"
+        );
+        assert!(
+            out.len() <= MAX_COLLECT_FILES,
+            "collected {} files, expected at most {MAX_COLLECT_FILES}",
+            out.len()
+        );
+    }
 }


### PR DESCRIPTION
Re-applies the dial9-viewer/src/storage.rs changes originally landed by PR #276 (squash 461848e). The #280 squash commit (20b082a) was corrupted by the GitHub merge-queue incident and contained an exact revert of these changes, silently rolling them back. Viewer UI work lost by the same incident was already restored via #286; this restores the remaining piece.

Fetched verbatim from refs/pull/276/head so the content exactly matches the original PR. 
Authored-by preserved for Russell Cohen.

| File | Status | Why it's fine / what's fixed |                                                                      
  |---|---|---|                                                                                                         
  | `dial9-viewer/src/storage.rs` | **fixed by this branch** | #276's `collect_files` limits - exact revert by #280, never restored |                                                                                                      
  | `dial9-viewer/ui/viewer.html` | OK | Already restored by #286 (net matches #283 + a small propagation fix) |        
  | `dial9-tokio-telemetry/README.md` | OK | #276 changed it, #280 changed it back - net zero |                         
  | `dial9-tokio-telemetry/examples/many_workers.rs` | OK | #276 deleted 57 lines, #280 re-added them - net zero |      
  | `dial9-tokio-telemetry/benches/overhead_bench.rs` | OK | -1/+1 - net zero |                                         
  | `perf-self-profile/**`, `.github/workflows/benchmarks.yml` | OK | #280's legitimate ctimer/profiler work, correctly landed | 