### PR TITLE
free spawn function

### DIFF
--- a/dial9-tokio-telemetry/src/lib.rs
+++ b/dial9-tokio-telemetry/src/lib.rs
@@ -39,4 +39,4 @@ pub use current_config::{
     Dial9Config, Dial9ConfigBuilder, Dial9ConfigBuilderError, ValidationError,
 };
 pub use dial9_macro::main;
-pub use telemetry::{TelemetryRuntimeError, TracedRuntime};
+pub use telemetry::{TelemetryRuntimeError, TracedRuntime, spawn};

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -25,7 +25,7 @@ pub use format::{
 pub use recorder::{
     HasTracePath, NoTracePath, RuntimeTelemetryHandle, TelemetryCore, TelemetryCoreBuilder,
     TelemetryGuard, TelemetryHandle, TelemetryRuntimeError, TraceRuntimeCoreBuilder, TracedRuntime,
-    TracedRuntimeBuilder, current_worker_id,
+    TracedRuntimeBuilder, current_worker_id, spawn,
 };
 pub use task_metadata::{TaskId, UNKNOWN_TASK_ID};
 pub use writer::{NullWriter, RotatingWriter, TraceWriter};

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -496,13 +496,13 @@ impl TelemetryHandle {
     }
 }
 
-/// Spawn a future with telemetry wake tracking using the current thread's
-/// [`TelemetryHandle`].
+/// Spawn a traced task on the current tokio runtime.
 ///
-/// This is a convenience wrapper around
-/// [`TelemetryHandle::current().spawn(future)`](TelemetryHandle::spawn).
-/// If the current thread is not owned by a dial9 runtime, the future is
-/// spawned via plain [`tokio::spawn`] without wake tracking.
+/// Like [`tokio::spawn`], but wraps the future with wake-event tracking
+/// when called from a thread owned by a dial9 runtime. On other threads,
+/// falls back to plain [`tokio::spawn`].
+///
+/// Equivalent to [`TelemetryHandle::current().spawn(future)`](TelemetryHandle::spawn).
 ///
 /// # Panics
 ///

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -496,6 +496,27 @@ impl TelemetryHandle {
     }
 }
 
+/// Spawn a future with telemetry wake tracking using the current thread's
+/// [`TelemetryHandle`].
+///
+/// This is a convenience wrapper around
+/// [`TelemetryHandle::current().spawn(future)`](TelemetryHandle::spawn).
+/// If the current thread is not owned by a dial9 runtime, the future is
+/// spawned via plain [`tokio::spawn`] without wake tracking.
+///
+/// # Panics
+///
+/// Panics if called from outside a tokio runtime context (same
+/// as [`tokio::spawn`]).
+#[track_caller]
+pub fn spawn<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    TelemetryHandle::current().spawn(future)
+}
+
 /// RAII guard that sets `INSTRUMENTED_SPAWN` to `true` on creation and
 /// resets it to `false` on drop, even if `tokio::spawn` panics.
 struct InstrumentedSpawnGuard;


### PR DESCRIPTION
### Summary

Adds a free function `spawn()` as a convenience wrapper around `TelemetryHandle::current().spawn(future)`. This lets callers spawn traced tasks without first obtaining a handle, mirroring the ergonomics of `tokio::spawn`.

The function is re-exported from both `telemetry::` and the crate root, matching the export locations of `TelemetryHandle` itself.

If the current thread is not owned by a dial9 runtime, the call falls through to plain `tokio::spawn` without wake tracking (via the disabled handle path).