### PR TITLE
Expose runtime pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-s3-transfer-manager",
  "bon",
+ "bytes",
  "clap",
  "criterion",
  "crossbeam-queue",

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -29,6 +29,7 @@ pin-project-lite = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smallvec = "1"
+bytes = "1"
 dial9-perf-self-profile = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, features = ["serde"] }
 tracing = "0.1.44"

--- a/dial9-tokio-telemetry/examples/custom_pipeline.rs
+++ b/dial9-tokio-telemetry/examples/custom_pipeline.rs
@@ -1,0 +1,226 @@
+//! Custom segment-processor pipeline.
+//!
+//! The dial9 worker processes each sealed trace segment by passing it through
+//! a chain of [`SegmentProcessor`]s. The library ships built-ins
+//! (`gzip`, `write_back`, `s3`, `symbolize`); this example shows how to plug
+//! your own processors into the chain via `with_custom_pipeline`.
+//!
+//! Three processor patterns are demonstrated:
+//!
+//! 1. [`LoggingProcessor`] - stateless pass-through. The simplest possible
+//!    processor: it inspects [`SegmentData`] and returns it unchanged.
+//! 2. [`MetadataTagger`] - stateless with construction-time config. Adds
+//!    static key/value tags into the segment's metadata map. Downstream
+//!    processors (and built-ins like `s3` for object metadata) can read
+//!    those keys.
+//! 3. [`SizeReporter`] - stateful. Holds counters across calls behind
+//!    `&mut self` and prints a running summary every N segments.
+//!
+//! The pipeline wires the customs first, then `gzip` + `write_back` so the
+//! resulting `*.bin.gz` files are still readable by the trace tooling.
+//!
+//! Usage:
+//!   cargo run --example custom_pipeline
+//!
+//! Inspect the trace afterwards (gunzip first, the analysis tools read raw bytes):
+//!   gunzip /tmp/dial9-custom-pipeline/trace.0.bin.gz
+//!   cargo run --features analysis --example analyze_trace -- /tmp/dial9-custom-pipeline/trace.0.bin
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use dial9_tokio_telemetry::Dial9Config;
+use dial9_tokio_telemetry::background_task::{ProcessError, SegmentData, SegmentProcessor};
+use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+
+const TRACE_DIR: &str = "/tmp/dial9-custom-pipeline";
+
+// ---------------------------------------------------------------------------
+// 1. Stateless pass-through: log and forward.
+// ---------------------------------------------------------------------------
+
+/// Logs each segment as it arrives and forwards it unchanged.
+#[derive(Debug, Default)]
+struct LoggingProcessor;
+
+impl SegmentProcessor for LoggingProcessor {
+    fn name(&self) -> &'static str {
+        "Logging"
+    }
+
+    fn process(
+        &mut self,
+        data: SegmentData,
+    ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
+        Box::pin(async move {
+            println!(
+                "[Logging]   segment {:>3}  {:>8} bytes  metadata={:?}",
+                data.segment().index(),
+                data.bytes().len(),
+                data.metadata(),
+            );
+            Ok(data)
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Stateless with config: tag the segment's metadata map.
+// ---------------------------------------------------------------------------
+
+/// Inserts a fixed set of key/value pairs into the segment's metadata map.
+///
+/// Metadata flows alongside the bytes through the rest of the pipeline.
+/// Downstream processors can read it with [`SegmentData::metadata`]; the
+/// built-in `s3` uploader, for example, forwards specific keys as S3
+/// object metadata. Note that some metadata keys are reserved by built-in
+/// processors (e.g. `content_encoding`, `write_back_extension`), avoid
+/// reusing them here.
+struct MetadataTagger {
+    tags: HashMap<String, String>,
+}
+
+impl MetadataTagger {
+    fn new<I, K, V>(tags: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        Self {
+            tags: tags
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl SegmentProcessor for MetadataTagger {
+    fn name(&self) -> &'static str {
+        "MetadataTagger"
+    }
+
+    fn process(
+        &mut self,
+        mut data: SegmentData,
+    ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
+        let tags = self.tags.clone();
+        Box::pin(async move {
+            data.metadata_mut().extend(tags);
+            Ok(data)
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Stateful: track running totals across segments.
+// ---------------------------------------------------------------------------
+
+/// Accumulates per-pipeline-instance counters. Demonstrates that processors
+/// can hold state across calls - `process` takes `&mut self`.
+///
+/// # Panic safety
+/// The worker catches panics in `process` and reuses the same instance for
+/// the next segment. State updates in this processor are eager and
+/// monotonically increasing, so there's no half-updated invariant to worry
+/// about. If you accumulate state that must roll back on failure, do the
+/// update at the end of `process` once everything else has succeeded.
+#[derive(Debug, Default)]
+struct SizeReporter {
+    segments_seen: u64,
+    bytes_seen: u64,
+    report_every: u64,
+}
+
+impl SizeReporter {
+    fn every(n: u64) -> Self {
+        Self {
+            report_every: n.max(1),
+            ..Self::default()
+        }
+    }
+}
+
+impl SegmentProcessor for SizeReporter {
+    fn name(&self) -> &'static str {
+        "SizeReporter"
+    }
+
+    fn process(
+        &mut self,
+        data: SegmentData,
+    ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
+        self.segments_seen += 1;
+        self.bytes_seen += data.bytes().len() as u64;
+        if self.segments_seen.is_multiple_of(self.report_every) {
+            println!(
+                "[Stats]     {} segments processed, {} bytes total",
+                self.segments_seen, self.bytes_seen,
+            );
+        }
+        Box::pin(async move { Ok(data) })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Workload - generate enough activity for a few segments to seal.
+// ---------------------------------------------------------------------------
+
+async fn worker_task(id: usize) {
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let mut acc: u64 = 0;
+        for i in 0..50_000 {
+            acc = acc.wrapping_add((i ^ id as u64).wrapping_mul(31));
+        }
+        std::hint::black_box(acc);
+        tokio::task::yield_now().await;
+    }
+}
+
+#[dial9_tokio_telemetry::main(config = || {
+    let _ = std::fs::create_dir_all(TRACE_DIR);
+    let base_path = format!("{TRACE_DIR}/trace.bin");
+
+    Dial9Config::builder()
+        .base_path(base_path)
+        // Small per-file budget + short rotation period so we get several
+        // sealed segments in a few seconds of work - otherwise the whole
+        // run might fit in a single segment and the stateful processor
+        // would never have anything to count.
+        .max_file_size(512 * 1024)
+        .max_total_size(16 * 1024 * 1024)
+        .rotation_period(Duration::from_secs(2))
+        .with_tokio(|t| { t.worker_threads(4); })
+        .with_runtime(|r| r
+            .with_task_tracking(true)
+            .with_custom_pipeline(|p| p
+                .pipe(MetadataTagger::new([
+                    ("service", "custom-pipeline-demo"),
+                    ("environment", "local"),
+                ]))
+                .pipe(LoggingProcessor)
+                .pipe(SizeReporter::every(1))
+                .gzip()
+                .write_back()))
+        .build_or_disabled()
+})]
+async fn main() {
+    println!("Running workload, traces under {TRACE_DIR}/");
+
+    let handle = TelemetryHandle::current();
+    let tasks: Vec<_> = (0..32).map(|i| handle.spawn(worker_task(i))).collect();
+    for task in tasks {
+        let _ = task.await;
+    }
+
+    // Give the worker a beat to seal + process the final segment before
+    // the runtime shuts down. Not required in production - `TelemetryGuard`
+    // honors the configured drain timeout on drop - but it makes the demo
+    // output more satisfying.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    println!("Done. Sealed segments are gzipped under {TRACE_DIR}/*.bin.gz");
+}

--- a/dial9-tokio-telemetry/examples/custom_pipeline.rs
+++ b/dial9-tokio-telemetry/examples/custom_pipeline.rs
@@ -58,7 +58,7 @@ impl SegmentProcessor for LoggingProcessor {
             println!(
                 "[Logging]   segment {:>3}  {:>8} bytes  metadata={:?}",
                 data.segment().index(),
-                data.bytes().len(),
+                data.payload().len(),
                 data.metadata(),
             );
             Ok(data)
@@ -154,7 +154,7 @@ impl SegmentProcessor for SizeReporter {
         data: SegmentData,
     ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
         self.segments_seen += 1;
-        self.bytes_seen += data.bytes().len() as u64;
+        self.bytes_seen += data.payload().len() as u64;
         if self.segments_seen.is_multiple_of(self.report_every) {
             println!(
                 "[Stats]     {} segments processed, {} bytes total",

--- a/dial9-tokio-telemetry/examples/production_use.rs
+++ b/dial9-tokio-telemetry/examples/production_use.rs
@@ -116,7 +116,9 @@ use std::time::Duration;
 
 use clap::Parser;
 use dial9_tokio_telemetry::Dial9Config;
-use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+use dial9_tokio_telemetry::telemetry::{
+    HasTracePath, PipelineUnset, TelemetryHandle, TracedRuntimeBuilder,
+};
 
 const LINUX: bool = cfg!(target_os = "linux");
 
@@ -172,6 +174,31 @@ impl Dial9Opts {
     }
 }
 
+#[cfg(feature = "cpu-profiling")]
+fn configure_runtime_common(
+    mut r: TracedRuntimeBuilder<HasTracePath, PipelineUnset>,
+    cpu_profile_enabled: bool,
+    schedule_profile_enabled: bool,
+    cpu_sample_hz: u64,
+) -> TracedRuntimeBuilder<HasTracePath, PipelineUnset> {
+    r = r.with_task_tracking(true);
+    use dial9_tokio_telemetry::telemetry::cpu_profile::{CpuProfilingConfig, SchedEventConfig};
+    if cpu_profile_enabled {
+        r = r.with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(cpu_sample_hz));
+    }
+    if schedule_profile_enabled {
+        r = r.with_sched_events(SchedEventConfig::default());
+    }
+    r
+}
+
+#[cfg(not(feature = "cpu-profiling"))]
+fn configure_runtime_common(
+    r: TracedRuntimeBuilder<HasTracePath, PipelineUnset>,
+) -> TracedRuntimeBuilder<HasTracePath, PipelineUnset> {
+    r.with_task_tracking(true)
+}
+
 /// Translate parsed options into a [`Dial9Config`] the `#[main]` macro can consume.
 ///
 /// `build_or_disabled()` is the important piece here: any writer I/O or
@@ -205,40 +232,46 @@ fn configure_dial9(opts: &Dial9Opts) -> Dial9Config {
     #[cfg(feature = "worker-s3")]
     let (s3_bucket, s3_service) = (opts.s3_bucket.clone(), opts.service_name.clone());
 
-    Dial9Config::builder()
+    let cfg = Dial9Config::builder()
         .enabled(opts.enabled)
         .base_path(base_path)
         .max_file_size(max_file_size)
         .max_total_size(max_disk)
-        .rotation_period(opts.rotation())
-        .with_runtime(move |mut r| {
-            r = r.with_task_tracking(true);
-            #[cfg(feature = "cpu-profiling")]
-            {
-                use dial9_tokio_telemetry::telemetry::cpu_profile::{
-                    CpuProfilingConfig, SchedEventConfig,
-                };
-                if cpu_enabled {
-                    r = r.with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(cpu_hz));
+        .rotation_period(opts.rotation());
+
+    #[cfg(feature = "worker-s3")]
+    if let (Some(bucket), Some(service_name)) = (s3_bucket, s3_service) {
+        use dial9_tokio_telemetry::background_task::s3::S3Config;
+        let s3 = S3Config::builder()
+            .bucket(bucket)
+            .service_name(service_name)
+            .build();
+        return cfg
+            .with_runtime(move |r| {
+                #[cfg(feature = "cpu-profiling")]
+                {
+                    configure_runtime_common(r, cpu_enabled, sched_enabled, cpu_hz)
+                        .with_s3_uploader(s3)
                 }
-                if sched_enabled {
-                    r = r.with_sched_events(SchedEventConfig::default());
+                #[cfg(not(feature = "cpu-profiling"))]
+                {
+                    configure_runtime_common(r).with_s3_uploader(s3)
                 }
-            }
-            #[cfg(feature = "worker-s3")]
-            {
-                use dial9_tokio_telemetry::background_task::s3::S3Config;
-                if let (Some(bucket), Some(service_name)) = (&s3_bucket, &s3_service) {
-                    let s3 = S3Config::builder()
-                        .bucket(bucket.clone())
-                        .service_name(service_name.clone())
-                        .build();
-                    r = r.with_s3_uploader(s3);
-                }
-            }
-            r
-        })
-        .build_or_disabled()
+            })
+            .build_or_disabled();
+    }
+
+    cfg.with_runtime(move |r| {
+        #[cfg(feature = "cpu-profiling")]
+        {
+            configure_runtime_common(r, cpu_enabled, sched_enabled, cpu_hz)
+        }
+        #[cfg(not(feature = "cpu-profiling"))]
+        {
+            configure_runtime_common(r)
+        }
+    })
+    .build_or_disabled()
 }
 
 /// Complain at startup when the operator asked for something a feature flag

--- a/dial9-tokio-telemetry/src/background_task/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/mod.rs
@@ -185,8 +185,11 @@ impl ProcessError {
 #[non_exhaustive]
 pub enum ProcessErrorKind {
     /// The processor hit an `std::io::Error`.
+    #[non_exhaustive]
     Io(std::io::Error),
-    /// An S3 transfer manager error.
+
+    /// An error transferring data off the host
+    #[non_exhaustive]
     Transfer {
         /// Underlying error source.
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -290,6 +293,25 @@ pub trait SegmentProcessor: Send {
 /// ([`gzip`](Self::gzip), [`write_back`](Self::write_back),
 /// [`s3`](Self::s3), [`symbolize`](Self::symbolize)); custom processors
 /// are added with [`pipe`](Self::pipe).
+///
+/// # Example
+///
+/// ```ignore
+/// struct Logger;
+/// impl SegmentProcessor for Logger {
+///     fn name(&self) -> &'static str { "logger" }
+///     fn process(&mut self, data: SegmentData)
+///         -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>>
+///     {
+///         Box::pin(async move {
+///             println!("segment {} ({} bytes)", data.segment().index(), data.bytes().len());
+///             Ok(data)
+///         })
+///     }
+/// }
+///
+/// builder.with_custom_pipeline(|p| p.pipe(Logger).gzip().write_back())
+/// ```
 #[must_use]
 pub struct PipelineBuilder {
     processors: Vec<Box<dyn SegmentProcessor>>,

--- a/dial9-tokio-telemetry/src/background_task/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/mod.rs
@@ -6,6 +6,8 @@ pub(crate) mod pipeline_metrics;
 pub mod s3;
 pub(crate) mod sealed;
 
+pub use sealed::SealedSegment;
+
 use crate::metrics::{Operation, SegmentProcessMetrics, SegmentProcessMetricsGuard};
 use crate::rate_limit::rate_limited;
 use futures_util::FutureExt;
@@ -23,10 +25,8 @@ pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Configuration for the in-process worker pipeline.
 ///
-/// Only `trace_path` and `s3` are required. Optional fields:
-///
-/// - `poll_interval`: how often to check for sealed segments (default: 1 second)
-/// - `client`: pre-built `aws_sdk_s3::Client` for custom credentials or endpoints
+/// The pipeline is composed of a sequence of [`SegmentProcessor`]s supplied
+/// via `processors`. When none are provided the worker runs no processing.
 #[derive(bon::Builder)]
 #[builder(on(String, into))]
 pub struct BackgroundTaskConfig {
@@ -36,19 +36,9 @@ pub struct BackgroundTaskConfig {
     /// How often the worker checks for sealed segments. Defaults to 1 second.
     #[builder(default = DEFAULT_POLL_INTERVAL)]
     poll_interval: Duration,
-    /// S3 upload configuration. When `None`, the worker symbolizes and
-    /// gzip-writes back to disk without uploading.
-    #[cfg(feature = "worker-s3")]
-    s3: Option<s3::S3Config>,
-    /// Pre-built S3 client. When provided, the worker uses this client
-    /// instead of building one from `aws_config::load_defaults`.
-    /// Region auto-detection still applies unless `region` is set on `S3Config`.
-    #[cfg(feature = "worker-s3")]
-    client: Option<aws_sdk_s3::Client>,
-    /// When true, run the symbolize processor on each segment.
+    /// The processor pipeline executed for each sealed segment, in order.
     #[builder(default)]
-    #[allow(dead_code)]
-    symbolize: bool,
+    processors: Vec<Box<dyn SegmentProcessor>>,
     /// Metrics sink. Defaults to [`DevNullSink`](metrique_writer::sink::DevNullSink).
     #[builder(default = metrique_writer::sink::DevNullSink::boxed())]
     metrics_sink: BoxEntrySink,
@@ -94,12 +84,6 @@ impl BackgroundTaskConfig {
             }
         }
     }
-
-    /// S3 upload configuration.
-    #[cfg(feature = "worker-s3")]
-    pub fn s3(&self) -> Option<&s3::S3Config> {
-        self.s3.as_ref()
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -111,19 +95,56 @@ impl BackgroundTaskConfig {
 /// The worker reads the sealed segment file into `bytes`, populates initial
 /// `metadata`, then passes this through each [`SegmentProcessor`] in order.
 /// Metrics are flushed automatically when the `SegmentData` is dropped.
-pub(crate) struct SegmentData {
-    /// Original sealed segment (path, index).
-    // dead if s3 is not enabled
-    #[allow(unused)]
-    pub(crate) segment: sealed::SealedSegment,
-    /// The payload bytes (raw, symbolized, compressed, etc.).
-    #[allow(unused)]
+pub struct SegmentData {
+    pub(crate) segment: SealedSegment,
     pub(crate) bytes: Vec<u8>,
-    /// Metadata accumulated by processors. Keyed by convention.
-    #[allow(unused)]
     pub(crate) metadata: HashMap<String, String>,
-    /// Metrics guard — processors can record metrics; flushed on drop.
     pub(crate) metrics: SegmentProcessMetricsGuard,
+}
+
+impl SegmentData {
+    /// Information about the sealed segment being processed.
+    pub fn segment(&self) -> &SealedSegment {
+        &self.segment
+    }
+
+    /// Current payload bytes (raw, symbolized, compressed, etc.).
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Mutable reference to the payload bytes.
+    pub fn bytes_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.bytes
+    }
+
+    /// Take ownership of the payload bytes, leaving an empty `Vec` in its place.
+    pub fn take_bytes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.bytes)
+    }
+
+    /// Replace the payload bytes.
+    pub fn set_bytes(&mut self, bytes: Vec<u8>) {
+        self.bytes = bytes;
+    }
+
+    /// Metadata accumulated by upstream processors.
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.metadata
+    }
+
+    /// Mutable reference to the metadata map. Processors can insert keys
+    /// (e.g. `"content_encoding"`, `"write_back_extension"`) to signal
+    /// downstream stages.
+    pub fn metadata_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.metadata
+    }
+
+    /// Record the segment's post-compression size. Surfaces as the
+    /// `CompressedSize` metric for this segment.
+    pub fn set_compressed_size(&mut self, bytes: u64) {
+        self.metrics.compressed_size = Some(bytes);
+    }
 }
 
 impl std::fmt::Debug for SegmentData {
@@ -142,16 +163,35 @@ impl std::fmt::Debug for SegmentData {
 /// Carries the [`SegmentData`] back so the caller can still record metrics
 /// and pass the data to subsequent error-handling logic.
 #[derive(Debug)]
-pub(crate) struct ProcessError {
+pub struct ProcessError {
     pub(crate) data: SegmentData,
     pub(crate) kind: ProcessErrorKind,
 }
 
+impl ProcessError {
+    /// Wrap `data` and `kind` into a new [`ProcessError`].
+    pub fn new(data: SegmentData, kind: ProcessErrorKind) -> Self {
+        Self { data, kind }
+    }
+
+    /// Shorthand for [`ProcessError::new`] with an I/O error.
+    pub fn io(data: SegmentData, err: std::io::Error) -> Self {
+        Self::new(data, ProcessErrorKind::Io(err))
+    }
+}
+
+/// Kind of failure reported by a [`SegmentProcessor`].
 #[derive(Debug)]
-pub(crate) enum ProcessErrorKind {
+#[non_exhaustive]
+pub enum ProcessErrorKind {
+    /// The processor hit an `std::io::Error`.
     Io(std::io::Error),
+    /// An S3 transfer manager error.
     Transfer {
+        /// Underlying error source.
         source: Box<dyn std::error::Error + Send + Sync>,
+        /// Whether this error is transient and the segment should be kept on
+        /// disk for retry.
         retryable: bool,
     },
 }
@@ -230,7 +270,7 @@ impl From<aws_sdk_s3_transfer_manager::error::Error> for ProcessErrorKind {
 /// subsequent segments, so implementations **must** remain in a valid state
 /// after a panic (i.e., no partially-updated invariants that would cause
 /// incorrect behavior on the next call).
-pub(crate) trait SegmentProcessor: Send {
+pub trait SegmentProcessor: Send {
     /// Human-readable name for this processor (used in metrics).
     fn name(&self) -> &'static str;
 
@@ -243,31 +283,90 @@ pub(crate) trait SegmentProcessor: Send {
     ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>>;
 }
 
-/// Build the processor pipeline based on config flags and available features.
-async fn build_pipeline(_config: &mut BackgroundTaskConfig) -> Vec<Box<dyn SegmentProcessor>> {
-    let mut pipeline: Vec<Box<dyn SegmentProcessor>> = Vec::new();
+/// Closure-scoped builder for assembling a custom processor pipeline.
+///
+/// Obtained via `with_custom_pipeline(|p| ...)` on the runtime builder.
+/// Built-in processors are reachable through dedicated methods
+/// ([`gzip`](Self::gzip), [`write_back`](Self::write_back),
+/// [`s3`](Self::s3), [`symbolize`](Self::symbolize)); custom processors
+/// are added with [`pipe`](Self::pipe).
+#[must_use]
+pub struct PipelineBuilder {
+    processors: Vec<Box<dyn SegmentProcessor>>,
+}
 
+impl PipelineBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            processors: Vec::new(),
+        }
+    }
+
+    pub(crate) fn into_processors(self) -> Vec<Box<dyn SegmentProcessor>> {
+        self.processors
+    }
+
+    /// Append a user-supplied [`SegmentProcessor`] to the pipeline.
+    pub fn pipe<S>(mut self, processor: S) -> Self
+    where
+        S: SegmentProcessor + 'static,
+    {
+        self.processors.push(Box::new(processor));
+        self
+    }
+
+    /// Gzip the segment payload in-memory.
+    pub fn gzip(mut self) -> Self {
+        self.processors.push(Box::new(GzipCompressor));
+        self
+    }
+
+    /// Write the current payload bytes back to disk. When the payload has
+    /// been gzipped earlier in the pipeline, the file is written with a
+    /// `.gz` suffix and the original sealed segment is removed.
+    pub fn write_back(mut self) -> Self {
+        self.processors.push(Box::new(WriteBackProcessor));
+        self
+    }
+
+    /// Resolve stack-frame addresses in the segment to symbol names.
+    /// Only valid when the runtime is built with the `cpu-profiling` feature.
     #[cfg(feature = "cpu-profiling")]
-    if _config.symbolize {
-        pipeline.push(Box::new(SymbolizeProcessor));
+    pub fn symbolize(mut self) -> Self {
+        self.processors.push(Box::new(SymbolizeProcessor));
+        self
     }
 
-    #[allow(unused_mut)]
-    let mut has_s3 = false;
+    /// Upload the current payload to S3 with the given configuration. The
+    /// AWS SDK default credential chain is used; call [`s3_with_client`]
+    /// to supply a pre-built client.
+    ///
+    /// Does not auto-add gzip — chain `.gzip()` first if you want
+    /// compressed uploads.
+    ///
+    /// [`s3_with_client`]: Self::s3_with_client
     #[cfg(feature = "worker-s3")]
-    if let Some(s3_config) = _config.s3.take() {
-        let s3_uploader = S3PipelineUploader::new(s3_config, _config.client.take()).await;
-        pipeline.push(Box::new(GzipCompressor));
-        pipeline.push(Box::new(s3_uploader));
-        has_s3 = true;
+    pub fn s3(mut self, config: s3::S3Config) -> Self {
+        self.processors
+            .push(Box::new(S3PipelineUploader::new(config, None)));
+        self
     }
 
-    if !has_s3 {
-        pipeline.push(Box::new(GzipCompressor));
-        pipeline.push(Box::new(WriteBackProcessor));
+    /// Variant of [`s3`](Self::s3) that uses the supplied pre-built S3 client.
+    #[cfg(feature = "worker-s3")]
+    pub fn s3_with_client(mut self, config: s3::S3Config, client: aws_sdk_s3::Client) -> Self {
+        self.processors
+            .push(Box::new(S3PipelineUploader::new(config, Some(client))));
+        self
     }
+}
 
-    pipeline
+impl std::fmt::Debug for PipelineBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PipelineBuilder")
+            .field("len", &self.processors.len())
+            .finish()
+    }
 }
 
 /// The worker loop function. Runs on a dedicated thread, polls for sealed
@@ -285,7 +384,7 @@ pub(crate) fn run_background_task(
         .build()
         .expect("failed to create worker runtime");
 
-    let processors = rt.block_on(build_pipeline(&mut config));
+    let processors = std::mem::take(&mut config.processors);
     let metrics_sink = config.metrics_sink.clone();
 
     tracing::info!(target: "dial9_worker", dir = %config.trace_dir().display(), stem = %config.trace_stem(), processors = processors.len(), "worker started");
@@ -314,7 +413,12 @@ pub(crate) fn run_background_task(
 // GzipCompressor — compresses segment bytes in-memory
 // ---------------------------------------------------------------------------
 
-struct GzipCompressor;
+/// Gzips the segment payload in-memory. Sets the `content_encoding` and
+/// `write_back_extension` metadata keys so downstream stages know the
+/// payload is gzipped. Already-gzipped segments (detected by magic bytes)
+/// pass through unchanged.
+#[derive(Debug, Default)]
+pub(crate) struct GzipCompressor;
 
 impl SegmentProcessor for GzipCompressor {
     fn name(&self) -> &'static str {
@@ -376,7 +480,10 @@ impl SegmentProcessor for GzipCompressor {
 // SymbolizeProcessor — resolves stack frame addresses to symbol names
 // ---------------------------------------------------------------------------
 
+/// Resolves stack-frame addresses in the segment to symbol names using
+/// the current process's `/proc/self/maps`.
 #[cfg(feature = "cpu-profiling")]
+#[derive(Debug, Default)]
 pub(crate) struct SymbolizeProcessor;
 
 #[cfg(feature = "cpu-profiling")]
@@ -437,7 +544,11 @@ impl SegmentProcessor for SymbolizeProcessor {
 // WriteBackProcessor — writes processed bytes back to disk
 // ---------------------------------------------------------------------------
 
-struct WriteBackProcessor;
+/// Writes the current payload bytes back to disk. If a
+/// `write_back_extension` metadata key is present, the bytes are written to
+/// `{original}{extension}` and the original segment file is removed.
+#[derive(Debug, Default)]
+pub(crate) struct WriteBackProcessor;
 
 impl SegmentProcessor for WriteBackProcessor {
     fn name(&self) -> &'static str {
@@ -722,15 +833,73 @@ impl WorkerLoop {
 // S3PipelineUploader — production S3 upload processor
 // ---------------------------------------------------------------------------
 
+/// S3 uploader processor. Construction is synchronous — the AWS client and
+/// bucket region are resolved lazily on the first `process()` call, inside
+/// the worker's tokio runtime.
 #[cfg(feature = "worker-s3")]
 pub(crate) struct S3PipelineUploader {
-    uploader: s3::S3Uploader,
-    circuit_breaker: connection::CircuitBreaker,
+    state: S3UploaderState,
+}
+
+#[cfg(feature = "worker-s3")]
+enum S3UploaderState {
+    Pending {
+        s3_config: s3::S3Config,
+        client: Option<aws_sdk_s3::Client>,
+    },
+    Ready {
+        uploader: s3::S3Uploader,
+        circuit_breaker: connection::CircuitBreaker,
+    },
+}
+
+#[cfg(feature = "worker-s3")]
+impl std::fmt::Debug for S3PipelineUploader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3PipelineUploader").finish_non_exhaustive()
+    }
 }
 
 #[cfg(feature = "worker-s3")]
 impl S3PipelineUploader {
-    async fn new(s3_config: s3::S3Config, client: Option<aws_sdk_s3::Client>) -> Self {
+    /// Create a new uploader from an [`S3Config`](s3::S3Config) and an
+    /// optional pre-built S3 client. If `client` is `None`, the default
+    /// AWS configuration chain is used. Region detection and transfer
+    /// manager construction are deferred to the first `process()` call.
+    pub(crate) fn new(s3_config: s3::S3Config, client: Option<aws_sdk_s3::Client>) -> Self {
+        Self {
+            state: S3UploaderState::Pending { s3_config, client },
+        }
+    }
+
+    /// Set (or override) the pre-built S3 client. Only effective before
+    /// the uploader has been initialized (i.e. before the first segment
+    /// has been processed); otherwise this is a no-op.
+    pub(crate) fn set_client(&mut self, client: aws_sdk_s3::Client) {
+        if let S3UploaderState::Pending { client: slot, .. } = &mut self.state {
+            *slot = Some(client);
+        }
+    }
+
+    /// Construct an uploader directly in the `Ready` state. Test-only —
+    /// production code goes through [`new`](Self::new) and lazy init.
+    #[cfg(test)]
+    pub(crate) fn from_ready(
+        uploader: s3::S3Uploader,
+        circuit_breaker: connection::CircuitBreaker,
+    ) -> Self {
+        Self {
+            state: S3UploaderState::Ready {
+                uploader,
+                circuit_breaker,
+            },
+        }
+    }
+
+    async fn initialize(
+        s3_config: s3::S3Config,
+        client: Option<aws_sdk_s3::Client>,
+    ) -> (s3::S3Uploader, connection::CircuitBreaker) {
         let bootstrap_client = match client {
             Some(c) => c,
             None => {
@@ -761,10 +930,10 @@ impl S3PipelineUploader {
                 .build(),
         );
 
-        Self {
-            uploader: s3::S3Uploader::new(tm_client, s3_config),
-            circuit_breaker: connection::CircuitBreaker::new(),
-        }
+        (
+            s3::S3Uploader::new(tm_client, s3_config),
+            connection::CircuitBreaker::new(),
+        )
     }
 }
 
@@ -779,7 +948,37 @@ impl SegmentProcessor for S3PipelineUploader {
         mut data: SegmentData,
     ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
         Box::pin(async move {
-            if !self.circuit_breaker.should_attempt() {
+            // Lazy init: clone the config + client and run `initialize`
+            // without mutating `self.state`. If the init future panics or
+            // is cancelled mid-await, the worker's outer `catch_unwind`
+            // recovers and `self.state` stays `Pending`, so the next
+            // segment will retry. Mutating before the await would leave
+            // the uploader stuck in a transient state forever.
+            if let S3UploaderState::Pending { s3_config, client } = &self.state {
+                let cfg = s3_config.clone();
+                let cli = client.clone();
+                let (uploader, circuit_breaker) = Self::initialize(cfg, cli).await;
+                self.state = S3UploaderState::Ready {
+                    uploader,
+                    circuit_breaker,
+                };
+            }
+            let S3UploaderState::Ready {
+                uploader,
+                circuit_breaker,
+            } = &mut self.state
+            else {
+                // unreachable: we just transitioned above and the state
+                // doesn't otherwise revert. Fall through with an error so
+                // a future refactor doesn't silently break.
+                return Err(ProcessError {
+                    data,
+                    kind: ProcessErrorKind::Io(std::io::Error::other(
+                        "S3 uploader in unexpected state",
+                    )),
+                });
+            };
+            if !circuit_breaker.should_attempt() {
                 tracing::debug!(target: "dial9_worker", path = %data.segment.path.display(), "circuit breaker open, skipping upload");
                 return Err(ProcessError {
                     data,
@@ -790,13 +989,12 @@ impl SegmentProcessor for S3PipelineUploader {
                 });
             }
             let bytes = std::mem::take(&mut data.bytes);
-            match self
-                .uploader
+            match uploader
                 .upload_and_delete(&data.segment, bytes, &data.metadata)
                 .await
             {
                 Ok(key) => {
-                    self.circuit_breaker.on_success();
+                    circuit_breaker.on_success();
                     rate_limited!(Duration::from_secs(10), {
                         tracing::info!(target: "dial9_worker", "uploaded {key}");
                     });
@@ -807,7 +1005,7 @@ impl SegmentProcessor for S3PipelineUploader {
                     {
                         tracing::debug!(target: "dial9_worker", path = %data.segment.path.display(), "segment already evicted, skipping");
                     } else {
-                        self.circuit_breaker.on_failure();
+                        circuit_breaker.on_failure();
                         rate_limited!(Duration::from_secs(60), {
                             tracing::warn!(target: "dial9_worker", error = %kind, "upload failed");
                         });
@@ -960,10 +1158,10 @@ mod tests {
         let uploader = s3::S3Uploader::new(tm_client, s3_config);
         let mut processors: Vec<Box<dyn SegmentProcessor>> = vec![
             Box::new(GzipCompressor),
-            Box::new(S3PipelineUploader {
+            Box::new(S3PipelineUploader::from_ready(
                 uploader,
-                circuit_breaker: connection::CircuitBreaker::new(),
-            }),
+                connection::CircuitBreaker::new(),
+            )),
         ];
 
         let segment = sealed::SealedSegment {
@@ -1080,12 +1278,6 @@ mod tests {
         stop.cancel();
         let config = BackgroundTaskConfig::builder()
             .trace_path(dir.path().join("trace.bin"))
-            .s3(s3::S3Config::builder()
-                .bucket("b")
-                .service_name("s")
-                .instance_path("i")
-                .boot_id("b")
-                .build())
             .build();
 
         let processors: Vec<Box<dyn SegmentProcessor>> =
@@ -1150,12 +1342,6 @@ mod tests {
         stop.cancel();
         let config = BackgroundTaskConfig::builder()
             .trace_path(dir.path().join("trace.bin"))
-            .s3(s3::S3Config::builder()
-                .bucket("b")
-                .service_name("s")
-                .instance_path("i")
-                .boot_id("b")
-                .build())
             .build();
 
         let processors: Vec<Box<dyn SegmentProcessor>> = vec![Box::new(FailFirstProcessor {
@@ -1187,25 +1373,15 @@ mod tests {
 
 // --- Review finding #9: trace_stem edge cases ---
 
-#[cfg(all(test, feature = "worker-s3"))]
+#[cfg(test)]
 mod trace_stem_tests {
     use super::*;
     use assert2::check;
-
-    fn dummy_s3() -> s3::S3Config {
-        s3::S3Config::builder()
-            .bucket("b")
-            .service_name("s")
-            .instance_path("i")
-            .boot_id("b")
-            .build()
-    }
 
     #[test]
     fn trace_stem_normal_path() {
         let config = BackgroundTaskConfig::builder()
             .trace_path("/tmp/traces/trace.bin")
-            .s3(dummy_s3())
             .build();
         check!(config.trace_stem() == "trace");
     }
@@ -1215,7 +1391,6 @@ mod trace_stem_tests {
         // A path like "/tmp/traces/" — file_stem returns "traces", not an error
         let config = BackgroundTaskConfig::builder()
             .trace_path("/tmp/traces/")
-            .s3(dummy_s3())
             .build();
         // This is the current behavior — it returns "traces" not "trace"
         // which would silently match the wrong files
@@ -1225,10 +1400,7 @@ mod trace_stem_tests {
     #[test]
     fn trace_stem_root_path() {
         // A path like "/" has no file stem
-        let config = BackgroundTaskConfig::builder()
-            .trace_path("/")
-            .s3(dummy_s3())
-            .build();
+        let config = BackgroundTaskConfig::builder().trace_path("/").build();
         // Should fall back to "trace" and log an error
         check!(config.trace_stem() == "trace");
     }
@@ -1237,7 +1409,6 @@ mod trace_stem_tests {
     fn trace_dir_for_directory_path() {
         let config = BackgroundTaskConfig::builder()
             .trace_path("/tmp/traces/")
-            .s3(dummy_s3())
             .build();
         // trace_dir should be the parent of the path
         check!(config.trace_dir() == std::path::Path::new("/tmp"));
@@ -1340,10 +1511,9 @@ mod worker_pipeline_tests {
         std::fs::write(&seg_path, b"bad data").unwrap();
 
         let (uploader, _s3_root) = always_failing_s3_uploader();
-        let processors: Vec<Box<dyn SegmentProcessor>> = vec![Box::new(S3PipelineUploader {
-            uploader,
-            circuit_breaker: connection::CircuitBreaker::new(),
-        })];
+        let processors: Vec<Box<dyn SegmentProcessor>> = vec![Box::new(
+            S3PipelineUploader::from_ready(uploader, connection::CircuitBreaker::new()),
+        )];
 
         let stop = tokio_util::sync::CancellationToken::new();
         let mut worker = WorkerLoop::new(
@@ -1371,10 +1541,8 @@ mod worker_pipeline_tests {
         let mut cb = connection::CircuitBreaker::new();
         // Trip the circuit breaker so it refuses attempts.
         cb.on_failure();
-        let processors: Vec<Box<dyn SegmentProcessor>> = vec![Box::new(S3PipelineUploader {
-            uploader,
-            circuit_breaker: cb,
-        })];
+        let processors: Vec<Box<dyn SegmentProcessor>> =
+            vec![Box::new(S3PipelineUploader::from_ready(uploader, cb))];
 
         let stop = tokio_util::sync::CancellationToken::new();
         let mut worker = WorkerLoop::new(

--- a/dial9-tokio-telemetry/src/background_task/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/mod.rs
@@ -881,6 +881,16 @@ impl S3PipelineUploader {
         }
     }
 
+    /// Take any previously-stashed client out of a `Pending` uploader so it
+    /// can be carried into a replacement. Returns `None` once the uploader
+    /// has been initialized.
+    pub(crate) fn take_client(&mut self) -> Option<aws_sdk_s3::Client> {
+        match &mut self.state {
+            S3UploaderState::Pending { client, .. } => client.take(),
+            S3UploaderState::Ready { .. } => None,
+        }
+    }
+
     /// Construct an uploader directly in the `Ready` state. Test-only —
     /// production code goes through [`new`](Self::new) and lazy init.
     #[cfg(test)]

--- a/dial9-tokio-telemetry/src/background_task/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/mod.rs
@@ -1,11 +1,13 @@
 #[cfg(feature = "worker-s3")]
 pub(crate) mod connection;
 pub mod instance_metadata;
+mod payload;
 pub(crate) mod pipeline_metrics;
 #[cfg(feature = "worker-s3")]
 pub mod s3;
 pub(crate) mod sealed;
 
+pub use payload::Payload;
 pub use sealed::SealedSegment;
 
 use crate::metrics::{Operation, SegmentProcessMetrics, SegmentProcessMetricsGuard};
@@ -92,12 +94,12 @@ impl BackgroundTaskConfig {
 
 /// Data flowing through the processor pipeline.
 ///
-/// The worker reads the sealed segment file into `bytes`, populates initial
+/// The worker reads the sealed segment file into `payload`, populates initial
 /// `metadata`, then passes this through each [`SegmentProcessor`] in order.
 /// Metrics are flushed automatically when the `SegmentData` is dropped.
 pub struct SegmentData {
     pub(crate) segment: SealedSegment,
-    pub(crate) bytes: Vec<u8>,
+    pub(crate) payload: Payload,
     pub(crate) metadata: HashMap<String, String>,
     pub(crate) metrics: SegmentProcessMetricsGuard,
 }
@@ -108,24 +110,19 @@ impl SegmentData {
         &self.segment
     }
 
-    /// Current payload bytes (raw, symbolized, compressed, etc.).
-    pub fn bytes(&self) -> &[u8] {
-        &self.bytes
+    /// Current payload (raw, symbolized, compressed, etc.).
+    pub fn payload(&self) -> &Payload {
+        &self.payload
     }
 
-    /// Mutable reference to the payload bytes.
-    pub fn bytes_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.bytes
+    /// Take ownership of the payload, leaving an empty [`Payload`] in its place.
+    pub fn take_payload(&mut self) -> Payload {
+        std::mem::take(&mut self.payload)
     }
 
-    /// Take ownership of the payload bytes, leaving an empty `Vec` in its place.
-    pub fn take_bytes(&mut self) -> Vec<u8> {
-        std::mem::take(&mut self.bytes)
-    }
-
-    /// Replace the payload bytes.
-    pub fn set_bytes(&mut self, bytes: Vec<u8>) {
-        self.bytes = bytes;
+    /// Replace the payload.
+    pub fn set_payload(&mut self, payload: impl Into<Payload>) {
+        self.payload = payload.into();
     }
 
     /// Metadata accumulated by upstream processors.
@@ -151,7 +148,7 @@ impl std::fmt::Debug for SegmentData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SegmentData")
             .field("segment", &self.segment)
-            .field("bytes", &format_args!("[{} bytes]", self.bytes.len()))
+            .field("payload", &self.payload)
             .field("metadata", &self.metadata)
             .field("metrics", &self.metrics)
             .finish()
@@ -304,7 +301,7 @@ pub trait SegmentProcessor: Send {
 ///         -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>>
 ///     {
 ///         Box::pin(async move {
-///             println!("segment {} ({} bytes)", data.segment().index(), data.bytes().len());
+///             println!("segment {} ({} bytes)", data.segment().index(), data.payload().len());
 ///             Ok(data)
 ///         })
 ///     }
@@ -453,46 +450,42 @@ impl SegmentProcessor for GzipCompressor {
     ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
         Box::pin(async move {
             // Skip already-compressed segments to avoid double-gzip.
-            if data.bytes.starts_with(&[0x1f, 0x8b]) {
+            if data.payload.starts_with(&[0x1f, 0x8b]) {
                 data.metadata
                     .insert("content_encoding".into(), "gzip".into());
                 data.metadata
                     .insert("write_back_extension".into(), ".gz".into());
                 return Ok(data);
             }
-            let raw = data.bytes;
+            let raw = std::mem::take(&mut data.payload);
             let compressed = tokio::task::spawn_blocking(move || {
                 use flate2::write::GzEncoder;
                 use std::io::Write;
                 let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
-                encoder.write_all(&raw)?;
+                for chunk in raw.chunks() {
+                    encoder.write_all(chunk)?;
+                }
                 encoder.finish()
             })
             .await;
             match compressed {
                 Ok(Ok(bytes)) => {
                     data.metrics.compressed_size = Some(bytes.len() as u64);
-                    data.bytes = bytes;
+                    data.payload = Payload::from_vec(bytes);
                     data.metadata
                         .insert("content_encoding".into(), "gzip".into());
                     data.metadata
                         .insert("write_back_extension".into(), ".gz".into());
                     Ok(data)
                 }
-                Ok(Err(e)) => {
-                    data.bytes = vec![];
-                    Err(ProcessError {
-                        data,
-                        kind: ProcessErrorKind::Io(e),
-                    })
-                }
-                Err(e) => {
-                    data.bytes = vec![];
-                    Err(ProcessError {
-                        data,
-                        kind: ProcessErrorKind::Io(std::io::Error::other(e)),
-                    })
-                }
+                Ok(Err(e)) => Err(ProcessError {
+                    data,
+                    kind: ProcessErrorKind::Io(e),
+                }),
+                Err(e) => Err(ProcessError {
+                    data,
+                    kind: ProcessErrorKind::Io(std::io::Error::other(e)),
+                }),
             }
         })
     }
@@ -520,28 +513,34 @@ impl SegmentProcessor for SymbolizeProcessor {
     ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
         Box::pin(async move {
             // Skip already-compressed segments (e.g. leftover from a previous run).
-            if data.bytes.starts_with(&[0x1f, 0x8b]) {
+            if data.payload.starts_with(&[0x1f, 0x8b]) {
                 tracing::debug!(target: "dial9_worker", "segment is gzip-compressed, skipping symbolization");
                 return Ok(data);
             }
-            let input = std::mem::take(&mut data.bytes);
+            // The symbolize FFI reads `&[u8]`, so we materialize a single
+            // contiguous `Bytes`. When there's only one chunk this is a
+            // zero-copy `Bytes::clone`-equivalent; the `BytesMut` concat
+            // path runs only on already-segmented input (rare).
+            let input = std::mem::take(&mut data.payload).into_bytes();
             let result = tokio::task::spawn_blocking(move || {
                 let maps = dial9_perf_self_profile::read_proc_maps();
-                // TODO: reduce the amount of reallocation we are doing here, probably by making it possible to extend segment data instead of all the copying
                 let mut output = Vec::new();
                 dial9_perf_self_profile::offline_symbolize::symbolize_trace_with_maps(
                     &input,
                     &maps,
                     &mut output,
                 )?;
-                let mut combined = input;
-                combined.extend_from_slice(&output);
+                // Hand back the original bytes plus the symbol output as two
+                // chunks — no copy of `input`.
+                let mut combined = Payload::new();
+                combined.push(input);
+                combined.push(bytes::Bytes::from(output));
                 Ok::<_, std::io::Error>(combined)
             })
             .await;
             match result {
-                Ok(Ok(bytes)) => {
-                    data.bytes = bytes;
+                Ok(Ok(payload)) => {
+                    data.payload = payload;
                     Ok(data)
                 }
                 Ok(Err(e)) => {
@@ -591,10 +590,17 @@ impl SegmentProcessor for WriteBackProcessor {
                 }
                 None => original_path.clone(),
             };
-            let bytes = data.bytes.clone();
+            let payload = data.payload.clone();
             let write_dest = dest_path.clone();
-            let result =
-                tokio::task::spawn_blocking(move || std::fs::write(&write_dest, &bytes)).await;
+            let result = tokio::task::spawn_blocking(move || {
+                use std::io::{BufWriter, Write};
+                let mut f = BufWriter::new(std::fs::File::create(&write_dest)?);
+                for chunk in payload.chunks() {
+                    f.write_all(chunk)?;
+                }
+                f.flush()
+            })
+            .await;
             match result {
                 Ok(Ok(())) => {
                     if dest_path != original_path {
@@ -742,7 +748,7 @@ impl WorkerLoop {
 
             let mut data = SegmentData {
                 segment: segment.clone(),
-                bytes,
+                payload: Payload::from_vec(bytes),
                 metadata: HashMap::from([
                     ("epoch_secs".into(), epoch_secs.to_string()),
                     ("segment_index".into(), segment.index.to_string()),
@@ -1020,9 +1026,9 @@ impl SegmentProcessor for S3PipelineUploader {
                     },
                 });
             }
-            let bytes = std::mem::take(&mut data.bytes);
+            let payload = std::mem::take(&mut data.payload);
             match uploader
-                .upload_and_delete(&data.segment, bytes, &data.metadata)
+                .upload_and_delete(&data.segment, payload, &data.metadata)
                 .await
             {
                 Ok(key) => {
@@ -1217,7 +1223,7 @@ mod tests {
 
         let mut pipe_data = SegmentData {
             segment,
-            bytes: data,
+            payload: Payload::from_vec(data),
             metadata: HashMap::from([
                 ("epoch_secs".into(), "1741209000".into()),
                 ("segment_index".into(), "0".into()),
@@ -1709,7 +1715,7 @@ mod worker_pipeline_tests {
                 data: SegmentData,
             ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>>
             {
-                *self.0.lock().unwrap() = data.bytes.clone();
+                *self.0.lock().unwrap() = data.payload.clone().into_vec();
                 Box::pin(async { Ok(data) })
             }
         }
@@ -1764,7 +1770,7 @@ mod worker_pipeline_tests {
 
         let data = SegmentData {
             segment,
-            bytes: b"payload".to_vec(),
+            payload: Payload::from(b"payload"),
             metadata: HashMap::from([("write_back_extension".into(), ".gz".into())]),
             metrics,
         };
@@ -1809,7 +1815,7 @@ mod worker_pipeline_tests {
 
         let data = SegmentData {
             segment,
-            bytes: b"new".to_vec(),
+            payload: Payload::from(b"new"),
             metadata: HashMap::new(),
             metrics,
         };

--- a/dial9-tokio-telemetry/src/background_task/payload.rs
+++ b/dial9-tokio-telemetry/src/background_task/payload.rs
@@ -1,0 +1,227 @@
+//! Segment payload buffer.
+//!
+//! [`Payload`] is the byte container threaded through the processor pipeline.
+//! It owns one or more [`Bytes`] chunks so that processors that produce
+//! a payload by appending (e.g. symbolization, which emits the original
+//! trace plus a symbol table) can do so without copying the original input.
+//! For consumers that need a contiguous view, [`Payload::into_bytes`] /
+//! [`Payload::into_vec`] produce one — fast-pathing zero-copy when the
+//! payload already has a single chunk.
+
+use bytes::{Bytes, BytesMut};
+
+/// A segment payload — zero or more contiguous [`Bytes`] chunks.
+///
+/// Cloning a `Payload` is cheap: each chunk is `Bytes`, which clones via an
+/// `Arc` bump.
+#[derive(Default, Clone)]
+pub struct Payload {
+    chunks: Vec<Bytes>,
+    len: usize,
+}
+
+impl Payload {
+    /// Create an empty payload.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Wrap a single `Bytes` as a payload.
+    pub fn from_bytes(b: Bytes) -> Self {
+        let mut p = Self::new();
+        p.push(b);
+        p
+    }
+
+    /// Wrap a `Vec<u8>` as a payload (zero-copy via `Bytes::from`).
+    pub fn from_vec(v: Vec<u8>) -> Self {
+        Self::from_bytes(Bytes::from(v))
+    }
+
+    /// Total byte length across all chunks.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// True when the payload has no bytes.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Number of chunks. Useful for tests that want to verify zero-copy.
+    pub fn chunk_count(&self) -> usize {
+        self.chunks.len()
+    }
+
+    /// Borrow the chunk slice. Stable order; may be empty.
+    pub fn chunks(&self) -> &[Bytes] {
+        &self.chunks
+    }
+
+    /// Iterate over chunks in order.
+    pub fn iter(&self) -> std::slice::Iter<'_, Bytes> {
+        self.chunks.iter()
+    }
+
+    /// Append a chunk. Empty chunks are dropped to keep `chunk_count` honest.
+    pub fn push(&mut self, b: Bytes) {
+        if b.is_empty() {
+            return;
+        }
+        self.len += b.len();
+        self.chunks.push(b);
+    }
+
+    /// Check whether the payload begins with `prefix`. Walks across chunk
+    /// boundaries so callers do not have to know the internal layout.
+    pub fn starts_with(&self, prefix: &[u8]) -> bool {
+        if prefix.len() > self.len {
+            return false;
+        }
+        let mut remaining = prefix;
+        for chunk in &self.chunks {
+            if remaining.is_empty() {
+                return true;
+            }
+            let take = remaining.len().min(chunk.len());
+            if chunk[..take] != remaining[..take] {
+                return false;
+            }
+            remaining = &remaining[take..];
+        }
+        remaining.is_empty()
+    }
+
+    /// Concatenate chunks into a single contiguous [`Bytes`].
+    ///
+    /// Fast path: if there is exactly one chunk, it is returned as-is
+    /// (zero-copy). Otherwise a `BytesMut` of `self.len()` is allocated and
+    /// each chunk is copied in order.
+    pub fn into_bytes(mut self) -> Bytes {
+        match self.chunks.len() {
+            0 => Bytes::new(),
+            1 => self.chunks.pop().unwrap(),
+            _ => {
+                let mut out = BytesMut::with_capacity(self.len);
+                for chunk in self.chunks {
+                    out.extend_from_slice(&chunk);
+                }
+                out.freeze()
+            }
+        }
+    }
+
+    /// Concatenate chunks into a single contiguous `Vec<u8>`.
+    pub fn into_vec(self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.len);
+        for chunk in &self.chunks {
+            out.extend_from_slice(chunk);
+        }
+        out
+    }
+}
+
+impl From<Bytes> for Payload {
+    fn from(b: Bytes) -> Self {
+        Self::from_bytes(b)
+    }
+}
+
+impl From<Vec<u8>> for Payload {
+    fn from(v: Vec<u8>) -> Self {
+        Self::from_vec(v)
+    }
+}
+
+impl From<&'static [u8]> for Payload {
+    fn from(s: &'static [u8]) -> Self {
+        Self::from_bytes(Bytes::from_static(s))
+    }
+}
+
+impl<const N: usize> From<&'static [u8; N]> for Payload {
+    fn from(s: &'static [u8; N]) -> Self {
+        Self::from_bytes(Bytes::from_static(s))
+    }
+}
+
+impl std::fmt::Debug for Payload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Payload")
+            .field("len", &self.len)
+            .field("chunks", &self.chunks.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert2::check;
+
+    #[test]
+    fn empty_payload_round_trips() {
+        let p = Payload::new();
+        check!(p.is_empty());
+        check!(p.len() == 0);
+        check!(p.chunk_count() == 0);
+        check!(p.into_vec().is_empty());
+    }
+
+    #[test]
+    fn from_vec_is_single_chunk() {
+        let p = Payload::from_vec(b"hello".to_vec());
+        check!(p.len() == 5);
+        check!(p.chunk_count() == 1);
+    }
+
+    #[test]
+    fn push_drops_empty_chunks() {
+        let mut p = Payload::new();
+        p.push(Bytes::new());
+        p.push(Bytes::from_static(b"abc"));
+        p.push(Bytes::new());
+        check!(p.chunk_count() == 1);
+        check!(p.len() == 3);
+    }
+
+    #[test]
+    fn into_bytes_single_chunk_is_zero_copy() {
+        let original = Bytes::from(vec![1u8, 2, 3, 4, 5]);
+        let original_ptr = original.as_ptr();
+        let p = Payload::from_bytes(original);
+        let out = p.into_bytes();
+        check!(out.as_ptr() == original_ptr);
+    }
+
+    #[test]
+    fn into_bytes_multi_chunk_concatenates() {
+        let mut p = Payload::new();
+        p.push(Bytes::from_static(b"ab"));
+        p.push(Bytes::from_static(b"cde"));
+        p.push(Bytes::from_static(b"f"));
+        check!(p.chunk_count() == 3);
+        let out = p.into_bytes();
+        check!(&out[..] == b"abcdef");
+    }
+
+    #[test]
+    fn starts_with_walks_chunks() {
+        let mut p = Payload::new();
+        p.push(Bytes::from_static(&[0x1f]));
+        p.push(Bytes::from_static(&[0x8b, 0x08]));
+        check!(p.starts_with(&[0x1f, 0x8b]));
+        check!(p.starts_with(&[0x1f, 0x8b, 0x08]));
+        check!(!p.starts_with(&[0x1f, 0x8b, 0x08, 0x00]));
+        check!(!p.starts_with(&[0x1f, 0x00]));
+    }
+
+    #[test]
+    fn starts_with_empty_prefix_is_true() {
+        let p = Payload::from_vec(b"x".to_vec());
+        check!(p.starts_with(&[]));
+        let empty = Payload::new();
+        check!(empty.starts_with(&[]));
+        check!(!empty.starts_with(&[0]));
+    }
+}

--- a/dial9-tokio-telemetry/src/background_task/s3.rs
+++ b/dial9-tokio-telemetry/src/background_task/s3.rs
@@ -251,7 +251,7 @@ impl S3Uploader {
     pub(crate) async fn upload_and_delete(
         &self,
         segment: &SealedSegment,
-        data: Vec<u8>,
+        payload: super::Payload,
         metadata: &HashMap<String, String>,
     ) -> Result<String, ProcessErrorKind> {
         let key = self.config.object_key(segment, metadata);
@@ -280,7 +280,7 @@ impl S3Uploader {
                     .unwrap_or("0"),
             )
             .metadata("host", self.config.instance_path.as_str())
-            .body(data.into())
+            .body(payload.into_bytes().into())
             .initiate_with(&self.client)?;
 
         handle.join().await?;
@@ -299,6 +299,7 @@ impl S3Uploader {
 
 #[cfg(test)]
 mod tests {
+    use super::super::Payload;
     use super::*;
     use crate::background_task::sealed::SealedSegment;
     use assert2::check;
@@ -537,7 +538,7 @@ mod tests {
         let compressed = gzip_compress_file_sync(&segment_path).unwrap();
         let metadata = make_metadata(1741209000);
         let key = uploader
-            .upload_and_delete(&segment, compressed, &metadata)
+            .upload_and_delete(&segment, Payload::from_vec(compressed), &metadata)
             .await
             .unwrap();
 
@@ -583,7 +584,7 @@ mod tests {
         let compressed = gzip_compress_file_sync(&segment_path).unwrap();
         let metadata = make_metadata(1741209000);
         let _key = uploader
-            .upload_and_delete(&segment, compressed, &metadata)
+            .upload_and_delete(&segment, Payload::from_vec(compressed), &metadata)
             .await
             .unwrap();
 
@@ -630,7 +631,7 @@ mod tests {
         let compressed = gzip_compress_file_sync(&segment_path).unwrap();
         let metadata = make_metadata(1741209000);
         let key = uploader
-            .upload_and_delete(&segment, compressed, &metadata)
+            .upload_and_delete(&segment, Payload::from_vec(compressed), &metadata)
             .await
             .unwrap();
 
@@ -672,7 +673,7 @@ mod tests {
         drop(s3_root);
 
         let result = uploader
-            .upload_and_delete(&segment, compressed, &metadata)
+            .upload_and_delete(&segment, Payload::from_vec(compressed), &metadata)
             .await;
 
         check!(result.is_err());

--- a/dial9-tokio-telemetry/src/background_task/sealed.rs
+++ b/dial9-tokio-telemetry/src/background_task/sealed.rs
@@ -7,9 +7,21 @@ use std::path::{Path, PathBuf};
 
 /// A sealed trace segment ready for processing.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SealedSegment {
+pub struct SealedSegment {
     pub(crate) path: PathBuf,
     pub(crate) index: u32,
+}
+
+impl SealedSegment {
+    /// Path to the sealed segment file on disk.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Segment index (e.g. `3` for `trace.3.bin`).
+    pub fn index(&self) -> u32 {
+        self.index
+    }
 }
 
 /// Segment creation time as epoch seconds, parsed from the first clock

--- a/dial9-tokio-telemetry/src/config.rs
+++ b/dial9-tokio-telemetry/src/config.rs
@@ -29,8 +29,30 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::telemetry::recorder::{HasTracePath, TracedRuntime, TracedRuntimeBuilder};
+use crate::telemetry::recorder::{
+    HasTracePath, PipelineUnset, TelemetryGuard, TracedRuntime, TracedRuntimeBuilder,
+};
 use crate::telemetry::writer::RotatingWriter;
+
+/// Type-erased terminal step for a [`TracedRuntimeBuilder`]: hides the
+/// pipeline-mode marker `M` so [`Inner::Enabled`] can stay non-generic.
+pub(crate) trait BuildTracedRuntime: Send {
+    fn build_and_start(
+        self: Box<Self>,
+        tokio_builder: tokio::runtime::Builder,
+        writer: RotatingWriter,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>;
+}
+
+impl<M: Send + 'static> BuildTracedRuntime for TracedRuntimeBuilder<HasTracePath, M> {
+    fn build_and_start(
+        self: Box<Self>,
+        tokio_builder: tokio::runtime::Builder,
+        writer: RotatingWriter,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        TracedRuntimeBuilder::<HasTracePath, M>::build_and_start(*self, tokio_builder, writer)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Dial9ConfigBuilderError — unified error for builder validation and writer I/O
@@ -121,7 +143,7 @@ pub(crate) enum Inner {
     Enabled {
         writer: RotatingWriter,
         tokio_configurators: Vec<TokioConfigurator>,
-        runtime_builder: TracedRuntimeBuilder<HasTracePath>,
+        runtime_builder: Box<dyn BuildTracedRuntime>,
     },
     Disabled {
         tokio_configurators: Vec<TokioConfigurator>,
@@ -134,12 +156,11 @@ impl fmt::Debug for Inner {
             Inner::Enabled {
                 writer,
                 tokio_configurators,
-                runtime_builder,
+                runtime_builder: _,
             } => f
                 .debug_struct("Enabled")
                 .field("writer", writer)
                 .field("tokio_configurators", &tokio_configurators.len())
-                .field("runtime_builder", runtime_builder)
                 .finish(),
             Inner::Disabled {
                 tokio_configurators,
@@ -165,8 +186,9 @@ pub(crate) fn materialize_tokio_builder(
 // Dial9ConfigBuilder — single bon-generated fluent entry point
 // ---------------------------------------------------------------------------
 
-type RuntimeConfigurator =
-    Box<dyn FnOnce(TracedRuntimeBuilder<HasTracePath>) -> TracedRuntimeBuilder<HasTracePath>>;
+type RuntimeConfigurator = Box<
+    dyn FnOnce(TracedRuntimeBuilder<HasTracePath, PipelineUnset>) -> Box<dyn BuildTracedRuntime>,
+>;
 
 fn default_tokio_builder() -> tokio::runtime::Builder {
     let mut b = tokio::runtime::Builder::new_multi_thread();
@@ -192,7 +214,7 @@ impl Dial9Config {
     pub fn builder(
         #[builder(field)] tokio_configurators: Vec<TokioConfigurator>,
 
-        #[builder(field)] runtime_configurators: Vec<RuntimeConfigurator>,
+        #[builder(field)] runtime_finalizer: Option<RuntimeConfigurator>,
 
         /// Defaults to `true`. When `false`, required writer fields are
         /// ignored and the runtime is built without telemetry.
@@ -210,7 +232,7 @@ impl Dial9Config {
     ) -> Result<Dial9Config, Dial9ConfigBuilderError> {
         assemble(AssembleArgs {
             tokio_configurators,
-            runtime_configurators,
+            runtime_finalizer,
             enabled,
             base_path,
             max_file_size,
@@ -223,7 +245,7 @@ impl Dial9Config {
 
 struct AssembleArgs {
     tokio_configurators: Vec<TokioConfigurator>,
-    runtime_configurators: Vec<RuntimeConfigurator>,
+    runtime_finalizer: Option<RuntimeConfigurator>,
     enabled: bool,
     base_path: Option<PathBuf>,
     max_file_size: Option<u64>,
@@ -238,7 +260,7 @@ struct AssembleArgs {
 fn assemble(args: AssembleArgs) -> Result<Inner, Dial9ConfigBuilderError> {
     let AssembleArgs {
         tokio_configurators,
-        runtime_configurators,
+        runtime_finalizer,
         enabled,
         base_path,
         max_file_size,
@@ -278,10 +300,12 @@ fn assemble(args: AssembleArgs) -> Result<Inner, Dial9ConfigBuilderError> {
         .build()
         .map_err(Dial9ConfigBuilderError::Io)?;
 
-    let mut runtime_builder = TracedRuntime::builder().with_trace_path(base_path);
-    for configure in runtime_configurators {
-        runtime_builder = configure(runtime_builder);
-    }
+    let runtime_builder: TracedRuntimeBuilder<HasTracePath, PipelineUnset> =
+        TracedRuntime::builder().with_trace_path(base_path);
+    let runtime_builder: Box<dyn BuildTracedRuntime> = match runtime_finalizer {
+        Some(configure) => configure(runtime_builder),
+        None => Box::new(runtime_builder),
+    };
 
     Ok(Inner::Enabled {
         writer,
@@ -313,22 +337,30 @@ impl<S: dial9_config_builder::State> Dial9ConfigBuilder<S> {
         self
     }
 
-    /// Queue a configurator for the dial9 [`TracedRuntimeBuilder`].
+    /// Set the configurator for the dial9 [`TracedRuntimeBuilder`].
     ///
     /// The closure receives the staged builder by value and must return it.
     /// Use this to access runtime configuration methods like
-    /// `with_runtime_name` and `with_task_tracking`; see
-    /// [`TracedRuntimeBuilder`] for the full list.
+    /// `with_runtime_name`, `with_task_tracking`, `with_s3_uploader`, or
+    /// `with_custom_pipeline`; see [`TracedRuntimeBuilder`] for the full list.
     ///
-    /// Queued configurators are applied in call order during `build()`
-    /// once `base_path` is known. When `.enabled(false)` is set, queued
-    /// configurators are ignored.
-    pub fn with_runtime<F>(mut self, f: F) -> Self
+    /// The closure may transition the builder's pipeline-mode marker
+    /// (e.g. by calling `.with_s3_uploader(...)` or
+    /// `.with_custom_pipeline(...)`); the resulting mode is preserved
+    /// through to runtime construction.
+    ///
+    /// The configurator is applied during `build()` once `base_path` is
+    /// known. When `.enabled(false)` is set the configurator is ignored.
+    /// Calling this method more than once replaces the prior closure.
+    pub fn with_runtime<F, N>(mut self, f: F) -> Self
     where
-        F: FnOnce(TracedRuntimeBuilder<HasTracePath>) -> TracedRuntimeBuilder<HasTracePath>
+        F: FnOnce(
+                TracedRuntimeBuilder<HasTracePath, PipelineUnset>,
+            ) -> TracedRuntimeBuilder<HasTracePath, N>
             + 'static,
+        N: Send + 'static,
     {
-        self.runtime_configurators.push(Box::new(f));
+        self.runtime_finalizer = Some(Box::new(move |b| Box::new(f(b))));
         self
     }
 }

--- a/dial9-tokio-telemetry/src/legacy_config.rs
+++ b/dial9-tokio-telemetry/src/legacy_config.rs
@@ -16,9 +16,29 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::telemetry::recorder::{
-    HasTracePath, TelemetryGuard, TracedRuntime, TracedRuntimeBuilder,
+    HasTracePath, PipelineUnset, TelemetryGuard, TracedRuntime, TracedRuntimeBuilder,
 };
 use crate::telemetry::writer::RotatingWriter;
+
+/// Type-erased terminal step for a [`TracedRuntimeBuilder`]: hides the
+/// pipeline-mode marker `M` so [`Dial9Config`] can stay non-generic.
+trait BuildTracedRuntime: Send {
+    fn build_and_start(
+        self: Box<Self>,
+        tokio_builder: tokio::runtime::Builder,
+        writer: RotatingWriter,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>;
+}
+
+impl<M: Send + 'static> BuildTracedRuntime for TracedRuntimeBuilder<HasTracePath, M> {
+    fn build_and_start(
+        self: Box<Self>,
+        tokio_builder: tokio::runtime::Builder,
+        writer: RotatingWriter,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        TracedRuntimeBuilder::<HasTracePath, M>::build_and_start(*self, tokio_builder, writer)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Dial9Config — opaque value the macro consumes
@@ -39,7 +59,7 @@ enum Inner {
         max_total_size: u64,
         rotation_period: Option<Duration>,
         tokio_builder: tokio::runtime::Builder,
-        runtime_builder: TracedRuntimeBuilder<HasTracePath>,
+        runtime_builder: Box<dyn BuildTracedRuntime>,
     },
     Disabled {
         tokio_builder: tokio::runtime::Builder,
@@ -86,14 +106,20 @@ impl Dial9Config {
 ///
 /// Created via [`Dial9ConfigBuilder::new`]. Exposes both tokio and dial9
 /// runtime knobs. Call [`.build()`](Self::build) to produce a [`Dial9Config`].
+///
+/// The `M` parameter mirrors the inner [`TracedRuntimeBuilder`]'s
+/// pipeline-mode marker. It defaults to
+/// [`PipelineUnset`](crate::telemetry::PipelineUnset) and transitions when
+/// `with_runtime` returns a builder in a different mode (e.g. after
+/// `.with_s3_uploader(...)` or `.with_custom_pipeline(...)`).
 #[derive(Debug)]
-pub struct Dial9ConfigBuilder {
+pub struct Dial9ConfigBuilder<M = PipelineUnset> {
     base_path: PathBuf,
     max_file_size: u64,
     max_total_size: u64,
     rotation_period: Option<Duration>,
     tokio_builder: tokio::runtime::Builder,
-    runtime_builder: TracedRuntimeBuilder<HasTracePath>,
+    runtime_builder: TracedRuntimeBuilder<HasTracePath, M>,
 }
 
 impl Dial9ConfigBuilder {
@@ -122,7 +148,9 @@ impl Dial9ConfigBuilder {
     pub fn disabled() -> DisabledDial9ConfigBuilder {
         DisabledDial9ConfigBuilder::new()
     }
+}
 
+impl<M: Send + 'static> Dial9ConfigBuilder<M> {
     /// Set the time-based rotation period for the writer.
     pub fn rotation_period(mut self, period: Duration) -> Self {
         self.rotation_period = Some(period);
@@ -133,16 +161,28 @@ impl Dial9ConfigBuilder {
     ///
     /// The closure receives the staged builder by value and must return it.
     /// Use this to access runtime configuration methods like
-    /// `with_runtime_name` and `with_task_tracking`; see
-    /// [`TracedRuntimeBuilder`] for the full list.
+    /// `with_runtime_name`, `with_task_tracking`, `with_s3_uploader`, or
+    /// `with_custom_pipeline`; see [`TracedRuntimeBuilder`] for the full list.
+    ///
+    /// Closures may transition the pipeline-mode marker (`M`) — e.g. calling
+    /// `.with_s3_uploader(...)` returns a builder in
+    /// [`PipelineS3`](crate::telemetry::PipelineS3) mode. The transition is
+    /// reflected on the returned `Dial9ConfigBuilder<N>`.
     ///
     /// Can be called multiple times; each call composes onto the prior state.
-    pub fn with_runtime<F>(mut self, f: F) -> Self
+    pub fn with_runtime<F, N>(self, f: F) -> Dial9ConfigBuilder<N>
     where
-        F: FnOnce(TracedRuntimeBuilder<HasTracePath>) -> TracedRuntimeBuilder<HasTracePath>,
+        F: FnOnce(TracedRuntimeBuilder<HasTracePath, M>) -> TracedRuntimeBuilder<HasTracePath, N>,
+        N: Send + 'static,
     {
-        self.runtime_builder = f(self.runtime_builder);
-        self
+        Dial9ConfigBuilder {
+            base_path: self.base_path,
+            max_file_size: self.max_file_size,
+            max_total_size: self.max_total_size,
+            rotation_period: self.rotation_period,
+            tokio_builder: self.tokio_builder,
+            runtime_builder: f(self.runtime_builder),
+        }
     }
 
     /// Customize the underlying [`tokio::runtime::Builder`].
@@ -171,7 +211,7 @@ impl Dial9ConfigBuilder {
             max_total_size: self.max_total_size,
             rotation_period: self.rotation_period,
             tokio_builder: self.tokio_builder,
-            runtime_builder: self.runtime_builder,
+            runtime_builder: Box::new(self.runtime_builder),
         })
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -23,9 +23,9 @@ pub use format::{
     WorkerUnparkEvent,
 };
 pub use recorder::{
-    HasTracePath, NoTracePath, RuntimeTelemetryHandle, TelemetryCore, TelemetryCoreBuilder,
-    TelemetryGuard, TelemetryHandle, TelemetryRuntimeError, TraceRuntimeCoreBuilder, TracedRuntime,
-    TracedRuntimeBuilder, current_worker_id, spawn,
+    HasTracePath, NoTracePath, PipelineCustom, PipelineS3, PipelineUnset, RuntimeTelemetryHandle,
+    TelemetryCore, TelemetryCoreBuilder, TelemetryGuard, TelemetryHandle, TelemetryRuntimeError,
+    TraceRuntimeCoreBuilder, TracedRuntime, TracedRuntimeBuilder, current_worker_id, spawn,
 };
 pub use task_metadata::{TaskId, UNKNOWN_TASK_ID};
 pub use writer::{NullWriter, RotatingWriter, TraceWriter};

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -3055,7 +3055,10 @@ mod tests {
             .with_s3_client(dummy_client());
         match &mut builder.pipeline {
             PipelineConfig::S3(u) => {
-                assert!(u.take_client().is_some(), "client must be present in order A");
+                assert!(
+                    u.take_client().is_some(),
+                    "client must be present in order A"
+                );
             }
             _ => panic!("expected S3 pipeline"),
         }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -837,8 +837,31 @@ pub struct NoTracePath;
 #[derive(Debug)]
 pub struct HasTracePath;
 
+/// Marker: no pipeline strategy has been chosen yet. From this state the
+/// builder can transition to either S3 (via `with_s3_uploader`) or a custom
+/// pipeline (via `with_custom_pipeline`).
+#[derive(Debug)]
+pub struct PipelineUnset;
+
+/// Marker: the S3 preset has been selected. `with_s3_client` is available
+/// to bind a pre-built client; `with_custom_pipeline` is not in scope.
+#[derive(Debug)]
+pub struct PipelineS3;
+
+/// Marker: a custom pipeline has been configured. No further pipeline
+/// methods are available.
+#[derive(Debug)]
+pub struct PipelineCustom;
+
+enum PipelineConfig {
+    Unset,
+    #[cfg(feature = "worker-s3")]
+    S3(crate::background_task::S3PipelineUploader),
+    Custom(Vec<Box<dyn crate::background_task::SegmentProcessor>>),
+}
+
 /// Builder for configuring a traced Tokio runtime.
-pub struct TracedRuntimeBuilder<P = NoTracePath> {
+pub struct TracedRuntimeBuilder<P = NoTracePath, M = PipelineUnset> {
     enabled: bool,
     task_tracking_enabled: bool,
     trace_path: Option<PathBuf>,
@@ -847,24 +870,25 @@ pub struct TracedRuntimeBuilder<P = NoTracePath> {
     cpu_profiling_config: Option<crate::telemetry::cpu_profile::CpuProfilingConfig>,
     #[cfg(feature = "cpu-profiling")]
     sched_event_config: Option<crate::telemetry::cpu_profile::SchedEventConfig>,
-    #[cfg(feature = "worker-s3")]
-    s3_config: Option<crate::background_task::s3::S3Config>,
-    #[cfg(feature = "worker-s3")]
-    s3_client: Option<aws_sdk_s3::Client>,
+    pipeline: PipelineConfig,
+    /// Static segment metadata to inject into every rotated segment's
+    /// header. The S3 preset populates this from `S3Config::as_metadata`
+    /// so traces stay self-describing.
+    segment_metadata: Vec<(String, String)>,
     worker_poll_interval: Option<Duration>,
     worker_metrics_sink: Option<metrique_writer::BoxEntrySink>,
-    _marker: std::marker::PhantomData<P>,
+    _marker: std::marker::PhantomData<(P, M)>,
 }
 
-impl<P> std::fmt::Debug for TracedRuntimeBuilder<P> {
+impl<P, M> std::fmt::Debug for TracedRuntimeBuilder<P, M> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TracedRuntimeBuilder")
             .finish_non_exhaustive()
     }
 }
 
-// Methods available on both NoTracePath and HasTracePath.
-impl<P> TracedRuntimeBuilder<P> {
+// Methods available regardless of trace-path or pipeline state.
+impl<P, M> TracedRuntimeBuilder<P, M> {
     /// Set to `false` to build a plain runtime with no telemetry
     /// installed and a dummy [`TelemetryGuard`]. Defaults to `true`.
     ///
@@ -909,20 +933,6 @@ impl<P> TracedRuntimeBuilder<P> {
         self
     }
 
-    /// Configure S3 upload for sealed trace segments.
-    #[cfg(feature = "worker-s3")]
-    pub fn with_s3_uploader(mut self, config: crate::background_task::s3::S3Config) -> Self {
-        self.s3_config = Some(config);
-        self
-    }
-
-    /// Provide a pre-built S3 client (for custom credentials or endpoints).
-    #[cfg(feature = "worker-s3")]
-    pub fn with_s3_client(mut self, client: aws_sdk_s3::Client) -> Self {
-        self.s3_client = Some(client);
-        self
-    }
-
     /// Set how often the background worker polls for sealed segments.
     pub fn with_worker_poll_interval(mut self, interval: Duration) -> Self {
         self.worker_poll_interval = Some(interval);
@@ -960,7 +970,7 @@ impl<P> TracedRuntimeBuilder<P> {
         )
     }
 
-    fn into_state<Q>(self) -> TracedRuntimeBuilder<Q> {
+    fn into_state<Q, N>(self) -> TracedRuntimeBuilder<Q, N> {
         TracedRuntimeBuilder {
             enabled: self.enabled,
             task_tracking_enabled: self.task_tracking_enabled,
@@ -970,10 +980,8 @@ impl<P> TracedRuntimeBuilder<P> {
             cpu_profiling_config: self.cpu_profiling_config,
             #[cfg(feature = "cpu-profiling")]
             sched_event_config: self.sched_event_config,
-            #[cfg(feature = "worker-s3")]
-            s3_config: self.s3_config,
-            #[cfg(feature = "worker-s3")]
-            s3_client: self.s3_client,
+            pipeline: self.pipeline,
+            segment_metadata: self.segment_metadata,
             worker_poll_interval: self.worker_poll_interval,
             worker_metrics_sink: self.worker_metrics_sink,
             _marker: std::marker::PhantomData,
@@ -981,13 +989,82 @@ impl<P> TracedRuntimeBuilder<P> {
     }
 }
 
-impl TracedRuntimeBuilder<NoTracePath> {
+// Pipeline-strategy entry points: only available before a strategy has
+// been chosen, so the user picks S3 OR a custom pipeline, not both.
+impl<P> TracedRuntimeBuilder<P, PipelineUnset> {
+    /// Configure the S3 upload preset for sealed trace segments.
+    ///
+    /// The resulting pipeline is `[Gzip, S3]` (with `[Symbolize, ...]`
+    /// prepended when CPU profiling is enabled). After this call, only
+    /// [`with_s3_client`](TracedRuntimeBuilder::with_s3_client) and a
+    /// repeated [`with_s3_uploader`](TracedRuntimeBuilder::with_s3_uploader)
+    /// override are available — `with_custom_pipeline` is no longer in scope.
+    #[cfg(feature = "worker-s3")]
+    pub fn with_s3_uploader(
+        mut self,
+        config: crate::background_task::s3::S3Config,
+    ) -> TracedRuntimeBuilder<P, PipelineS3> {
+        self.segment_metadata = config
+            .as_metadata()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        self.pipeline = PipelineConfig::S3(crate::background_task::S3PipelineUploader::new(
+            config, None,
+        ));
+        self.into_state()
+    }
+
+    /// Configure a fully custom processor pipeline. The closure receives a
+    /// [`PipelineBuilder`](crate::background_task::PipelineBuilder); chain
+    /// methods like `.gzip()`, `.write_back()`, `.s3(cfg)` for built-ins
+    /// and `.pipe(processor)` for user-supplied processors.
+    ///
+    /// Mutually exclusive with [`with_s3_uploader`](Self::with_s3_uploader).
+    pub fn with_custom_pipeline<F>(mut self, build: F) -> TracedRuntimeBuilder<P, PipelineCustom>
+    where
+        F: FnOnce(
+            crate::background_task::PipelineBuilder,
+        ) -> crate::background_task::PipelineBuilder,
+    {
+        let pipeline = build(crate::background_task::PipelineBuilder::new());
+        self.pipeline = PipelineConfig::Custom(pipeline.into_processors());
+        self.into_state()
+    }
+}
+
+// S3 mode — once the S3 preset is chosen, only S3-specific tweaks remain.
+#[cfg(feature = "worker-s3")]
+impl<P> TracedRuntimeBuilder<P, PipelineS3> {
+    /// Provide a pre-built S3 client (for custom credentials or endpoints).
+    /// Replaces any client previously bound to the configured S3 uploader.
+    pub fn with_s3_client(mut self, client: aws_sdk_s3::Client) -> Self {
+        if let PipelineConfig::S3(ref mut uploader) = self.pipeline {
+            uploader.set_client(client);
+        }
+        self
+    }
+
+    /// Replace the configured S3 uploader. Any previously-set client is
+    /// discarded.
+    pub fn with_s3_uploader(mut self, config: crate::background_task::s3::S3Config) -> Self {
+        self.segment_metadata = config
+            .as_metadata()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        self.pipeline = PipelineConfig::S3(crate::background_task::S3PipelineUploader::new(
+            config, None,
+        ));
+        self
+    }
+}
+
+impl<M> TracedRuntimeBuilder<NoTracePath, M> {
     /// Set the trace output path. This transitions the builder to
     /// `HasTracePath`, enabling `build()` and `build_and_start()`.
     pub fn with_trace_path(
         mut self,
         path: impl Into<PathBuf>,
-    ) -> TracedRuntimeBuilder<HasTracePath> {
+    ) -> TracedRuntimeBuilder<HasTracePath, M> {
         self.trace_path = Some(path.into());
         self.into_state()
     }
@@ -999,7 +1076,7 @@ impl TracedRuntimeBuilder<NoTracePath> {
         builder: tokio::runtime::Builder,
         writer: impl TraceWriter + 'static,
     ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
-        self.into_state::<HasTracePath>()
+        self.into_state::<HasTracePath, M>()
             .build_inner(builder, Box::new(writer))
     }
 
@@ -1034,7 +1111,7 @@ impl TracedRuntimeBuilder<NoTracePath> {
     }
 }
 
-impl TracedRuntimeBuilder<HasTracePath> {
+impl<M> TracedRuntimeBuilder<HasTracePath, M> {
     /// Set the trace output path (no-op, already set).
     pub fn with_trace_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.trace_path = Some(path.into());
@@ -1043,9 +1120,10 @@ impl TracedRuntimeBuilder<HasTracePath> {
 
     /// Build the traced runtime with a `RotatingWriter`.
     ///
-    /// The background worker is auto-spawned when cpu-profiling or S3 is
-    /// configured. Recording starts disabled; call [`TelemetryGuard::enable`]
-    /// to begin, or use [`build_and_start`](Self::build_and_start).
+    /// The background worker is auto-spawned when cpu-profiling or any
+    /// pipeline strategy is configured. Recording starts disabled; call
+    /// [`TelemetryGuard::enable`] to begin, or use
+    /// [`build_and_start`](Self::build_and_start).
     pub fn build(
         self,
         builder: tokio::runtime::Builder,
@@ -1066,8 +1144,8 @@ impl TracedRuntimeBuilder<HasTracePath> {
     }
 
     /// Build with a custom writer (for tests). The background worker is
-    /// still spawned if cpu-profiling or S3 is configured and `trace_path`
-    /// is set.
+    /// still spawned if cpu-profiling or any pipeline strategy is configured
+    /// and `trace_path` is set.
     pub fn build_with_writer(
         self,
         builder: tokio::runtime::Builder,
@@ -1096,21 +1174,24 @@ impl TracedRuntimeBuilder<HasTracePath> {
             return TracedRuntime::build_disabled(builder);
         }
 
+        let processors = assemble_processors(
+            #[cfg(feature = "cpu-profiling")]
+            self.cpu_profiling_config.is_some(),
+            self.pipeline,
+        );
+
         let core_builder = TelemetryCore::builder()
             .writer(writer)
             .maybe_trace_path(self.trace_path)
             .maybe_worker_poll_interval(self.worker_poll_interval)
-            .maybe_worker_metrics_sink(self.worker_metrics_sink);
+            .maybe_worker_metrics_sink(self.worker_metrics_sink)
+            .processors(processors)
+            .segment_metadata(self.segment_metadata);
 
         #[cfg(feature = "cpu-profiling")]
         let core_builder = core_builder
             .maybe_cpu_profiling(self.cpu_profiling_config)
             .maybe_sched_events(self.sched_event_config);
-
-        #[cfg(feature = "worker-s3")]
-        let core_builder = core_builder
-            .maybe_s3_config(self.s3_config)
-            .maybe_s3_client(self.s3_client);
 
         let guard = core_builder.build()?;
         let control_tx = guard
@@ -1129,6 +1210,51 @@ impl TracedRuntimeBuilder<HasTracePath> {
         )?;
         Ok((runtime, guard))
     }
+}
+
+/// Build the final processor pipeline.
+///
+/// `Symbolize` is auto-prepended whenever CPU profiling is enabled,
+/// regardless of pipeline strategy.
+///
+/// Behaviour matrix:
+///
+/// | strategy | CPU profiling on               | CPU profiling off |
+/// |----------|--------------------------------|-------------------|
+/// | Unset    | `[Symbolize, Gzip, WriteBack]` | (worker skipped)  |
+/// | S3       | `[Symbolize, Gzip, S3]`        | `[Gzip, S3]`      |
+/// | Custom   | `[Symbolize, ...user]`         | `[...user]`       |
+fn assemble_processors(
+    #[cfg(feature = "cpu-profiling")] cpu_profiling_enabled: bool,
+    pipeline: PipelineConfig,
+) -> Vec<Box<dyn crate::background_task::SegmentProcessor>> {
+    #[cfg(not(feature = "cpu-profiling"))]
+    let cpu_profiling_enabled = false;
+
+    if matches!(pipeline, PipelineConfig::Unset) && !cpu_profiling_enabled {
+        return Vec::new();
+    }
+
+    let mut processors: Vec<Box<dyn crate::background_task::SegmentProcessor>> = Vec::new();
+    #[cfg(feature = "cpu-profiling")]
+    if cpu_profiling_enabled {
+        processors.push(Box::new(crate::background_task::SymbolizeProcessor));
+    }
+    match pipeline {
+        PipelineConfig::Unset => {
+            processors.push(Box::new(crate::background_task::GzipCompressor));
+            processors.push(Box::new(crate::background_task::WriteBackProcessor));
+        }
+        #[cfg(feature = "worker-s3")]
+        PipelineConfig::S3(uploader) => {
+            processors.push(Box::new(crate::background_task::GzipCompressor));
+            processors.push(Box::new(uploader));
+        }
+        PipelineConfig::Custom(user) => {
+            processors.extend(user);
+        }
+    }
+    processors
 }
 
 /// Builder for attaching a runtime to an existing telemetry session.
@@ -1220,8 +1346,8 @@ impl TelemetryCore {
     pub fn new(
         /// The trace writer (e.g. [`RotatingWriter`], [`NullWriter`]).
         writer: impl TraceWriter + 'static,
-        /// Path for trace output. Enables the background worker when
-        /// cpu-profiling or S3 is configured.
+        /// Path for trace output. Enables the background worker when any
+        /// segment processors are configured.
         #[builder(into)]
         trace_path: Option<PathBuf>,
         /// Enable CPU profiling (Linux only).
@@ -1230,12 +1356,16 @@ impl TelemetryCore {
         /// Enable scheduler event capture (Linux only).
         #[cfg(feature = "cpu-profiling")]
         sched_events: Option<crate::telemetry::cpu_profile::SchedEventConfig>,
-        /// S3 upload configuration.
-        #[cfg(feature = "worker-s3")]
-        s3_config: Option<crate::background_task::s3::S3Config>,
-        /// Pre-built S3 client.
-        #[cfg(feature = "worker-s3")]
-        s3_client: Option<aws_sdk_s3::Client>,
+        /// The pipeline of [`SegmentProcessor`](crate::background_task::SegmentProcessor)s
+        /// to run on each sealed segment. When empty the background worker
+        /// is not spawned.
+        #[builder(default)]
+        processors: Vec<Box<dyn crate::background_task::SegmentProcessor>>,
+        /// Static segment metadata injected into every rotated segment's
+        /// header. Empty by default; the S3 preset populates it from the
+        /// configured `S3Config` so traces stay self-describing.
+        #[builder(default)]
+        segment_metadata: Vec<(String, String)>,
         /// How often the background worker polls for sealed segments.
         worker_poll_interval: Option<Duration>,
         /// Metrics sink for the flush/worker threads.
@@ -1243,16 +1373,10 @@ impl TelemetryCore {
     ) -> std::io::Result<TelemetryGuard> {
         let start_mono_ns = crate::telemetry::events::clock_monotonic_ns();
         let shared = Arc::new(SharedState::new(start_mono_ns));
-        #[allow(unused_mut)]
         let mut event_writer = EventWriter::new(Box::new(writer));
-        #[cfg(feature = "worker-s3")]
-        if let Some(s3_config) = s3_config.as_ref() {
-            event_writer.update_segment_metadata(
-                s3_config
-                    .as_metadata()
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect(),
-            )
+
+        if !segment_metadata.is_empty() {
+            event_writer.update_segment_metadata(segment_metadata);
         }
 
         #[cfg(feature = "cpu-profiling")]
@@ -1303,25 +1427,10 @@ impl TelemetryCore {
         };
 
         // Auto-construct worker config when we have a trace path and
-        // either cpu-profiling or S3 is configured.
+        // at least one processor. When the user supplies no processors
+        // there is nothing for the worker to do, so skip spawning it.
         let worker_config = trace_path.and_then(|trace_path| {
-            #[allow(unused_mut)]
-            let mut needs_worker = false;
-            #[allow(unused_mut)]
-            let mut symbolize = false;
-
-            #[cfg(feature = "cpu-profiling")]
-            if cpu_profiling.is_some() {
-                needs_worker = true;
-                symbolize = true;
-            }
-
-            #[cfg(feature = "worker-s3")]
-            if s3_config.is_some() {
-                needs_worker = true;
-            }
-
-            if !needs_worker {
+            if processors.is_empty() {
                 return None;
             }
 
@@ -1330,16 +1439,14 @@ impl TelemetryCore {
             let metrics_sink =
                 worker_metrics_sink.unwrap_or_else(metrique_writer::sink::DevNullSink::boxed);
 
-            let config = crate::background_task::BackgroundTaskConfig::builder()
-                .trace_path(trace_path)
-                .poll_interval(poll_interval)
-                .symbolize(symbolize)
-                .metrics_sink(metrics_sink);
-
-            #[cfg(feature = "worker-s3")]
-            let config = config.maybe_s3(s3_config).maybe_client(s3_client);
-
-            Some(config.build())
+            Some(
+                crate::background_task::BackgroundTaskConfig::builder()
+                    .trace_path(trace_path)
+                    .poll_interval(poll_interval)
+                    .processors(processors)
+                    .metrics_sink(metrics_sink)
+                    .build(),
+            )
         });
 
         #[allow(unused_mut)]
@@ -1560,7 +1667,7 @@ pub struct TracedRuntime {
 
 impl TracedRuntime {
     /// Create a new [`TracedRuntimeBuilder`].
-    pub fn builder() -> TracedRuntimeBuilder<NoTracePath> {
+    pub fn builder() -> TracedRuntimeBuilder<NoTracePath, PipelineUnset> {
         TracedRuntimeBuilder {
             enabled: true,
             task_tracking_enabled: false,
@@ -1570,10 +1677,8 @@ impl TracedRuntime {
             cpu_profiling_config: None,
             #[cfg(feature = "cpu-profiling")]
             sched_event_config: None,
-            #[cfg(feature = "worker-s3")]
-            s3_config: None,
-            #[cfg(feature = "worker-s3")]
-            s3_client: None,
+            pipeline: PipelineConfig::Unset,
+            segment_metadata: Vec::new(),
             worker_poll_interval: None,
             worker_metrics_sink: None,
             _marker: std::marker::PhantomData,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1046,15 +1046,20 @@ impl<P> TracedRuntimeBuilder<P, PipelineS3> {
         self
     }
 
-    /// Replace the configured S3 uploader. Any previously-set client is
-    /// discarded.
+    /// Replace the configured S3 uploader. A client previously bound via
+    /// [`with_s3_client`](Self::with_s3_client) is carried over to the new
+    /// uploader so that call order between the two is irrelevant.
     pub fn with_s3_uploader(mut self, config: crate::background_task::s3::S3Config) -> Self {
         self.segment_metadata = config
             .as_metadata()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
+        let carried = match &mut self.pipeline {
+            PipelineConfig::S3(uploader) => uploader.take_client(),
+            _ => None,
+        };
         self.pipeline = PipelineConfig::S3(crate::background_task::S3PipelineUploader::new(
-            config, None,
+            config, carried,
         ));
         self
     }
@@ -3018,5 +3023,57 @@ mod tests {
         // The runtime still works end-to-end.
         let value = rt.block_on(async { 21u32 });
         assert_eq!(value, 21);
+    }
+
+    #[cfg(feature = "worker-s3")]
+    #[test]
+    fn with_s3_client_then_with_s3_uploader_preserves_client() {
+        use crate::background_task::s3::S3Config;
+
+        fn dummy_client() -> aws_sdk_s3::Client {
+            let conf = aws_sdk_s3::Config::builder()
+                .behavior_version_latest()
+                .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                    "test", "test", None, None, "test",
+                ))
+                .region(aws_sdk_s3::config::Region::new("us-east-1"))
+                .build();
+            aws_sdk_s3::Client::from_conf(conf)
+        }
+
+        fn cfg(boot_id: &str) -> S3Config {
+            S3Config::builder()
+                .bucket("b")
+                .service_name("s")
+                .boot_id(boot_id)
+                .build()
+        }
+
+        // Order A: client set after the uploader — already worked.
+        let mut builder = TracedRuntime::builder()
+            .with_s3_uploader(cfg("a"))
+            .with_s3_client(dummy_client());
+        match &mut builder.pipeline {
+            PipelineConfig::S3(u) => {
+                assert!(u.take_client().is_some(), "client must be present in order A");
+            }
+            _ => panic!("expected S3 pipeline"),
+        }
+
+        // Order B: client set first, then a follow-up `with_s3_uploader`. The
+        // replacement must carry the previously-bound client across.
+        let mut builder = TracedRuntime::builder()
+            .with_s3_uploader(cfg("a"))
+            .with_s3_client(dummy_client())
+            .with_s3_uploader(cfg("b"));
+        match &mut builder.pipeline {
+            PipelineConfig::S3(u) => {
+                assert!(
+                    u.take_client().is_some(),
+                    "client bound before the second with_s3_uploader must be carried over"
+                );
+            }
+            _ => panic!("expected S3 pipeline"),
+        }
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -920,6 +920,25 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
         self
     }
 
+    /// Set static metadata embedded as a `SegmentMetadata` event in every
+    /// sealed segment file. Read back during analysis and attached to every
+    /// Span.
+    ///
+    /// [`with_s3_uploader`](Self::with_s3_uploader) injects bucket /
+    /// service_name / instance_path / boot_id automatically; call this
+    /// method when using [`with_custom_pipeline`](Self::with_custom_pipeline)
+    /// (or no pipeline) and you still want those entries — or when you want
+    /// to override the preset's defaults.
+    ///
+    /// Repeated calls **replace** the metadata, matching how
+    /// `with_s3_uploader` overwrites on a second call. The last call wins,
+    /// so `with_segment_metadata` placed *after* `with_s3_uploader`
+    /// overrides the preset's injection.
+    pub fn with_segment_metadata(mut self, entries: Vec<(String, String)>) -> Self {
+        self.segment_metadata = entries;
+        self
+    }
+
     /// Enable CPU profiling with the given configuration (Linux only).
     #[cfg(feature = "cpu-profiling")]
     pub fn with_cpu_profiling(
@@ -1027,6 +1046,11 @@ impl<P> TracedRuntimeBuilder<P, PipelineUnset> {
     /// and `.pipe(processor)` for user-supplied processors.
     ///
     /// Mutually exclusive with [`with_s3_uploader`](Self::with_s3_uploader).
+    ///
+    /// Unlike the S3 preset, this path does **not** auto-populate writer-side
+    /// segment metadata — call
+    /// [`with_segment_metadata`](Self::with_segment_metadata) if you want
+    /// identity entries (service, host, etc.) embedded in trace files.
     pub fn with_custom_pipeline<F>(mut self, build: F) -> TracedRuntimeBuilder<P, PipelineCustom>
     where
         F: FnOnce(
@@ -3082,6 +3106,139 @@ mod tests {
                 );
             }
             _ => panic!("expected S3 pipeline"),
+        }
+    }
+
+    /// Pin which builder paths populate `segment_metadata` (the static
+    /// entries the writer embeds as a `SegmentMetadata` event in every
+    /// sealed segment file). Today the S3 preset auto-injects;
+    /// `with_custom_pipeline` does not, so users on that path opt in via
+    /// `with_segment_metadata`.
+    mod segment_metadata_routing {
+        use super::*;
+
+        fn entries<P, M>(builder: &TracedRuntimeBuilder<P, M>) -> &[(String, String)] {
+            &builder.segment_metadata
+        }
+
+        #[cfg(feature = "worker-s3")]
+        fn s3_cfg() -> crate::background_task::s3::S3Config {
+            crate::background_task::s3::S3Config::builder()
+                .bucket("test-bucket")
+                .service_name("checkout-api")
+                .instance_path("us-east-1/i-0abc123")
+                .boot_id("test-boot")
+                .build()
+        }
+
+        #[cfg(feature = "worker-s3")]
+        #[test]
+        fn s3_preset_populates_from_config() {
+            let builder = TracedRuntime::builder().with_s3_uploader(s3_cfg());
+            let m: std::collections::HashMap<&str, &str> = entries(&builder)
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            assert_eq!(m.get("bucket"), Some(&"test-bucket"));
+            assert_eq!(m.get("service_name"), Some(&"checkout-api"));
+            assert_eq!(m.get("instance_path"), Some(&"us-east-1/i-0abc123"));
+            assert_eq!(m.get("boot_id"), Some(&"test-boot"));
+        }
+
+        #[cfg(feature = "worker-s3")]
+        #[test]
+        fn s3_preset_replace_overwrites_metadata() {
+            let cfg2 = crate::background_task::s3::S3Config::builder()
+                .bucket("other-bucket")
+                .service_name("other-svc")
+                .boot_id("other-boot")
+                .build();
+            let builder = TracedRuntime::builder()
+                .with_s3_uploader(s3_cfg())
+                .with_s3_uploader(cfg2);
+            let m: std::collections::HashMap<&str, &str> = entries(&builder)
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            // cfg2 wins; nothing leaks from the first call.
+            assert_eq!(m.get("bucket"), Some(&"other-bucket"));
+            assert_eq!(m.get("service_name"), Some(&"other-svc"));
+            assert_eq!(m.get("boot_id"), Some(&"other-boot"));
+        }
+
+        /// Custom pipeline does NOT auto-populate, even when `b.s3(cfg)` is
+        /// composed inside it. Documented behavior — pinned here so a future
+        /// change is intentional.
+        #[cfg(feature = "worker-s3")]
+        #[test]
+        fn custom_pipeline_with_s3_does_not_auto_populate() {
+            let builder =
+                TracedRuntime::builder().with_custom_pipeline(|b| b.gzip().s3(s3_cfg()));
+            assert!(
+                entries(&builder).is_empty(),
+                "with_custom_pipeline must not auto-inject segment metadata; got {:?}",
+                entries(&builder)
+            );
+        }
+
+        #[test]
+        fn custom_pipeline_without_s3_is_empty() {
+            let builder = TracedRuntime::builder()
+                .with_custom_pipeline(|b| b.gzip().write_back());
+            assert!(entries(&builder).is_empty());
+        }
+
+        #[test]
+        fn unset_pipeline_is_empty() {
+            let builder = TracedRuntime::builder();
+            assert!(entries(&builder).is_empty());
+        }
+
+        /// Custom-pipeline users can recover S3-preset parity by calling
+        /// `with_segment_metadata` explicitly.
+        #[cfg(feature = "worker-s3")]
+        #[test]
+        fn with_segment_metadata_recovers_parity_in_custom_pipeline() {
+            let cfg = s3_cfg();
+            let preset_entries: Vec<(String, String)> = cfg
+                .as_metadata()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            let builder = TracedRuntime::builder()
+                .with_custom_pipeline(|b| b.gzip().s3(s3_cfg()))
+                .with_segment_metadata(preset_entries.clone());
+            assert_eq!(entries(&builder), preset_entries.as_slice());
+        }
+
+        /// `with_segment_metadata` after `with_s3_uploader` overrides the
+        /// preset's injection — last call wins.
+        #[cfg(feature = "worker-s3")]
+        #[test]
+        fn with_segment_metadata_after_s3_overrides_preset() {
+            let custom = vec![("env".to_string(), "prod".to_string())];
+            let builder = TracedRuntime::builder()
+                .with_s3_uploader(s3_cfg())
+                .with_segment_metadata(custom.clone());
+            assert_eq!(entries(&builder), custom.as_slice());
+        }
+
+        /// `with_s3_uploader` after `with_segment_metadata` overwrites the
+        /// custom entries — same "last call wins" rule.
+        #[cfg(feature = "worker-s3")]
+        #[test]
+        fn s3_after_with_segment_metadata_overwrites() {
+            let builder = TracedRuntime::builder()
+                .with_segment_metadata(vec![("env".into(), "prod".into())])
+                .with_s3_uploader(s3_cfg());
+            let m: std::collections::HashMap<&str, &str> = entries(&builder)
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            assert_eq!(m.get("bucket"), Some(&"test-bucket"));
+            assert!(
+                !m.contains_key("env"),
+                "with_s3_uploader should overwrite, not merge"
+            );
         }
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -834,25 +834,30 @@ impl Drop for TelemetryGuard {
 
 /// Marker: no trace path has been set yet.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct NoTracePath;
 /// Marker: a trace path has been set.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct HasTracePath;
 
 /// Marker: no pipeline strategy has been chosen yet. From this state the
 /// builder can transition to either S3 (via `with_s3_uploader`) or a custom
 /// pipeline (via `with_custom_pipeline`).
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct PipelineUnset;
 
 /// Marker: the S3 preset has been selected. `with_s3_client` is available
 /// to bind a pre-built client; `with_custom_pipeline` is not in scope.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct PipelineS3;
 
 /// Marker: a custom pipeline has been configured. No further pipeline
 /// methods are available.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct PipelineCustom;
 
 enum PipelineConfig {

--- a/examples/metrics-service/src/main.rs
+++ b/examples/metrics-service/src/main.rs
@@ -165,17 +165,15 @@ fn main() -> std::io::Result<()> {
 
     let mut builder = Builder::new_multi_thread();
     builder.worker_threads(args.worker_threads).enable_all();
-    #[allow(unused_mut)]
-    let mut traced_builder = TracedRuntime::builder()
+    let traced_builder = TracedRuntime::builder()
         .with_trace_path(&args.trace_path)
         .with_task_tracking(true);
     #[cfg(target_os = "linux")]
-    {
-        traced_builder = traced_builder
-            .with_cpu_profiling(CpuProfilingConfig::default())
-            .with_sched_events(SchedEventConfig::default().include_kernel(true));
-    }
-    if let Some(bucket) = &args.s3_bucket {
+    let traced_builder = traced_builder
+        .with_cpu_profiling(CpuProfilingConfig::default())
+        .with_sched_events(SchedEventConfig::default().include_kernel(true));
+
+    let (runtime, guard) = if let Some(bucket) = &args.s3_bucket {
         use dial9_tokio_telemetry::background_task::s3::S3Config;
 
         let s3_config = S3Config::builder()
@@ -192,9 +190,12 @@ fn main() -> std::io::Result<()> {
             .maybe_region(args.s3_region.as_ref())
             .build();
 
-        traced_builder = traced_builder.with_s3_uploader(s3_config);
-    }
-    let (runtime, guard) = traced_builder.build(builder, writer)?;
+        traced_builder
+            .with_s3_uploader(s3_config)
+            .build(builder, writer)?
+    } else {
+        traced_builder.build(builder, writer)?
+    };
     guard.enable();
     let handle = guard.handle();
 


### PR DESCRIPTION
closes #144 

## Summary
Open up the worker pipeline so users can plug in their own segment processors. Previously, the worker had a hard-coded chain `([Symbolize?, Gzip, S3 or WriteBack])` and S3 was the only supported sink. This PR turns the chain into a first-class public API and reorganizes the builder around it.
                                                                                                        
###  Core decisions  
  1. Make `SegmentProcessor` a public trait, with a `PipelineBuilder` for composition. Users can now implement processors and chain them with `.pipe(...)` **(Are we ok with this naming?)** alongside built-ins `(.gzip(), .write_back(), .s3(), .symbolize())`. `SegmentData`, `ProcessError`, and `SealedSegment` are also lifted to public, with accessors and constructors, so any third-party processor has what they need without reaching into internals.                                                         
  2. PipelineBuilder doesn't add any steps, leaving the user full control over the pipeline. `PipelineBuilder::s3()` deliberately does not auto-gzip; the user chains `.gzip().s3(cfg)` if they want compressed uploads. Hiding implicit steps in the primitive makes downstream surprises hard to debug. Presets (with_s3_uploader) are the place to compose, the builder is the place to be literal.
  3. Pipeline strategy is enforced at the type level. `TracedRuntimeBuilder<P, M>` gains a second marker: PipelineUnset > either `PipelineS3` (via `with_s3_uploader`) or `PipelineCustom` (via `with_custom_pipeline`). The two are mutually exclusive at compile time, so misconfigurations like "S3 preset and a custom chain" become unrepresentable. Once in PipelineS3, only S3-shaped tweaks (`with_s3_client`, replacing the uploader) remain in scope; once in `PipelineCustom`, the pipeline is frozen.
  4. `S3PipelineUploader::new` is now synchronous;  Previously new was async, which forced a tokio runtime at builder time. The uploader now holds a `Pending { config, client: Option<_> } / Ready { ... }` state and resolves the client + bucket region on the first `process()` call, inside the worker's own runtime. The whole runtime-builder API can stay sync end-to-end.                                                                                                                        
  5. `with_s3_uploader` and `with_s3_client` are call-order independent. The previous shape silently dropped the client when `with_s3_client` was followed by `with_s3_uploader` (the replacement uploader was rebuilt without it). Fixed by `S3PipelineUploader::take_client`, which carries a pending client across uploader replacement. There's a regression test for it.
  6. The worker is now pipeline-agnostic. `BackgroundTaskConfig` no longer carries s3, client, or symbolize fields. It takes a `Vec<Box<dyn SegmentProcessor>>` and runs them. Strategy-to-processor desugaring lives in one place (assemble_processors), with a documented behaviour matrix:                    
 