### PR TITLE
Add simple example for local execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,6 +3888,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "simple-local"
+version = "0.1.0"
+dependencies = [
+ "dial9-tokio-telemetry",
+ "tokio",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "dial9-viewer",
     "perf-self-profile",
     "examples/metrics-service",
+    "examples/simple-local",
 ]
 exclude = [
     "dial9-trace-format/fuzz",

--- a/examples/simple-local/Cargo.toml
+++ b/examples/simple-local/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "simple-local"
+edition = "2024"
+version = "0.1.0"
+publish = false
+
+[dependencies]
+tokio = { version = "1.51.0", default-features = false, features = ["time"] }
+dial9-tokio-telemetry = { path = "../../dial9-tokio-telemetry", features = ["tracing-layer"] }

--- a/examples/simple-local/src/main.rs
+++ b/examples/simple-local/src/main.rs
@@ -1,0 +1,80 @@
+use dial9_tokio_telemetry::telemetry::{RotatingWriter, TelemetryHandle, TracedRuntime};
+use std::time::Duration;
+use tokio::runtime::Builder;
+
+const TRACE_DIR: &str = "/tmp/simple-local-traces";
+
+fn fibonacci_recursive(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci_recursive(n - 1) + fibonacci_recursive(n - 2),
+    }
+}
+
+async fn do_some_work() {
+    // do some work here
+    fibonacci_recursive(25);
+}
+
+fn main() -> std::io::Result<()> {
+    // Configure the trace writer
+    let trace_path = format!("{}/trace.bin", TRACE_DIR);
+    let writer = RotatingWriter::builder()
+        .base_path(&trace_path)
+        .max_file_size(10_000_000) // 10MB per file
+        .max_total_size(50_000_000) // 50MB total
+        .segment_metadata(vec![
+            ("service".into(), "simple-local".into()),
+            ("example".into(), "basic".into()),
+        ])
+        .build()?;
+
+    // Build the traced runtime
+    let mut builder = Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let traced_builder = TracedRuntime::builder()
+        .with_trace_path(&trace_path)
+        .with_task_tracking(true);
+
+    let (runtime, guard) = traced_builder.build(builder, writer)?;
+    guard.enable();
+    let handle = guard.handle();
+
+    // Run the async code
+    runtime.block_on(async {
+        handle
+            .spawn(async move {
+                let telemetry_handle = TelemetryHandle::current();
+                let mut handles = vec![];
+
+                // Run some concurrent work
+                for _ in 0..100 {
+                    handles.push(telemetry_handle.spawn(do_some_work()));
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+
+                // Wait for all tasks to complete
+                for handle in handles {
+                    handle.await.unwrap()
+                }
+            })
+            .await
+            .unwrap();
+    });
+
+    // Clean shutdown
+    drop(runtime);
+
+    guard.graceful_shutdown(Duration::from_secs(1))?;
+
+    println!("\n✓ Trace files written to: {}", trace_path);
+    println!(
+        "  You can view them with: cargo run --package dial9-viewer -- --local-dir {}",
+        TRACE_DIR
+    );
+    println!("  Then open http://localhost:3000 in your browser");
+
+    Ok(())
+}


### PR DESCRIPTION
I thought it would be nice if we have an example that doesn't depend on AWS services. (From what I understand, the existing example `metrics-service` requires some aws accesses.)
The example itself is fairly simple, it just spawns some tasks and wait until they complete.

This is the tracing result that I got on my local machine from this example.
<img width="1379" height="775" alt="Screenshot 2026-04-26 at 14 10 59" src="https://github.com/user-attachments/assets/3f1ad720-9e10-4341-8ec4-df9e99bbb7b5" />
