### PR TITLE
fix: Don't register sched events on blocking pool threads

### DIFF
--- a/dial9-tokio-telemetry/design/cpu-sampling-and-worker-id-design.md
+++ b/dial9-tokio-telemetry/design/cpu-sampling-and-worker-id-design.md
@@ -136,7 +136,7 @@ The `SchedProfiler` captures context switches on each worker thread:
 
 - Created during `TracedRuntimeBuilder::build()` if `with_sched_events()` was called.
 - Stored in `SharedState.sched_profiler` (behind `Mutex<Option<...>>`).
-- `on_thread_start` hook calls `profiler.track_current_thread()` → opens a perf fd for the calling thread.
+- `on_thread_start` registers the thread as `Blocking`; worker threads re-register as `Worker(i)` in `register_tid_if_needed()` on their first poll/park, which also calls `profiler.track_current_thread()` → opens a perf fd for the calling thread.
 - `on_thread_stop` hook calls `profiler.stop_tracking_current_thread()`.
 - Flush thread drains samples, maps tids, writes `CpuSample` events with `source: SchedEvent`.
 

--- a/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
+++ b/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
@@ -59,7 +59,7 @@ impl CpuProfilingConfig {
 /// Configuration for per-worker sched event capture (context switches).
 ///
 /// Uses `perf_event_open` with `SwContextSwitches` in per-thread mode,
-/// so each worker thread gets its own perf fd via `on_thread_start`.
+/// so each worker thread gets its own perf fd on first poll/park.
 #[derive(Debug, Clone, Default)]
 pub struct SchedEventConfig {
     sampling_interval: Option<u64>,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -25,37 +25,6 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
-/// Guard that cleans up per-thread telemetry state when dropped.
-///
-/// Stored in a thread-local so cleanup happens automatically when the thread
-/// exits — even if Tokio's `on_thread_stop` doesn't fire or panics before
-/// reaching cleanup code. This also covers the calling thread (which never
-/// gets an `on_thread_stop` callback).
-struct ThreadCleanupGuard {
-    shared: Arc<SharedState>,
-}
-
-impl Drop for ThreadCleanupGuard {
-    fn drop(&mut self) {
-        // Clear the per-thread handle so the Arc<SharedState> it holds is released.
-        CURRENT_HANDLE.with(|cell| {
-            *cell.borrow_mut() = None;
-        });
-
-        #[cfg(feature = "cpu-profiling")]
-        {
-            let tid = crate::telemetry::events::current_tid();
-            self.shared.thread_roles.lock().unwrap().remove(&tid);
-            if let Ok(mut prof) = self.shared.sched_profiler.lock()
-                && let Some(ref mut p) = *prof
-            {
-                p.stop_tracking_current_thread();
-            }
-            dial9_perf_self_profile::unregister_current_thread();
-        }
-    }
-}
-
 thread_local! {
     /// Per-thread [`TelemetryHandle`], populated in `on_thread_start` and
     /// cleared in `on_thread_stop`. Enables [`TelemetryHandle::current`].
@@ -64,12 +33,6 @@ thread_local! {
     /// Set by `TelemetryHandle::spawn()` before calling `tokio::spawn()`,
     /// so the `on_task_spawn` hook can distinguish instrumented from raw spawns.
     static INSTRUMENTED_SPAWN: Cell<bool> = const { Cell::new(false) };
-
-    /// Per-thread cleanup guard. Its `Drop` impl handles all teardown:
-    /// clearing CURRENT_HANDLE, removing thread roles, stopping sched
-    /// profiling, and unregistering ctimer. Fires when the thread exits
-    /// or when explicitly cleared (e.g. during TelemetryGuard drop).
-    static CLEANUP_GUARD: RefCell<Option<ThreadCleanupGuard>> = const { RefCell::new(None) };
 }
 
 // ---------------------------------------------------------------------------
@@ -253,9 +216,10 @@ fn register_hooks(
         shared: shared.clone(),
         control_tx: control_tx.clone(),
     };
-    let shared_for_guard = shared.clone();
     #[cfg(feature = "cpu-profiling")]
     let s_start = shared.clone();
+    #[cfg(feature = "cpu-profiling")]
+    let s_stop = shared.clone();
 
     builder
         .on_thread_start(move || {
@@ -263,14 +227,6 @@ fn register_hooks(
             // `TelemetryHandle::current()` from anywhere on this thread.
             CURRENT_HANDLE.with(|cell| {
                 *cell.borrow_mut() = Some(handle_for_tl.clone());
-            });
-
-            // Install the cleanup guard. Its Drop impl handles all teardown
-            // (clearing CURRENT_HANDLE, thread roles, sched profiler, ctimer).
-            CLEANUP_GUARD.with(|cell| {
-                *cell.borrow_mut() = Some(ThreadCleanupGuard {
-                    shared: shared_for_guard.clone(),
-                });
             });
 
             #[cfg(feature = "cpu-profiling")]
@@ -295,13 +251,21 @@ fn register_hooks(
             }
         })
         .on_thread_stop(move || {
-            // Cleanup is handled by ThreadCleanupGuard's Drop impl, which
-            // fires when the thread exits. Explicitly drop it here so cleanup
-            // happens at on_thread_stop time (before Tokio joins the thread)
-            // rather than during thread-local destruction (unspecified order).
-            CLEANUP_GUARD.with(|cell| {
-                cell.borrow_mut().take();
+            CURRENT_HANDLE.with(|cell| {
+                *cell.borrow_mut() = None;
             });
+
+            #[cfg(feature = "cpu-profiling")]
+            {
+                let tid = crate::telemetry::events::current_tid();
+                s_stop.thread_roles.lock().unwrap().remove(&tid);
+                if let Ok(mut prof) = s_stop.sched_profiler.lock()
+                    && let Some(ref mut p) = *prof
+                {
+                    p.stop_tracking_current_thread();
+                }
+                dial9_perf_self_profile::unregister_current_thread();
+            }
         });
 }
 
@@ -332,16 +296,6 @@ fn attach_runtime(
         *cell.borrow_mut() = Some(TelemetryHandle {
             shared: shared.clone(),
             control_tx: control_tx.clone(),
-        });
-    });
-
-    // Install the cleanup guard on the calling thread so that
-    // CURRENT_HANDLE (and its Arc<SharedState>) is released when the
-    // guard is dropped — either explicitly in stop_flush_thread or
-    // when the thread exits.
-    CLEANUP_GUARD.with(|cell| {
-        *cell.borrow_mut() = Some(ThreadCleanupGuard {
-            shared: shared.clone(),
         });
     });
 
@@ -599,15 +553,6 @@ impl TelemetryGuard {
         if let Some(t) = self.flush_thread.take() {
             let _ = t.join();
         }
-
-        // Drop the calling thread's cleanup guard. This releases the
-        // Arc<SharedState> held by CURRENT_HANDLE and performs cpu-profiling
-        // cleanup. Without this, the calling thread's thread-local keeps
-        // SharedState (and any perf_event fds in the SchedProfiler) alive
-        // until the thread exits.
-        CLEANUP_GUARD.with(|cell| {
-            cell.borrow_mut().take();
-        });
     }
 
     /// Flush remaining events, seal the final segment, and wait for the

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -241,12 +241,10 @@ fn register_hooks(
                     .lock()
                     .unwrap()
                     .insert(tid, crate::telemetry::events::ThreadRole::Blocking);
-                if let Ok(mut prof) = s_start.sched_profiler.lock()
-                    && let Some(ref mut p) = *prof
-                {
-                    // Register the current thread for sched event sampling.
-                    let _ = p.track_current_thread();
-                }
+                // Sched event sampling is deferred to register_tid_if_needed(),
+                // which runs only for worker threads on their first poll/park.
+                // This avoids opening perf fds for blocking pool threads.
+
                 // Registers the current thread for the CPU-profiling fallback (ctimer).
                 // No-op when perf is the active backend (perf uses inherit).
                 let _ = dial9_perf_self_profile::register_current_thread();

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -25,6 +25,37 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
+/// Guard that cleans up per-thread telemetry state when dropped.
+///
+/// Stored in a thread-local so cleanup happens automatically when the thread
+/// exits — even if Tokio's `on_thread_stop` doesn't fire or panics before
+/// reaching cleanup code. This also covers the calling thread (which never
+/// gets an `on_thread_stop` callback).
+struct ThreadCleanupGuard {
+    shared: Arc<SharedState>,
+}
+
+impl Drop for ThreadCleanupGuard {
+    fn drop(&mut self) {
+        // Clear the per-thread handle so the Arc<SharedState> it holds is released.
+        CURRENT_HANDLE.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+
+        #[cfg(feature = "cpu-profiling")]
+        {
+            let tid = crate::telemetry::events::current_tid();
+            self.shared.thread_roles.lock().unwrap().remove(&tid);
+            if let Ok(mut prof) = self.shared.sched_profiler.lock()
+                && let Some(ref mut p) = *prof
+            {
+                p.stop_tracking_current_thread();
+            }
+            dial9_perf_self_profile::unregister_current_thread();
+        }
+    }
+}
+
 thread_local! {
     /// Per-thread [`TelemetryHandle`], populated in `on_thread_start` and
     /// cleared in `on_thread_stop`. Enables [`TelemetryHandle::current`].
@@ -33,6 +64,12 @@ thread_local! {
     /// Set by `TelemetryHandle::spawn()` before calling `tokio::spawn()`,
     /// so the `on_task_spawn` hook can distinguish instrumented from raw spawns.
     static INSTRUMENTED_SPAWN: Cell<bool> = const { Cell::new(false) };
+
+    /// Per-thread cleanup guard. Its `Drop` impl handles all teardown:
+    /// clearing CURRENT_HANDLE, removing thread roles, stopping sched
+    /// profiling, and unregistering ctimer. Fires when the thread exits
+    /// or when explicitly cleared (e.g. during TelemetryGuard drop).
+    static CLEANUP_GUARD: RefCell<Option<ThreadCleanupGuard>> = const { RefCell::new(None) };
 }
 
 // ---------------------------------------------------------------------------
@@ -216,10 +253,9 @@ fn register_hooks(
         shared: shared.clone(),
         control_tx: control_tx.clone(),
     };
+    let shared_for_guard = shared.clone();
     #[cfg(feature = "cpu-profiling")]
     let s_start = shared.clone();
-    #[cfg(feature = "cpu-profiling")]
-    let s_stop = shared.clone();
 
     builder
         .on_thread_start(move || {
@@ -227,6 +263,14 @@ fn register_hooks(
             // `TelemetryHandle::current()` from anywhere on this thread.
             CURRENT_HANDLE.with(|cell| {
                 *cell.borrow_mut() = Some(handle_for_tl.clone());
+            });
+
+            // Install the cleanup guard. Its Drop impl handles all teardown
+            // (clearing CURRENT_HANDLE, thread roles, sched profiler, ctimer).
+            CLEANUP_GUARD.with(|cell| {
+                *cell.borrow_mut() = Some(ThreadCleanupGuard {
+                    shared: shared_for_guard.clone(),
+                });
             });
 
             #[cfg(feature = "cpu-profiling")]
@@ -251,21 +295,13 @@ fn register_hooks(
             }
         })
         .on_thread_stop(move || {
-            CURRENT_HANDLE.with(|cell| {
-                *cell.borrow_mut() = None;
+            // Cleanup is handled by ThreadCleanupGuard's Drop impl, which
+            // fires when the thread exits. Explicitly drop it here so cleanup
+            // happens at on_thread_stop time (before Tokio joins the thread)
+            // rather than during thread-local destruction (unspecified order).
+            CLEANUP_GUARD.with(|cell| {
+                cell.borrow_mut().take();
             });
-
-            #[cfg(feature = "cpu-profiling")]
-            {
-                let tid = crate::telemetry::events::current_tid();
-                s_stop.thread_roles.lock().unwrap().remove(&tid);
-                if let Ok(mut prof) = s_stop.sched_profiler.lock()
-                    && let Some(ref mut p) = *prof
-                {
-                    p.stop_tracking_current_thread();
-                }
-                dial9_perf_self_profile::unregister_current_thread();
-            }
         });
 }
 
@@ -296,6 +332,16 @@ fn attach_runtime(
         *cell.borrow_mut() = Some(TelemetryHandle {
             shared: shared.clone(),
             control_tx: control_tx.clone(),
+        });
+    });
+
+    // Install the cleanup guard on the calling thread so that
+    // CURRENT_HANDLE (and its Arc<SharedState>) is released when the
+    // guard is dropped — either explicitly in stop_flush_thread or
+    // when the thread exits.
+    CLEANUP_GUARD.with(|cell| {
+        *cell.borrow_mut() = Some(ThreadCleanupGuard {
+            shared: shared.clone(),
         });
     });
 
@@ -553,6 +599,15 @@ impl TelemetryGuard {
         if let Some(t) = self.flush_thread.take() {
             let _ = t.join();
         }
+
+        // Drop the calling thread's cleanup guard. This releases the
+        // Arc<SharedState> held by CURRENT_HANDLE and performs cpu-profiling
+        // cleanup. Without this, the calling thread's thread-local keeps
+        // SharedState (and any perf_event fds in the SchedProfiler) alive
+        // until the thread exits.
+        CLEANUP_GUARD.with(|cell| {
+            cell.borrow_mut().take();
+        });
     }
 
     /// Flush remaining events, seal the final segment, and wait for the

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -110,6 +110,7 @@ fn register_worker_if_needed(ctx: &RuntimeContext, local_index: usize, global_id
 }
 
 /// Register the current thread's OS tid for CPU profiling (once per thread).
+/// Also starts sched event sampling for this worker thread.
 #[cfg(feature = "cpu-profiling")]
 fn register_tid_if_needed(global_id: u64, shared: &SharedState) {
     TID_REGISTERED.with(|cell| {
@@ -119,6 +120,15 @@ fn register_tid_if_needed(global_id: u64, shared: &SharedState) {
                 os_tid,
                 crate::telemetry::events::ThreadRole::Worker(global_id as usize),
             );
+            // Start sched event sampling for this worker thread. Deferred from
+            // on_thread_start so that only worker threads (not blocking pool
+            // threads) open perf fds.
+            if let Ok(mut prof) = shared.sched_profiler.lock()
+                && let Some(ref mut p) = *prof
+                && let Err(e) = p.track_current_thread()
+            {
+                tracing::warn!("failed to start sched profiling for worker thread: {e}");
+            }
             cell.set(true);
         }
     });

--- a/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
+++ b/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
@@ -21,13 +21,6 @@ use std::time::Duration;
 /// so concurrent tests would see each other's fds.
 static PERF_FD_TEST_LOCK: Mutex<()> = Mutex::new(());
 
-/// Count the number of open file descriptors for the current process.
-fn count_open_fds() -> usize {
-    std::fs::read_dir("/proc/self/fd")
-        .expect("failed to read /proc/self/fd")
-        .count()
-}
-
 /// Count open perf_event fds specifically.
 fn count_perf_fds() -> usize {
     std::fs::read_dir("/proc/self/fd")
@@ -66,7 +59,7 @@ fn sched_profiler_fds_bounded_with_many_blocking_threads() {
         tokio::time::sleep(Duration::from_millis(100)).await;
     });
 
-    let fds_before = count_open_fds();
+    let perf_fds_before = count_perf_fds();
 
     // Spawn many blocking tasks. Each one creates a new blocking pool thread.
     // Use std::thread::sleep to ensure they actually block and force new threads.
@@ -84,20 +77,18 @@ fn sched_profiler_fds_bounded_with_many_blocking_threads() {
         tokio::time::sleep(Duration::from_millis(500)).await;
     });
 
-    let fds_after = count_open_fds();
+    let perf_fds_after = count_perf_fds();
 
     drop(runtime);
     drop(guard);
 
-    // The fd growth should be small (a few fds for misc runtime work).
-    // Before the fix, we'd see ~50 new fds (one per blocking thread) that
-    // are never cleaned up. After the fix, blocking threads don't open
-    // sched profiler fds at all.
-    let fd_growth = fds_after.saturating_sub(fds_before);
-    assert!(
-        fd_growth < 10,
-        "fd count grew by {fd_growth} after spawning {num_blocking_tasks} blocking tasks \
-         (before={fds_before}, after={fds_after}). \
+    // Only worker threads should have perf fds. Before the fix, we'd see
+    // ~50 new perf fds (one per blocking thread). After the fix, the count
+    // should stay at exactly num_workers.
+    assert_eq!(
+        perf_fds_before, perf_fds_after,
+        "perf fd count changed from {perf_fds_before} to {perf_fds_after} after \
+         spawning {num_blocking_tasks} blocking tasks. \
          Sched profiler is likely opening fds for blocking pool threads."
     );
 }

--- a/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
+++ b/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
@@ -13,7 +13,13 @@ mod common;
 
 use dial9_tokio_telemetry::telemetry::TracedRuntime;
 use dial9_tokio_telemetry::telemetry::cpu_profile::SchedEventConfig;
+use std::sync::Mutex;
 use std::time::Duration;
+
+/// Serialize tests that inspect process-wide perf_event fd counts.
+/// `cargo test` runs tests in the same binary in parallel (threads),
+/// so concurrent tests would see each other's fds.
+static PERF_FD_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 /// Count the number of open file descriptors for the current process.
 fn count_open_fds() -> usize {
@@ -41,6 +47,7 @@ fn count_perf_fds() -> usize {
 /// After the fix, only worker threads (a fixed, small number) get perf fds.
 #[test]
 fn sched_profiler_fds_bounded_with_many_blocking_threads() {
+    let _lock = PERF_FD_TEST_LOCK.lock().unwrap();
     let (writer, _events) = common::CapturingWriter::new();
 
     let num_workers = 2;
@@ -101,6 +108,7 @@ fn sched_profiler_fds_bounded_with_many_blocking_threads() {
 /// the event to remove because `open_perf_event` stored tid=0 instead of the real tid.
 #[test]
 fn sched_profiler_fds_cleaned_up_on_shutdown() {
+    let _lock = PERF_FD_TEST_LOCK.lock().unwrap();
     assert_eq!(count_perf_fds(), 0, "no perf fds should exist before test");
 
     {

--- a/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
+++ b/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
@@ -1,0 +1,145 @@
+//! Integration test: sched profiler should only track worker threads, not blocking pool threads.
+//!
+//! Before the fix, every thread that started (including blocking pool threads) opened a
+//! perf_event_open fd + 2 MB mmap ring buffer for sched event sampling. With Tokio's default
+//! blocking pool limit of 512 threads, this could exhaust file descriptors.
+//!
+//! Additionally, `stop_tracking_current_thread` never cleaned up fds because `open_perf_event`
+//! stored `tid: 0` (the "current thread" sentinel) while the cleanup searched for `gettid()`.
+
+#![cfg(all(feature = "cpu-profiling", target_os = "linux"))]
+
+mod common;
+
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use dial9_tokio_telemetry::telemetry::cpu_profile::SchedEventConfig;
+use std::time::Duration;
+
+/// Count the number of open file descriptors for the current process.
+fn count_open_fds() -> usize {
+    std::fs::read_dir("/proc/self/fd")
+        .expect("failed to read /proc/self/fd")
+        .count()
+}
+
+/// Count open perf_event fds specifically.
+fn count_perf_fds() -> usize {
+    std::fs::read_dir("/proc/self/fd")
+        .expect("failed to read /proc/self/fd")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            std::fs::read_link(e.path())
+                .map(|p| p.to_string_lossy().contains("perf_event"))
+                .unwrap_or(false)
+        })
+        .count()
+}
+
+/// Spawning many blocking threads should NOT cause fd count to grow proportionally.
+///
+/// With the bug, each `spawn_blocking` call opens a perf fd that is never reclaimed.
+/// After the fix, only worker threads (a fixed, small number) get perf fds.
+#[test]
+fn sched_profiler_fds_bounded_with_many_blocking_threads() {
+    let (writer, _events) = common::CapturingWriter::new();
+
+    let num_workers = 2;
+    let num_blocking_tasks = 50;
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(num_workers).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_sched_events(SchedEventConfig::default())
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    // Let workers start and resolve their identity.
+    runtime.block_on(async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    let fds_before = count_open_fds();
+
+    // Spawn many blocking tasks. Each one creates a new blocking pool thread.
+    // Use std::thread::sleep to ensure they actually block and force new threads.
+    runtime.block_on(async {
+        let mut handles = Vec::new();
+        for _ in 0..num_blocking_tasks {
+            handles.push(tokio::task::spawn_blocking(|| {
+                std::thread::sleep(Duration::from_millis(50));
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        // Wait for threads to exit and on_thread_stop to fire.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    });
+
+    let fds_after = count_open_fds();
+
+    drop(runtime);
+    drop(guard);
+
+    // The fd growth should be small (a few fds for misc runtime work).
+    // Before the fix, we'd see ~50 new fds (one per blocking thread) that
+    // are never cleaned up. After the fix, blocking threads don't open
+    // sched profiler fds at all.
+    let fd_growth = fds_after.saturating_sub(fds_before);
+    assert!(
+        fd_growth < 10,
+        "fd count grew by {fd_growth} after spawning {num_blocking_tasks} blocking tasks \
+         (before={fds_before}, after={fds_after}). \
+         Sched profiler is likely opening fds for blocking pool threads."
+    );
+}
+
+/// Verify that sched profiler fds are properly cleaned up when the runtime shuts down.
+///
+/// This catches the tid=0 bug where `stop_tracking_current_thread` can never find
+/// the event to remove because `open_perf_event` stored tid=0 instead of the real tid.
+#[test]
+fn sched_profiler_fds_cleaned_up_on_shutdown() {
+    assert_eq!(count_perf_fds(), 0, "no perf fds should exist before test");
+
+    {
+        let (writer, _events) = common::CapturingWriter::new();
+
+        let num_workers = 4;
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder.worker_threads(num_workers).enable_all();
+
+        let (runtime, guard) = TracedRuntime::builder()
+            .with_sched_events(SchedEventConfig::default())
+            .build_and_start(builder, writer)
+            .unwrap();
+
+        // Do some work so workers resolve their identity.
+        runtime.block_on(async {
+            for _ in 0..10 {
+                tokio::spawn(async { tokio::task::yield_now().await })
+                    .await
+                    .unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        // Workers should have perf fds while running.
+        let perf_fds_during = count_perf_fds();
+        assert!(
+            perf_fds_during > 0,
+            "expected perf fds while runtime is running, got 0"
+        );
+
+        drop(runtime);
+        drop(guard);
+    }
+
+    let perf_fds_after = count_perf_fds();
+    assert_eq!(
+        perf_fds_after, 0,
+        "leaked {perf_fds_after} perf_event fds after runtime shutdown. \
+         stop_tracking_current_thread likely failed to find events due to tid=0 bug."
+    );
+}

--- a/perf-self-profile/src/sampler.rs
+++ b/perf-self-profile/src/sampler.rs
@@ -41,6 +41,10 @@ pub struct SamplerConfig {
     pub(crate) event_source: EventSource,
     pub(crate) sampling: SamplingMode,
     pub(crate) include_kernel: bool,
+    /// Maximum number of threads that can be tracked simultaneously in
+    /// per-thread mode. Prevents unbounded fd/mmap growth if cleanup fails.
+    /// Default: 256.
+    pub(crate) max_tracked_threads: usize,
 }
 
 impl Default for SamplerConfig {
@@ -49,6 +53,7 @@ impl Default for SamplerConfig {
             sampling: SamplingMode::FrequencyHz(999),
             event_source: EventSource::SwCpuClock,
             include_kernel: false,
+            max_tracked_threads: 256,
         }
     }
 }
@@ -70,6 +75,14 @@ impl SamplerConfig {
     /// Requires `perf_event_paranoid` <= 1 (or CAP_PERFMON).
     pub fn include_kernel(mut self, yes: bool) -> Self {
         self.include_kernel = yes;
+        self
+    }
+
+    /// Maximum number of threads tracked simultaneously in per-thread mode.
+    /// If the cap is reached, `track_current_thread` returns an error instead
+    /// of opening another fd. Default: 256.
+    pub fn max_tracked_threads(mut self, max: usize) -> Self {
+        self.max_tracked_threads = max;
         self
     }
 }

--- a/perf-self-profile/src/sys/linux/ctimer_sampler.rs
+++ b/perf-self-profile/src/sys/linux/ctimer_sampler.rs
@@ -216,6 +216,7 @@ mod tests {
             sampling: SamplingMode::Period(1),
             event_source: EventSource::SwCpuClock,
             include_kernel: false,
+            max_tracked_threads: 256,
         };
         let err = CtimerSampler::start(&config).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Unsupported);

--- a/perf-self-profile/src/sys/linux/perf_sampler.rs
+++ b/perf-self-profile/src/sys/linux/perf_sampler.rs
@@ -92,6 +92,7 @@ pub(super) struct PerfSamplerImpl {
     parse_config: ParseConfig<Little>,
     attr: perf_event_attr,
     include_kernel: bool,
+    max_tracked_threads: usize,
 }
 
 impl PerfSamplerImpl {
@@ -122,6 +123,7 @@ impl PerfSamplerImpl {
             parse_config: ParseConfig::from(attr),
             attr,
             include_kernel: config.include_kernel,
+            max_tracked_threads: config.max_tracked_threads,
         })
     }
 
@@ -150,6 +152,7 @@ impl PerfSamplerImpl {
             parse_config: ParseConfig::from(attr),
             attr,
             include_kernel: config.include_kernel,
+            max_tracked_threads: config.max_tracked_threads,
         })
     }
 
@@ -279,6 +282,13 @@ impl super::sampler::SamplerBackend for PerfSamplerImpl {
     // Per-thread mode: call from the thread you want to monitor.
     // This opens an event fd scoped to the calling tid with cpu=-1.
     fn track_current_thread(&mut self) -> io::Result<()> {
+        if self.events.len() >= self.max_tracked_threads {
+            return Err(io::Error::other(format!(
+                "perf sampler: max tracked threads ({}) reached, \
+                 refusing to open another fd",
+                self.max_tracked_threads
+            )));
+        }
         let mut ev = open_perf_event(&mut self.attr, 0, -1)?;
         // open_perf_event stores tid=0 (the "current thread" sentinel passed to
         // perf_event_open). Resolve to the real tid so stop_tracking_current_thread

--- a/perf-self-profile/src/sys/linux/perf_sampler.rs
+++ b/perf-self-profile/src/sys/linux/perf_sampler.rs
@@ -279,7 +279,11 @@ impl super::sampler::SamplerBackend for PerfSamplerImpl {
     // Per-thread mode: call from the thread you want to monitor.
     // This opens an event fd scoped to the calling tid with cpu=-1.
     fn track_current_thread(&mut self) -> io::Result<()> {
-        let ev = open_perf_event(&mut self.attr, 0, -1)?;
+        let mut ev = open_perf_event(&mut self.attr, 0, -1)?;
+        // open_perf_event stores tid=0 (the "current thread" sentinel passed to
+        // perf_event_open). Resolve to the real tid so stop_tracking_current_thread
+        // can find this event later.
+        ev.tid = gettid() as i32;
         self.events.push(ev);
         Ok(())
     }


### PR DESCRIPTION
fixes #314 

The combination of two bugs:
1. perf file descriptors were never closed
2. blocking threads opened their own perf fd

Caused a leak of perf file descriptors over time