### PR TITLE
Intern stack frames for smaller traces

### DIFF
--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -66,7 +66,7 @@ impl TraceReader {
                     }
                     _ => {}
                 }
-                let owned = format::to_owned_event(r, ev.string_pool);
+                let owned = format::to_owned_event(r, ev.string_pool, ev.stack_pool);
                 if let TelemetryEvent::CpuSample {
                     tid,
                     thread_name: Some(ref name),
@@ -78,7 +78,8 @@ impl TraceReader {
                 events.push(owned);
             } else {
                 // Unknown event name: capture as Custom, resolving any
-                // PooledString fields to String while the pool is available.
+                // pooled fields to owned data while the segment-local pools
+                // are still available.
                 let fields = ev
                     .field_names()
                     .zip(ev.fields.iter())
@@ -91,6 +92,14 @@ impl TraceReader {
                                     .unwrap_or("<unresolved>")
                                     .to_string();
                                 FieldValue::String(s)
+                            }
+                            dial9_trace_format::types::FieldValueRef::PooledStackFrames(id) => {
+                                let frames = ev
+                                    .stack_pool
+                                    .get(*id)
+                                    .map(|s| s.to_vec())
+                                    .unwrap_or_default();
+                                FieldValue::StackFrames(frames)
                             }
                             other => other.to_owned(),
                         };

--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -97,9 +97,9 @@ impl TraceReader {
                                 let frames = ev
                                     .stack_pool
                                     .get(*id)
-                                    .map(|s| s.to_vec())
-                                    .unwrap_or_default();
-                                FieldValue::StackFrames(frames)
+                                    .expect("stack pool entry must exist for PooledStackFrames")
+                                    .to_vec();
+                                FieldValue::StackFrames(frames.into())
                             }
                             other => other.to_owned(),
                         };

--- a/dial9-tokio-telemetry/src/telemetry/buffer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/buffer.rs
@@ -9,8 +9,8 @@
 use crate::telemetry::collector::CentralCollector;
 use crate::telemetry::events::RawEvent;
 use crate::telemetry::format::*;
-use dial9_trace_format::InternedString;
 use dial9_trace_format::encoder::{Encoder, FxHashMap};
+use dial9_trace_format::{InternedStackFrames, InternedString};
 use std::panic::Location;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -44,6 +44,15 @@ impl ThreadLocalEncoder<'_> {
     /// encoding within this same [`Encodable::encode`] call.
     pub fn intern_string(&mut self, s: &str) -> InternedString {
         self.encoder.intern_string_infallible(s)
+    }
+
+    /// Intern a stack-frame vector into the trace's stack pool, returning a compact handle.
+    ///
+    /// If the stack was already interned in this batch, returns the existing handle
+    /// (no duplicate wire data). The returned [`InternedStackFrames`] is only valid for
+    /// encoding within this same [`Encodable::encode`] call.
+    pub fn intern_stack_frames(&mut self, frames: &[u64]) -> InternedStackFrames {
+        self.encoder.intern_stack_frames_infallible(frames)
     }
 
     /// Encode a [`TraceEvent`](dial9_trace_format::TraceEvent) struct into the buffer.
@@ -250,13 +259,14 @@ impl Encodable for RawEvent {
                     .thread_name
                     .as_ref()
                     .map(|n| enc.intern_string(n.as_str()));
+                let callchain = enc.intern_stack_frames(&data.callchain);
                 enc.encode(&CpuSampleEvent {
                     timestamp_ns: data.timestamp_nanos,
                     worker_id: data.worker_id,
                     tid: data.tid,
                     source: data.source,
                     thread_name,
-                    callchain: dial9_trace_format::StackFrames(data.callchain.clone()),
+                    callchain,
                 });
             }
         }

--- a/dial9-tokio-telemetry/src/telemetry/format.rs
+++ b/dial9-tokio-telemetry/src/telemetry/format.rs
@@ -412,8 +412,8 @@ pub(crate) fn to_owned_event(
             source: e.source,
             callchain: stack_pool
                 .get(e.callchain)
-                .map(|s| s.to_vec())
-                .unwrap_or_default(),
+                .expect("stack pool entry must exist for CpuSample callchain")
+                .to_vec(),
         },
         TelemetryEventRef::WakeEvent(e) => TelemetryEvent::WakeEvent {
             timestamp_nanos: e.timestamp_ns,

--- a/dial9-tokio-telemetry/src/telemetry/format.rs
+++ b/dial9-tokio-telemetry/src/telemetry/format.rs
@@ -3,11 +3,11 @@ use crate::telemetry::events::CpuSampleSource;
 use crate::telemetry::events::TelemetryEvent;
 use crate::telemetry::task_metadata::TaskId;
 #[cfg(any(feature = "analysis", test))]
-use dial9_trace_format::decoder::StringPool;
+use dial9_trace_format::decoder::{StackPool, StringPool};
 #[cfg(any(feature = "analysis", test))]
 use dial9_trace_format::schema::SchemaEntry;
 use dial9_trace_format::types::{EventEncoder, FieldType, FieldValueRef};
-use dial9_trace_format::{InternedString, StackFrames, TraceEvent, TraceField};
+use dial9_trace_format::{InternedStackFrames, InternedString, TraceEvent, TraceField};
 use serde::Serialize;
 use std::fmt;
 use std::io::{self, Write};
@@ -195,7 +195,7 @@ pub(crate) struct CpuSampleEvent {
     pub tid: u32,
     pub source: CpuSampleSource,
     pub thread_name: Option<InternedString>,
-    pub callchain: StackFrames,
+    pub callchain: InternedStackFrames,
 }
 
 /// Wire-format event for a wake notification.
@@ -248,7 +248,7 @@ pub fn decode_events(data: &[u8]) -> io::Result<Vec<TelemetryEvent>> {
 
     dec.for_each_event(|ev| {
         if let Some(r) = decode_ref(ev.name, ev.timestamp_ns, ev.fields, ev.schema) {
-            events.push(to_owned_event(r, ev.string_pool));
+            events.push(to_owned_event(r, ev.string_pool, ev.stack_pool));
         }
     })
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
@@ -355,10 +355,14 @@ pub(crate) fn decode_ref<'a>(
 }
 
 /// Convert a zero-copy `TelemetryEventRef` into an owned `TelemetryEvent`,
-/// resolving any `InternedString` fields (e.g. `thread_name`) via the
-/// string pool that was active when the event was decoded.
+/// resolving any interned fields (e.g. `InternedString` for `thread_name`) via the
+/// corresponding pools that were active when the event was decoded.
 #[cfg(any(feature = "analysis", test))]
-pub(crate) fn to_owned_event(r: TelemetryEventRef<'_>, pool: &StringPool) -> TelemetryEvent {
+pub(crate) fn to_owned_event(
+    r: TelemetryEventRef<'_>,
+    pool: &StringPool,
+    stack_pool: &StackPool,
+) -> TelemetryEvent {
     match r {
         TelemetryEventRef::PollStart(e) => TelemetryEvent::PollStart {
             timestamp_nanos: e.timestamp_ns,
@@ -406,7 +410,10 @@ pub(crate) fn to_owned_event(r: TelemetryEventRef<'_>, pool: &StringPool) -> Tel
                 .thread_name
                 .and_then(|s| pool.get(s).map(|n| n.to_string())),
             source: e.source,
-            callchain: e.callchain.iter().collect(),
+            callchain: stack_pool
+                .get(e.callchain)
+                .map(|s| s.to_vec())
+                .unwrap_or_default(),
         },
         TelemetryEventRef::WakeEvent(e) => TelemetryEvent::WakeEvent {
             timestamp_nanos: e.timestamp_ns,

--- a/dial9-trace-format/SPEC.md
+++ b/dial9-trace-format/SPEC.md
@@ -36,10 +36,9 @@ Every frame begins with a 1-byte tag:
 | `0x01` | Schema |
 | `0x02` | Event |
 | `0x03` | String Pool |
-| `0x04` | *(reserved)* |
+| `0x04` | Stack Pool |
 | `0x05` | Timestamp Reset |
 | `0x06` | *(reserved)* |
-| `0x07` | Stack Pool |
 
 Unknown tags **must** cause the decoder to stop (the stream cannot be advanced without knowing the frame size).
 
@@ -118,13 +117,13 @@ Each **PoolEntry**:
 
 Multiple string pool frames may appear in a stream. A `pool_id` should be defined before it is referenced, but a decoder may choose to resolve references lazily.
 
-### Stack Pool Frame (`0x07`)
+### Stack Pool Frame (`0x04`)
 
 Provides stack-frame data that can be referenced by `PooledStackFrames` fields.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| tag | u8 | `0x07` |
+| tag | u8 | `0x04` |
 | count | u32 | Number of entries |
 | entries | [StackPoolEntry; count] | Pool entries (see below) |
 
@@ -206,7 +205,7 @@ Stack frame addresses are stored as raw little-endian u64 values:
 
 ### PooledStackFrames Encoding
 
-A `PooledStackFrames` field is encoded as a u32 LE pool ID (4 bytes) referencing a `StackPoolEntry` from a previously-emitted **Stack Pool Frame** (`0x07`). The encoder deduplicates identical stack traces into the pool; the same pool ID may be referenced by many events, which is the primary size win for high-frequency CPU sampling.
+A `PooledStackFrames` field is encoded as a u32 LE pool ID (4 bytes) referencing a `StackPoolEntry` from a previously-emitted **Stack Pool Frame** (`0x04`). The encoder deduplicates identical stack traces into the pool; the same pool ID may be referenced by many events, which is the primary size win for high-frequency CPU sampling.
 
 Decoders **must** resolve the pool ID against the accumulated stack pool to recover the addresses. A reference to an undefined `pool_id` is a stream error.
 

--- a/dial9-trace-format/SPEC.md
+++ b/dial9-trace-format/SPEC.md
@@ -4,7 +4,7 @@ Version: 1
 
 ## Overview
 
-A self-describing binary trace format. The stream is a sequence of frames preceded by a header. Schema frames describe event layouts; event frames carry data whose structure is defined by a previously-seen schema. String pool, symbol table, and timestamp reset frames provide auxiliary data.
+A self-describing binary trace format. The stream is a sequence of frames preceded by a header. Schema frames describe event layouts; event frames carry data whose structure is defined by a previously-seen schema. String pool, stack pool, and timestamp reset frames provide auxiliary data.
 
 All multi-byte integers are **little-endian** unless stated otherwise. Variable-length integers use **LEB128** encoding.
 
@@ -38,6 +38,8 @@ Every frame begins with a 1-byte tag:
 | `0x03` | String Pool |
 | `0x04` | *(reserved)* |
 | `0x05` | Timestamp Reset |
+| `0x06` | *(reserved)* |
+| `0x07` | Stack Pool |
 
 Unknown tags **must** cause the decoder to stop (the stream cannot be advanced without knowing the frame size).
 
@@ -116,6 +118,26 @@ Each **PoolEntry**:
 
 Multiple string pool frames may appear in a stream. A `pool_id` should be defined before it is referenced, but a decoder may choose to resolve references lazily.
 
+### Stack Pool Frame (`0x07`)
+
+Provides stack-frame data that can be referenced by `PooledStackFrames` fields.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tag | u8 | `0x07` |
+| count | u32 | Number of entries |
+| entries | [StackPoolEntry; count] | Pool entries (see below) |
+
+Each **StackPoolEntry**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| pool_id | u32 | Identifier referenced by `PooledStackFrames` values |
+| frame_count | u32 | Number of stack frame addresses |
+| frames | [u64; frame_count] | Frame addresses, leaf-first, u64 LE |
+
+Multiple stack pool frames may appear in a stream. A `pool_id` should be defined before it is referenced, but a decoder may choose to resolve references lazily.
+
 ### Timestamp Reset Frame (`0x05`)
 
 Resets the running timestamp base used for packed event timestamps. The encoder emits this frame when the nanosecond delta between the current base and the next event's timestamp exceeds what a u24 can represent (16,777,215 ns ≈ 16.7 ms), or when the next event's timestamp is earlier than the current base.
@@ -138,6 +160,7 @@ After decoding this frame, the decoder sets `timestamp_base_ns = timestamp_ns`. 
 | 3 | Bool | 1 byte (`0x00` = false, nonzero = true) | 1 |
 | 4 | String | u32 length prefix + UTF-8 bytes | 4 + len |
 | 5 | Bytes | u32 length prefix + raw bytes | 4 + len |
+| 6 | PooledStackFrames | u32 pool ID | 4 |
 | 7 | PooledString | u32 pool ID | 4 |
 | 8 | StackFrames | u32 count + count × u64 LE addresses | 4 + 8×count |
 | 9 | Varint | Unsigned LEB128 | 1–10 |
@@ -181,6 +204,12 @@ Stack frame addresses are stored as raw little-endian u64 values:
 1. Write `count` as u32 (number of addresses).
 2. For each address (in order), write the address as **u64 LE** (8 bytes).
 
+### PooledStackFrames Encoding
+
+A `PooledStackFrames` field is encoded as a u32 LE pool ID (4 bytes) referencing a `StackPoolEntry` from a previously-emitted **Stack Pool Frame** (`0x07`). The encoder deduplicates identical stack traces into the pool; the same pool ID may be referenced by many events, which is the primary size win for high-frequency CPU sampling.
+
+Decoders **must** resolve the pool ID against the accumulated stack pool to recover the addresses. A reference to an undefined `pool_id` is a stream error.
+
 ### StringMap Encoding
 
 A string map carries an ordered list of key-value pairs (both UTF-8 strings):
@@ -202,6 +231,8 @@ A string map carries an ordered list of key-value pairs (both UTF-8 strings):
 | string/bytes field length | 0–4,294,967,295 bytes | u32 length prefix |
 | StackFrames count | 0–4,294,967,295 | u32 count |
 | string pool entry count | 0–4,294,967,295 per frame | u32 count |
-| pool_id | 0–4,294,967,295 | u32 |
+| stack pool entry count | 0–4,294,967,295 per frame | u32 count |
+| stack pool frame_count | 0–4,294,967,295 | u32 count per entry |
+| pool_id | 0–4,294,967,295 | u32 (shared range across pools) |
 | Varint | 0–2^64-1 | unsigned LEB128 |
 | Timestamp delta | 0–16,777,215 ns | u24; overflow triggers Timestamp Reset frame |

--- a/dial9-trace-format/benches/codec.rs
+++ b/dial9-trace-format/benches/codec.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use dial9_trace_format::decoder::Decoder;
 use dial9_trace_format::encoder::Encoder;
-use dial9_trace_format::{StackFrames, TraceEvent};
+use dial9_trace_format::{InternedStackFrames, TraceEvent};
 
 #[derive(TraceEvent)]
 struct PollStart {
@@ -41,7 +41,7 @@ struct CpuSample {
     worker_id: u64,
     tid: u32,
     source: u8,
-    frames: StackFrames,
+    frames: InternedStackFrames,
 }
 
 const N: u64 = 1_000_000;
@@ -74,17 +74,33 @@ fn encode_events(enc: &mut Encoder, n: u64) {
                 woken_task_id: 1000 + ((i + 1) % 5000),
                 target_worker: i % 8,
             }),
-            _ => enc.write(&CpuSample {
-                timestamp_ns: ts,
-                worker_id: i % 8,
-                tid: 12345 + (i % 4) as u32,
-                source: 0,
-                frames: StackFrames(vec![
+            _ => {
+                let frames = enc.intern_stack_frames_infallible(&[
                     0x5555_5555_0000 + (i % 100) * 0x10,
                     0x5555_5555_1000 + (i % 50) * 0x20,
                     0x5555_5555_2000,
-                ]),
-            }),
+                    0x5555_5555_3000,
+                    0x5555_5555_4000,
+                    0x5555_5555_5000,
+                    0x5555_5555_6000,
+                    0x5555_5555_7000,
+                    0x5555_5555_8000,
+                    0x5555_5555_9000,
+                    0x5555_5555_a000,
+                    0x5555_5555_b000,
+                    0x5555_5555_c000,
+                    0x5555_5555_d000,
+                    0x5555_5555_e000,
+                    0x5555_5555_f000,
+                ]);
+                enc.write(&CpuSample {
+                    timestamp_ns: ts,
+                    worker_id: i % 8,
+                    tid: 12345 + (i % 4) as u32,
+                    source: 0,
+                    frames,
+                })
+            }
         }
         .unwrap()
     }

--- a/dial9-trace-format/fuzz/Cargo.lock
+++ b/dial9-trace-format/fuzz/Cargo.lock
@@ -42,14 +42,14 @@ dependencies = [
 
 [[package]]
 name = "dial9-trace-format"
-version = "0.2.0"
+version = "0.3.5"
 dependencies = [
  "dial9-trace-format-derive",
 ]
 
 [[package]]
 name = "dial9-trace-format-derive"
-version = "0.2.0"
+version = "0.3.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dial9-trace-format/fuzz/fuzz_targets/fuzz_structured_round_trip.rs
+++ b/dial9-trace-format/fuzz/fuzz_targets/fuzz_structured_round_trip.rs
@@ -72,7 +72,7 @@ fn gen_value(ft: FuzzFieldType, u: &mut Unstructured) -> arbitrary::Result<Field
             for _ in 0..count {
                 addrs.push(u.arbitrary()?);
             }
-            FieldValue::StackFrames(addrs)
+            FieldValue::StackFrames(addrs.into())
         }
         FuzzFieldType::Varint => {
             if u.ratio(1, 4)? {

--- a/dial9-trace-format/fuzz/fuzz_targets/fuzz_structured_round_trip.rs
+++ b/dial9-trace-format/fuzz/fuzz_targets/fuzz_structured_round_trip.rs
@@ -9,7 +9,7 @@ use libfuzzer_sys::fuzz_target;
 use dial9_trace_format::decoder::{DecodedFrame, Decoder};
 use dial9_trace_format::encoder::{Encoder, Schema};
 use dial9_trace_format::schema::FieldDef;
-use dial9_trace_format::types::{FieldType, FieldValue, InternedString};
+use dial9_trace_format::types::{FieldType, FieldValue, InternedStackFrames, InternedString};
 
 /// Varint boundary values that stress LEB128 encoding edges.
 const VARINT_INTERESTING: [u64; 8] = [
@@ -32,6 +32,7 @@ enum FuzzFieldType {
     Bytes,
     PooledString,
     StackFrames,
+    PooledStackFrames,
     Varint,
     StringMap,
 }
@@ -46,13 +47,18 @@ impl FuzzFieldType {
             Self::Bytes => FieldType::Bytes,
             Self::PooledString => FieldType::PooledString,
             Self::StackFrames => FieldType::StackFrames,
+            Self::PooledStackFrames => FieldType::PooledStackFrames,
             Self::Varint => FieldType::Varint,
             Self::StringMap => FieldType::StringMap,
         }
     }
 }
 
-fn gen_value(ft: FuzzFieldType, u: &mut Unstructured) -> arbitrary::Result<FieldValue> {
+fn gen_value(
+    ft: FuzzFieldType,
+    u: &mut Unstructured,
+    interned_stack_ids: &[u32],
+) -> arbitrary::Result<FieldValue> {
     Ok(match ft {
         FuzzFieldType::I64 => FieldValue::I64(u.arbitrary()?),
         FuzzFieldType::F64 => FieldValue::F64(u.arbitrary()?),
@@ -73,6 +79,18 @@ fn gen_value(ft: FuzzFieldType, u: &mut Unstructured) -> arbitrary::Result<Field
                 addrs.push(u.arbitrary()?);
             }
             FieldValue::StackFrames(addrs.into())
+        }
+        FuzzFieldType::PooledStackFrames => {
+            // Prefer real interned IDs (so the decoder's pool resolution path is
+            // exercised). Fall back to a random ID when none are available yet
+            // or to occasionally test unresolved-ID decoding.
+            let id = if !interned_stack_ids.is_empty() && u.ratio(3, 4)? {
+                let idx = u.int_in_range(0..=interned_stack_ids.len() - 1)?;
+                interned_stack_ids[idx]
+            } else {
+                u.int_in_range(0..=50)?
+            };
+            FieldValue::PooledStackFrames(InternedStackFrames::from_raw(id))
         }
         FuzzFieldType::Varint => {
             if u.ratio(1, 4)? {
@@ -112,11 +130,18 @@ struct FuzzSchema {
 enum FuzzAction {
     Event { schema_idx: u8 },
     PoolString(String8),
+    PoolStackFrames(StackFrames8),
 }
 
 #[derive(Arbitrary, Debug)]
 struct String8 {
     data: [u8; 8],
+    len: u8,
+}
+
+#[derive(Arbitrary, Debug)]
+struct StackFrames8 {
+    addrs: [u64; 8],
     len: u8,
 }
 
@@ -155,10 +180,18 @@ fuzz_target!(|data: &[u8]| {
             .fields
             .iter()
             .enumerate()
-            .map(|(j, ft)| FieldDef {
-                name: format!("f{j}"),
-                field_type: ft.to_field_type(),
-                optional: fuzz_schema.optional.get(j).copied().unwrap_or(false),
+            .map(|(j, ft)| {
+                let base = ft.to_field_type();
+                let is_optional = fuzz_schema.optional.get(j).copied().unwrap_or(false);
+                let field_type = if is_optional {
+                    FieldType::from_tag(base as u8 | FieldType::OPTIONAL_BIT).unwrap_or(base)
+                } else {
+                    base
+                };
+                FieldDef {
+                    name: format!("f{j}"),
+                    field_type,
+                }
             })
             .collect();
         schemas.push(enc.register_schema(names[i], fields).unwrap());
@@ -166,6 +199,8 @@ fuzz_target!(|data: &[u8]| {
 
     // Execute actions in fuzz-determined interleaved order
     let mut expected_events: Vec<(usize, Option<u64>, Vec<FieldValue>)> = Vec::new();
+    let mut interned_stack_ids: Vec<u32> = Vec::new();
+    let mut expected_stack_pool: Vec<(u32, Vec<u64>)> = Vec::new();
     for action in &actions {
         match action {
             FuzzAction::Event { schema_idx } => {
@@ -180,7 +215,7 @@ fuzz_target!(|data: &[u8]| {
                         if is_optional && u.ratio(1, 3).unwrap_or(false) {
                             Ok(FieldValue::None)
                         } else {
-                            gen_value(*ft, &mut u)
+                            gen_value(*ft, &mut u, &interned_stack_ids)
                         }
                     })
                     .collect::<arbitrary::Result<Vec<_>>>()
@@ -204,6 +239,15 @@ fuzz_target!(|data: &[u8]| {
                 let len = (ps.len % 8) as usize;
                 let s = String::from_utf8_lossy(&ps.data[..len]);
                 enc.intern_string(&s).unwrap();
+            }
+            FuzzAction::PoolStackFrames(sf) => {
+                let len = (sf.len % 8) as usize;
+                let frames = &sf.addrs[..len];
+                let id = enc.intern_stack_frames(frames).unwrap().raw_id();
+                if !interned_stack_ids.contains(&id) {
+                    interned_stack_ids.push(id);
+                    expected_stack_pool.push((id, frames.to_vec()));
+                }
             }
         }
     }
@@ -229,6 +273,18 @@ fuzz_target!(|data: &[u8]| {
         expected_events.len(),
         "event count mismatch"
     );
+
+    for (id, expected_frames) in &expected_stack_pool {
+        let resolved = dec
+            .stack_pool()
+            .get(InternedStackFrames::from_raw(*id))
+            .unwrap_or_else(|| panic!("stack pool missing entry for id {id}"));
+        assert_eq!(
+            resolved,
+            expected_frames.as_slice(),
+            "stack pool frames mismatch for id {id}"
+        );
+    }
 
     for (i, ((schema_idx, expected_ts, expected_vals), (_type_id, decoded_ts, decoded_vals))) in
         expected_events.iter().zip(decoded_events.iter()).enumerate()

--- a/dial9-trace-format/js/decode.js
+++ b/dial9-trace-format/js/decode.js
@@ -11,8 +11,8 @@ const TAG_STACK_POOL = 0x07;
 
 const FieldType = {
   I64: 1, F64: 2, Bool: 3, String: 4,
-  Bytes: 5, PooledString: 7, StackFrames: 8, Varint: 9,
-  StringMap: 10, U8: 11, U16: 12, U32: 13, PooledStackFrames: 14,
+  Bytes: 5, PooledStackFrames: 6, PooledString: 7, StackFrames: 8, Varint: 9,
+  StringMap: 10, U8: 11, U16: 12, U32: 13,
 };
 
 function decodeULEB128(view, offset) {

--- a/dial9-trace-format/js/decode.js
+++ b/dial9-trace-format/js/decode.js
@@ -5,9 +5,8 @@ const MAGIC = [0x54, 0x52, 0x43, 0x00];
 const TAG_SCHEMA = 0x01;
 const TAG_EVENT = 0x02;
 const TAG_STRING_POOL = 0x03;
-// Tag 0x04 is reserved (formerly SymbolTable, now a schema-based event).
+const TAG_STACK_POOL = 0x04;
 const TAG_TIMESTAMP_RESET = 0x05;
-const TAG_STACK_POOL = 0x07;
 
 const FieldType = {
   I64: 1, F64: 2, Bool: 3, String: 4,

--- a/dial9-trace-format/js/decode.js
+++ b/dial9-trace-format/js/decode.js
@@ -7,11 +7,12 @@ const TAG_EVENT = 0x02;
 const TAG_STRING_POOL = 0x03;
 // Tag 0x04 is reserved (formerly SymbolTable, now a schema-based event).
 const TAG_TIMESTAMP_RESET = 0x05;
+const TAG_STACK_POOL = 0x07;
 
 const FieldType = {
   I64: 1, F64: 2, Bool: 3, String: 4,
   Bytes: 5, PooledString: 7, StackFrames: 8, Varint: 9,
-  StringMap: 10, U8: 11, U16: 12, U32: 13,
+  StringMap: 10, U8: 11, U16: 12, U32: 13, PooledStackFrames: 14,
 };
 
 function decodeULEB128(view, offset) {
@@ -54,6 +55,7 @@ function decodeFieldValue(view, offset, fieldType) {
       return [val.toString(), consumed];
     }
     case FieldType.PooledString: return [view.getUint32(offset, true), 4];
+    case FieldType.PooledStackFrames: return [view.getUint32(offset, true), 4];
     case FieldType.StackFrames: {
       const count = view.getUint32(offset, true);
       let pos = 4;
@@ -97,6 +99,7 @@ class TraceDecoder {
     this._pos = 0;
     this.schemas = new Map();
     this.stringPool = new Map();
+    this.stackPool = new Map();
     this.version = 0;
     this._timestampBaseNs = 0n;
   }
@@ -123,6 +126,7 @@ class TraceDecoder {
         if (isHeader) {
           this.schemas = new Map();
           this.stringPool = new Map();
+          this.stackPool = new Map();
           this._timestampBaseNs = 0n;
           this._pos += 5; // skip header
           return this.nextFrame();
@@ -133,6 +137,7 @@ class TraceDecoder {
         case TAG_SCHEMA: return this._decodeSchema();
         case TAG_EVENT: return this._decodeEvent();
         case TAG_STRING_POOL: return this._decodeStringPool();
+        case TAG_STACK_POOL: return this._decodeStackPool();
         case TAG_TIMESTAMP_RESET: {
           const lo = this._view.getUint32(this._pos, true);
           const hi = this._view.getUint32(this._pos + 4, true);
@@ -203,6 +208,8 @@ class TraceDecoder {
       const innerType = field.fieldType & 0x7F;
       if (innerType === FieldType.PooledString && val !== null) {
         values[field.name] = this.stringPool.get(val) ?? `<unresolved pool#${val}>`;
+      } else if (innerType === FieldType.PooledStackFrames && val !== null) {
+        values[field.name] = this.stackPool.get(val) ?? `<unresolved stack#${val}>`;
       } else {
         values[field.name] = val;
       }
@@ -234,6 +241,25 @@ class TraceDecoder {
     return { type: 'string_pool', entries };
   }
 
+  _decodeStackPool() {
+    const count = this._view.getUint32(this._pos, true); this._pos += 4;
+    const entries = [];
+    for (let i = 0; i < count; i++) {
+      const poolId = this._view.getUint32(this._pos, true); this._pos += 4;
+      const frameCount = this._view.getUint32(this._pos, true); this._pos += 4;
+      const addrs = [];
+      for (let j = 0; j < frameCount; j++) {
+        const lo = this._view.getUint32(this._pos, true);
+        const hi = this._view.getUint32(this._pos + 4, true);
+        addrs.push((BigInt(hi) << 32n | BigInt(lo)).toString());
+        this._pos += 8;
+      }
+      this.stackPool.set(poolId, addrs);
+      entries.push({ poolId, addrs });
+    }
+    return { type: 'stack_pool', entries };
+  }
+
 }
 
 // --- CLI: decode a file and print JSON ---
@@ -249,6 +275,7 @@ if (typeof require !== 'undefined' && require.main === module) {
     version: dec.version,
     frames,
     stringPool: Object.fromEntries(dec.stringPool),
+    stackPool: Object.fromEntries(dec.stackPool),
   }, (_, v) => typeof v === 'bigint' ? v.toString() : v, 2);
   console.log(json);
 }

--- a/dial9-trace-format/src/codec.rs
+++ b/dial9-trace-format/src/codec.rs
@@ -26,6 +26,7 @@ pub(crate) const TAG_EVENT: u8 = 0x02;
 pub(crate) const TAG_STRING_POOL: u8 = 0x03;
 // Tags 0x04 and 0x06 are reserved (formerly SymbolTable and ProcMaps, now schema-based events).
 pub(crate) const TAG_TIMESTAMP_RESET: u8 = 0x05;
+pub(crate) const TAG_STACK_POOL: u8 = 0x07;
 
 /// Maximum nanosecond delta that fits in a u24 (3 bytes).
 pub(crate) const MAX_TIMESTAMP_DELTA_NS: u64 = 0xFF_FFFF; // 16,777,215
@@ -53,6 +54,15 @@ pub struct PoolEntry {
     pub data: Vec<u8>,
 }
 
+/// An owned stack-frame pool entry. Frames are leaf-first u64 addresses.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StackPoolEntry {
+    /// Pool ID assigned by the encoder.
+    pub pool_id: u32,
+    /// Stack frame addresses (leaf-first).
+    pub frames: Vec<u64>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Frame {
     Schema {
@@ -66,6 +76,7 @@ pub(crate) enum Frame {
         values: Vec<FieldValue>,
     },
     StringPool(Vec<PoolEntry>),
+    StackPool(Vec<StackPoolEntry>),
     TimestampReset(u64),
 }
 
@@ -77,6 +88,33 @@ pub struct PoolEntryRef<'a> {
     pub pool_id: u32,
     /// Raw string data borrowed from the decode buffer.
     pub data: &'a [u8],
+}
+
+/// Zero-copy stack-frame pool entry borrowing from the input buffer.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct StackPoolEntryRef<'a> {
+    /// Pool ID assigned by the encoder.
+    pub pool_id: u32,
+    /// Raw u64-LE bytes borrowed from the decode buffer.
+    pub frames_le: &'a [u8],
+}
+
+impl<'a> StackPoolEntryRef<'a> {
+    /// Number of frames in the entry.
+    pub fn frame_count(&self) -> u32 {
+        (self.frames_le.len() / 8) as u32
+    }
+
+    /// Iterate the stack frame addresses.
+    pub fn iter(&self) -> crate::types::StackFrameIter<'a> {
+        crate::types::StackFrameIter::new(self.frames_le, self.frame_count())
+    }
+
+    /// Collect into an owned `Vec<u64>`.
+    pub fn to_vec(&self) -> Vec<u64> {
+        self.iter().collect()
+    }
 }
 
 /// Zero-copy frame that borrows from the input buffer.
@@ -92,6 +130,7 @@ pub(crate) enum FrameRef<'a> {
         values: Vec<FieldValueRef<'a>>,
     },
     StringPool(Vec<PoolEntryRef<'a>>),
+    StackPool(Vec<StackPoolEntryRef<'a>>),
     TimestampReset(u64),
 }
 
@@ -161,6 +200,19 @@ pub(crate) fn encode_string_pool(entries: &[PoolEntry], w: &mut impl Write) -> i
     Ok(())
 }
 
+pub(crate) fn encode_stack_pool(entries: &[StackPoolEntry], w: &mut impl Write) -> io::Result<()> {
+    w.write_all(&[TAG_STACK_POOL])?;
+    w.write_all(&(entries.len() as u32).to_le_bytes())?;
+    for e in entries {
+        w.write_all(&e.pool_id.to_le_bytes())?;
+        w.write_all(&(e.frames.len() as u32).to_le_bytes())?;
+        for &addr in &e.frames {
+            w.write_all(&addr.to_le_bytes())?;
+        }
+    }
+    Ok(())
+}
+
 // --- Decoding ---
 
 pub(crate) fn decode_header(data: &[u8]) -> Option<u8> {
@@ -182,6 +234,7 @@ pub(crate) fn decode_frame<'s>(
         TAG_SCHEMA => decode_schema_frame(data),
         TAG_EVENT => decode_event_frame(data, schema_lookup, timestamp_base_ns),
         TAG_STRING_POOL => decode_string_pool_frame(data),
+        TAG_STACK_POOL => decode_stack_pool_frame(data),
         TAG_TIMESTAMP_RESET => {
             let ts = u64::from_le_bytes(data.get(1..9)?.try_into().ok()?);
             Some((Frame::TimestampReset(ts), 9))
@@ -295,6 +348,29 @@ fn decode_string_pool_frame(data: &[u8]) -> Option<(Frame, usize)> {
     Some((Frame::StringPool(entries), pos))
 }
 
+fn decode_stack_pool_frame(data: &[u8]) -> Option<(Frame, usize)> {
+    let mut pos = 1;
+    let count = u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?) as usize;
+    pos += 4;
+    let mut entries = Vec::with_capacity(count.min((data.len() - pos) / 16));
+    for _ in 0..count {
+        let pool_id = u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?);
+        pos += 4;
+        let frame_count = u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?) as usize;
+        pos += 4;
+        let bytes = frame_count.checked_mul(8)?;
+        let mut frames = Vec::with_capacity(frame_count);
+        for i in 0..frame_count {
+            let off = pos + i * 8;
+            let addr = u64::from_le_bytes(data.get(off..off + 8)?.try_into().ok()?);
+            frames.push(addr);
+        }
+        pos += bytes;
+        entries.push(StackPoolEntry { pool_id, frames });
+    }
+    Some((Frame::StackPool(entries), pos))
+}
+
 // --- Zero-copy decoding ---
 
 /// Decode a single frame without allocating owned data for field values.
@@ -316,6 +392,7 @@ pub(crate) fn decode_frame_ref<'a, 's>(
         }
         TAG_EVENT => decode_event_frame_ref(data, schema_lookup, timestamp_base_ns),
         TAG_STRING_POOL => decode_string_pool_frame_ref(data),
+        TAG_STACK_POOL => decode_stack_pool_frame_ref(data),
         TAG_TIMESTAMP_RESET => {
             let ts = u64::from_le_bytes(data.get(1..9)?.try_into().ok()?);
             Some((FrameRef::TimestampReset(ts), 9))
@@ -386,6 +463,24 @@ fn decode_string_pool_frame_ref<'a>(data: &'a [u8]) -> Option<(FrameRef<'a>, usi
         entries.push(PoolEntryRef { pool_id, data: d });
     }
     Some((FrameRef::StringPool(entries), pos))
+}
+
+fn decode_stack_pool_frame_ref<'a>(data: &'a [u8]) -> Option<(FrameRef<'a>, usize)> {
+    let mut pos = 1;
+    let count = u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?) as usize;
+    pos += 4;
+    let mut entries = Vec::with_capacity(count.min((data.len() - pos) / 16));
+    for _ in 0..count {
+        let pool_id = u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?);
+        pos += 4;
+        let frame_count = u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?) as usize;
+        pos += 4;
+        let bytes = frame_count.checked_mul(8)?;
+        let frames_le = data.get(pos..pos + bytes)?;
+        pos += bytes;
+        entries.push(StackPoolEntryRef { pool_id, frames_le });
+    }
+    Some((FrameRef::StackPool(entries), pos))
 }
 
 #[cfg(test)]

--- a/dial9-trace-format/src/codec.rs
+++ b/dial9-trace-format/src/codec.rs
@@ -24,9 +24,9 @@ pub(crate) const HEADER_SIZE: usize = 5;
 pub(crate) const TAG_SCHEMA: u8 = 0x01;
 pub(crate) const TAG_EVENT: u8 = 0x02;
 pub(crate) const TAG_STRING_POOL: u8 = 0x03;
-// Tags 0x04 and 0x06 are reserved (formerly SymbolTable and ProcMaps, now schema-based events).
+pub(crate) const TAG_STACK_POOL: u8 = 0x04;
 pub(crate) const TAG_TIMESTAMP_RESET: u8 = 0x05;
-pub(crate) const TAG_STACK_POOL: u8 = 0x07;
+// Tag 0x06 is reserved (formerly ProcMaps, now schema-based events).
 
 /// Maximum nanosecond delta that fits in a u24 (3 bytes).
 pub(crate) const MAX_TIMESTAMP_DELTA_NS: u64 = 0xFF_FFFF; // 16,777,215

--- a/dial9-trace-format/src/codec.rs
+++ b/dial9-trace-format/src/codec.rs
@@ -111,8 +111,8 @@ impl<'a> StackPoolEntryRef<'a> {
         crate::types::StackFrameIter::new(self.frames_le, self.frame_count())
     }
 
-    /// Collect into an owned `Vec<u64>`.
-    pub fn to_vec(&self) -> Vec<u64> {
+    /// Collect into an owned [`StackFrames`](crate::types::StackFrames).
+    pub fn to_stack_frames(&self) -> crate::types::StackFrames {
         self.iter().collect()
     }
 }

--- a/dial9-trace-format/src/decoder.rs
+++ b/dial9-trace-format/src/decoder.rs
@@ -7,10 +7,11 @@
 //! allocation-free processing.
 
 use crate::codec::{
-    self, Frame, FrameRef, HEADER_SIZE, PoolEntry, PoolEntryRef, SchemaInfo, WireTypeId,
+    self, Frame, FrameRef, HEADER_SIZE, PoolEntry, PoolEntryRef, SchemaInfo, StackPoolEntry,
+    StackPoolEntryRef, WireTypeId,
 };
 use crate::schema::{SchemaEntry, SchemaRegistry};
-use crate::types::{FieldType, FieldValueRef, InternedString};
+use crate::types::{FieldType, FieldValueRef, InternedStackFrames, InternedString};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -61,6 +62,7 @@ pub struct RawEvent<'a, 'f> {
     pub fields: &'f [FieldValueRef<'a>],
     pub schema: &'f SchemaEntry,
     pub string_pool: &'f StringPool,
+    pub stack_pool: &'f StackPool,
 }
 
 impl<'a, 'f> RawEvent<'a, 'f> {
@@ -105,6 +107,39 @@ impl StringPool {
     }
 }
 
+/// A map from interned stack-frame IDs to their resolved address vectors.
+///
+/// Populated automatically by the [`Decoder`] as it processes `StackPool` frames.
+#[derive(Debug, Default)]
+pub struct StackPool(pub(crate) HashMap<InternedStackFrames, Vec<u64>>);
+
+impl StackPool {
+    pub(crate) fn new() -> Self {
+        Self(HashMap::default())
+    }
+
+    pub(crate) fn insert(&mut self, id: InternedStackFrames, frames: Vec<u64>) {
+        self.0.insert(id, frames);
+    }
+
+    pub fn get(&self, id: InternedStackFrames) -> Option<&[u64]> {
+        self.0.get(&id).map(|v| v.as_slice())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Iterate over all interned stack frames as `(id, frames)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (InternedStackFrames, &[u64])> {
+        self.0.iter().map(|(&id, v)| (id, v.as_slice()))
+    }
+}
+
 /// Decoded events yielded by the decoder.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DecodedFrame {
@@ -116,6 +151,7 @@ pub enum DecodedFrame {
         values: Vec<crate::types::FieldValue>,
     },
     StringPool(Vec<PoolEntry>),
+    StackPool(Vec<StackPoolEntry>),
 }
 
 /// Zero-copy decoded frame that borrows from the input buffer.
@@ -128,6 +164,7 @@ pub enum DecodedFrameRef<'a> {
         values: Vec<FieldValueRef<'a>>,
     },
     StringPool(Vec<PoolEntryRef<'a>>),
+    StackPool(Vec<StackPoolEntryRef<'a>>),
 }
 
 struct SchemaCache {
@@ -146,6 +183,7 @@ pub struct Decoder<'a> {
     registry: SchemaRegistry,
     schema_cache: Vec<Option<SchemaCache>>,
     string_pool: StringPool,
+    stack_pool: StackPool,
     version: u8,
     timestamp_base_ns: u64,
 }
@@ -159,6 +197,7 @@ impl<'a> Decoder<'a> {
             registry: SchemaRegistry::new(),
             schema_cache: Vec::new(),
             string_pool: StringPool::new(),
+            stack_pool: StackPool::new(),
             version,
             timestamp_base_ns: 0,
         })
@@ -176,6 +215,10 @@ impl<'a> Decoder<'a> {
         &self.string_pool
     }
 
+    pub fn stack_pool(&self) -> &StackPool {
+        &self.stack_pool
+    }
+
     /// Reset decoder state (schemas, string pool, timestamp base) as if
     /// starting a fresh stream. Used when a mid-stream header is encountered
     /// (the "reset frame" pattern for concatenated thread-local batches).
@@ -183,6 +226,7 @@ impl<'a> Decoder<'a> {
         self.registry = SchemaRegistry::new();
         self.schema_cache.clear();
         self.string_pool = StringPool::new();
+        self.stack_pool = StackPool::new();
         self.timestamp_base_ns = 0;
     }
 
@@ -210,6 +254,7 @@ impl<'a> Decoder<'a> {
         crate::encoder::Encoder::from_decoder(
             self.registry,
             self.string_pool,
+            self.stack_pool,
             self.timestamp_base_ns,
             writer,
         )
@@ -287,6 +332,13 @@ impl<'a> Decoder<'a> {
                 }
                 Ok(Some(DecodedFrame::StringPool(entries)))
             }
+            Frame::StackPool(entries) => {
+                for e in &entries {
+                    self.stack_pool
+                        .insert(InternedStackFrames(e.pool_id), e.frames.clone());
+                }
+                Ok(Some(DecodedFrame::StackPool(entries)))
+            }
             Frame::TimestampReset(ts) => {
                 self.timestamp_base_ns = ts;
                 self.next_frame() // consume silently, return next real frame
@@ -352,6 +404,13 @@ impl<'a> Decoder<'a> {
                     }
                 }
                 Ok(Some(DecodedFrameRef::StringPool(entries)))
+            }
+            FrameRef::StackPool(entries) => {
+                for e in &entries {
+                    self.stack_pool
+                        .insert(InternedStackFrames(e.pool_id), e.to_vec());
+                }
+                Ok(Some(DecodedFrameRef::StackPool(entries)))
             }
             FrameRef::TimestampReset(ts) => {
                 self.timestamp_base_ns = ts;
@@ -528,6 +587,7 @@ impl<'a> Decoder<'a> {
                         fields: &values_buf,
                         schema: &cache.entry,
                         string_pool: &self.string_pool,
+                        stack_pool: &self.stack_pool,
                     })
                     .map_err(TryForEachError::User)?;
                 }

--- a/dial9-trace-format/src/decoder.rs
+++ b/dial9-trace-format/src/decoder.rs
@@ -11,7 +11,7 @@ use crate::codec::{
     StackPoolEntryRef, WireTypeId,
 };
 use crate::schema::{SchemaEntry, SchemaRegistry};
-use crate::types::{FieldType, FieldValueRef, InternedStackFrames, InternedString};
+use crate::types::{FieldType, FieldValueRef, InternedStackFrames, InternedString, StackFrames};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -118,8 +118,8 @@ impl StackPool {
         Self(HashMap::default())
     }
 
-    pub(crate) fn insert(&mut self, id: InternedStackFrames, frames: Vec<u64>) {
-        self.0.insert(id, frames);
+    pub(crate) fn insert(&mut self, id: InternedStackFrames, frames: StackFrames) {
+        self.0.insert(id, frames.0);
     }
 
     pub fn get(&self, id: InternedStackFrames) -> Option<&[u64]> {
@@ -335,7 +335,7 @@ impl<'a> Decoder<'a> {
             Frame::StackPool(entries) => {
                 for e in &entries {
                     self.stack_pool
-                        .insert(InternedStackFrames(e.pool_id), e.frames.clone());
+                        .insert(InternedStackFrames(e.pool_id), e.frames.clone().into());
                 }
                 Ok(Some(DecodedFrame::StackPool(entries)))
             }
@@ -408,7 +408,7 @@ impl<'a> Decoder<'a> {
             FrameRef::StackPool(entries) => {
                 for e in &entries {
                     self.stack_pool
-                        .insert(InternedStackFrames(e.pool_id), e.to_vec());
+                        .insert(InternedStackFrames(e.pool_id), e.to_stack_frames());
                 }
                 Ok(Some(DecodedFrameRef::StackPool(entries)))
             }

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -26,7 +26,12 @@ pub struct FxHasher(u64);
 
 impl Hasher for FxHasher {
     #[inline]
-    fn write(&mut self, bytes: &[u8]) {
+    fn write(&mut self, mut bytes: &[u8]) {
+        while bytes.len() >= 8 {
+            let v = u64::from_ne_bytes(bytes[..8].try_into().unwrap());
+            self.0 = (self.0.rotate_left(5) ^ v).wrapping_mul(0x517cc1b727220a95);
+            bytes = &bytes[8..];
+        }
         for &b in bytes {
             self.0 = (self.0.rotate_left(5) ^ b as u64).wrapping_mul(0x517cc1b727220a95);
         }

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -24,43 +24,58 @@ use std::sync::Arc;
 #[derive(Default)]
 pub struct FxHasher(u64);
 
+impl FxHasher {
+    #[inline]
+    fn hash_word(&mut self, word: u64) {
+        self.0 = (self.0.rotate_left(5) ^ word).wrapping_mul(0x517cc1b727220a95);
+    }
+}
+
 impl Hasher for FxHasher {
     #[inline]
     fn write(&mut self, mut bytes: &[u8]) {
         while bytes.len() >= 8 {
-            let v = u64::from_ne_bytes(bytes[..8].try_into().unwrap());
-            self.0 = (self.0.rotate_left(5) ^ v).wrapping_mul(0x517cc1b727220a95);
+            self.hash_word(u64::from_ne_bytes(bytes[..8].try_into().unwrap()));
             bytes = &bytes[8..];
         }
+        if bytes.len() >= 4 {
+            self.hash_word(u32::from_ne_bytes(bytes[..4].try_into().unwrap()) as u64);
+            bytes = &bytes[4..];
+        }
         for &b in bytes {
-            self.0 = (self.0.rotate_left(5) ^ b as u64).wrapping_mul(0x517cc1b727220a95);
+            self.hash_word(b as u64);
         }
     }
 
     #[inline]
-    fn write_u64(&mut self, i: u64) {
-        self.0 = (self.0.rotate_left(5) ^ i).wrapping_mul(0x517cc1b727220a95);
-    }
-
-    #[inline]
-    fn write_u32(&mut self, i: u32) {
-        self.write_u64(i as u64)
+    fn write_u8(&mut self, i: u8) {
+        self.hash_word(i as u64);
     }
 
     #[inline]
     fn write_u16(&mut self, i: u16) {
-        self.write_u64(i as u64)
+        self.hash_word(i as u64);
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.hash_word(i as u64);
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.hash_word(i);
     }
 
     #[inline]
     fn write_usize(&mut self, i: usize) {
-        self.write_u64(i as u64)
+        self.hash_word(i as u64);
     }
 
     #[inline]
     fn write_u128(&mut self, i: u128) {
-        self.write_u64(i as u64);
-        self.write_u64((i >> 64) as u64);
+        self.hash_word(i as u64);
+        self.hash_word((i >> 64) as u64);
     }
 
     #[inline]

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -5,9 +5,11 @@
 //! point for producing trace data.
 
 use crate::TraceEvent;
-use crate::codec::{self, PoolEntry, WireTypeId};
+use crate::codec::{self, PoolEntry, StackPoolEntry, WireTypeId};
 use crate::schema::{SchemaEntry, SchemaRegistry};
-use crate::types::{CountingWriter, EncodeState, EventEncoder, InternedString};
+use crate::types::{
+    CountingWriter, EncodeState, EventEncoder, InternedStackFrames, InternedString,
+};
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hasher};
@@ -131,6 +133,8 @@ pub struct Encoder<W: Write = Vec<u8>> {
     registry: SchemaRegistry,
     string_pool: FxHashMap<String, u32>,
     next_pool_id: u32,
+    stack_pool: FxHashMap<Box<[u64]>, u32>,
+    next_stack_pool_id: u32,
     schema_ids: FxHashMap<SchemaKey, WireTypeId>,
 }
 
@@ -149,6 +153,8 @@ impl Encoder<Vec<u8>> {
             registry: SchemaRegistry::new(),
             string_pool: FxHashMap::default(),
             next_pool_id: 0,
+            stack_pool: FxHashMap::default(),
+            next_stack_pool_id: 0,
             schema_ids: FxHashMap::default(),
         }
     }
@@ -169,6 +175,8 @@ impl<W: Write> Encoder<W> {
             registry: SchemaRegistry::new(),
             string_pool: FxHashMap::default(),
             next_pool_id: 0,
+            stack_pool: FxHashMap::default(),
+            next_stack_pool_id: 0,
             schema_ids: FxHashMap::default(),
         })
     }
@@ -178,6 +186,7 @@ impl<W: Write> Encoder<W> {
     pub(crate) fn from_decoder(
         mut registry: SchemaRegistry,
         string_pool: crate::decoder::StringPool,
+        stack_pool: crate::decoder::StackPool,
         timestamp_base_ns: u64,
         writer: W,
     ) -> Self {
@@ -187,6 +196,15 @@ impl<W: Write> Encoder<W> {
             pool.insert(value, id.raw_id());
             if id.raw_id() >= next_pool_id {
                 next_pool_id = id.raw_id() + 1;
+            }
+        }
+
+        let mut new_stack_pool: FxHashMap<Box<[u64]>, u32> = FxHashMap::default();
+        let mut next_stack_pool_id: u32 = 0;
+        for (id, frames) in stack_pool.0.into_iter() {
+            new_stack_pool.insert(frames.into_boxed_slice(), id.raw_id());
+            if id.raw_id() >= next_stack_pool_id {
+                next_stack_pool_id = id.raw_id() + 1;
             }
         }
 
@@ -204,6 +222,8 @@ impl<W: Write> Encoder<W> {
             registry,
             string_pool: pool,
             next_pool_id,
+            stack_pool: new_stack_pool,
+            next_stack_pool_id,
             schema_ids,
         }
     }
@@ -229,6 +249,8 @@ impl<W: Write> Encoder<W> {
         codec::encode_header(&mut new_writer)?;
         self.string_pool.clear();
         self.next_pool_id = 0;
+        self.stack_pool.clear();
+        self.next_stack_pool_id = 0;
         self.registry.clear();
         self.schema_ids.clear();
         // creating a new EncodeState resets the timestamp delta
@@ -385,6 +407,29 @@ impl<W: Write> Encoder<W> {
         codec::encode_string_pool(entries, &mut self.state.writer)
     }
 
+    /// Intern a stack-frame vector, emitting a stack-pool frame if new.
+    /// Returns an [`InternedStackFrames`] handle.
+    pub fn intern_stack_frames(&mut self, frames: &[u64]) -> io::Result<InternedStackFrames> {
+        if let Some(&id) = self.stack_pool.get(frames) {
+            return Ok(InternedStackFrames(id));
+        }
+        let id = self.next_stack_pool_id;
+        self.next_stack_pool_id += 1;
+        self.stack_pool.insert(frames.into(), id);
+        codec::encode_stack_pool(
+            &[StackPoolEntry {
+                pool_id: id,
+                frames: frames.to_vec(),
+            }],
+            &mut self.state.writer,
+        )?;
+        Ok(InternedStackFrames(id))
+    }
+
+    pub fn write_stack_pool(&mut self, entries: &[StackPoolEntry]) -> io::Result<()> {
+        codec::encode_stack_pool(entries, &mut self.state.writer)
+    }
+
     /// Flush the underlying writer.
     pub fn flush(&mut self) -> io::Result<()> {
         self.state.writer.flush()
@@ -443,6 +488,11 @@ impl Encoder<Vec<u8>> {
 
     pub fn intern_string_infallible(&mut self, s: &str) -> InternedString {
         self.intern_string(s)
+            .expect("interning into Vec<u8> is infallible")
+    }
+
+    pub fn intern_stack_frames_infallible(&mut self, frames: &[u64]) -> InternedStackFrames {
+        self.intern_stack_frames(frames)
             .expect("interning into Vec<u8> is infallible")
     }
 
@@ -597,6 +647,156 @@ mod tests {
         let id3 = enc.intern_string("world").unwrap();
         assert_eq!(id1, id2);
         assert_ne!(id1, id3);
+    }
+
+    #[test]
+    fn encoder_intern_stack_frames_deduplicates() {
+        let mut enc = Encoder::new();
+        let stack_a: &[u64] = &[0x1000, 0x2000, 0x3000];
+        let stack_b: &[u64] = &[0x4000, 0x5000];
+        let id1 = enc.intern_stack_frames(stack_a).unwrap();
+        let id2 = enc.intern_stack_frames(stack_a).unwrap();
+        let id3 = enc.intern_stack_frames(stack_b).unwrap();
+        assert_eq!(id1, id2);
+        assert_ne!(id1, id3);
+    }
+
+    #[test]
+    fn stack_pool_round_trip_via_decoder() {
+        use crate::decoder::Decoder;
+        use crate::types::InternedStackFrames;
+
+        let mut enc = Encoder::new();
+        let stack_a: &[u64] = &[0xdead, 0xbeef, 0xcafe];
+        let stack_b: &[u64] = &[0x1, 0x2];
+        let id_a = enc.intern_stack_frames(stack_a).unwrap();
+        let id_b = enc.intern_stack_frames(stack_b).unwrap();
+        let bytes = enc.finish();
+
+        let mut dec = Decoder::new(&bytes).unwrap();
+        let _ = dec.decode_all();
+        assert_eq!(
+            dec.stack_pool().get(InternedStackFrames(id_a.raw_id())),
+            Some(stack_a)
+        );
+        assert_eq!(
+            dec.stack_pool().get(InternedStackFrames(id_b.raw_id())),
+            Some(stack_b)
+        );
+    }
+
+    #[test]
+    fn for_each_event_populates_stack_pool() {
+        use crate::decoder::Decoder;
+        use crate::schema::FieldDef;
+        use crate::types::{FieldType, FieldValue, InternedStackFrames};
+
+        let mut enc = Encoder::new();
+        let schema = enc
+            .register_schema(
+                "CpuSampleEvent",
+                vec![FieldDef {
+                    name: "callchain".into(),
+                    field_type: FieldType::PooledStackFrames,
+                }],
+            )
+            .unwrap();
+        let stack: &[u64] = &[0x1234, 0x5678, 0x9abc];
+        let id = enc.intern_stack_frames(stack).unwrap();
+        enc.write_event(
+            &schema,
+            &[
+                FieldValue::Varint(1_000_000),
+                FieldValue::PooledStackFrames(id),
+            ],
+        )
+        .unwrap();
+        let bytes = enc.finish();
+
+        let mut dec = Decoder::new(&bytes).unwrap();
+        let mut event_count = 0;
+        dec.for_each_event(|_ev| {
+            event_count += 1;
+        })
+        .unwrap();
+        assert_eq!(event_count, 1);
+        assert_eq!(
+            dec.stack_pool().get(InternedStackFrames(id.raw_id())),
+            Some(stack),
+        );
+    }
+
+    #[test]
+    fn encoder_intern_empty_stack_frames() {
+        use crate::decoder::Decoder;
+        use crate::types::InternedStackFrames;
+
+        let mut enc = Encoder::new();
+        let id1 = enc.intern_stack_frames(&[]).unwrap();
+        let id2 = enc.intern_stack_frames(&[]).unwrap();
+        assert_eq!(id1, id2);
+        let bytes = enc.finish();
+
+        let mut dec = Decoder::new(&bytes).unwrap();
+        let _ = dec.decode_all();
+        assert_eq!(
+            dec.stack_pool().get(InternedStackFrames(id1.raw_id())),
+            Some(&[][..])
+        );
+    }
+
+    #[test]
+    fn write_stack_pool_multi_entry_round_trip() {
+        use crate::decoder::Decoder;
+        use crate::types::InternedStackFrames;
+
+        let mut enc = Encoder::new();
+        let entries = vec![
+            StackPoolEntry {
+                pool_id: 0,
+                frames: vec![0xaaaa, 0xbbbb, 0xcccc],
+            },
+            StackPoolEntry {
+                pool_id: 1,
+                frames: vec![0x1111],
+            },
+            StackPoolEntry {
+                pool_id: 2,
+                frames: vec![],
+            },
+        ];
+        enc.write_stack_pool(&entries).unwrap();
+        let bytes = enc.finish();
+
+        let mut dec = Decoder::new(&bytes).unwrap();
+        let _ = dec.decode_all();
+        assert_eq!(
+            dec.stack_pool().get(InternedStackFrames(0)),
+            Some(&[0xaaaa, 0xbbbb, 0xcccc][..])
+        );
+        assert_eq!(
+            dec.stack_pool().get(InternedStackFrames(1)),
+            Some(&[0x1111][..])
+        );
+        assert_eq!(dec.stack_pool().get(InternedStackFrames(2)), Some(&[][..]));
+    }
+
+    #[test]
+    fn decoder_into_encoder_deduplicates_interned_stack_frames() {
+        use crate::decoder::Decoder;
+
+        let mut enc = Encoder::new();
+        let id1 = enc.intern_stack_frames(&[0x10, 0x20]).unwrap();
+        let base = enc.finish();
+
+        let mut decoder = Decoder::new(&base).unwrap();
+        while decoder.next_frame_ref().ok().flatten().is_some() {}
+        let mut output = Vec::new();
+        let mut ext = decoder.into_encoder(&mut output);
+        let id2 = ext.intern_stack_frames(&[0x10, 0x20]).unwrap();
+        let id3 = ext.intern_stack_frames(&[0x30]).unwrap();
+        assert_eq!(id1.raw_id(), id2.raw_id());
+        assert_ne!(id2.raw_id(), id3.raw_id());
     }
 
     #[test]

--- a/dial9-trace-format/src/lib.rs
+++ b/dial9-trace-format/src/lib.rs
@@ -26,6 +26,7 @@ pub mod types;
 pub use dial9_trace_format_derive::TraceEvent;
 pub use types::EventEncoder;
 pub use types::FieldValue;
+pub use types::InternedStackFrames;
 pub use types::InternedString;
 pub use types::StackFrames;
 pub use types::TraceField;

--- a/dial9-trace-format/src/types.rs
+++ b/dial9-trace-format/src/types.rs
@@ -50,6 +50,25 @@ pub enum FieldType {
 #[derive(Debug, Clone, PartialEq)]
 pub struct StackFrames(pub Vec<u64>);
 
+impl From<Vec<u64>> for StackFrames {
+    fn from(v: Vec<u64>) -> Self {
+        StackFrames(v)
+    }
+}
+
+impl FromIterator<u64> for StackFrames {
+    fn from_iter<I: IntoIterator<Item = u64>>(iter: I) -> Self {
+        StackFrames(iter.into_iter().collect())
+    }
+}
+
+impl std::ops::Deref for StackFrames {
+    type Target = [u64];
+    fn deref(&self) -> &[u64] {
+        &self.0
+    }
+}
+
 /// An interned string reference (pool ID). Created by [`Encoder::intern_string`](crate::encoder::Encoder::intern_string).
 /// On the wire this is a `PooledString` (u32 LE).
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -126,7 +145,7 @@ pub enum FieldValue {
     String(String),
     Bytes(Vec<u8>),
     PooledString(InternedString),
-    StackFrames(Vec<u64>),
+    StackFrames(StackFrames),
     PooledStackFrames(InternedStackFrames),
     Varint(u64),
     StringMap(Vec<(Vec<u8>, Vec<u8>)>),
@@ -144,7 +163,7 @@ impl serde::Serialize for FieldValue {
             FieldValue::String(v) => serializer.serialize_str(v),
             FieldValue::Bytes(v) => serializer.serialize_bytes(v),
             FieldValue::PooledString(id) => id.serialize(serializer),
-            FieldValue::StackFrames(v) => v.serialize(serializer),
+            FieldValue::StackFrames(v) => v.0.serialize(serializer),
             FieldValue::PooledStackFrames(id) => id.serialize(serializer),
             FieldValue::Varint(v) => serializer.serialize_u64(*v),
             FieldValue::StringMap(pairs) => {
@@ -237,7 +256,7 @@ impl FieldValue {
             FieldValue::Varint(v) => crate::leb128::encode_unsigned(*v, w),
             FieldValue::StackFrames(addrs) => {
                 w.write_all(&(addrs.len() as u32).to_le_bytes())?;
-                for &addr in addrs {
+                for &addr in addrs.iter() {
                     w.write_all(&addr.to_le_bytes())?;
                 }
                 Ok(())
@@ -321,7 +340,7 @@ impl FieldValue {
                     addrs.push(addr);
                     pos += 8;
                 }
-                Some((FieldValue::StackFrames(addrs), &data[pos..]))
+                Some((FieldValue::StackFrames(addrs.into()), &data[pos..]))
             }
             FieldType::StringMap => {
                 let count = u32::from_le_bytes(data.get(..4)?.try_into().ok()?) as usize;
@@ -764,8 +783,8 @@ impl<'a, W: Write> EventEncoder<'a, W> {
     pub fn write_stack_frames(&mut self, v: &StackFrames) -> io::Result<()> {
         self.state
             .writer
-            .write_all(&(v.0.len() as u32).to_le_bytes())?;
-        for &addr in &v.0 {
+            .write_all(&(v.len() as u32).to_le_bytes())?;
+        for &addr in v.iter() {
             self.state.writer.write_all(&addr.to_le_bytes())?;
         }
         Ok(())
@@ -1188,7 +1207,7 @@ mod tests {
             0x5555_5555_0800,
             0x5555_5555_0100,
         ];
-        let val = FieldValue::StackFrames(addrs.clone());
+        let val = FieldValue::StackFrames(addrs.clone().into());
         let mut buf = Vec::new();
         val.encode(&mut buf).unwrap();
         assert_eq!(buf.len(), 4 + 4 * 8); // count(4) + 4 raw u64s

--- a/dial9-trace-format/src/types.rs
+++ b/dial9-trace-format/src/types.rs
@@ -30,6 +30,7 @@ pub enum FieldType {
     U8 = 11,
     U16 = 12,
     U32 = 13,
+    PooledStackFrames = 14,
     // Optional variants (inner tag | 0x80).
     OptionalI64 = 0x81,
     OptionalF64 = 0x82,
@@ -44,6 +45,7 @@ pub enum FieldType {
     OptionalU8 = 0x8B,
     OptionalU16 = 0x8C,
     OptionalU32 = 0x8D,
+    OptionalPooledStackFrames = 0x8E,
 }
 
 /// Newtype for stack frame addresses (leaf-first).
@@ -80,6 +82,38 @@ impl std::fmt::Debug for InternedString {
         write!(f, "pool#{}", self.0)
     }
 }
+
+/// An interned stack-frame reference (pool ID).
+/// On the wire this is a `PooledStackFrames` (u32 LE).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InternedStackFrames(pub(crate) u32);
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for InternedStackFrames {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u32(self.0)
+    }
+}
+
+impl InternedStackFrames {
+    /// Construct from a raw pool ID. Intended for building data from external
+    /// sources (e.g. wire decoding outside the `Encoder`).
+    pub const fn from_raw(id: u32) -> Self {
+        Self(id)
+    }
+
+    /// Returns the underlying pool ID.
+    pub const fn raw_id(self) -> u32 {
+        self.0
+    }
+}
+
+impl std::fmt::Debug for InternedStackFrames {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "stack#{}", self.0)
+    }
+}
+
 /// Owned field value. Decoded from the wire format.
 ///
 /// Note: `U8`, `U16`, and `U32` wire types are decoded into `Varint(v as u64)`.
@@ -95,6 +129,7 @@ pub enum FieldValue {
     Bytes(Vec<u8>),
     PooledString(InternedString),
     StackFrames(Vec<u64>),
+    PooledStackFrames(InternedStackFrames),
     Varint(u64),
     StringMap(Vec<(Vec<u8>, Vec<u8>)>),
     /// Absent optional field.
@@ -112,6 +147,7 @@ impl serde::Serialize for FieldValue {
             FieldValue::Bytes(v) => serializer.serialize_bytes(v),
             FieldValue::PooledString(id) => id.serialize(serializer),
             FieldValue::StackFrames(v) => v.serialize(serializer),
+            FieldValue::PooledStackFrames(id) => id.serialize(serializer),
             FieldValue::Varint(v) => serializer.serialize_u64(*v),
             FieldValue::StringMap(pairs) => {
                 use serde::ser::SerializeMap;
@@ -153,6 +189,7 @@ impl FieldType {
             11 => Some(FieldType::U8),
             12 => Some(FieldType::U16),
             13 => Some(FieldType::U32),
+            14 => Some(FieldType::PooledStackFrames),
             0x81 => Some(FieldType::OptionalI64),
             0x82 => Some(FieldType::OptionalF64),
             0x83 => Some(FieldType::OptionalBool),
@@ -165,6 +202,7 @@ impl FieldType {
             0x8B => Some(FieldType::OptionalU8),
             0x8C => Some(FieldType::OptionalU16),
             0x8D => Some(FieldType::OptionalU32),
+            0x8E => Some(FieldType::OptionalPooledStackFrames),
             _ => None,
         }
     }
@@ -197,6 +235,7 @@ impl FieldValue {
                 w.write_all(v)
             }
             FieldValue::PooledString(id) => w.write_all(&id.0.to_le_bytes()),
+            FieldValue::PooledStackFrames(id) => w.write_all(&id.0.to_le_bytes()),
             FieldValue::Varint(v) => crate::leb128::encode_unsigned(*v, w),
             FieldValue::StackFrames(addrs) => {
                 w.write_all(&(addrs.len() as u32).to_le_bytes())?;
@@ -254,6 +293,13 @@ impl FieldValue {
             FieldType::PooledString => {
                 let id = u32::from_le_bytes(data.get(..4)?.try_into().ok()?);
                 Some((FieldValue::PooledString(InternedString(id)), &data[4..]))
+            }
+            FieldType::PooledStackFrames => {
+                let id = u32::from_le_bytes(data.get(..4)?.try_into().ok()?);
+                Some((
+                    FieldValue::PooledStackFrames(InternedStackFrames(id)),
+                    &data[4..],
+                ))
             }
             FieldType::Varint => {
                 let (v, consumed) = crate::leb128::decode_unsigned(data)?;
@@ -316,6 +362,8 @@ pub enum FieldValueRef<'a> {
     PooledString(InternedString),
     /// Raw stack frame bytes. Use [`StackFramesRef::iter`] to iterate addresses.
     StackFrames(StackFramesRef<'a>),
+    /// Reference to a stack-frame pool entry. Resolve via the decoder's stack pool.
+    PooledStackFrames(InternedStackFrames),
     Varint(u64),
     StringMap(StringMapRef<'a>),
     /// Absent optional field.
@@ -410,6 +458,10 @@ impl<'a> FieldValueRef<'a> {
                 let id = u32::from_le_bytes(d.get(..4)?.try_into().ok()?);
                 Some((FieldValueRef::PooledString(InternedString(id)), 4))
             }
+            FieldType::PooledStackFrames => {
+                let id = u32::from_le_bytes(d.get(..4)?.try_into().ok()?);
+                Some((FieldValueRef::PooledStackFrames(InternedStackFrames(id)), 4))
+            }
             FieldType::Varint => {
                 let (v, consumed) = crate::leb128::decode_unsigned(d)?;
                 Some((FieldValueRef::Varint(v), consumed))
@@ -469,6 +521,7 @@ impl<'a> FieldValueRef<'a> {
             FieldValueRef::Bytes(v) => FieldValue::Bytes(v.to_vec()),
             FieldValueRef::PooledString(id) => FieldValue::PooledString(*id),
             FieldValueRef::StackFrames(sf) => FieldValue::StackFrames(sf.iter().collect()),
+            FieldValueRef::PooledStackFrames(id) => FieldValue::PooledStackFrames(*id),
             FieldValueRef::Varint(v) => FieldValue::Varint(*v),
             FieldValueRef::StringMap(sm) => FieldValue::StringMap(
                 sm.iter()
@@ -703,6 +756,10 @@ impl<'a, W: Write> EventEncoder<'a, W> {
     }
 
     pub fn write_interned(&mut self, v: InternedString) -> io::Result<()> {
+        self.state.writer.write_all(&v.0.to_le_bytes())
+    }
+
+    pub fn write_interned_stack_frames(&mut self, v: InternedStackFrames) -> io::Result<()> {
         self.state.writer.write_all(&v.0.to_le_bytes())
     }
 
@@ -956,6 +1013,22 @@ impl TraceField for InternedString {
     }
 }
 
+impl TraceField for InternedStackFrames {
+    type Ref<'a> = InternedStackFrames;
+    fn field_type() -> FieldType {
+        FieldType::PooledStackFrames
+    }
+    fn encode<W: Write>(&self, enc: &mut EventEncoder<'_, W>) -> io::Result<()> {
+        enc.write_interned_stack_frames(*self)
+    }
+    fn decode_ref<'a>(val: &FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
+        match val {
+            FieldValueRef::PooledStackFrames(id) => Some(*id),
+            _ => None,
+        }
+    }
+}
+
 impl TraceField for Vec<(String, String)> {
     type Ref<'a> = StringMapRef<'a>;
     fn field_type() -> FieldType {
@@ -1021,6 +1094,7 @@ macro_rules! impl_optional_trace_field {
 }
 
 impl_optional_trace_field!(InternedString);
+impl_optional_trace_field!(InternedStackFrames);
 impl_optional_trace_field!(u8);
 impl_optional_trace_field!(u16);
 impl_optional_trace_field!(u32);
@@ -1039,12 +1113,12 @@ mod tests {
 
     #[test]
     fn field_type_round_trip() {
-        for tag in [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13u8] {
+        for tag in [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14u8] {
             let ft = FieldType::from_tag(tag).unwrap();
             assert_eq!(ft as u8, tag);
         }
         assert!(FieldType::from_tag(0).is_none());
-        assert!(FieldType::from_tag(14).is_none());
+        assert!(FieldType::from_tag(15).is_none());
     }
 
     #[test]
@@ -1121,6 +1195,16 @@ mod tests {
         val.encode(&mut buf).unwrap();
         assert_eq!(buf.len(), 4 + 4 * 8); // count(4) + 4 raw u64s
         let (decoded, _) = FieldValue::decode(FieldType::StackFrames, &buf).unwrap();
+        assert_eq!(decoded, val);
+    }
+
+    #[test]
+    fn encode_decode_pooled_stack_frames() {
+        let val = FieldValue::PooledStackFrames(InternedStackFrames(42));
+        let mut buf = Vec::new();
+        val.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), 4);
+        let (decoded, _) = FieldValue::decode(FieldType::PooledStackFrames, &buf).unwrap();
         assert_eq!(decoded, val);
     }
 

--- a/dial9-trace-format/src/types.rs
+++ b/dial9-trace-format/src/types.rs
@@ -22,7 +22,7 @@ pub enum FieldType {
     Bool = 3,
     String = 4,
     Bytes = 5,
-    // Tag 6 was legacy Timestamp (removed).
+    PooledStackFrames = 6,
     PooledString = 7,
     StackFrames = 8,
     Varint = 9,
@@ -30,14 +30,13 @@ pub enum FieldType {
     U8 = 11,
     U16 = 12,
     U32 = 13,
-    PooledStackFrames = 14,
     // Optional variants (inner tag | 0x80).
     OptionalI64 = 0x81,
     OptionalF64 = 0x82,
     OptionalBool = 0x83,
     OptionalString = 0x84,
     OptionalBytes = 0x85,
-    // Tag 6 was legacy Timestamp (removed).
+    OptionalPooledStackFrames = 0x86,
     OptionalPooledString = 0x87,
     OptionalStackFrames = 0x88,
     OptionalVarint = 0x89,
@@ -45,7 +44,6 @@ pub enum FieldType {
     OptionalU8 = 0x8B,
     OptionalU16 = 0x8C,
     OptionalU32 = 0x8D,
-    OptionalPooledStackFrames = 0x8E,
 }
 
 /// Newtype for stack frame addresses (leaf-first).
@@ -182,6 +180,7 @@ impl FieldType {
             3 => Some(FieldType::Bool),
             4 => Some(FieldType::String),
             5 => Some(FieldType::Bytes),
+            6 => Some(FieldType::PooledStackFrames),
             7 => Some(FieldType::PooledString),
             8 => Some(FieldType::StackFrames),
             9 => Some(FieldType::Varint),
@@ -189,12 +188,12 @@ impl FieldType {
             11 => Some(FieldType::U8),
             12 => Some(FieldType::U16),
             13 => Some(FieldType::U32),
-            14 => Some(FieldType::PooledStackFrames),
             0x81 => Some(FieldType::OptionalI64),
             0x82 => Some(FieldType::OptionalF64),
             0x83 => Some(FieldType::OptionalBool),
             0x84 => Some(FieldType::OptionalString),
             0x85 => Some(FieldType::OptionalBytes),
+            0x86 => Some(FieldType::OptionalPooledStackFrames),
             0x87 => Some(FieldType::OptionalPooledString),
             0x88 => Some(FieldType::OptionalStackFrames),
             0x89 => Some(FieldType::OptionalVarint),
@@ -202,7 +201,6 @@ impl FieldType {
             0x8B => Some(FieldType::OptionalU8),
             0x8C => Some(FieldType::OptionalU16),
             0x8D => Some(FieldType::OptionalU32),
-            0x8E => Some(FieldType::OptionalPooledStackFrames),
             _ => None,
         }
     }
@@ -1113,12 +1111,12 @@ mod tests {
 
     #[test]
     fn field_type_round_trip() {
-        for tag in [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14u8] {
+        for tag in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13u8] {
             let ft = FieldType::from_tag(tag).unwrap();
             assert_eq!(ft as u8, tag);
         }
         assert!(FieldType::from_tag(0).is_none());
-        assert!(FieldType::from_tag(15).is_none());
+        assert!(FieldType::from_tag(14).is_none());
     }
 
     #[test]

--- a/dial9-trace-format/tests/derive_round_trip.rs
+++ b/dial9-trace-format/tests/derive_round_trip.rs
@@ -6,7 +6,7 @@ use dial9_trace_format::decoder::{DecodedFrame, DecodedFrameRef, Decoder};
 use dial9_trace_format::encoder::Encoder;
 use dial9_trace_format::schema::SchemaEntry;
 use dial9_trace_format::types::{FieldType, FieldValueRef};
-use dial9_trace_format::{InternedString, StackFrames, TraceEvent};
+use dial9_trace_format::{InternedStackFrames, InternedString, StackFrames, TraceEvent};
 
 // ── Structs covering every supported field type ─────────────────────────
 
@@ -1124,6 +1124,13 @@ struct WithoutOptional {
     required_id: u32,
 }
 
+#[derive(TraceEvent)]
+struct WithOptionalStack {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    optional_callchain: Option<InternedStackFrames>,
+}
+
 #[test]
 fn optional_field_schema_has_optional_flag() {
     let defs = WithOptionalString::field_defs();
@@ -1216,6 +1223,36 @@ fn optional_u64_round_trip() {
     })
     .unwrap();
     assert_eq!(events, vec![(100, Some(200)), (300, None)]);
+}
+
+#[test]
+fn optional_interned_stack_frames_round_trip() {
+    let mut enc = Encoder::new();
+    let stack = enc.intern_stack_frames(&[0xdead, 0xbeef, 0xcafe]).unwrap();
+    enc.write(&WithOptionalStack {
+        timestamp_ns: 1000,
+        optional_callchain: Some(stack),
+    })
+    .unwrap();
+    enc.write(&WithOptionalStack {
+        timestamp_ns: 2000,
+        optional_callchain: None,
+    })
+    .unwrap();
+    let data = enc.finish();
+
+    let mut dec = Decoder::new(&data).unwrap();
+    let mut events = Vec::new();
+    dec.for_each_event(|ev| {
+        let defs = WithOptionalStack::field_defs();
+        let decoded = WithOptionalStack::decode(ev.timestamp_ns, ev.fields, &defs).unwrap();
+        events.push((decoded.timestamp_ns, decoded.optional_callchain));
+    })
+    .unwrap();
+    assert_eq!(events, vec![(1000, Some(stack)), (2000, None)]);
+
+    let defs = WithOptionalStack::field_defs();
+    assert_eq!(defs[0].field_type, FieldType::OptionalPooledStackFrames);
 }
 
 #[test]

--- a/dial9-trace-format/tests/js_parser.rs
+++ b/dial9-trace-format/tests/js_parser.rs
@@ -296,3 +296,131 @@ fn js_decodes_optional_pooled_string() {
     assert!(events[1]["values"]["opt_name"].is_null());
     assert_eq!(events[1]["values"]["required_id"].as_str().unwrap(), "99");
 }
+
+#[test]
+fn js_decodes_pooled_stack_frames() {
+    let mut enc = Encoder::new();
+    let tid = enc
+        .register_schema(
+            "CpuSample",
+            vec![
+                FieldDef {
+                    name: "worker".into(),
+                    field_type: FieldType::Varint,
+                },
+                FieldDef {
+                    name: "callchain".into(),
+                    field_type: FieldType::PooledStackFrames,
+                },
+            ],
+        )
+        .unwrap();
+
+    // Two distinct stacks, then reuse stack_a → exercises dedup.
+    let stack_a = enc.intern_stack_frames(&[0x1000, 0x0F00, 0x0E00]).unwrap();
+    let stack_b = enc.intern_stack_frames(&[0x2000, 0x2100]).unwrap();
+
+    enc.write_event(
+        &tid,
+        &[
+            FieldValue::Varint(1_000_000),
+            FieldValue::Varint(1),
+            FieldValue::PooledStackFrames(stack_a),
+        ],
+    )
+    .unwrap();
+    enc.write_event(
+        &tid,
+        &[
+            FieldValue::Varint(2_000_000),
+            FieldValue::Varint(2),
+            FieldValue::PooledStackFrames(stack_b),
+        ],
+    )
+    .unwrap();
+    enc.write_event(
+        &tid,
+        &[
+            FieldValue::Varint(3_000_000),
+            FieldValue::Varint(3),
+            FieldValue::PooledStackFrames(stack_a),
+        ],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let json = js_decode(&data);
+    let frames = json["frames"].as_array().unwrap();
+    let events: Vec<_> = frames.iter().filter(|f| f["type"] == "event").collect();
+    assert_eq!(events.len(), 3);
+
+    // Resolved value matches the inline `StackFrames` shape: array of decimal
+    // address strings. This is what downstream JS consumers expect.
+    assert_eq!(
+        events[0]["values"]["callchain"],
+        serde_json::json!(["4096", "3840", "3584"])
+    );
+    assert_eq!(
+        events[1]["values"]["callchain"],
+        serde_json::json!(["8192", "8448"])
+    );
+    // Reused pool ID resolves to same array as event 0.
+    assert_eq!(
+        events[2]["values"]["callchain"],
+        serde_json::json!(["4096", "3840", "3584"])
+    );
+
+    // Stack pool is exposed in the CLI JSON output.
+    let stack_pool = json["stackPool"].as_object().unwrap();
+    assert_eq!(stack_pool.len(), 2);
+    assert_eq!(
+        stack_pool[&stack_a.raw_id().to_string()],
+        serde_json::json!(["4096", "3840", "3584"])
+    );
+    assert_eq!(
+        stack_pool[&stack_b.raw_id().to_string()],
+        serde_json::json!(["8192", "8448"])
+    );
+}
+
+#[test]
+fn js_decodes_optional_pooled_stack_frames() {
+    let mut enc = Encoder::new();
+    let tid = enc
+        .register_schema(
+            "MaybeStack",
+            vec![FieldDef {
+                name: "callchain".into(),
+                field_type: FieldType::OptionalPooledStackFrames,
+            }],
+        )
+        .unwrap();
+
+    let stack = enc.intern_stack_frames(&[0xAAAA, 0xBBBB]).unwrap();
+    enc.write_event(
+        &tid,
+        &[
+            FieldValue::Varint(1_000_000),
+            FieldValue::PooledStackFrames(stack),
+        ],
+    )
+    .unwrap();
+    enc.write_event(&tid, &[FieldValue::Varint(2_000_000), FieldValue::None])
+        .unwrap();
+
+    let data = enc.finish();
+    let json = js_decode(&data);
+    let events: Vec<_> = json["frames"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|f| f["type"] == "event")
+        .collect();
+    assert_eq!(events.len(), 2);
+
+    assert_eq!(
+        events[0]["values"]["callchain"],
+        serde_json::json!(["43690", "48059"])
+    );
+    assert!(events[1]["values"]["callchain"].is_null());
+}

--- a/dial9-trace-format/tests/js_parser.rs
+++ b/dial9-trace-format/tests/js_parser.rs
@@ -82,7 +82,7 @@ fn js_decodes_all_field_types() {
             FieldValue::String("world".to_string()),
             FieldValue::Bytes(vec![0xDE, 0xAD]),
             FieldValue::PooledString(pool_id),
-            FieldValue::StackFrames(vec![0x1000, 0x0F00, 0x0E00]),
+            FieldValue::StackFrames(vec![0x1000, 0x0F00, 0x0E00].into()),
             FieldValue::Varint(999),
         ],
     )

--- a/dial9-trace-format/tests/round_trip.rs
+++ b/dial9-trace-format/tests/round_trip.rs
@@ -56,7 +56,7 @@ fn full_round_trip() {
         &[
             FieldValue::Varint(1_000_100),
             FieldValue::PooledString(thread_id),
-            FieldValue::StackFrames(frames.clone()),
+            FieldValue::StackFrames(frames.clone().into()),
         ],
     )
     .unwrap();
@@ -121,7 +121,7 @@ fn full_round_trip() {
     // Verify cpu sample with stack frames
     if let DecodedFrame::Event { values, .. } = &decoded[4] {
         assert_eq!(values[0], FieldValue::PooledString(thread_id));
-        assert_eq!(values[1], FieldValue::StackFrames(frames));
+        assert_eq!(values[1], FieldValue::StackFrames(frames.into()));
     } else {
         panic!("expected event frame");
     }
@@ -190,7 +190,7 @@ fn round_trip_all_field_types() {
         FieldValue::String("hello".to_string()),
         FieldValue::Bytes(vec![0xDE, 0xAD]),
         FieldValue::PooledString(pool_id),
-        FieldValue::StackFrames(vec![0xAAAA, 0xBBBB, 0xCCCC]),
+        FieldValue::StackFrames(vec![0xAAAA, 0xBBBB, 0xCCCC].into()),
     ];
     enc.write_event(&tid, &values).unwrap();
     let data = enc.finish();

--- a/dial9-trace-format/tests/spec_edge_cases.rs
+++ b/dial9-trace-format/tests/spec_edge_cases.rs
@@ -327,7 +327,7 @@ fn interleaved_pool_and_events() {
 
 #[test]
 fn all_field_type_tags_valid() {
-    for tag in [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13u8] {
+    for tag in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13u8] {
         assert!(
             FieldType::from_tag(tag).is_some(),
             "tag {tag} should be valid"
@@ -341,8 +341,8 @@ fn field_type_tag_0_invalid() {
 }
 
 #[test]
-fn field_type_tag_15_invalid() {
-    assert!(FieldType::from_tag(15).is_none());
+fn field_type_tag_14_invalid() {
+    assert!(FieldType::from_tag(14).is_none());
 }
 
 #[test]

--- a/dial9-trace-format/tests/spec_edge_cases.rs
+++ b/dial9-trace-format/tests/spec_edge_cases.rs
@@ -341,8 +341,8 @@ fn field_type_tag_0_invalid() {
 }
 
 #[test]
-fn field_type_tag_14_invalid() {
-    assert!(FieldType::from_tag(14).is_none());
+fn field_type_tag_15_invalid() {
+    assert!(FieldType::from_tag(15).is_none());
 }
 
 #[test]

--- a/dial9-trace-format/tests/spec_edge_cases.rs
+++ b/dial9-trace-format/tests/spec_edge_cases.rs
@@ -144,7 +144,7 @@ fn empty_bytes_field() {
 
 #[test]
 fn empty_stack_frames() {
-    let v = FieldValue::StackFrames(vec![]);
+    let v = FieldValue::StackFrames(vec![].into());
     let mut buf = Vec::new();
     v.encode(&mut buf).unwrap();
     assert_eq!(buf.len(), 4);
@@ -196,7 +196,7 @@ fn varint_leb128_boundary_values() {
 
 #[test]
 fn stack_frames_single_address() {
-    let v = FieldValue::StackFrames(vec![0x7fff_ffff_ffff]);
+    let v = FieldValue::StackFrames(vec![0x7fff_ffff_ffff].into());
     let mut buf = Vec::new();
     v.encode(&mut buf).unwrap();
     let (decoded, _) = FieldValue::decode(FieldType::StackFrames, &buf).unwrap();
@@ -206,7 +206,7 @@ fn stack_frames_single_address() {
 #[test]
 fn stack_frames_identical_addresses() {
     let addrs = vec![0x1000u64; 5];
-    let v = FieldValue::StackFrames(addrs);
+    let v = FieldValue::StackFrames(addrs.into());
     let mut buf = Vec::new();
     v.encode(&mut buf).unwrap();
     assert_eq!(buf.len(), 4 + 5 * 8); // count + 5 raw u64s
@@ -217,7 +217,7 @@ fn stack_frames_identical_addresses() {
 #[test]
 fn stack_frames_descending_addresses() {
     let addrs = vec![0x5555_5555_5000u64, 0x5555_5555_4000, 0x5555_5555_3000];
-    let v = FieldValue::StackFrames(addrs);
+    let v = FieldValue::StackFrames(addrs.into());
     let mut buf = Vec::new();
     v.encode(&mut buf).unwrap();
     let (decoded, _) = FieldValue::decode(FieldType::StackFrames, &buf).unwrap();

--- a/perf-self-profile/src/offline_symbolize.rs
+++ b/perf-self-profile/src/offline_symbolize.rs
@@ -6,7 +6,7 @@
 //! (with a `StringPool` frame for symbol names).
 
 use dial9_trace_format::{
-    decoder::Decoder,
+    decoder::{Decoder, StackPool},
     types::{FieldValueRef, InternedString},
 };
 use std::collections::BTreeSet;
@@ -55,7 +55,7 @@ pub fn symbolize_trace_with_maps(
 
     decoder
         .for_each_event(|event| {
-            collect_stack_frame_addresses(event.fields, &mut addresses);
+            collect_stack_frame_addresses(event.fields, event.stack_pool, &mut addresses);
         })
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
@@ -66,14 +66,30 @@ pub fn symbolize_trace_with_maps(
     crate::sys::write_symbol_data(decoder, &addresses, maps, output)
 }
 
-fn collect_stack_frame_addresses(values: &[FieldValueRef<'_>], addresses: &mut BTreeSet<u64>) {
+fn collect_stack_frame_addresses(
+    values: &[FieldValueRef<'_>],
+    stack_pool: &StackPool,
+    addresses: &mut BTreeSet<u64>,
+) {
     for field in values {
-        if let FieldValueRef::StackFrames(frames) = field {
-            for addr in frames.iter() {
-                if addr != 0 {
-                    addresses.insert(addr);
+        match field {
+            FieldValueRef::StackFrames(frames) => {
+                for addr in frames.iter() {
+                    if addr != 0 {
+                        addresses.insert(addr);
+                    }
                 }
             }
+            FieldValueRef::PooledStackFrames(id) => {
+                if let Some(frames) = stack_pool.get(*id) {
+                    for &addr in frames {
+                        if addr != 0 {
+                            addresses.insert(addr);
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
     }
 }

--- a/perf-self-profile/src/offline_symbolize.rs
+++ b/perf-self-profile/src/offline_symbolize.rs
@@ -196,7 +196,10 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
-            &[FieldValue::Varint(0), FieldValue::StackFrames(vec![0x1000])],
+            &[
+                FieldValue::Varint(0),
+                FieldValue::StackFrames(vec![0x1000].into()),
+            ],
         )
         .unwrap();
         let buf = enc.finish();

--- a/perf-self-profile/src/offline_symbolize.rs
+++ b/perf-self-profile/src/offline_symbolize.rs
@@ -9,7 +9,7 @@ use dial9_trace_format::{
     decoder::{Decoder, StackPool},
     types::{FieldValueRef, InternedString},
 };
-use std::collections::BTreeSet;
+use std::collections::HashSet;
 use std::io::{self, Write};
 
 use crate::MapsEntry;
@@ -48,7 +48,7 @@ pub fn symbolize_trace_with_maps(
     maps: &[MapsEntry],
     output: &mut impl Write,
 ) -> io::Result<()> {
-    let mut addresses: BTreeSet<u64> = BTreeSet::new();
+    let mut addresses: HashSet<u64> = HashSet::new();
 
     let mut decoder = Decoder::new(input)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid trace header"))?;
@@ -69,7 +69,7 @@ pub fn symbolize_trace_with_maps(
 fn collect_stack_frame_addresses(
     values: &[FieldValueRef<'_>],
     stack_pool: &StackPool,
-    addresses: &mut BTreeSet<u64>,
+    addresses: &mut HashSet<u64>,
 ) {
     for field in values {
         match field {

--- a/perf-self-profile/src/sys/linux/offline_symbolize.rs
+++ b/perf-self-profile/src/sys/linux/offline_symbolize.rs
@@ -2,7 +2,7 @@
 
 use blazesym::symbolize::{Input, Symbolized, Symbolizer, source};
 use dial9_trace_format::{decoder::Decoder, encoder::Encoder};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 
 use super::USER_ADDR_LIMIT;
@@ -11,7 +11,7 @@ use crate::offline_symbolize::SymbolTableEntry;
 
 pub(crate) fn write_symbol_data(
     decoder: Decoder<'_>,
-    addresses: &BTreeSet<u64>,
+    addresses: &HashSet<u64>,
     maps: &[MapsEntry],
     output: &mut impl Write,
 ) -> io::Result<()> {

--- a/perf-self-profile/src/sys/linux/offline_symbolize.rs
+++ b/perf-self-profile/src/sys/linux/offline_symbolize.rs
@@ -280,7 +280,10 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
-            &[FieldValue::Varint(0), FieldValue::StackFrames(vec![addr])],
+            &[
+                FieldValue::Varint(0),
+                FieldValue::StackFrames(vec![addr].into()),
+            ],
         )
         .unwrap();
         let buf = enc.finish();
@@ -333,7 +336,10 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
-            &[FieldValue::Varint(0), FieldValue::StackFrames(vec![addr])],
+            &[
+                FieldValue::Varint(0),
+                FieldValue::StackFrames(vec![addr].into()),
+            ],
         )
         .unwrap();
         let buf = enc.finish();

--- a/perf-self-profile/src/sys/linux/offline_symbolize.rs
+++ b/perf-self-profile/src/sys/linux/offline_symbolize.rs
@@ -181,6 +181,88 @@ mod tests {
         types::{FieldType, FieldValue},
     };
 
+    fn symbol_table_addrs(dec: &Decoder<'_>, frames: &[DecodedFrame]) -> Vec<u64> {
+        let mut out = Vec::new();
+        for frame in frames {
+            if let DecodedFrame::Event {
+                type_id, values, ..
+            } = frame
+                && let Some(entry) = dec.registry().get(*type_id)
+                && entry.name == SymbolTableEntry::event_name()
+                && let Some(FieldValue::Varint(addr)) = values.first()
+            {
+                out.push(*addr);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn symbolize_with_maps_handles_multi_segment_pooled_stacks() {
+        let addr_a = symbolize_with_maps_handles_multi_segment_pooled_stacks as *const () as u64;
+        let addr_b = symbolize_with_maps_produces_symbol_events as *const () as u64;
+        let raw_maps = crate::read_proc_maps();
+
+        // Segment 1: contains addr_a in its pool.
+        let mut enc1 = Encoder::new();
+        let schema1 = enc1
+            .register_schema(
+                "Ev",
+                vec![FieldDef {
+                    name: "frames".into(),
+                    field_type: FieldType::PooledStackFrames,
+                }],
+            )
+            .unwrap();
+        let id_a = enc1.intern_stack_frames(&[addr_a]).unwrap();
+        enc1.write_event(
+            &schema1,
+            &[FieldValue::Varint(0), FieldValue::PooledStackFrames(id_a)],
+        )
+        .unwrap();
+        let seg1 = enc1.finish();
+
+        // Segment 2: contains addr_b.
+        let mut enc2 = Encoder::new();
+        let schema2 = enc2
+            .register_schema(
+                "Ev",
+                vec![FieldDef {
+                    name: "frames".into(),
+                    field_type: FieldType::PooledStackFrames,
+                }],
+            )
+            .unwrap();
+        let id_b = enc2.intern_stack_frames(&[addr_b]).unwrap();
+        enc2.write_event(
+            &schema2,
+            &[FieldValue::Varint(0), FieldValue::PooledStackFrames(id_b)],
+        )
+        .unwrap();
+        let seg2 = enc2.finish();
+
+        let mut concatenated = seg1;
+        concatenated.extend_from_slice(&seg2);
+
+        let mut output = Vec::new();
+        symbolize_trace_with_maps(&concatenated, &raw_maps, &mut output).unwrap();
+
+        let mut combined = concatenated.clone();
+        combined.extend_from_slice(&output);
+        let mut dec = Decoder::new(&combined).unwrap();
+        let frames = dec.decode_all();
+
+        let addrs = symbol_table_addrs(&dec, &frames);
+        assert!(
+            addrs.contains(&addr_a),
+            "missing SymbolTableEntry for first-segment address"
+        );
+        assert!(
+            addrs.contains(&addr_b),
+            "missing SymbolTableEntry for second-segment address"
+        );
+    }
+
     #[test]
     fn symbolize_with_maps_produces_symbol_events() {
         let addr = symbolize_with_maps_produces_symbol_events as *const () as u64;

--- a/perf-self-profile/src/sys/unsupported.rs
+++ b/perf-self-profile/src/sys/unsupported.rs
@@ -49,7 +49,7 @@ impl PerfSampler {
 
 pub(crate) fn write_symbol_data(
     _decoder: dial9_trace_format::decoder::Decoder<'_>,
-    _addresses: &std::collections::BTreeSet<u64>,
+    _addresses: &std::collections::HashSet<u64>,
     _maps: &[crate::MapsEntry],
     _output: &mut impl std::io::Write,
 ) -> std::io::Result<()> {


### PR DESCRIPTION
closes #222 

`CpuSample` currently writes the full stack on every sample, which dominates trace size at hundreds-of-Hz sampling. 
This PR adds interning of stack frames to mitigate this.

## Summary

Adds a `PooledStackFrames` field type alongside the existing `StackFrames` and switches `CpuSample.callchain` to use it, the encoder dedups stacks into a per-segment pool, mostly follows the existing approach interned strings.

Based on testing across 10:1 to 1000:1 samples-per-unique-stack ratios, interned output is 6–16x smaller than inline pre-gzip and ~3x smaller post-gzip.

I'm including a small improvement to `FxHasher::write` in 970aa66628c52e67e60ed2336562330d703e2005:

After adding interning, encoding with `FxHasher` (following what we do for interned strings) was 2-5x slower than inline. Default `HashMap` was _alright_ , but still ended up ~60% slower than inline. 
We could just use the default `HashMap`, but I was surprised that `FxHasher` turned out to be *worse* than default. 
Our local `write` impl looped byte-by-byte, so the new `Box<[u64]>` stack-pool keys paid 8x more ops than necessary on every intern. Making `write` word-wise (chunks of 8 bytes via `from_ne_bytes`) restores parity with inline, and beats it when pool IDs are smaller than the inline frames. Other FxHashMap uses (string_pool, schema name lookups) should get a speed up too on keys ≥8 bytes (though those paths are not as hot really).

Encode-time impact, measured against the inline (pre-interning) baseline:

| bench (encode)        | inline   |  interned + byte-wise | interned + word-wise |
|-----------------------|----------|----------------------|----------------------|
| codec_1M_events       | 22.85ms  | 50.68ms  (+122%)     | 20.20ms  (-12%)      |
| stack_intern 100u/10k | 745us     | 2.55ms   (+242%)     | 587us    (-21%)      |
| stack_intern 500u/10k | 669us    | 2.81ms   (+320%)     | 632us    (-6%)       |
| stack_intern 1000u/10k| 669us    | 3.04ms   (+354%)     | 719us    (+7%)       |