### PR TITLE
Add SpanCloseEvent to tracing layer

### DIFF
--- a/dial9-tokio-telemetry/src/tracing_layer.rs
+++ b/dial9-tokio-telemetry/src/tracing_layer.rs
@@ -57,6 +57,7 @@
 //! for production use with appropriate span filtering.
 
 use crate::telemetry::{TelemetryHandle, clock_monotonic_ns, current_worker_id};
+use dial9_trace_format::TraceEvent;
 use dial9_trace_format::encoder::Schema;
 use dial9_trace_format::schema::FieldDef;
 use dial9_trace_format::types::{FieldType, FieldValue};
@@ -66,6 +67,13 @@ use std::sync::Mutex;
 use tracing::callsite::Identifier;
 use tracing::span;
 use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
+
+#[derive(TraceEvent)]
+struct SpanCloseEvent {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    span_id: u64,
+}
 
 // ── Per-callsite schema cache ───────────────────────────────────────────────
 
@@ -369,6 +377,17 @@ where
                 }
             }
             enc.write_event(&schemas.exit, &values);
+        });
+    }
+
+    fn on_close(&self, id: span::Id, _ctx: Context<'_, S>) {
+        let Some(handle) = TelemetryHandle::try_current() else {
+            return;
+        };
+
+        handle.record_encodable_event(&SpanCloseEvent {
+            timestamp_ns: clock_monotonic_ns(),
+            span_id: id.into_u64(),
         });
     }
 }

--- a/dial9-tokio-telemetry/tests/tracing_layer.rs
+++ b/dial9-tokio-telemetry/tests/tracing_layer.rs
@@ -14,6 +14,7 @@ use tracing_subscriber::prelude::*;
 struct SpanEvents {
     enter_count: u32,
     exit_count: u32,
+    close_count: u32,
     enter_names: Vec<String>,
     /// All (field_key, field_value) pairs seen on enter events.
     enter_fields: Vec<(String, String)>,
@@ -34,6 +35,7 @@ fn decode_span_events(path: &std::path::Path) -> SpanEvents {
     let mut result = SpanEvents {
         enter_count: 0,
         exit_count: 0,
+        close_count: 0,
         enter_names: Vec::new(),
         enter_fields: Vec::new(),
         exit_fields: Vec::new(),
@@ -88,6 +90,8 @@ fn decode_span_events(path: &std::path::Path) -> SpanEvents {
                             .push((field_def.name.clone(), v.to_owned()));
                     }
                 }
+            } else if ev.name == "SpanCloseEvent" {
+                result.close_count += 1;
             }
         })
         .unwrap();
@@ -183,6 +187,12 @@ fn span_events_appear_in_trace() {
     assert_eq!(
         events.enter_count, events.exit_count,
         "enter/exit count mismatch"
+    );
+
+    // Close events: one per unique span instance
+    assert!(
+        events.close_count > 0,
+        "expected at least 1 SpanCloseEvent, got 0"
     );
 
     // Span names

--- a/dial9-tokio-telemetry/tests/tracing_layer.rs
+++ b/dial9-tokio-telemetry/tests/tracing_layer.rs
@@ -26,6 +26,10 @@ struct SpanEvents {
     worker_ids: HashSet<u64>,
     /// Unique schema names seen for enter events.
     enter_schema_names: HashSet<String>,
+    /// Unique span IDs seen on enter events.
+    entered_span_ids: HashSet<u64>,
+    /// Span IDs seen on close events.
+    closed_span_ids: HashSet<u64>,
 }
 
 fn decode_span_events(path: &std::path::Path) -> SpanEvents {
@@ -42,6 +46,8 @@ fn decode_span_events(path: &std::path::Path) -> SpanEvents {
         saw_parent_span_id: false,
         worker_ids: HashSet::new(),
         enter_schema_names: HashSet::new(),
+        entered_span_ids: HashSet::new(),
+        closed_span_ids: HashSet::new(),
     };
 
     decoder
@@ -55,6 +61,11 @@ fn decode_span_events(path: &std::path::Path) -> SpanEvents {
                         && let Some(name) = ev.string_pool.get(*id)
                     {
                         result.enter_names.push(name.to_owned());
+                    }
+                    if field_def.name == "span_id"
+                        && let FieldValueRef::Varint(v) = field_val
+                    {
+                        result.entered_span_ids.insert(*v);
                     }
                     if field_def.name == "parent_span_id"
                         && let FieldValueRef::Varint(v) = field_val
@@ -92,6 +103,13 @@ fn decode_span_events(path: &std::path::Path) -> SpanEvents {
                 }
             } else if ev.name == "SpanCloseEvent" {
                 result.close_count += 1;
+                for (field_def, field_val) in ev.schema.fields.iter().zip(ev.fields.iter()) {
+                    if field_def.name == "span_id"
+                        && let FieldValueRef::Varint(v) = field_val
+                    {
+                        result.closed_span_ids.insert(*v);
+                    }
+                }
             }
         })
         .unwrap();
@@ -189,10 +207,15 @@ fn span_events_appear_in_trace() {
         "enter/exit count mismatch"
     );
 
-    // Close events: one per unique span instance
-    assert!(
-        events.close_count > 0,
-        "expected at least 1 SpanCloseEvent, got 0"
+    // Close events: one per unique span instance, and every entered span must be closed
+    assert_eq!(
+        events.entered_span_ids, events.closed_span_ids,
+        "every entered span should have a matching close event"
+    );
+    assert_eq!(
+        events.close_count,
+        events.entered_span_ids.len() as u32,
+        "each span should close exactly once"
     );
 
     // Span names
@@ -344,5 +367,9 @@ fn span_events_on_current_thread_runtime() {
     assert!(
         events.enter_names.contains(&"do_work".to_string()),
         "missing do_work span on current_thread runtime"
+    );
+    assert_eq!(
+        events.entered_span_ids, events.closed_span_ids,
+        "every entered span should have a matching close event on current_thread runtime"
     );
 }


### PR DESCRIPTION
## Summary

Emit a `SpanCloseEvent` when a tracing span is closed (dropped). This records the `span_id` and timestamp, enabling the viewer to determine span lifetimes — not just enter/exit intervals within individual polls.

we need a span close event because tracing will reuse span ids

## Changes

- **`tracing_layer.rs`**: Add `SpanCloseEvent` struct (derived via `TraceEvent`) and `on_close` handler that emits it via `record_encodable_event`
- **`tests/tracing_layer.rs`**: Add `close_count` tracking to the test decoder and assert at least 1 `SpanCloseEvent` is emitted

Split from #342 — contains only the backend event addition, no UI or viewer changes.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features` — clean
- `cargo nextest run --test tracing_layer` — 3/3 pass
- `cargo nextest run --test tracing_layer --stress-duration 20s` — 92 iterations, all green