### PR TITLE
viewer: Allow opening .gz trace files in the file picker

### DIFF
--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -563,7 +563,7 @@
             <div>
                 <div style="font-size: 2em; margin-bottom: 12px">📊</div>
                 <div>
-                    Drop a <code>.bin</code> trace file here or click to open
+                    Drop a <code>.bin</code> or <code>.bin.gz</code> trace file here or click to open
                 </div>
                 <div style="font-size: 0.8em; margin-top: 8px; color: #666">
                     Expects D9TF binary format
@@ -572,7 +572,7 @@
                     <a href="#" id="load-demo" style="color: #6c63ff; font-size: 0.9em">or load demo trace</a>
                 </div>
             </div>
-            <input type="file" id="file-input" accept=".bin" />
+            <input type="file" id="file-input" accept=".bin,.gz" />
         </div>
 
         <div id="viewer">
@@ -1142,7 +1142,7 @@
                 dropZone.innerHTML = `
                     <div>
                         <div style="font-size: 2em; margin-bottom: 12px">📊</div>
-                        <div>Drop a <code>.bin</code> trace file here or click to open</div>
+                        <div>Drop a <code>.bin</code> or <code>.bin.gz</code> trace file here or click to open</div>
                         <div style="font-size: 0.8em; margin-top: 8px; color: #666">Expects D9TF binary format</div>
                         <div style="margin-top: 12px">
                             <a href="#" id="load-demo" style="color: #6c63ff; font-size: 0.9em">or load demo trace</a>


### PR DESCRIPTION
currently .bin.gz files generated by dial9 are unselectable using the browse function in viewer...