### PR TITLE
fix: align span panel to worker lane coordinate system

### DIFF
--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -2063,7 +2063,11 @@
                 if (panel.style.display === "none") return;
                 const c = document.getElementById("span-panel-canvas");
                 const dpr = devicePixelRatio || 1;
-                const pw = panel.clientWidth;
+                // panel.clientWidth includes the 100px padding-left where the
+                // label sits.  The canvas lives inside that padded area, so its
+                // drawing width must exclude LABEL_W (and the scrollbar
+                // reservation) to match the lane canvases' coordinate system.
+                const pw = panel.clientWidth - LABEL_W - (scrollbarW || 0);
                 const ph = 120;
                 c.width = pw * dpr;
                 c.height = ph * dpr;


### PR DESCRIPTION
## Problem

Spans rendered in the span panel did not line up with their corresponding PollStart/PollEnd events in the worker lanes above. The offset was zero at the left edge of the viewport and grew linearly with x-position — a scale-mismatch signature, not a translation offset.

## Cause

`renderSpanPanel` was computing the canvas width as `panel.clientWidth`, which:
- **Includes** the 100px `padding-left` on `#span-panel` (where the label sits).
- **Excludes** any scrollbar, but `#span-panel` is not scrollable so it doesn't have one.

Meanwhile the lane canvases live inside `lanesContainer`, whose vertical scrollbar eats ~15px on the right. The lane content area is therefore narrower by `LABEL_W + scrollbarW`, but both renderers map the same `[viewStart, viewEnd]` range onto their respective widths. Result: two different ns-per-pixel scales, and spans drift right of their polls proportionally to x.

## Fix

One line in `renderSpanPanel`:
```js
-const pw = panel.clientWidth;
+const pw = panel.clientWidth - LABEL_W - (scrollbarW || 0);
```
`scrollbarW` was already being passed in — just needed to be used.

## Verification

Verified interactively with the demo trace at multiple zoom levels. Spans now align with PollStart/PollEnd events from the far left to the far right of the viewport.

Mouse handlers on the span-panel canvas use `getBoundingClientRect().width`, so they remain self-consistent with the resized canvas (tooltip hover and click targets still work).

## Scope

This is a rendering-only fix. No test coverage because we don't currently have pixel-level viewer tests. If we want regression coverage, a follow-up could add a headless-browser test that loads a known trace and asserts span/poll x-coordinates match at a chosen timestamp.