### PR TITLE
fix security audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,21 +1,13 @@
-# Ignored advisories for rustls-webpki name constraint bugs.
-#
-# Both are low-severity: exploitable only after signature verification
-# passes, and require certificate misissuance. The vulnerable crate
-# (rustls-webpki 0.101.7) is pulled in transitively by
-# aws-sdk-s3-transfer-manager and s3s-aws, which unconditionally enable
-# the legacy rustls feature on aws-sdk-s3. We cannot remove it without
-# upstream changes.
-#
-# Upstream issues:
-#   https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/138
-#   https://github.com/s3s-project/s3s/issues/571
-#
-# Remove these ignores once the upstream crates stop pulling in the
-# legacy rustls 0.21 dependency chain.
+# Advisories against rustls-webpki 0.101.7, pulled in transitively by
+# aws-sdk-s3-transfer-manager and s3s-aws (legacy rustls 0.21 chain).
+# No patch exists in 0.101.x; not reachable in our usage (TLS client
+# only, no CRL parsing). Remove once the upstream fixes below ship:
+#   aws-s3-transfer-manager-rs: PR #141
+#   s3s: merged to main, awaiting s3s-aws 0.14 release
 
 [advisories]
 ignore = [
     "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints incorrectly accepted
     "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for wildcard certs
+    "RUSTSEC-2026-0104", # rustls-webpki: reachable panic in CRL parsing (we do not parse CRLs)
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,7 +3466,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3504,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -63,7 +63,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 s3s = "0.13.0"
 s3s-fs = "0.13.0"
 s3s-aws = "0.13.0"
-aws-sdk-s3 = "1"
+aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "http-1x", "rt-tokio", "sigv4a"] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 async-trait = "0.1.89"
 uuid = { version = "1", features = ["v4"] }

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -38,7 +38,7 @@ tower-http = { version = "0.6", features = ["fs"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
-aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "http-1x", "rt-tokio", "sigv4a"] }
 anyhow = "1"
 s3s = { version = "0.13.0", optional = true }
 s3s-fs = { version = "0.13.0", optional = true }

--- a/examples/metrics-service/Cargo.toml
+++ b/examples/metrics-service/Cargo.toml
@@ -17,7 +17,7 @@ futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 aws-config = "1"
-aws-sdk-dynamodb = "1"
+aws-sdk-dynamodb = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dial9-tokio-telemetry = { path = "../../dial9-tokio-telemetry", features = ["worker-s3", "tracing-layer"] }


### PR DESCRIPTION
### Summary

`cargo audit` failed on [RUSTSEC-2026-0104][rustsec] against both copies of `rustls-webpki` in our lockfile: the modern `0.103.12` (patched in `0.103.13`) and the legacy `0.101.7` (no patch exists). The `0.101.x` copy is pulled in transitively by `aws-sdk-s3-transfer-manager` and `s3s-aws` via the default `rustls` feature on `aws-sdk-s3`; feature unification means we can't remove it without upstream fixes.

Three commits:

1. `cargo update` to pick up `rustls-webpki 0.103.13`. Real fix for the modern stack.
2. Add `RUSTSEC-2026-0104` to the existing `.cargo/audit.toml` ignore list. All three entries there now cover the same unreachable `0.101.7` copy (we're a TLS client only, no CRL parsing).
3. Disable the `rustls` default feature on our own `aws-sdk-s3`/`aws-sdk-dynamodb` usages. Hygiene: doesn't change the lockfile today, but means we need no follow-up once upstream lands.

Upstream status: [awslabs/aws-s3-transfer-manager-rs#141][tm-pr] open, [s3s fix already on main][s3s-fix] pending `s3s-aws 0.14`. When both ship, the ignore file can be deleted.

### Testing

`cargo audit` clean; `cargo check` and `cargo clippy` pass across the workspace with the trimmed feature sets.

[rustsec]: https://rustsec.org/advisories/RUSTSEC-2026-0104.html
[tm-pr]: https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/141
[s3s-fix]: https://github.com/Nugine/s3s/commit/2a6c2cf
