### PR TITLE
Follow up - Expose runtime pipeline

### DIFF
--- a/dial9-tokio-telemetry/src/background_task/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/mod.rs
@@ -905,12 +905,17 @@ impl S3PipelineUploader {
         }
     }
 
-    /// Set (or override) the pre-built S3 client. Only effective before
-    /// the uploader has been initialized (i.e. before the first segment
-    /// has been processed); otherwise this is a no-op.
+    /// Set (or override) the pre-built S3 client. Must be called before the
+    /// uploader has been initialized (i.e. before the first segment has been
+    /// processed);
+    /// Note: the only caller is the builder, which runs before the
+    /// worker is spawned, so reaching the `Ready` arm is a programmer error.
     pub(crate) fn set_client(&mut self, client: aws_sdk_s3::Client) {
-        if let S3UploaderState::Pending { client: slot, .. } = &mut self.state {
-            *slot = Some(client);
+        match &mut self.state {
+            S3UploaderState::Pending { client: slot, .. } => *slot = Some(client),
+            S3UploaderState::Ready { .. } => {
+                unreachable!("set_client called after uploader initialization")
+            }
         }
     }
 
@@ -1257,6 +1262,38 @@ mod tests {
             "CompressedSize should be non-zero, got {}",
             compressed
         );
+    }
+
+    /// `set_client` is only valid while the uploader is `Pending`. Calling it
+    /// on a `Ready` uploader indicates an internal misuse and must panic
+    /// rather than silently drop the new client.
+    #[test]
+    #[should_panic(expected = "set_client called after uploader initialization")]
+    fn set_client_after_ready_panics() {
+        let s3_config = s3::S3Config::builder()
+            .bucket("test")
+            .service_name("test")
+            .instance_path("test")
+            .boot_id("test")
+            .region("us-east-1")
+            .build();
+        let sdk_config = aws_sdk_s3::Config::builder()
+            .behavior_version_latest()
+            .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                "test", "test", None, None, "test",
+            ))
+            .region(aws_sdk_s3::config::Region::new("us-east-1"))
+            .build();
+        let sdk_client = aws_sdk_s3::Client::from_conf(sdk_config);
+        let tm_client = aws_sdk_s3_transfer_manager::Client::new(
+            aws_sdk_s3_transfer_manager::Config::builder()
+                .client(sdk_client.clone())
+                .build(),
+        );
+        let uploader = s3::S3Uploader::new(tm_client, s3_config);
+        let mut pipeline_uploader =
+            S3PipelineUploader::from_ready(uploader, connection::CircuitBreaker::new());
+        pipeline_uploader.set_client(sdk_client);
     }
 
     // --- Review finding #10: uncompressed_size should use bytes.len() ---

--- a/dial9-tokio-telemetry/src/background_task/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/mod.rs
@@ -350,6 +350,11 @@ impl PipelineBuilder {
 
     /// Resolve stack-frame addresses in the segment to symbol names.
     /// Only valid when the runtime is built with the `cpu-profiling` feature.
+    ///
+    /// The built-in S3 / default presets prepend this automatically when
+    /// CPU profiling is on; on the custom path the pipeline is passed
+    /// through verbatim, so chain `.symbolize()` first if you want
+    /// symbolized stack frames in your trace files.
     #[cfg(feature = "cpu-profiling")]
     pub fn symbolize(mut self) -> Self {
         self.processors.push(Box::new(SymbolizeProcessor));

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1095,10 +1095,16 @@ impl<P> TracedRuntimeBuilder<P, PipelineUnset> {
     ///
     /// Mutually exclusive with [`with_s3_uploader`](Self::with_s3_uploader).
     ///
-    /// Unlike the S3 preset, this path does **not** auto-populate writer-side
-    /// segment metadata — call
-    /// [`with_segment_metadata`](Self::with_segment_metadata) if you want
-    /// identity entries (service, host, etc.) embedded in trace files.
+    /// This is the "full control" path: the resulting pipeline is exactly
+    /// what the closure builds, with nothing prepended or appended. In
+    /// particular, unlike the S3 preset, this path does **not**:
+    /// - auto-populate writer-side segment metadata — call
+    ///   [`with_segment_metadata`](Self::with_segment_metadata) if you want
+    ///   identity entries (service, host, etc.) embedded in trace files.
+    /// - auto-prepend the `Symbolize` step when CPU profiling is enabled.
+    ///   Chain
+    ///   [`.symbolize()`](crate::background_task::PipelineBuilder::symbolize)
+    ///   first if you want symbolized stack frames.
     pub fn with_custom_pipeline<F>(mut self, build: F) -> TracedRuntimeBuilder<P, PipelineCustom>
     where
         F: FnOnce(
@@ -1299,8 +1305,11 @@ impl<M> TracedRuntimeBuilder<HasTracePath, M> {
 
 /// Build the final processor pipeline.
 ///
-/// `Symbolize` is auto-prepended whenever CPU profiling is enabled,
-/// regardless of pipeline strategy.
+/// `Symbolize` is auto-prepended for the built-in presets (`Unset`, `S3`)
+/// when CPU profiling is enabled. The `Custom` path is "full control" — the
+/// user's processor list is passed through verbatim, and they're expected to
+/// chain [`PipelineBuilder::symbolize`](crate::background_task::PipelineBuilder::symbolize)
+/// themselves if they want symbolization.
 ///
 /// Behaviour matrix:
 ///
@@ -1308,7 +1317,7 @@ impl<M> TracedRuntimeBuilder<HasTracePath, M> {
 /// |----------|--------------------------------|-------------------|
 /// | Unset    | `[Symbolize, Gzip, WriteBack]` | (worker skipped)  |
 /// | S3       | `[Symbolize, Gzip, S3]`        | `[Gzip, S3]`      |
-/// | Custom   | `[Symbolize, ...user]`         | `[...user]`       |
+/// | Custom   | `[...user]`                    | `[...user]`       |
 fn assemble_processors(
     #[cfg(feature = "cpu-profiling")] cpu_profiling_enabled: bool,
     pipeline: PipelineConfig,
@@ -1321,17 +1330,21 @@ fn assemble_processors(
     }
 
     let mut processors: Vec<Box<dyn crate::background_task::SegmentProcessor>> = Vec::new();
-    #[cfg(feature = "cpu-profiling")]
-    if cpu_profiling_enabled {
-        processors.push(Box::new(crate::background_task::SymbolizeProcessor));
-    }
     match pipeline {
         PipelineConfig::Unset => {
+            #[cfg(feature = "cpu-profiling")]
+            if cpu_profiling_enabled {
+                processors.push(Box::new(crate::background_task::SymbolizeProcessor));
+            }
             processors.push(Box::new(crate::background_task::GzipCompressor));
             processors.push(Box::new(crate::background_task::WriteBackProcessor));
         }
         #[cfg(feature = "worker-s3")]
         PipelineConfig::S3(uploader) => {
+            #[cfg(feature = "cpu-profiling")]
+            if cpu_profiling_enabled {
+                processors.push(Box::new(crate::background_task::SymbolizeProcessor));
+            }
             processors.push(Box::new(crate::background_task::GzipCompressor));
             processors.push(Box::new(uploader));
         }


### PR DESCRIPTION
follow-up for #355 

### Summary
Since some comments from @noxware were not adressed, this PR proposes continuation to it.

> 
> Since the discussed idea was to have "a custom path where the user can fully pick their own list of pipeline stages", having a Symbolize stage still added automatically may defeat the purpose of the PipelineConfig::Custom path.
> 
> And it may be difficult to remove this implicit step in future versions of the library, similar to what happens with the gzip step in the default s3 flow. But well, at least that default is the "easy path", but this is the "full control path", so doing something like that here is probably riskier.

Adressed at [1cd6](https://github.com/dial9-rs/dial9-tokio-telemetry/commit/1cd608ac6b6b2343c71ef93bd5b983899ebddc3e)

> 
> Can the final user trigger this incorrectly from public APIs? Or the no-op disclaimer is only relevant internally?
> 
> In any case, debugging a no-op (if ever happens) would be a nightmare, so I would not do this silently. I would at least emit a warning. If it's not possible to cause this assuming correct internal code, I may even consider a panic, maybe backed up by a unit test.

Adressed at [8e95](https://github.com/dial9-rs/dial9-tokio-telemetry/commit/8e95d98628ae9fc00f6b68e3c15ed5fcd7c08f94)