### PR TITLE
ci: Fix broken benchmarks.yml, make audit output readable, bump rustls-webpki

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,18 +4,40 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - '.github/workflows/audit.yml'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/audit.yml'
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+
 permissions:
-  checks: write
   contents: read
 
 jobs:
   security_audit:
+    name: cargo audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2.0.0
+
+      # Install a prebuilt cargo-audit binary (fast; avoids a source build).
+      - uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit
+
+      # Run cargo audit directly so the full advisory output (crate, version,
+      # dependency tree, solution) is visible in the workflow logs rather than
+      # hidden behind the Checks API.
+      #
+      # Ignored advisories (with justification):
+      #   RUSTSEC-2026-0104  rustls-webpki 0.101.7 — panic reachable only when
+      #     parsing certificate revocation lists (CRLs). Pulled in transitively
+      #     by the AWS SDK's legacy hyper-0.14 connector. We don't use CRLs,
+      #     and rustls 0.21.x has no patched release (fix is in 0.103.13+).
+      #     Revisit when the AWS SDK drops the legacy-rustls-ring feature.
+      - name: Run cargo audit
+        run: cargo audit --ignore RUSTSEC-2026-0104

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,9 +26,10 @@ permissions:
 jobs:
   # Runs on every push to main to build the statistical baseline.
   benchmark_main:
-    if: ${{ false }} # skip job
+    # Jobs are currently disabled; re-enable by restoring the original condition:
+    #   if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: ${{ false }}
     name: Benchmark — ${{ matrix.bench.name }} (main baseline)
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -77,9 +78,10 @@ jobs:
   # Runs on same-repo PRs. Fork PRs are skipped — they have no access to
   # BENCHER_API_TOKEN, so the job would fail rather than silently skip.
   benchmark_pr:
-    if: ${{ false }} # skip job
+    # Jobs are currently disabled; re-enable by restoring the original condition:
+    #   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ false }}
     name: Benchmark — ${{ matrix.bench.name }} (PR regression check)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,7 +3553,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3591,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Fixes three related CI issues found in #326's check list.

## 1. benchmarks.yml invalid YAML

```
(Line: 31, Col: 5): 'if' is already defined, (Line: 82, Col: 5): 'if' is already defined
```

Commit 3feb4bf added `if: ${{ false }} # skip job` to both jobs but didn't remove the original `if:` line below. GitHub rejected the workflow entirely. Merged each pair into a single `if: ${{ false }}` with a comment preserving the original trigger condition so it can be re-enabled easily.

## 2. Security audit output was unhelpful

`rustsec/audit-check` writes results to the Checks API but logs only:

```
Warning: 2 vulnerabilities found!
Found 2 advisories
Error: Critical vulnerabilities were found, marking check as failed
```

You had to dig through the Check page annotations to find out what the advisories were. Replaced with direct `cargo audit` (prebuilt binary via `taiki-e/install-action` — fast, no source build) so the full advisory text (crate, version, dependency tree, suggested fix) shows up directly in the workflow logs. Also added a `pull_request` trigger so the audit runs on PRs, not only on pushes to main.

## 3. rustls-webpki vulnerabilities (RUSTSEC-2026-0104)

Two rustls-webpki copies were hitting the same advisory — a reachable panic in CRL parsing:

- **rustls-webpki 0.103.12** → bumped to **0.103.13** via `cargo update -p rustls-webpki@0.103.12 --precise 0.103.13`. One-line Cargo.lock delta.
- **rustls-webpki 0.101.7** is pulled in transitively by `aws-smithy-http-client`'s `legacy-rustls-ring` feature (used by the AWS SDK's hyper-0.14 legacy connector). No patched rustls 0.21.x exists — the fix landed only in 0.103.13+.

The bug is only reachable when parsing certificate revocation lists, which none of our code does. Added `--ignore RUSTSEC-2026-0104` to the cargo audit step with a comment explaining the rationale and when to revisit (once the AWS SDK drops the legacy feature).

## Verification

- `cargo fmt --check` ✓
- `cargo check --all-targets --all-features` ✓
- `cargo clippy --all-targets --all-features` ✓
- `cargo nextest run --stress-duration 20s` ✓ (408/408 tests × 2 iterations)
- `cargo audit --ignore RUSTSEC-2026-0104` ✓
- `actionlint` on both workflow files ✓