### PR TITLE
feat: Store S3 metadata into segement metadata

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,26 @@
+# Eager worker_ids population
+
+## What changed
+Pre-populate `RuntimeContext::worker_ids` in `attach_runtime()` immediately after `metrics_and_base` is set, instead of lazily on each worker thread's first poll/park event.
+
+## Why
+When a runtime is attached, we already know `num_workers` and `base` from `RuntimeMetrics`. Eagerly populating the map means `metadata_entry()` returns complete runtime→worker mappings from the very first flush cycle, rather than converging over time as workers come online.
+
+## Change
+One block added in `attach_runtime()` (recorder/mod.rs):
+```rust
+{
+    let mut ids = ctx.worker_ids.write().unwrap();
+    for i in 0..num_workers {
+        ids.insert(i as usize, base + i);
+    }
+}
+```
+
+`register_worker_if_needed` remains idempotent — guarded by a thread-local flag, and the insert is a no-op overwrite with the same value.
+
+## Verification
+- `cargo fmt --check` ✅
+- `cargo clippy --all-targets --all-features` ✅
+- `cargo nextest run` — 460/461 pass (1 pre-existing CPU-load-sensitive flaky test in dial9-perf-self-profile)
+- `cargo nextest run --stress-duration 20s` — 2 iterations, 460/460 pass

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -49,7 +49,7 @@ tracing-layer = ["dep:tracing-subscriber"]
 worker-s3 = ["dep:aws-sdk-s3-transfer-manager", "dep:aws-sdk-s3", "dep:aws-config", "dep:time"]
 
 [dev-dependencies]
-dial9-tokio-telemetry = { path = ".", features = ["analysis", "tracing-layer"] }
+dial9-tokio-telemetry = { path = ".", features = ["analysis", "tracing-layer", "worker-s3"] }
 assert2 = { workspace = true }
 criterion = "0.5"
 clap = { version = "4", features = ["derive"] }

--- a/dial9-tokio-telemetry/src/background_task/s3.rs
+++ b/dial9-tokio-telemetry/src/background_task/s3.rs
@@ -125,6 +125,17 @@ impl S3Config {
         &self.bucket
     }
 
+    pub(crate) fn as_metadata(&self) -> impl Iterator<Item = (&str, &str)> {
+        [
+            ("bucket", self.bucket.as_str()),
+            ("service_name", self.service_name.as_str()),
+            ("instance_path", self.instance_path.as_str()),
+            ("boot_id", self.boot_id.as_str()),
+        ]
+        .into_iter()
+        .chain(self.prefix.as_ref().map(|p| ("prefix", p.as_str())))
+    }
+
     /// Optional region override for the S3 client.
     pub(crate) fn region(&self) -> Option<&str> {
         self.region.as_deref()

--- a/dial9-tokio-telemetry/src/background_task/s3.rs
+++ b/dial9-tokio-telemetry/src/background_task/s3.rs
@@ -134,6 +134,7 @@ impl S3Config {
         ]
         .into_iter()
         .chain(self.prefix.as_ref().map(|p| ("prefix", p.as_str())))
+        .chain(self.region.as_ref().map(|r| ("region", r.as_str())))
     }
 
     /// Optional region override for the S3 client.

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -317,6 +317,16 @@ fn attach_runtime(
             });
         });
 
+    // Eagerly populate worker_ids so segment metadata is complete from the
+    // first flush cycle, rather than waiting for each worker thread to lazily
+    // register on its first poll/park event.
+    {
+        let mut ids = ctx.worker_ids.write().unwrap();
+        for i in 0..num_workers {
+            ids.insert(i as usize, base + i);
+        }
+    }
+
     shared.contexts.lock().unwrap().push(ctx);
 
     Ok(runtime)

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1007,6 +1007,15 @@ impl TelemetryCore {
         let shared = Arc::new(SharedState::new(start_mono_ns));
         #[allow(unused_mut)]
         let mut event_writer = EventWriter::new(Box::new(writer));
+        #[cfg(feature = "worker-s3")]
+        if let Some(s3_config) = s3_config.as_ref() {
+            event_writer.update_segment_metadata(
+                s3_config
+                    .as_metadata()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            )
+        }
 
         #[cfg(feature = "cpu-profiling")]
         {

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1776,15 +1776,18 @@ mod tests {
             "expected at least one SegmentMetadata event in trace files"
         );
 
-        // At least one segment's metadata should contain both runtime mappings.
+        // At least one segment's metadata should contain both runtime mappings
+        // with the exact worker IDs (eagerly populated at attach time).
         let has_both = all_metadata.iter().any(|entries| {
-            let has_main = entries.iter().any(|(k, _)| k == "runtime.main");
-            let has_io = entries.iter().any(|(k, _)| k == "runtime.io");
+            let has_main = entries
+                .iter()
+                .any(|(k, v)| k == "runtime.main" && v == "0,1");
+            let has_io = entries.iter().any(|(k, v)| k == "runtime.io" && v == "2,3");
             has_main && has_io
         });
         assert!(
             has_both,
-            "expected segment metadata to contain both runtime.main and runtime.io, \
+            "expected segment metadata to contain runtime.main=0,1 and runtime.io=2,3, \
              got: {all_metadata:?}"
         );
     }

--- a/dial9-tokio-telemetry/src/telemetry/writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/writer.rs
@@ -1950,11 +1950,9 @@ mod tests {
             ("service_name".into(), "my-svc".into()),
         ]);
 
-        // Step 2: flush loop merges static + runtime entries (like recorder/mod.rs)
-        let static_metadata = writer.segment_metadata().to_vec();
-        let mut merged = static_metadata.clone();
-        merged.push(("runtime.main".into(), "0,1".into()));
-        writer.update_segment_metadata(merged);
+        // Step 2: flush loop merges only runtime entries — S3 metadata
+        // set in step 1 must be preserved by the merge logic.
+        writer.update_segment_metadata(vec![("runtime.main".into(), "0,1".into())]);
 
         // Write enough to trigger rotation
         for _ in 0..4 {

--- a/dial9-tokio-telemetry/src/telemetry/writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/writer.rs
@@ -32,7 +32,7 @@ pub trait TraceWriter: Send {
     fn segment_metadata(&self) -> &[(String, String)] {
         &[]
     }
-    /// Replace the segment metadata entries that will be written into the next
+    /// Merge the segment metadata entries that will be written into the next
     /// rotated segment (e.g. merged static + runtime names). Default is a no-op.
     fn update_segment_metadata(&mut self, _entries: Vec<(String, String)>) {}
     /// Write a `SegmentMetadataEvent` into the current segment. Called before
@@ -83,6 +83,34 @@ impl<W: TraceWriter + ?Sized> TraceWriter for Box<W> {
     }
     fn drained(&mut self) -> std::io::Result<bool> {
         (**self).drained()
+    }
+}
+
+#[derive(Default, Clone)]
+struct SegmentMetadata {
+    entries: Vec<(String, String)>,
+}
+
+impl SegmentMetadata {
+    fn new(entries: Vec<(String, String)>) -> Self {
+        Self { entries }
+    }
+
+    /// Merge incoming entries with existing ones. Incoming entries take priority
+    /// on key conflict; existing entries with keys not in the incoming set are preserved.
+    /// Returns `true` if the resulting entries differ from the previous state.
+    fn merge(&mut self, entries: impl Iterator<Item = (String, String)>) -> bool {
+        let mut merged: Vec<(String, String)> = entries.collect();
+        for (k, v) in &self.entries {
+            if !merged.iter().any(|(mk, _)| mk == k) {
+                merged.push((k.clone(), v.clone()));
+            }
+        }
+        if merged == self.entries {
+            return false;
+        }
+        self.entries = merged;
+        true
     }
 }
 
@@ -147,7 +175,7 @@ pub struct RotatingWriter {
     did_rotate: bool,
     /// Metadata written at the start of each segment. Updated by the flush
     /// thread to include runtime names alongside any user-provided entries.
-    segment_metadata: Vec<(String, String)>,
+    segment_metadata: SegmentMetadata,
     /// Events silently dropped because the writer was finished/stopped.
     dropped_events: usize,
     /// Whether any real (non-metadata) events have been written to the current segment.
@@ -174,7 +202,12 @@ impl std::fmt::Debug for RotatingWriter {
 // but we don't want to force going through a pointer every time we want to write.
 #[allow(clippy::large_enum_variant)]
 enum WriterState {
-    Active(RawEncoder<BufWriter<File>>),
+    /// Writer is open and events can be written
+    Active {
+        writer: RawEncoder<BufWriter<File>>,
+        need_metadata: bool,
+    },
+
     /// Writer has been finalized or stopped — no encoder, no fd, no writes.
     Finished,
 }
@@ -193,7 +226,7 @@ impl RotatingWriter {
             max_file_size,
             max_total_size,
             DEFAULT_ROTATION_PERIOD,
-            Vec::new(),
+            SegmentMetadata::default(),
         )
     }
 
@@ -214,7 +247,9 @@ impl RotatingWriter {
             max_file_size,
             max_total_size,
             rotation_period.unwrap_or(DEFAULT_ROTATION_PERIOD),
-            segment_metadata.unwrap_or_default(),
+            segment_metadata
+                .map(SegmentMetadata::new)
+                .unwrap_or_default(),
         )
     }
 
@@ -223,7 +258,7 @@ impl RotatingWriter {
         max_file_size: u64,
         max_total_size: u64,
         rotation_period: Duration,
-        segment_metadata: Vec<(String, String)>,
+        segment_metadata: SegmentMetadata,
     ) -> std::io::Result<Self> {
         if rotation_period == Duration::from_secs(0) {
             return Err(std::io::Error::other("Rotation period must not be zero"));
@@ -235,7 +270,7 @@ impl RotatingWriter {
         let first_path = Self::active_path(&base_path, 0);
         let file = File::create(&first_path)?;
         let writer = BufWriter::new(file);
-        let raw = Self::write_header_and_metadata(writer, &segment_metadata)?;
+        let state = Self::prepare_segment(writer)?;
         let now = time_source().system_time().as_std();
         let drain_interval = rotation_period.min(DEFAULT_DRAIN_INTERVAL);
 
@@ -247,7 +282,7 @@ impl RotatingWriter {
             next_rotation_time: Self::next_boundary(now, rotation_period),
             closed_files: VecDeque::new(),
             active_path: first_path,
-            state: WriterState::Active(raw),
+            state,
             next_index: 1,
             did_rotate: false,
             segment_metadata,
@@ -273,7 +308,7 @@ impl RotatingWriter {
         let active_path = Self::active_path(&path, 0);
         let file = File::create(&active_path)?;
         let writer = BufWriter::new(file);
-        let raw = Self::write_header_and_metadata(writer, &Vec::new())?;
+        let state = Self::prepare_segment(writer)?;
         let now = time_source().system_time().as_std();
 
         Ok(Self {
@@ -284,10 +319,10 @@ impl RotatingWriter {
             next_rotation_time: Self::next_boundary(now, Duration::MAX),
             closed_files: VecDeque::new(),
             active_path,
-            state: WriterState::Active(raw),
+            state,
             next_index: 1,
             did_rotate: false,
-            segment_metadata: Vec::new(),
+            segment_metadata: SegmentMetadata::default(),
             dropped_events: 0,
             has_real_events: false,
             drain_interval: DEFAULT_DRAIN_INTERVAL,
@@ -308,32 +343,43 @@ impl RotatingWriter {
     /// Create an encoder, write the file header, segment metadata, and a
     /// clock-sync anchor, then convert to a [`RawEncoder`] for the
     /// remainder of the file's lifetime.
-    fn write_header_and_metadata(
-        writer: BufWriter<File>,
-        segment_metadata: &[(String, String)],
-    ) -> std::io::Result<RawEncoder<BufWriter<File>>> {
+    fn prepare_segment(writer: BufWriter<File>) -> std::io::Result<WriterState> {
         let mut encoder = Encoder::new_to(writer)?;
-        let entries = segment_metadata.to_vec();
         let (mono, real) = clock_pair();
-        encoder.write(&SegmentMetadataEvent {
-            timestamp_ns: mono,
-            entries,
-        })?;
         encoder.write(&ClockSyncEvent {
             timestamp_ns: mono,
             realtime_ns: real,
         })?;
-        Ok(encoder.into_raw_encoder())
+        Ok(WriterState::Active {
+            writer: encoder.into_raw_encoder(),
+            need_metadata: true,
+        })
+    }
+
+    fn write_metadata_if_needed(&mut self) -> std::io::Result<()> {
+        match &mut self.state {
+            WriterState::Active {
+                writer,
+                need_metadata,
+            } => {
+                if *need_metadata {
+                    Self::write_segment_metadata(writer, &self.segment_metadata.entries)?;
+                }
+                *need_metadata = false;
+                Ok(())
+            }
+            WriterState::Finished => Ok(()),
+        }
     }
 
     /// Write a `SegmentMetadataEvent` and a fresh `ClockSyncEvent` into
     /// the current active segment.
-    fn write_segment_metadata(&mut self) -> std::io::Result<()> {
-        let WriterState::Active(raw) = &mut self.state else {
-            return Ok(());
-        };
-        let entries = self.segment_metadata.clone();
+    fn write_segment_metadata(
+        writer: &mut RawEncoder<BufWriter<File>>,
+        entries: &[(String, String)],
+    ) -> std::io::Result<()> {
         let mut enc = Encoder::new();
+        let entries = entries.to_vec();
         let (mono, real) = clock_pair();
         enc.write(&SegmentMetadataEvent {
             timestamp_ns: mono,
@@ -343,7 +389,7 @@ impl RotatingWriter {
             timestamp_ns: mono,
             realtime_ns: real,
         })?;
-        raw.write_raw(&enc.finish())?;
+        writer.write_raw(&enc.finish())?;
         Ok(())
     }
 
@@ -383,7 +429,7 @@ impl RotatingWriter {
     }
 
     fn rotate(&mut self) -> std::io::Result<()> {
-        let WriterState::Active(raw) = &mut self.state else {
+        let WriterState::Active { writer: raw, .. } = &mut self.state else {
             return Ok(());
         };
         raw.flush()?;
@@ -397,10 +443,7 @@ impl RotatingWriter {
         self.next_index += 1;
         let file = File::create(&new_path)?;
         let writer = BufWriter::new(file);
-        self.state = WriterState::Active(Self::write_header_and_metadata(
-            writer,
-            &self.segment_metadata,
-        )?);
+        self.state = Self::prepare_segment(writer)?;
         self.active_path = new_path;
         self.did_rotate = true;
         self.has_real_events = false;
@@ -420,7 +463,7 @@ impl RotatingWriter {
     fn total_size(&self) -> u64 {
         let closed: u64 = self.closed_files.iter().map(|(_, s)| s).sum();
         let active = match &self.state {
-            WriterState::Active(raw) => raw.bytes_written(),
+            WriterState::Active { writer, .. } => writer.bytes_written(),
             WriterState::Finished => 0,
         };
         closed + active
@@ -485,7 +528,7 @@ impl RotatingWriter {
     /// Rotate if the current file exceeds max_file_size.
     /// Called after writing a complete logical unit (def + event).
     fn maybe_rotate(&mut self) -> std::io::Result<()> {
-        let WriterState::Active(raw) = &self.state else {
+        let WriterState::Active { writer: raw, .. } = &self.state else {
             return Ok(());
         };
         if raw.bytes_written() > self.max_file_size {
@@ -497,7 +540,7 @@ impl RotatingWriter {
 
 impl TraceWriter for RotatingWriter {
     fn flush(&mut self) -> std::io::Result<()> {
-        if let WriterState::Active(raw) = &mut self.state {
+        if let WriterState::Active { writer: raw, .. } = &mut self.state {
             raw.flush()?;
         }
         Ok(())
@@ -508,15 +551,20 @@ impl TraceWriter for RotatingWriter {
     }
 
     fn segment_metadata(&self) -> &[(String, String)] {
-        &self.segment_metadata
+        &self.segment_metadata.entries
     }
 
     fn update_segment_metadata(&mut self, entries: Vec<(String, String)>) {
-        self.segment_metadata = entries;
+        if self.segment_metadata.merge(entries.into_iter()) {
+            match &mut self.state {
+                WriterState::Active { need_metadata, .. } => *need_metadata = true,
+                WriterState::Finished => {}
+            }
+        }
     }
 
     fn write_current_segment_metadata(&mut self) -> std::io::Result<()> {
-        self.write_segment_metadata()
+        self.write_metadata_if_needed()
     }
 
     fn should_drain(&self) -> bool {
@@ -573,7 +621,8 @@ impl TraceWriter for RotatingWriter {
     }
 
     fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()> {
-        let WriterState::Active(raw) = &mut self.state else {
+        self.write_metadata_if_needed()?;
+        let WriterState::Active { writer: raw, .. } = &mut self.state else {
             self.dropped_events += batch.event_count as usize;
             return Ok(());
         };
@@ -1840,6 +1889,141 @@ mod tests {
         assert!(
             diff < 5_000_000_000,
             "reconstructed wall clock {reconstructed_wall_ns} diverges from now {now_ns} by {diff}ns"
+        );
+    }
+
+    /// S3-style metadata set via `update_segment_metadata` before any events
+    /// are written must appear in the segment's SegmentMetadata event.
+    #[test]
+    fn test_update_segment_metadata_appears_in_trace() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("trace");
+        let mut writer = RotatingWriter::new(&base, 100_000, 100_000).unwrap();
+
+        // Simulate TelemetryCore::new setting S3 metadata
+        writer.update_segment_metadata(vec![
+            ("bucket".into(), "my-bucket".into()),
+            ("service_name".into(), "my-svc".into()),
+        ]);
+
+        writer.write_encoded_batch(&test_batch()).unwrap();
+        writer.flush().unwrap();
+        writer.finalize().unwrap();
+
+        let all = format::decode_events(&std::fs::read(rotating_file(&base, 0)).unwrap()).unwrap();
+        let metadata: Vec<_> = all
+            .iter()
+            .filter_map(|e| match e {
+                TelemetryEvent::SegmentMetadata { entries, .. } => Some(entries.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(!metadata.is_empty(), "expected SegmentMetadata event");
+        assert!(
+            metadata
+                .last()
+                .unwrap()
+                .contains(&("bucket".to_string(), "my-bucket".to_string())),
+            "S3 metadata should be in segment"
+        );
+        assert!(
+            metadata
+                .last()
+                .unwrap()
+                .contains(&("service_name".to_string(), "my-svc".to_string())),
+            "S3 metadata should be in segment"
+        );
+    }
+
+    /// Simulates the flush loop pattern: S3 metadata is set once, then
+    /// runtime entries are merged repeatedly. S3 metadata must survive.
+    #[test]
+    fn test_merge_preserves_s3_metadata_across_runtime_updates() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("trace");
+        let one_event = single_event_file_size();
+        let mut writer = RotatingWriter::new(&base, one_event, 100_000).unwrap();
+
+        // Step 1: S3 metadata set (like TelemetryCore::new)
+        writer.update_segment_metadata(vec![
+            ("bucket".into(), "my-bucket".into()),
+            ("service_name".into(), "my-svc".into()),
+        ]);
+
+        // Step 2: flush loop merges static + runtime entries (like recorder/mod.rs)
+        let static_metadata = writer.segment_metadata().to_vec();
+        let mut merged = static_metadata.clone();
+        merged.push(("runtime.main".into(), "0,1".into()));
+        writer.update_segment_metadata(merged);
+
+        // Write enough to trigger rotation
+        for _ in 0..4 {
+            writer.write_encoded_batch(&test_batch()).unwrap();
+        }
+        writer.flush().unwrap();
+        writer.finalize().unwrap();
+
+        let mut files: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "bin"))
+            .collect();
+        files.sort();
+        assert!(files.len() >= 2, "expected rotation");
+
+        // Rotated segments should contain both S3 and runtime metadata
+        for file in &files[1..] {
+            let all = format::decode_events(&std::fs::read(file).unwrap()).unwrap();
+            let meta: Vec<_> = all
+                .iter()
+                .filter_map(|e| match e {
+                    TelemetryEvent::SegmentMetadata { entries, .. } => Some(entries.clone()),
+                    _ => None,
+                })
+                .collect();
+            let last = meta.last().expect("expected SegmentMetadata");
+            assert!(
+                last.contains(&("bucket".to_string(), "my-bucket".to_string())),
+                "{}: S3 metadata lost after merge",
+                file.display()
+            );
+            assert!(
+                last.contains(&("runtime.main".to_string(), "0,1".to_string())),
+                "{}: runtime metadata missing",
+                file.display()
+            );
+        }
+    }
+
+    /// Repeated calls to `update_segment_metadata` with identical entries
+    /// should not set `need_metadata`, avoiding redundant writes.
+    #[test]
+    fn test_update_segment_metadata_no_op_when_unchanged() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("trace");
+        let mut writer = RotatingWriter::new(&base, 100_000, 100_000).unwrap();
+
+        let entries = vec![("k".into(), "v".into())];
+        writer.update_segment_metadata(entries.clone());
+        // First batch writes metadata
+        writer.write_encoded_batch(&test_batch()).unwrap();
+
+        // Same entries again — should be a no-op
+        writer.update_segment_metadata(entries.clone());
+        // Second batch should NOT write another metadata event
+        writer.write_encoded_batch(&test_batch()).unwrap();
+        writer.flush().unwrap();
+        writer.finalize().unwrap();
+
+        let all = format::decode_events(&std::fs::read(rotating_file(&base, 0)).unwrap()).unwrap();
+        let metadata_count = all
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::SegmentMetadata { .. }))
+            .count();
+        assert_eq!(
+            metadata_count, 1,
+            "identical update_segment_metadata should not trigger another write"
         );
     }
 }

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -202,7 +202,10 @@ fn end_to_end_trace_to_s3_roundtrip() {
         .collect::<HashMap<String, String>>();
     assert_eq!(metadata["bucket"], "test-bucket");
     assert_eq!(metadata["service_name"], "test-svc");
-    assert_eq!(metadata["runtime.test-runtime"], "0,1");
+    assert_eq!(
+        metadata["runtime.test-runtime"], "0,1",
+        "expected eagerly populated worker IDs"
+    );
     assert_eq!(metadata["custom-metadata"], "value");
     let events = &reader.runtime_events;
     assert!(

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -6,12 +6,13 @@ mod fake_s3;
 use aws_config::Region;
 use aws_sdk_s3::Client;
 use dial9_tokio_telemetry::background_task::s3::S3Config;
-use dial9_tokio_telemetry::telemetry::{RotatingWriter, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::{RotatingWriter, TraceWriter, TracedRuntime};
 use fake_s3::{
     fake_s3_client, fake_s3_client_always_failing, fake_s3_client_flaky, fake_s3_client_hanging,
     fake_s3_client_with_region,
 };
 use flate2::read::GzDecoder;
+use std::collections::HashMap;
 use std::io::Read;
 use std::time::Duration;
 
@@ -106,7 +107,8 @@ fn end_to_end_trace_to_s3_roundtrip() {
     let client = fake_s3_client(s3_root.path());
 
     // Small max_file_size to force rotation quickly
-    let writer = RotatingWriter::new(&trace_path, 512, 50 * 1024).unwrap();
+    let mut writer = RotatingWriter::new(&trace_path, 512, 50 * 1024).unwrap();
+    writer.update_segment_metadata(vec![("custom-metadata".to_string(), "value".to_string())]);
 
     let s3_config = S3Config::builder()
         .bucket("test-bucket")
@@ -122,6 +124,7 @@ fn end_to_end_trace_to_s3_roundtrip() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_trace_path(&trace_path)
+        .with_runtime_name("test-runtime")
         .with_s3_uploader(s3_config.clone())
         .with_s3_client(client.clone())
         .with_worker_poll_interval(std::time::Duration::from_millis(50))
@@ -192,6 +195,15 @@ fn end_to_end_trace_to_s3_roundtrip() {
 
     // Parse the downloaded trace with TraceReader
     let reader = TraceReader::new(downloaded_path.to_str().unwrap()).unwrap();
+    let metadata = reader
+        .segment_metadata
+        .clone()
+        .into_iter()
+        .collect::<HashMap<String, String>>();
+    assert_eq!(metadata["bucket"], "test-bucket");
+    assert_eq!(metadata["service_name"], "test-svc");
+    assert_eq!(metadata["runtime.test-runtime"], "0,1");
+    assert_eq!(metadata["custom-metadata"], "value");
     let events = &reader.runtime_events;
     assert!(
         !events.is_empty(),


### PR DESCRIPTION
- Make segment metadata writing lazy so late-bound items will still be persisted into segment metadata
- update sgement metadata now merges entries
- copy s3 config options into segment metadata