### PR TITLE
feat: support tracing futures in JoinSet and external spawn APIs

### DIFF
--- a/dial9-tokio-telemetry/src/lib.rs
+++ b/dial9-tokio-telemetry/src/lib.rs
@@ -43,4 +43,4 @@ pub use current_config::{
     Dial9Config, Dial9ConfigBuilder, Dial9ConfigBuilderError, ValidationError,
 };
 pub use dial9_macro::main;
-pub use telemetry::{TelemetryRuntimeError, Traced, TracedRuntime, spawn};
+pub use telemetry::{TelemetryRuntimeError, TracedFuture, TracedRuntime, spawn};

--- a/dial9-tokio-telemetry/src/lib.rs
+++ b/dial9-tokio-telemetry/src/lib.rs
@@ -43,4 +43,4 @@ pub use current_config::{
     Dial9Config, Dial9ConfigBuilder, Dial9ConfigBuilderError, ValidationError,
 };
 pub use dial9_macro::main;
-pub use telemetry::{TelemetryRuntimeError, TracedRuntime, spawn};
+pub use telemetry::{TelemetryRuntimeError, Traced, TracedRuntime, spawn};

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -1,11 +1,10 @@
 //! `TaskDumped<F>` wraps a future and captures async backtraces at yield
 //! points using Poisson sampling keyed on idle duration.
 //!
-//! This wrapper is intentionally separate from [`crate::traced::Traced`]: the
-//! wake-event capture in `Traced` runs on every instrumented spawn regardless
-//! of the `taskdump` feature, while task-dump capture is gated behind the
-//! `taskdump` feature and its own runtime toggle.  Typical stacking is
-//! `Traced<TaskDumped<F>>`.
+//! This wrapper is intentionally separate from the wake-event wrapper: wake
+//! capture runs on every instrumented spawn regardless of the `taskdump`
+//! feature, while task-dump capture is gated behind the `taskdump` feature and
+//! its own runtime toggle. Typical stacking is `WakeTracked<TaskDumped<F>>`.
 //!
 //! # Sampling model
 //!

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -17,6 +17,7 @@ pub mod task_dump_config;
 pub(crate) mod task_metadata;
 pub(crate) mod writer;
 
+pub use crate::traced::Traced;
 pub use buffer::{Encodable, ThreadLocalEncoder};
 pub use events::{CpuSampleSource, TelemetryEvent, clock_monotonic_ns};
 pub use format::{

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -17,7 +17,7 @@ pub mod task_dump_config;
 pub(crate) mod task_metadata;
 pub(crate) mod writer;
 
-pub use crate::traced::Traced;
+pub use crate::traced::TracedFuture;
 pub use buffer::{Encodable, ThreadLocalEncoder};
 pub use events::{CpuSampleSource, TelemetryEvent, clock_monotonic_ns};
 pub use format::{

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -33,9 +33,9 @@ crate::primitives::thread_local! {
     /// cleared in `on_thread_stop`. Enables [`TelemetryHandle::current`].
     static CURRENT_HANDLE: RefCell<Option<TelemetryHandle>> = const { RefCell::new(None) };
 
-    /// Set by `TelemetryHandle::spawn()` before calling `tokio::spawn()`,
-    /// so the `on_task_spawn` hook can distinguish instrumented from raw spawns.
-    static INSTRUMENTED_SPAWN: Cell<bool> = const { Cell::new(false) };
+    /// Nest count for [`InstrumentedSpawnGuard`]. `on_task_spawn` treats
+    /// any value `> 0` as an instrumented spawn.
+    static INSTRUMENTED_SPAWN: Cell<u32> = const { Cell::new(0) };
 }
 
 // ---------------------------------------------------------------------------
@@ -204,7 +204,7 @@ fn register_hooks(
             s5.if_enabled(|buf| {
                 let task_id = TaskId::from(meta.id());
                 let location = meta.spawned_at();
-                let instrumented = INSTRUMENTED_SPAWN.with(|f| f.get());
+                let instrumented = INSTRUMENTED_SPAWN.with(|f| f.get()) > 0;
                 let timestamp_ns = crate::telemetry::events::clock_monotonic_ns();
                 buf.record_encodable_event(&runtime_context::TaskSpawn {
                     timestamp_ns,
@@ -506,15 +506,66 @@ impl TelemetryHandle {
     {
         match self.traced_handle() {
             Some(traced_handle) => {
-                let _guard = InstrumentedSpawnGuard::set();
+                let _guard = InstrumentedSpawnGuard::enter();
                 tokio::spawn(async move {
-                    let task_id = tokio::task::try_id().map(TaskId::from).unwrap_or_default();
+                    let task_id = TaskId::from(tokio::task::id());
                     let inner = wrap_task_dumped(future, traced_handle.shared.clone(), task_id);
-                    crate::traced::Traced::new(inner, traced_handle, task_id).await
+                    crate::telemetry::Traced::new(inner, Some(traced_handle)).await
                 })
             }
             None => tokio::spawn(future),
         }
+    }
+
+    /// Spawn a wake-tracked future through a user-supplied spawn function.
+    ///
+    /// `spawn_fn` is invoked synchronously with a [`Traced<F>`] that
+    /// the caller is expected to spawn immediately. The closure's return
+    /// value is forwarded back to the caller, so you can keep the
+    /// [`tokio::task::JoinHandle`], [`tokio::task::AbortHandle`], or
+    /// whatever the spawn function returns.
+    ///
+    /// # Examples
+    ///
+    /// Spawn into a [`tokio::task::JoinSet`]:
+    ///
+    /// ```rust,no_run
+    /// # use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+    /// # use tokio::task::JoinSet;
+    /// # async fn work() {}
+    /// # async fn demo() {
+    /// let handle = TelemetryHandle::current();
+    /// let mut set: JoinSet<()> = JoinSet::new();
+    /// handle.spawn_with(work(), |f| set.spawn(f));
+    /// # }
+    /// ```
+    ///
+    /// Spawn into a [`tokio::task::JoinSet`] on a specific runtime:
+    ///
+    /// ```rust,no_run
+    /// # use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+    /// # use tokio::runtime::Runtime;
+    /// # use tokio::task::JoinSet;
+    /// # async fn work() {}
+    /// # fn demo(runtime: &Runtime) {
+    /// let handle = TelemetryHandle::current();
+    /// let mut set: JoinSet<()> = JoinSet::new();
+    /// handle.spawn_with(work(), |f| set.spawn_on(f, runtime.handle()));
+    /// # }
+    /// ```
+    ///
+    /// [`Traced<F>`]: crate::telemetry::Traced
+    pub fn spawn_with<F, S>(
+        &self,
+        future: F,
+        spawn_fn: impl FnOnce(crate::telemetry::Traced<F>) -> S,
+    ) -> S
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let _guard = InstrumentedSpawnGuard::enter();
+        spawn_fn(crate::telemetry::Traced::new(future, self.traced_handle()))
     }
 }
 
@@ -565,20 +616,20 @@ where
     TelemetryHandle::current().spawn(future)
 }
 
-/// RAII guard that sets `INSTRUMENTED_SPAWN` to `true` on creation and
-/// resets it to `false` on drop, even if `tokio::spawn` panics.
+/// RAII guard that increments `INSTRUMENTED_SPAWN` on creation and
+/// decrements it on drop, even if the protected closure panics.
 struct InstrumentedSpawnGuard;
 
 impl InstrumentedSpawnGuard {
-    fn set() -> Self {
-        INSTRUMENTED_SPAWN.with(|c| c.set(true));
+    fn enter() -> Self {
+        INSTRUMENTED_SPAWN.with(|c| c.set(c.get().saturating_add(1)));
         Self
     }
 }
 
 impl Drop for InstrumentedSpawnGuard {
     fn drop(&mut self) {
-        INSTRUMENTED_SPAWN.with(|c| c.set(false));
+        INSTRUMENTED_SPAWN.with(|c| c.set(c.get().saturating_sub(1)));
     }
 }
 
@@ -606,17 +657,46 @@ impl RuntimeTelemetryHandle {
         F: std::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        match &self.traced {
-            Some(traced) => {
-                let traced = traced.clone();
-                let _guard = InstrumentedSpawnGuard::set();
-                self.runtime.spawn(async move {
-                    let task_id = tokio::task::try_id().map(TaskId::from).unwrap_or_default();
-                    crate::traced::Traced::new(future, traced, task_id).await
-                })
-            }
-            None => self.runtime.spawn(future),
-        }
+        let _guard = InstrumentedSpawnGuard::enter();
+        self.runtime
+            .spawn(crate::telemetry::Traced::new(future, self.traced.clone()))
+    }
+
+    /// Spawn a wake-tracked future through a user-supplied spawn function.
+    ///
+    /// Mirrors [`TelemetryHandle::spawn_with`] but does not require an
+    /// ambient tokio runtime context — `spawn_fn` is invoked on the
+    /// calling thread, so it is the closure's responsibility to target
+    /// this handle's runtime (typically via
+    /// [`tokio::task::JoinSet::spawn_on`] passing the appropriate
+    /// [`tokio::runtime::Handle`]).
+    ///
+    /// # Examples
+    ///
+    /// Spawn into a [`tokio::task::JoinSet`] on a specific runtime:
+    ///
+    /// ```rust,no_run
+    /// # use dial9_tokio_telemetry::telemetry::RuntimeTelemetryHandle;
+    /// # use tokio::runtime::Runtime;
+    /// # use tokio::task::JoinSet;
+    /// # async fn work() {}
+    /// # fn demo(runtime: &Runtime, handle: RuntimeTelemetryHandle, set: &mut JoinSet<()>) {
+    /// handle.spawn_with(work(), |f| set.spawn_on(f, runtime.handle()));
+    /// # }
+    /// ```
+    ///
+    /// [`Traced<F>`]: crate::telemetry::Traced
+    pub fn spawn_with<F, S>(
+        &self,
+        future: F,
+        spawn_fn: impl FnOnce(crate::telemetry::Traced<F>) -> S,
+    ) -> S
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let _guard = InstrumentedSpawnGuard::enter();
+        spawn_fn(crate::telemetry::Traced::new(future, self.traced.clone()))
     }
 }
 
@@ -2079,6 +2159,23 @@ mod tests {
             Ok(())
         }
     }
+
+    /// Nested `InstrumentedSpawnGuard`s must compose: inner drop must not
+    /// clear the outer scope. Counter, not flag.
+    #[test]
+    fn instrumented_spawn_guard_nests() {
+        assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 0);
+        let outer = InstrumentedSpawnGuard::enter();
+        assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 1);
+        {
+            let _inner = InstrumentedSpawnGuard::enter();
+            assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 2);
+        }
+        assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 1);
+        drop(outer);
+        assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 0);
+    }
+
     #[test]
     fn current_thread_runtime_resolves_worker_ids() {
         let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -516,7 +516,7 @@ impl TelemetryHandle {
         }
     }
 
-    /// Spawn a wake-tracked future through a user-supplied spawn function.
+    /// Spawn an instrumented future through a user-supplied spawn function.
     ///
     /// `spawn_fn` is invoked synchronously with a [`TracedFuture<F>`] that
     /// the caller is expected to spawn immediately. The closure's return
@@ -613,7 +613,7 @@ impl Drop for InstrumentedSpawnGuard {
     }
 }
 
-/// Handle for spawning wake-tracked futures on a specific runtime.
+/// Handle for spawning instrumented futures on a specific runtime.
 ///
 /// Returned by [`TraceRuntimeCoreBuilder::build`]. Unlike [`TelemetryHandle::spawn`]
 /// which uses `tokio::spawn()` (requiring an ambient runtime context), this type
@@ -649,7 +649,7 @@ impl RuntimeTelemetryHandle {
         }
     }
 
-    /// Spawn a wake-tracked future through a user-supplied spawn function.
+    /// Spawn an instrumented future through a user-supplied spawn function.
     ///
     /// Mirrors [`TelemetryHandle::spawn_with`] but does not require an
     /// ambient tokio runtime context — `spawn_fn` is invoked on the
@@ -1451,7 +1451,7 @@ impl<'a> TraceRuntimeCoreBuilder<'a> {
     /// Install telemetry hooks, build the runtime, and reserve worker IDs.
     ///
     /// Returns the runtime and a [`RuntimeTelemetryHandle`] for spawning
-    /// wake-tracked futures via [`RuntimeTelemetryHandle::spawn`].
+    /// instrumented futures via [`RuntimeTelemetryHandle::spawn`].
     pub fn build(
         self,
         mut builder: tokio::runtime::Builder,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -507,11 +507,10 @@ impl TelemetryHandle {
         match self.traced_handle() {
             Some(traced_handle) => {
                 let _guard = InstrumentedSpawnGuard::enter();
-                tokio::spawn(async move {
-                    let task_id = TaskId::from(tokio::task::id());
-                    let inner = wrap_task_dumped(future, traced_handle.shared.clone(), task_id);
-                    crate::telemetry::Traced::new(inner, Some(traced_handle)).await
-                })
+                tokio::spawn(crate::telemetry::TracedFuture::new(
+                    future,
+                    Some(traced_handle),
+                ))
             }
             None => tokio::spawn(future),
         }
@@ -519,7 +518,7 @@ impl TelemetryHandle {
 
     /// Spawn a wake-tracked future through a user-supplied spawn function.
     ///
-    /// `spawn_fn` is invoked synchronously with a [`Traced<F>`] that
+    /// `spawn_fn` is invoked synchronously with a [`TracedFuture<F>`] that
     /// the caller is expected to spawn immediately. The closure's return
     /// value is forwarded back to the caller, so you can keep the
     /// [`tokio::task::JoinHandle`], [`tokio::task::AbortHandle`], or
@@ -554,45 +553,26 @@ impl TelemetryHandle {
     /// # }
     /// ```
     ///
-    /// [`Traced<F>`]: crate::telemetry::Traced
+    /// [`TracedFuture<F>`]: crate::telemetry::TracedFuture
     pub fn spawn_with<F, S>(
         &self,
         future: F,
-        spawn_fn: impl FnOnce(crate::telemetry::Traced<F>) -> S,
+        spawn_fn: impl FnOnce(crate::telemetry::TracedFuture<F>) -> S,
     ) -> S
     where
         F: std::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let _guard = InstrumentedSpawnGuard::enter();
-        spawn_fn(crate::telemetry::Traced::new(future, self.traced_handle()))
+        let traced_handle = self.traced_handle();
+        let future = crate::telemetry::TracedFuture::new(future, traced_handle.clone());
+        match traced_handle {
+            Some(_) => {
+                let _guard = InstrumentedSpawnGuard::enter();
+                spawn_fn(future)
+            }
+            None => spawn_fn(future),
+        }
     }
-}
-
-/// If the `taskdump` feature is on, wrap `future` in `TaskDumped<F>`; otherwise
-/// pass through unchanged. Factored so `TelemetryHandle::spawn` stays readable.
-#[cfg(feature = "taskdump")]
-fn wrap_task_dumped<F>(
-    future: F,
-    shared: Arc<crate::telemetry::recorder::SharedState>,
-    task_id: TaskId,
-) -> crate::task_dumped::TaskDumped<F>
-where
-    F: std::future::Future,
-{
-    crate::task_dumped::TaskDumped::new(future, shared, task_id)
-}
-
-#[cfg(not(feature = "taskdump"))]
-fn wrap_task_dumped<F>(
-    future: F,
-    _shared: Arc<crate::telemetry::recorder::SharedState>,
-    _task_id: TaskId,
-) -> F
-where
-    F: std::future::Future,
-{
-    future
 }
 
 /// Spawn a traced task on the current tokio runtime.
@@ -657,9 +637,16 @@ impl RuntimeTelemetryHandle {
         F: std::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let _guard = InstrumentedSpawnGuard::enter();
-        self.runtime
-            .spawn(crate::telemetry::Traced::new(future, self.traced.clone()))
+        match self.traced.clone() {
+            Some(traced_handle) => {
+                let _guard = InstrumentedSpawnGuard::enter();
+                self.runtime.spawn(crate::telemetry::TracedFuture::new(
+                    future,
+                    Some(traced_handle),
+                ))
+            }
+            None => self.runtime.spawn(future),
+        }
     }
 
     /// Spawn a wake-tracked future through a user-supplied spawn function.
@@ -685,18 +672,24 @@ impl RuntimeTelemetryHandle {
     /// # }
     /// ```
     ///
-    /// [`Traced<F>`]: crate::telemetry::Traced
+    /// [`TracedFuture<F>`]: crate::telemetry::TracedFuture
     pub fn spawn_with<F, S>(
         &self,
         future: F,
-        spawn_fn: impl FnOnce(crate::telemetry::Traced<F>) -> S,
+        spawn_fn: impl FnOnce(crate::telemetry::TracedFuture<F>) -> S,
     ) -> S
     where
         F: std::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let _guard = InstrumentedSpawnGuard::enter();
-        spawn_fn(crate::telemetry::Traced::new(future, self.traced.clone()))
+        let future = crate::telemetry::TracedFuture::new(future, self.traced.clone());
+        match self.traced {
+            Some(_) => {
+                let _guard = InstrumentedSpawnGuard::enter();
+                spawn_fn(future)
+            }
+            None => spawn_fn(future),
+        }
     }
 }
 
@@ -2586,7 +2579,7 @@ mod tests {
             .build_and_attach_to_telemetry(builder_b, &guard)
             .unwrap();
 
-        // Use handle.spawn on runtime B to get Traced waker wrapping → wake events.
+        // Use handle.spawn on runtime B to get wake-tracked wrapping → wake events.
         let handle = guard.handle();
         runtime_b.block_on(async {
             let mut handles = Vec::new();
@@ -3004,7 +2997,7 @@ mod tests {
         drop(runtime);
         drop(guard);
 
-        // Verify wake events were recorded (handle.spawn wraps with Traced)
+        // Verify wake events were recorded (handle.spawn wraps with wake tracking)
         let raw = data.lock().unwrap();
         let events = crate::telemetry::format::decode_events(&raw).unwrap();
         let wake_count = events

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -34,6 +34,7 @@ pub(crate) struct SharedState {
     pub(crate) task_dump_idle_threshold_ns: AtomicU64,
     /// Fixed RNG seed for deterministic task dump sampling. Set once at
     /// construction before the `Arc` is shared; read-only thereafter.
+    #[cfg_attr(not(feature = "taskdump"), allow(dead_code))]
     pub(crate) task_dump_rng_seed: Option<u64>,
     pub(crate) collector: Arc<CentralCollector>,
     /// Absolute `CLOCK_MONOTONIC` nanosecond timestamp captured at trace start.
@@ -85,7 +86,7 @@ impl SharedState {
     }
 
     /// Create a wake event. Pragmatic exception: calls `tokio::task::try_id()`
-    /// because `Traced` is inherently tokio-specific.
+    /// because the wake-tracking future is inherently tokio-specific.
     pub(crate) fn create_wake_event(
         &self,
         woken_task_id: TaskId,
@@ -106,7 +107,7 @@ impl SharedState {
     /// provides an [`EventBuffer`] that makes it structurally impossible to
     /// record without checking first. Use `is_enabled()` only for
     /// control-flow decisions that don't directly record events (e.g.
-    /// deciding whether to wrap a waker in `Traced::poll`).
+    /// deciding whether to wrap a waker in wake-tracking polls).
     pub(crate) fn is_enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
     }

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -202,9 +202,8 @@ impl<F: Future> Future for WakeTracked<F> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let waker_data = this.waker_data.clone();
 
-        if !waker_data.shared.is_enabled() {
+        if !this.waker_data.shared.is_enabled() {
             return this.inner.poll(cx);
         }
 
@@ -212,9 +211,9 @@ impl<F: Future> Future for WakeTracked<F> {
         // waker fires it can forward the notification to the correct waker,
         // even if the task has been moved to a different executor thread
         // between polls.
-        waker_data.inner.register(cx.waker());
+        this.waker_data.inner.register(cx.waker());
 
-        let traced_waker = make_traced_waker(waker_data);
+        let traced_waker = make_traced_waker(this.waker_data.clone());
         let mut traced_cx = Context::from_waker(&traced_waker);
         this.inner.poll(&mut traced_cx)
     }

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -1,5 +1,6 @@
 //! `Traced<F>` future wrapper for wake event capture and task dump collection.
 
+use crate::rate_limit::rate_limited;
 use crate::telemetry::recorder::SharedState;
 use crate::telemetry::task_metadata::TaskId;
 use futures_util::task::{ArcWake, AtomicWaker, waker as arc_waker};
@@ -8,6 +9,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
+use std::time::Duration;
 
 /// Handle used by `Traced<F>` to emit events into the telemetry system.
 #[derive(Clone)]
@@ -23,27 +25,32 @@ impl std::fmt::Debug for TracedHandle {
 
 pin_project! {
     /// Future wrapper that captures wake events (and later, task dumps).
+    ///
+    /// Values of this type are produced by
+    /// [`TelemetryHandle::spawn_with`](crate::telemetry::TelemetryHandle::spawn_with)
+    /// and
+    /// [`RuntimeTelemetryHandle::spawn_with`](crate::telemetry::RuntimeTelemetryHandle::spawn_with).
+    /// The constructor and fields are private so callers cannot construct a
+    /// `Traced<F>` directly.
+    ///
+    /// On first poll, `Traced<F>` resolves the surrounding Tokio task ID and
+    /// uses it for wake-event tracking. If the future is polled outside a
+    /// Tokio task context, it runs as a transparent passthrough without wake
+    /// tracking.
     pub struct Traced<F> {
         #[pin]
         inner: F,
-        handle: TracedHandle,
-        task_id: TaskId,
-        waker_data: Arc<TracedWakerData>, // reused across polls to avoid a per-poll Arc allocation
+        handle: Option<TracedHandle>,
+        waker_data: Option<Arc<TracedWakerData>>, // reused across polls to avoid a per-poll Arc allocation
     }
 }
 
 impl<F> Traced<F> {
-    pub(crate) fn new(inner: F, handle: TracedHandle, task_id: TaskId) -> Self {
-        let waker_data = Arc::new(TracedWakerData {
-            inner: AtomicWaker::new(),
-            woken_task_id: task_id,
-            shared: handle.shared.clone(),
-        });
+    pub(crate) fn new(inner: F, handle: Option<TracedHandle>) -> Self {
         Self {
             inner,
             handle,
-            task_id,
-            waker_data,
+            waker_data: None,
         }
     }
 }
@@ -96,7 +103,31 @@ impl<F: Future> Future for Traced<F> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        if !this.handle.shared.is_enabled() {
+
+        if this.waker_data.is_none()
+            && let Some(handle) = this.handle.take()
+        {
+            let Some(task_id) = tokio::task::try_id().map(TaskId::from) else {
+                rate_limited!(Duration::from_secs(60), {
+                    tracing::warn!(
+                        "Traced future polled outside a Tokio task context; running future without wake tracking"
+                    );
+                });
+                return this.inner.poll(cx);
+            };
+
+            *this.waker_data = Some(Arc::new(TracedWakerData {
+                inner: AtomicWaker::new(),
+                woken_task_id: task_id,
+                shared: handle.shared.clone(),
+            }));
+        }
+
+        let Some(waker_data) = this.waker_data.as_ref().cloned() else {
+            return this.inner.poll(cx);
+        };
+
+        if !waker_data.shared.is_enabled() {
             return this.inner.poll(cx);
         }
 
@@ -104,9 +135,9 @@ impl<F: Future> Future for Traced<F> {
         // waker fires it can forward the notification to the correct waker,
         // even if the task has been moved to a different executor thread
         // between polls.
-        this.waker_data.inner.register(cx.waker());
+        waker_data.inner.register(cx.waker());
 
-        let traced_waker = make_traced_waker(this.waker_data.clone());
+        let traced_waker = make_traced_waker(waker_data);
         let mut traced_cx = Context::from_waker(&traced_waker);
         this.inner.poll(&mut traced_cx)
     }
@@ -117,11 +148,39 @@ mod tests {
     use super::*;
     use crate::telemetry::buffer;
     use crate::telemetry::events::TelemetryEvent;
-    use crate::telemetry::recorder::TracedRuntime;
+    use crate::telemetry::recorder::{TelemetryCore, TracedRuntime};
     use crate::telemetry::task_metadata::UNKNOWN_TASK_ID;
-    use crate::telemetry::writer::RotatingWriter;
+    use crate::telemetry::writer::{NullWriter, RotatingWriter};
+    use futures_util::task::noop_waker;
+    use std::pin::Pin;
     use std::sync::{Arc, Mutex};
+    use std::task::Context;
     use tempfile::TempDir;
+
+    #[test]
+    fn traced_consumes_handle_after_missing_task_context() {
+        let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+        let handle = guard
+            .handle()
+            .traced_handle()
+            .expect("enabled handle yields TracedHandle");
+
+        let mut future = Traced::new(std::future::pending::<()>(), Some(handle));
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(Pin::new(&mut future).poll(&mut cx).is_pending());
+        assert!(future.handle.is_none());
+        assert!(future.waker_data.is_none());
+
+        // This is important to ensure the missing-task fallback is one-way:
+        // after the first failed task-id lookup, `handle` has been consumed
+        // and later polls go straight through without retrying `try_id()` or
+        // warning again.
+        assert!(Pin::new(&mut future).poll(&mut cx).is_pending());
+        assert!(future.handle.is_none());
+        assert!(future.waker_data.is_none());
+    }
 
     /// Verify that `Traced<F>` records a `WakeEvent` whose `woken_task_id`
     /// matches the spawned task when a `Notify` wakes it.

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -34,13 +34,6 @@ type InstrumentedFuture<F> = WakeTracked<MaybeTaskDumped<F>>;
 pin_project! {
     /// Future wrapper produced by `spawn_with` for custom spawn APIs.
     ///
-    /// Values of this type are produced by
-    /// [`TelemetryHandle::spawn_with`](crate::telemetry::TelemetryHandle::spawn_with)
-    /// and
-    /// [`RuntimeTelemetryHandle::spawn_with`](crate::telemetry::RuntimeTelemetryHandle::spawn_with).
-    /// The constructor and fields are private so callers cannot construct a
-    /// `TracedFuture<F>` directly.
-    ///
     /// On first poll, `TracedFuture<F>` resolves the surrounding Tokio task ID
     /// and uses it for task instrumentation. If the future is polled outside a
     /// Tokio task context, it runs as a transparent passthrough without wake

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -1,4 +1,4 @@
-//! `Traced<F>` future wrapper for wake event capture and task dump collection.
+//! Future wrappers for task instrumentation.
 
 use crate::rate_limit::rate_limited;
 use crate::telemetry::recorder::SharedState;
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 
-/// Handle used by `Traced<F>` to emit events into the telemetry system.
+/// Handle used by instrumented futures to emit events into the telemetry system.
 #[derive(Clone)]
 pub(crate) struct TracedHandle {
     pub(crate) shared: Arc<SharedState>,
@@ -23,35 +23,85 @@ impl std::fmt::Debug for TracedHandle {
     }
 }
 
+#[cfg(feature = "taskdump")]
+type MaybeTaskDumped<F> = crate::task_dumped::TaskDumped<F>;
+
+#[cfg(not(feature = "taskdump"))]
+type MaybeTaskDumped<F> = F;
+
+type InstrumentedFuture<F> = WakeTracked<MaybeTaskDumped<F>>;
+
 pin_project! {
-    /// Future wrapper that captures wake events (and later, task dumps).
+    /// Future wrapper produced by `spawn_with` for custom spawn APIs.
     ///
     /// Values of this type are produced by
     /// [`TelemetryHandle::spawn_with`](crate::telemetry::TelemetryHandle::spawn_with)
     /// and
     /// [`RuntimeTelemetryHandle::spawn_with`](crate::telemetry::RuntimeTelemetryHandle::spawn_with).
     /// The constructor and fields are private so callers cannot construct a
-    /// `Traced<F>` directly.
+    /// `TracedFuture<F>` directly.
     ///
-    /// On first poll, `Traced<F>` resolves the surrounding Tokio task ID and
-    /// uses it for wake-event tracking. If the future is polled outside a
+    /// On first poll, `TracedFuture<F>` resolves the surrounding Tokio task ID
+    /// and uses it for task instrumentation. If the future is polled outside a
     /// Tokio task context, it runs as a transparent passthrough without wake
-    /// tracking.
-    pub struct Traced<F> {
+    /// tracking or task dumps.
+    pub struct TracedFuture<F> {
         #[pin]
-        inner: F,
-        handle: Option<TracedHandle>,
-        waker_data: Option<Arc<TracedWakerData>>, // reused across polls to avoid a per-poll Arc allocation
+        state: TracedFutureState<F>,
     }
 }
 
-impl<F> Traced<F> {
+impl<F> std::fmt::Debug for TracedFuture<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TracedFuture").finish_non_exhaustive()
+    }
+}
+
+impl<F> TracedFuture<F> {
     pub(crate) fn new(inner: F, handle: Option<TracedHandle>) -> Self {
         Self {
-            inner,
-            handle,
-            waker_data: None,
+            state: TracedFutureState::Init { inner, handle },
         }
+    }
+}
+
+pin_project! {
+    #[project = TracedFutureStateProj]
+    #[project_replace = TracedFutureStateProjReplace]
+    enum TracedFutureState<F> {
+        Init {
+            inner: F,
+            handle: Option<TracedHandle>,
+        },
+        Passthrough {
+            #[pin]
+            inner: F,
+        },
+        Instrumented {
+            #[pin]
+            inner: InstrumentedFuture<F>,
+        },
+        Empty,
+    }
+}
+
+pin_project! {
+    /// Future wrapper that captures wake events for a known Tokio task.
+    pub(crate) struct WakeTracked<F> {
+        #[pin]
+        inner: F,
+        waker_data: Arc<TracedWakerData>, // reused across polls to avoid a per-poll Arc allocation
+    }
+}
+
+impl<F> WakeTracked<F> {
+    pub(crate) fn new(inner: F, handle: TracedHandle, task_id: TaskId) -> Self {
+        let waker_data = Arc::new(TracedWakerData {
+            inner: AtomicWaker::new(),
+            woken_task_id: task_id,
+            shared: handle.shared.clone(),
+        });
+        Self { inner, waker_data }
     }
 }
 
@@ -98,34 +148,68 @@ fn make_traced_waker(data: Arc<TracedWakerData>) -> Waker {
     arc_waker(data)
 }
 
-impl<F: Future> Future for Traced<F> {
+fn make_instrumented<F>(inner: F, handle: TracedHandle, task_id: TaskId) -> InstrumentedFuture<F>
+where
+    F: Future,
+{
+    let shared = handle.shared.clone();
+    #[cfg(feature = "taskdump")]
+    let inner = crate::task_dumped::TaskDumped::new(inner, shared, task_id);
+    #[cfg(not(feature = "taskdump"))]
+    let _ = shared;
+
+    WakeTracked::new(inner, handle, task_id)
+}
+
+impl<F: Future> Future for TracedFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.project().state;
+
+        loop {
+            match state.as_mut().project() {
+                TracedFutureStateProj::Init { .. } => {}
+                TracedFutureStateProj::Passthrough { inner } => return inner.poll(cx),
+                TracedFutureStateProj::Instrumented { inner } => return inner.poll(cx),
+                TracedFutureStateProj::Empty => {
+                    unreachable!("TracedFutureState::Empty is only used during state transitions")
+                }
+            }
+
+            let TracedFutureStateProjReplace::Init { inner, handle } =
+                state.as_mut().project_replace(TracedFutureState::Empty)
+            else {
+                unreachable!("Init was matched immediately before project_replace")
+            };
+
+            let Some(handle) = handle else {
+                state.set(TracedFutureState::Passthrough { inner });
+                continue;
+            };
+
+            let Some(task_id) = tokio::task::try_id().map(TaskId::from) else {
+                rate_limited!(Duration::from_secs(60), {
+                    tracing::warn!(
+                        "Traced future polled outside a Tokio task context; running future without instrumentation"
+                    );
+                });
+                state.set(TracedFutureState::Passthrough { inner });
+                continue;
+            };
+
+            let inner = make_instrumented(inner, handle, task_id);
+            state.set(TracedFutureState::Instrumented { inner });
+        }
+    }
+}
+
+impl<F: Future> Future for WakeTracked<F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-
-        if this.waker_data.is_none()
-            && let Some(handle) = this.handle.take()
-        {
-            let Some(task_id) = tokio::task::try_id().map(TaskId::from) else {
-                rate_limited!(Duration::from_secs(60), {
-                    tracing::warn!(
-                        "Traced future polled outside a Tokio task context; running future without wake tracking"
-                    );
-                });
-                return this.inner.poll(cx);
-            };
-
-            *this.waker_data = Some(Arc::new(TracedWakerData {
-                inner: AtomicWaker::new(),
-                woken_task_id: task_id,
-                shared: handle.shared.clone(),
-            }));
-        }
-
-        let Some(waker_data) = this.waker_data.as_ref().cloned() else {
-            return this.inner.poll(cx);
-        };
+        let waker_data = this.waker_data.clone();
 
         if !waker_data.shared.is_enabled() {
             return this.inner.poll(cx);
@@ -158,31 +242,34 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn traced_consumes_handle_after_missing_task_context() {
+    fn traced_future_falls_back_after_missing_task_context() {
         let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
         let handle = guard
             .handle()
             .traced_handle()
             .expect("enabled handle yields TracedHandle");
 
-        let mut future = Traced::new(std::future::pending::<()>(), Some(handle));
+        let mut future = TracedFuture::new(std::future::pending::<()>(), Some(handle));
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
 
         assert!(Pin::new(&mut future).poll(&mut cx).is_pending());
-        assert!(future.handle.is_none());
-        assert!(future.waker_data.is_none());
+        assert!(matches!(
+            future.state,
+            TracedFutureState::Passthrough { .. }
+        ));
 
         // This is important to ensure the missing-task fallback is one-way:
-        // after the first failed task-id lookup, `handle` has been consumed
-        // and later polls go straight through without retrying `try_id()` or
-        // warning again.
+        // after the first failed task-id lookup, later polls go straight
+        // through without retrying `try_id()` or warning again.
         assert!(Pin::new(&mut future).poll(&mut cx).is_pending());
-        assert!(future.handle.is_none());
-        assert!(future.waker_data.is_none());
+        assert!(matches!(
+            future.state,
+            TracedFutureState::Passthrough { .. }
+        ));
     }
 
-    /// Verify that `Traced<F>` records a `WakeEvent` whose `woken_task_id`
+    /// Verify that the wake-tracking wrapper records a `WakeEvent` whose `woken_task_id`
     /// matches the spawned task when a `Notify` wakes it.
     ///
     /// This is an integration test: events are written to a real file via
@@ -212,7 +299,7 @@ mod tests {
         let spawned_id_write = spawned_id.clone();
 
         runtime.block_on(async {
-            // Spawn a task wrapped in Traced that blocks on a Notify.
+            // Spawn a traced task that blocks on a Notify.
             let join = handle.spawn(async move {
                 *spawned_id_write.lock().unwrap() = tokio::task::try_id()
                     .map(TaskId::from)

--- a/dial9-tokio-telemetry/tests/joinset_tracing.rs
+++ b/dial9-tokio-telemetry/tests/joinset_tracing.rs
@@ -44,7 +44,7 @@ fn spawn_with_joinset_emits_wake_events() {
     runtime.block_on(async move {
         let mut set: JoinSet<()> = JoinSet::new();
         // `yield_now().await` self-wakes through the active waker, which
-        // here is our `Traced` waker — so a `WakeEvent` fires without
+        // here is our wake-tracking waker — so a `WakeEvent` fires without
         // depending on cross-task scheduling order.
         handle.spawn_with(
             async move {

--- a/dial9-tokio-telemetry/tests/joinset_tracing.rs
+++ b/dial9-tokio-telemetry/tests/joinset_tracing.rs
@@ -1,0 +1,202 @@
+//! Integration tests for the JoinSet-friendly tracing API:
+//! - [`TelemetryHandle::spawn_with`]
+//! - [`RuntimeTelemetryHandle::spawn_with`]
+//!
+//! `spawn_with(fut, |f| spawn_fn(f))` is the way to spawn a wake-tracked
+//! future through APIs other than `TelemetryHandle::spawn` (e.g.
+//! `tokio::task::JoinSet::spawn`, `JoinSet::spawn_on`, etc.). It must:
+//!   - emit `WakeEvent`s for the polled future, and
+//!   - mark the resulting `TaskSpawn` as `instrumented = true`,
+//!   - while preserving the user's call site as `spawn_loc`.
+
+mod common;
+
+use dial9_tokio_telemetry::analysis_unstable::TraceReader;
+use dial9_tokio_telemetry::telemetry::{
+    RotatingWriter, TaskId, TelemetryEvent, TelemetryGuard, TraceWriter, TracedRuntime,
+};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::task::JoinSet;
+
+/// Standard 2-worker multi_thread runtime with task tracking enabled.
+fn build_traced_runtime<W: TraceWriter + 'static>(writer: W) -> (Runtime, TelemetryGuard) {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+    TracedRuntime::builder()
+        .with_task_tracking(true)
+        .build_and_start(builder, writer)
+        .unwrap()
+}
+
+/// `spawn_with(fut, |f| set.spawn(f))` produces `WakeEvent`s for the
+/// spawned task — the same as `handle.spawn(fut)` would.
+#[test]
+fn spawn_with_joinset_emits_wake_events() {
+    let (writer, events) = common::CapturingWriter::new();
+    let (runtime, guard) = build_traced_runtime(writer);
+
+    let handle = guard.handle();
+    let spawned_id: Arc<Mutex<Option<TaskId>>> = Arc::new(Mutex::new(None));
+    let id_w = spawned_id.clone();
+
+    runtime.block_on(async move {
+        let mut set: JoinSet<()> = JoinSet::new();
+        // `yield_now().await` self-wakes through the active waker, which
+        // here is our `Traced` waker — so a `WakeEvent` fires without
+        // depending on cross-task scheduling order.
+        handle.spawn_with(
+            async move {
+                *id_w.lock().unwrap() = tokio::task::try_id().map(TaskId::from);
+                tokio::task::yield_now().await;
+            },
+            |f| set.spawn(f),
+        );
+        while set.join_next().await.is_some() {}
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let events = events.lock().unwrap();
+    let expected = spawned_id.lock().unwrap().expect("task id captured");
+    let saw_wake = events.iter().any(|e| {
+        matches!(e, TelemetryEvent::WakeEvent { woken_task_id, .. } if *woken_task_id == expected)
+    });
+    assert!(saw_wake, "expected WakeEvent for joinset task {expected:?}");
+}
+
+/// `spawn_with` flips the `TaskSpawn` `instrumented` flag for the spawn
+/// performed inside the closure, AND because the closure body lives in
+/// user code, `JoinSet::spawn`'s `#[track_caller]` resolves `spawn_loc`
+/// to the user's file (NOT the library).
+#[test]
+fn spawn_with_marks_taskspawn_and_preserves_caller() {
+    let dir = tempfile::tempdir().unwrap();
+    let trace_path = dir.path().join("trace.bin");
+    let writer = RotatingWriter::single_file(&trace_path).unwrap();
+    let (runtime, guard) = build_traced_runtime(writer);
+
+    let handle = guard.handle();
+
+    runtime.block_on(async move {
+        let mut set: JoinSet<()> = JoinSet::new();
+
+        // Inside `spawn_with`: marked instrumented, caller = this file.
+        handle.spawn_with(async {}, |f| set.spawn(f));
+
+        // Outside `spawn_with`: NOT instrumented.
+        tokio::spawn(async {}).await.unwrap();
+
+        while set.join_next().await.is_some() {}
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let sealed = dir.path().join("trace.0.bin");
+    let reader = TraceReader::new(sealed.to_str().unwrap()).unwrap();
+
+    let mut instrumented_user_loc = 0;
+    let mut raw = 0;
+    for event in &reader.all_events {
+        if let TelemetryEvent::TaskSpawn {
+            spawn_loc,
+            instrumented,
+            ..
+        } = event
+        {
+            match instrumented {
+                Some(true) => {
+                    let loc = reader
+                        .spawn_locations
+                        .get(spawn_loc)
+                        .expect("spawn_loc should resolve");
+                    assert!(
+                        loc.contains("joinset_tracing.rs"),
+                        "instrumented spawn caller should resolve to user code, got {loc}"
+                    );
+                    instrumented_user_loc += 1;
+                }
+                Some(false) => raw += 1,
+                None => {}
+            }
+        }
+    }
+    assert_eq!(
+        instrumented_user_loc, 1,
+        "expected 1 instrumented TaskSpawn pointing to joinset_tracing.rs"
+    );
+    assert!(raw >= 1, "expected at least 1 raw TaskSpawn, got {raw}");
+}
+
+/// `spawn_with` returns whatever the closure returns. Useful so callers
+/// can keep the `JoinHandle` / `AbortHandle` / etc. produced by their
+/// spawn function.
+#[test]
+fn spawn_with_returns_closure_value() {
+    let (writer, _events) = common::CapturingWriter::new();
+    let (runtime, guard) = build_traced_runtime(writer);
+
+    let handle = guard.handle();
+
+    runtime.block_on(async move {
+        let join = handle.spawn_with(async { 42u32 }, tokio::spawn);
+        let value = join.await.unwrap();
+        assert_eq!(value, 42);
+    });
+
+    drop(runtime);
+    drop(guard);
+}
+
+/// `RuntimeTelemetryHandle::spawn_with` composes with `JoinSet::spawn_on`
+/// to target a specific runtime even when called from outside any
+/// runtime context, while still emitting wake events and marking the
+/// `TaskSpawn` instrumented.
+#[test]
+fn runtime_handle_spawn_with_targets_correct_runtime() {
+    use dial9_tokio_telemetry::telemetry::{NullWriter, TelemetryCore};
+
+    let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+    guard.enable();
+
+    let mut builder_a = tokio::runtime::Builder::new_multi_thread();
+    builder_a.worker_threads(1).enable_all().thread_name("rt-a");
+    let (rt_a, handle_a) = guard.trace_runtime("a").build(builder_a).unwrap();
+
+    let mut builder_b = tokio::runtime::Builder::new_multi_thread();
+    builder_b.worker_threads(1).enable_all().thread_name("rt-b");
+    let (rt_b, handle_b) = guard.trace_runtime("b").build(builder_b).unwrap();
+
+    let mut set_a: JoinSet<String> = JoinSet::new();
+    handle_a.spawn_with(
+        async {
+            tokio::task::yield_now().await;
+            std::thread::current().name().unwrap_or("?").to_string()
+        },
+        |f| set_a.spawn_on(f, rt_a.handle()),
+    );
+
+    let mut set_b: JoinSet<String> = JoinSet::new();
+    handle_b.spawn_with(
+        async {
+            tokio::task::yield_now().await;
+            std::thread::current().name().unwrap_or("?").to_string()
+        },
+        |f| set_b.spawn_on(f, rt_b.handle()),
+    );
+
+    let name_a = rt_a.block_on(async move { set_a.join_next().await.unwrap().unwrap() });
+    let name_b = rt_b.block_on(async move { set_b.join_next().await.unwrap().unwrap() });
+
+    assert!(name_a.starts_with("rt-a"), "got {name_a}");
+    assert!(name_b.starts_with("rt-b"), "got {name_b}");
+
+    drop(rt_a);
+    drop(rt_b);
+    let _ = guard.graceful_shutdown(Duration::from_secs(1));
+}

--- a/dial9-tokio-telemetry/tests/spawn_with.rs
+++ b/dial9-tokio-telemetry/tests/spawn_with.rs
@@ -1,8 +1,8 @@
-//! Integration tests for the JoinSet-friendly tracing API:
+//! Integration tests for the custom-spawn tracing API:
 //! - [`TelemetryHandle::spawn_with`]
 //! - [`RuntimeTelemetryHandle::spawn_with`]
 //!
-//! `spawn_with(fut, |f| spawn_fn(f))` is the way to spawn a wake-tracked
+//! `spawn_with(fut, |f| spawn_fn(f))` is the way to spawn an instrumented
 //! future through APIs other than `TelemetryHandle::spawn` (e.g.
 //! `tokio::task::JoinSet::spawn`, `JoinSet::spawn_on`, etc.). It must:
 //!   - emit `WakeEvent`s for the polled future, and
@@ -116,7 +116,7 @@ fn spawn_with_marks_taskspawn_and_preserves_caller() {
                         .get(spawn_loc)
                         .expect("spawn_loc should resolve");
                     assert!(
-                        loc.contains("joinset_tracing.rs"),
+                        loc.contains("spawn_with.rs"),
                         "instrumented spawn caller should resolve to user code, got {loc}"
                     );
                     instrumented_user_loc += 1;
@@ -128,7 +128,7 @@ fn spawn_with_marks_taskspawn_and_preserves_caller() {
     }
     assert_eq!(
         instrumented_user_loc, 1,
-        "expected 1 instrumented TaskSpawn pointing to joinset_tracing.rs"
+        "expected 1 instrumented TaskSpawn pointing to spawn_with.rs"
     );
     assert!(raw >= 1, "expected at least 1 raw TaskSpawn, got {raw}");
 }

--- a/dial9-tokio-telemetry/tests/spawn_with.rs
+++ b/dial9-tokio-telemetry/tests/spawn_with.rs
@@ -69,9 +69,9 @@ fn spawn_with_joinset_emits_wake_events() {
 }
 
 /// `spawn_with` flips the `TaskSpawn` `instrumented` flag for the spawn
-/// performed inside the closure, AND because the closure body lives in
-/// user code, `JoinSet::spawn`'s `#[track_caller]` resolves `spawn_loc`
-/// to the user's file (NOT the library).
+/// performed inside the closure, AND because `JoinSet::spawn` is called
+/// from that closure, its `#[track_caller]` resolves `spawn_loc` to the
+/// closure call site (NOT the library).
 #[test]
 fn spawn_with_marks_taskspawn_and_preserves_caller() {
     let dir = tempfile::tempdir().unwrap();
@@ -117,7 +117,7 @@ fn spawn_with_marks_taskspawn_and_preserves_caller() {
                         .expect("spawn_loc should resolve");
                     assert!(
                         loc.contains("spawn_with.rs"),
-                        "instrumented spawn caller should resolve to user code, got {loc}"
+                        "instrumented spawn caller should resolve to the closure call site, got {loc}"
                     );
                     instrumented_user_loc += 1;
                 }
@@ -128,7 +128,7 @@ fn spawn_with_marks_taskspawn_and_preserves_caller() {
     }
     assert_eq!(
         instrumented_user_loc, 1,
-        "expected 1 instrumented TaskSpawn pointing to spawn_with.rs"
+        "expected 1 instrumented TaskSpawn pointing to the closure call site"
     );
     assert!(raw >= 1, "expected at least 1 raw TaskSpawn, got {raw}");
 }

--- a/dial9-tokio-telemetry/tests/task_dump.rs
+++ b/dial9-tokio-telemetry/tests/task_dump.rs
@@ -4,6 +4,7 @@ mod common;
 
 use dial9_tokio_telemetry::telemetry::{TaskDumpConfig, TelemetryEvent, TracedRuntime};
 use std::time::Duration;
+use tokio::task::JoinSet;
 
 /// A task that stays idle longer than the threshold between polls should
 /// produce at least one `TaskDump` event.
@@ -141,5 +142,51 @@ fn task_dump_does_not_produce_extra_events() {
     assert_eq!(
         baseline, with_dumps,
         "enabling task dumps changed PollStart/PollEnd/WakeEvent counts: {baseline:?} vs {with_dumps:?}"
+    );
+}
+
+/// Custom spawn APIs should get the same task-dump instrumentation as
+/// [`TelemetryHandle::spawn`](dial9_tokio_telemetry::telemetry::TelemetryHandle::spawn).
+#[test]
+fn spawn_with_joinset_emits_task_dump() {
+    let (writer, events) = common::CapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_current_thread();
+    builder.enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .with_task_dumps(TaskDumpConfig::builder().rng_seed(42).build())
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    runtime.block_on(async {
+        let mut set: JoinSet<()> = JoinSet::new();
+        handle.spawn_with(
+            async {
+                // Well above the 10ms default threshold.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            },
+            |f| set.spawn(f),
+        );
+        while set.join_next().await.is_some() {}
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let events = events.lock().unwrap();
+    let dumps: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, TelemetryEvent::TaskDump { .. }))
+        .collect();
+
+    assert!(
+        !dumps.is_empty(),
+        "expected TaskDump events from spawn_with JoinSet task; got: {:?}",
+        events
+            .iter()
+            .map(std::mem::discriminant)
+            .collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
## Current solution

Exposes a `handle.spawn_with(fut, |f: TracedFuture| { ... })` to allow spawning instrumented/traced futures through custom spawn APIs (like `JoinSet::spawn`).

## Example

```rust
let handle = TelemetryHandle::current();
let mut set: JoinSet<()> = JoinSet::new();
handle.spawn_with(fut, |f| set.spawn(f));
```

## Other
Closes #301 