### PR TITLE
feat!: Add TAG_SCHEMA_ANNOTATIONS frame and SchemaEntry::annotations

### DIFF
--- a/dial9-trace-format/SPEC.md
+++ b/dial9-trace-format/SPEC.md
@@ -38,8 +38,7 @@ Every frame begins with a 1-byte tag:
 | `0x03` | String Pool |
 | `0x04` | Stack Pool |
 | `0x05` | Timestamp Reset |
-| `0x06` | *(reserved)* |
-| `0x07` | Schema Annotations |
+| `0x06` | Schema Annotations |
 
 Unknown tags **must** cause the decoder to stop (the stream cannot be advanced without knowing the frame size).
 
@@ -151,14 +150,14 @@ Total: **9 bytes**.
 
 After decoding this frame, the decoder sets `timestamp_base_ns = timestamp_ns`. The next event's `timestamp_delta_ns` is relative to this new base.
 
-### Schema Annotations Frame (`0x07`)
+### Schema Annotations Frame (`0x06`)
 
 Carries per-field metadata for a previously-registered schema. Annotations are key-value string pairs attached to individual fields by index. A schema with no annotations produces no annotation frame.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| tag | u8 | `0x07` |
-| type_id | u16 | References a schema's `type_id` |
+| tag | u8 | `0x06` |
+| type_id | LEB128 u64 | References a schema's `type_id` (varint-encoded to allow future overflow beyond u16) |
 | count | u16 | Number of annotation entries |
 | entries | [FieldAnnotation; count] | Annotation entries (see below) |
 

--- a/dial9-trace-format/SPEC.md
+++ b/dial9-trace-format/SPEC.md
@@ -39,6 +39,7 @@ Every frame begins with a 1-byte tag:
 | `0x04` | Stack Pool |
 | `0x05` | Timestamp Reset |
 | `0x06` | *(reserved)* |
+| `0x07` | Schema Annotations |
 
 Unknown tags **must** cause the decoder to stop (the stream cannot be advanced without knowing the frame size).
 
@@ -149,6 +150,31 @@ Resets the running timestamp base used for packed event timestamps. The encoder 
 Total: **9 bytes**.
 
 After decoding this frame, the decoder sets `timestamp_base_ns = timestamp_ns`. The next event's `timestamp_delta_ns` is relative to this new base.
+
+### Schema Annotations Frame (`0x07`)
+
+Carries per-field metadata for a previously-registered schema. Annotations are key-value string pairs attached to individual fields by index. A schema with no annotations produces no annotation frame.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tag | u8 | `0x07` |
+| type_id | u16 | References a schema's `type_id` |
+| count | u16 | Number of annotation entries |
+| entries | [FieldAnnotation; count] | Annotation entries (see below) |
+
+Each **FieldAnnotation**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| field_index | u16 | Index into the schema's field list (0-based) |
+| key_len | u16 | Length of key in bytes |
+| key | [u8; key_len] | UTF-8 annotation key (e.g. `metrique.unit`) |
+| value_len | u32 | Length of value in bytes |
+| value | [u8; value_len] | UTF-8 annotation value (e.g. `microseconds`) |
+
+Multiple annotation frames for the same `type_id` are permitted; the decoder accumulates entries. The encoder typically emits one annotation frame immediately after the schema frame it annotates, but the format does not mandate ordering beyond the requirement that the referenced `type_id` must already be registered.
+
+A decoder that encounters an annotation frame referencing an unknown `type_id` may skip it leniently (the annotations have nowhere to attach).
 
 ## Field Types
 

--- a/dial9-trace-format/src/codec.rs
+++ b/dial9-trace-format/src/codec.rs
@@ -26,8 +26,7 @@ pub(crate) const TAG_EVENT: u8 = 0x02;
 pub(crate) const TAG_STRING_POOL: u8 = 0x03;
 pub(crate) const TAG_STACK_POOL: u8 = 0x04;
 pub(crate) const TAG_TIMESTAMP_RESET: u8 = 0x05;
-// Tag 0x06 is reserved (formerly ProcMaps, now schema-based events).
-pub(crate) const TAG_SCHEMA_ANNOTATIONS: u8 = 0x07;
+pub(crate) const TAG_SCHEMA_ANNOTATIONS: u8 = 0x06;
 
 /// Maximum nanosecond delta that fits in a u24 (3 bytes).
 pub(crate) const MAX_TIMESTAMP_DELTA_NS: u64 = 0xFF_FFFF; // 16,777,215
@@ -234,14 +233,14 @@ pub(crate) fn encode_schema_annotations(
         )
     })?;
     w.write_all(&[TAG_SCHEMA_ANNOTATIONS])?;
-    w.write_all(&type_id.0.to_le_bytes())?;
+    crate::leb128::encode_unsigned(type_id.0 as u64, w)?;
     w.write_all(&count.to_le_bytes())?;
     for a in annotations {
-        w.write_all(&a.field_index.to_le_bytes())?;
-        let key_bytes = a.key.as_bytes();
+        w.write_all(&a.field_index().to_le_bytes())?;
+        let key_bytes = a.key().as_bytes();
         w.write_all(&(key_bytes.len() as u16).to_le_bytes())?;
         w.write_all(key_bytes)?;
-        let value_bytes = a.value.as_bytes();
+        let value_bytes = a.value().as_bytes();
         w.write_all(&(value_bytes.len() as u32).to_le_bytes())?;
         w.write_all(value_bytes)?;
     }
@@ -410,8 +409,9 @@ fn decode_stack_pool_frame(data: &[u8]) -> Option<(Frame, usize)> {
 
 fn decode_schema_annotations_frame(data: &[u8]) -> Option<(Frame, usize)> {
     let mut pos = 1; // skip tag
-    let type_id = WireTypeId(u16::from_le_bytes(data.get(pos..pos + 2)?.try_into().ok()?));
-    pos += 2;
+    let (type_id_raw, consumed) = crate::leb128::decode_unsigned(&data[pos..])?;
+    let type_id = WireTypeId(type_id_raw as u16);
+    pos += consumed;
     let count = u16::from_le_bytes(data.get(pos..pos + 2)?.try_into().ok()?) as usize;
     pos += 2;
     let mut annotations = Vec::with_capacity(count);
@@ -426,11 +426,7 @@ fn decode_schema_annotations_frame(data: &[u8]) -> Option<(Frame, usize)> {
         pos += 4;
         let value = String::from_utf8(data.get(pos..pos + value_len)?.to_vec()).ok()?;
         pos += value_len;
-        annotations.push(FieldAnnotation {
-            field_index,
-            key,
-            value,
-        });
+        annotations.push(FieldAnnotation::new(field_index, key, value));
     }
     Some((
         Frame::SchemaAnnotations {

--- a/dial9-trace-format/src/codec.rs
+++ b/dial9-trace-format/src/codec.rs
@@ -5,7 +5,7 @@
 //! instead. The types [`WireTypeId`], [`PoolEntry`], and [`PoolEntryRef`] are
 //! re-exported here because they appear in the decoder's public API.
 
-use crate::schema::{FieldDef, SchemaEntry};
+use crate::schema::{FieldAnnotation, FieldDef, SchemaEntry};
 use crate::types::{FieldType, FieldValue, FieldValueRef};
 use std::io::{self, Write};
 
@@ -27,6 +27,7 @@ pub(crate) const TAG_STRING_POOL: u8 = 0x03;
 pub(crate) const TAG_STACK_POOL: u8 = 0x04;
 pub(crate) const TAG_TIMESTAMP_RESET: u8 = 0x05;
 // Tag 0x06 is reserved (formerly ProcMaps, now schema-based events).
+pub(crate) const TAG_SCHEMA_ANNOTATIONS: u8 = 0x07;
 
 /// Maximum nanosecond delta that fits in a u24 (3 bytes).
 pub(crate) const MAX_TIMESTAMP_DELTA_NS: u64 = 0xFF_FFFF; // 16,777,215
@@ -78,6 +79,10 @@ pub(crate) enum Frame {
     StringPool(Vec<PoolEntry>),
     StackPool(Vec<StackPoolEntry>),
     TimestampReset(u64),
+    SchemaAnnotations {
+        type_id: WireTypeId,
+        annotations: Vec<FieldAnnotation>,
+    },
 }
 
 /// Zero-copy pool entry borrowing from the input buffer.
@@ -132,6 +137,10 @@ pub(crate) enum FrameRef<'a> {
     StringPool(Vec<PoolEntryRef<'a>>),
     StackPool(Vec<StackPoolEntryRef<'a>>),
     TimestampReset(u64),
+    SchemaAnnotations {
+        type_id: WireTypeId,
+        annotations: Vec<FieldAnnotation>,
+    },
 }
 
 /// Schema info needed by the decoder: raw field type tags + has_timestamp flag.
@@ -213,6 +222,32 @@ pub(crate) fn encode_stack_pool(entries: &[StackPoolEntry], w: &mut impl Write) 
     Ok(())
 }
 
+pub(crate) fn encode_schema_annotations(
+    type_id: WireTypeId,
+    annotations: &[FieldAnnotation],
+    w: &mut impl Write,
+) -> io::Result<()> {
+    let count: u16 = annotations.len().try_into().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "annotation count exceeds u16::MAX",
+        )
+    })?;
+    w.write_all(&[TAG_SCHEMA_ANNOTATIONS])?;
+    w.write_all(&type_id.0.to_le_bytes())?;
+    w.write_all(&count.to_le_bytes())?;
+    for a in annotations {
+        w.write_all(&a.field_index.to_le_bytes())?;
+        let key_bytes = a.key.as_bytes();
+        w.write_all(&(key_bytes.len() as u16).to_le_bytes())?;
+        w.write_all(key_bytes)?;
+        let value_bytes = a.value.as_bytes();
+        w.write_all(&(value_bytes.len() as u32).to_le_bytes())?;
+        w.write_all(value_bytes)?;
+    }
+    Ok(())
+}
+
 // --- Decoding ---
 
 pub(crate) fn decode_header(data: &[u8]) -> Option<u8> {
@@ -239,6 +274,7 @@ pub(crate) fn decode_frame<'s>(
             let ts = u64::from_le_bytes(data.get(1..9)?.try_into().ok()?);
             Some((Frame::TimestampReset(ts), 9))
         }
+        TAG_SCHEMA_ANNOTATIONS => decode_schema_annotations_frame(data),
         _ => None,
     }
 }
@@ -276,6 +312,7 @@ fn decode_schema_frame(data: &[u8]) -> Option<(Frame, usize)> {
                 name,
                 has_timestamp,
                 fields,
+                annotations: Vec::new(),
             },
         },
         pos,
@@ -371,6 +408,39 @@ fn decode_stack_pool_frame(data: &[u8]) -> Option<(Frame, usize)> {
     Some((Frame::StackPool(entries), pos))
 }
 
+fn decode_schema_annotations_frame(data: &[u8]) -> Option<(Frame, usize)> {
+    let mut pos = 1; // skip tag
+    let type_id = WireTypeId(u16::from_le_bytes(data.get(pos..pos + 2)?.try_into().ok()?));
+    pos += 2;
+    let count = u16::from_le_bytes(data.get(pos..pos + 2)?.try_into().ok()?) as usize;
+    pos += 2;
+    let mut annotations = Vec::with_capacity(count);
+    for _ in 0..count {
+        let field_index = u16::from_le_bytes(data.get(pos..pos + 2)?.try_into().ok()?);
+        pos += 2;
+        let key_len = u16::from_le_bytes(data.get(pos..pos + 2)?.try_into().ok()?) as usize;
+        pos += 2;
+        let key = String::from_utf8(data.get(pos..pos + key_len)?.to_vec()).ok()?;
+        pos += key_len;
+        let value_len = u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?) as usize;
+        pos += 4;
+        let value = String::from_utf8(data.get(pos..pos + value_len)?.to_vec()).ok()?;
+        pos += value_len;
+        annotations.push(FieldAnnotation {
+            field_index,
+            key,
+            value,
+        });
+    }
+    Some((
+        Frame::SchemaAnnotations {
+            type_id,
+            annotations,
+        },
+        pos,
+    ))
+}
+
 // --- Zero-copy decoding ---
 
 /// Decode a single frame without allocating owned data for field values.
@@ -396,6 +466,22 @@ pub(crate) fn decode_frame_ref<'a, 's>(
         TAG_TIMESTAMP_RESET => {
             let ts = u64::from_le_bytes(data.get(1..9)?.try_into().ok()?);
             Some((FrameRef::TimestampReset(ts), 9))
+        }
+        TAG_SCHEMA_ANNOTATIONS => {
+            let (frame, consumed) = decode_schema_annotations_frame(data)?;
+            match frame {
+                Frame::SchemaAnnotations {
+                    type_id,
+                    annotations,
+                } => Some((
+                    FrameRef::SchemaAnnotations {
+                        type_id,
+                        annotations,
+                    },
+                    consumed,
+                )),
+                _ => unreachable!(),
+            }
         }
         _ => None,
     }
@@ -519,6 +605,7 @@ mod tests {
                 name: "worker".into(),
                 field_type: FieldType::Varint,
             }],
+            annotations: Vec::new(),
         };
         let mut buf = Vec::new();
         encode_schema(type_id, &entry, &mut buf).unwrap();
@@ -535,6 +622,7 @@ mod tests {
             name: "Empty".into(),
             has_timestamp: false,
             fields: vec![],
+            annotations: Vec::new(),
         };
         let mut buf = Vec::new();
         encode_schema(type_id, &entry, &mut buf).unwrap();

--- a/dial9-trace-format/src/decoder.rs
+++ b/dial9-trace-format/src/decoder.rs
@@ -152,6 +152,10 @@ pub enum DecodedFrame {
     },
     StringPool(Vec<PoolEntry>),
     StackPool(Vec<StackPoolEntry>),
+    SchemaAnnotations {
+        type_id: WireTypeId,
+        annotations: Vec<crate::schema::FieldAnnotation>,
+    },
 }
 
 /// Zero-copy decoded frame that borrows from the input buffer.
@@ -165,6 +169,10 @@ pub enum DecodedFrameRef<'a> {
     },
     StringPool(Vec<PoolEntryRef<'a>>),
     StackPool(Vec<StackPoolEntryRef<'a>>),
+    SchemaAnnotations {
+        type_id: WireTypeId,
+        annotations: Vec<crate::schema::FieldAnnotation>,
+    },
 }
 
 struct SchemaCache {
@@ -343,6 +351,26 @@ impl<'a> Decoder<'a> {
                 self.timestamp_base_ns = ts;
                 self.next_frame() // consume silently, return next real frame
             }
+            Frame::SchemaAnnotations {
+                type_id,
+                annotations,
+            } => {
+                // Merge annotations into the cached schema (lenient: skip if unknown type_id)
+                if let Some(cache) = self
+                    .schema_cache
+                    .get_mut(type_id.0 as usize)
+                    .and_then(|s| s.as_mut())
+                {
+                    cache.entry.annotations.extend_from_slice(&annotations);
+                }
+                if let Some(entry) = self.registry.schemas.get_mut(&type_id) {
+                    entry.annotations.extend_from_slice(&annotations);
+                }
+                Ok(Some(DecodedFrame::SchemaAnnotations {
+                    type_id,
+                    annotations,
+                }))
+            }
         }
     }
 
@@ -415,6 +443,25 @@ impl<'a> Decoder<'a> {
             FrameRef::TimestampReset(ts) => {
                 self.timestamp_base_ns = ts;
                 self.next_frame_ref()
+            }
+            FrameRef::SchemaAnnotations {
+                type_id,
+                annotations,
+            } => {
+                if let Some(cache) = self
+                    .schema_cache
+                    .get_mut(type_id.0 as usize)
+                    .and_then(|s| s.as_mut())
+                {
+                    cache.entry.annotations.extend_from_slice(&annotations);
+                }
+                if let Some(entry) = self.registry.schemas.get_mut(&type_id) {
+                    entry.annotations.extend_from_slice(&annotations);
+                }
+                Ok(Some(DecodedFrameRef::SchemaAnnotations {
+                    type_id,
+                    annotations,
+                }))
             }
         }
     }

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -117,7 +117,17 @@ impl Schema {
                 name: name.to_string(),
                 has_timestamp: true,
                 fields,
+                annotations: Vec::new(),
             }),
+            name_key,
+        }
+    }
+
+    /// Create a schema handle from a complete [`SchemaEntry`].
+    pub fn from_entry(entry: SchemaEntry) -> Self {
+        let name_key: Arc<str> = Arc::from(entry.name.as_str());
+        Self {
+            entry: Arc::new(entry),
             name_key,
         }
     }
@@ -305,6 +315,13 @@ impl<W: Write> Encoder<W> {
         }
         let id = self.registry.next_type_id();
         codec::encode_schema(id, &schema.entry, &mut self.state.writer)?;
+        if !schema.entry.annotations.is_empty() {
+            codec::encode_schema_annotations(
+                id,
+                &schema.entry.annotations,
+                &mut self.state.writer,
+            )?;
+        }
         self.registry
             .register(id, (*schema.entry).clone())
             .expect("schema registration failed");
@@ -329,6 +346,14 @@ impl<W: Write> Encoder<W> {
         let schema = Schema::new(name, fields);
         self.ensure_registered(&schema)?;
         Ok(schema)
+    }
+
+    /// Register a pre-built [`Schema`] handle with this encoder.
+    ///
+    /// Eagerly writes the schema frame (and annotation frame if annotations
+    /// are present). Idempotent if the definition matches.
+    pub fn register_existing(&mut self, schema: &Schema) -> io::Result<WireTypeId> {
+        self.ensure_registered(schema)
     }
 
     /// Write an event for a schema.

--- a/dial9-trace-format/src/lib.rs
+++ b/dial9-trace-format/src/lib.rs
@@ -70,6 +70,7 @@ pub trait TraceEvent {
             name: Self::event_name().to_string(),
             has_timestamp: Self::has_timestamp(),
             fields: Self::field_defs(),
+            annotations: Vec::new(),
         }
     }
 }

--- a/dial9-trace-format/src/schema.rs
+++ b/dial9-trace-format/src/schema.rs
@@ -23,11 +23,7 @@ pub struct FieldAnnotation {
 
 impl FieldAnnotation {
     /// Create a new field annotation.
-    pub fn new(
-        field_index: u16,
-        key: impl Into<String>,
-        value: impl Into<String>,
-    ) -> Self {
+    pub fn new(field_index: u16, key: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
             field_index,
             key: Cow::Owned(key.into()),

--- a/dial9-trace-format/src/schema.rs
+++ b/dial9-trace-format/src/schema.rs
@@ -7,6 +7,34 @@ use crate::codec::WireTypeId;
 use crate::encoder::FxHashMap;
 use crate::types::FieldType;
 
+/// A per-field annotation carrying arbitrary key-value metadata.
+///
+/// Annotations are emitted in a separate frame (`TAG_SCHEMA_ANNOTATIONS`)
+/// after the schema frame they belong to. They carry metadata such as units,
+/// display hints, or semantic-convention labels.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldAnnotation {
+    /// Index of the field this annotation applies to (0-based, matching the
+    /// field order in [`SchemaEntry::fields`]).
+    pub field_index: u16,
+    /// Annotation key (e.g. `"metrique.unit"`).
+    pub key: String,
+    /// Annotation value (e.g. `"microseconds"`).
+    pub value: String,
+}
+
+impl FieldAnnotation {
+    /// Create a new field annotation.
+    pub fn new(field_index: u16, key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            field_index,
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
 /// A single field within a schema: a name and a [`FieldType`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldDef {
@@ -28,6 +56,9 @@ pub struct SchemaEntry {
     pub has_timestamp: bool,
     /// Ordered list of fields (excluding the timestamp, which is in the header).
     pub fields: Vec<FieldDef>,
+    /// Per-field annotations (metadata such as units, display hints).
+    /// Empty by default; carried in a separate wire frame.
+    pub annotations: Vec<FieldAnnotation>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -111,6 +142,7 @@ mod tests {
                     field_type: FieldType::Varint,
                 },
             ],
+            annotations: Vec::new(),
         };
         reg.register(id, entry.clone()).unwrap();
         assert_eq!(reg.get(id), Some(&entry));
@@ -125,6 +157,7 @@ mod tests {
             name: "A".into(),
             has_timestamp: true,
             fields: vec![],
+            annotations: Vec::new(),
         };
         reg.register(id, entry.clone()).unwrap();
         reg.register(id, entry).unwrap();
@@ -140,6 +173,7 @@ mod tests {
                 name: "A".into(),
                 has_timestamp: true,
                 fields: vec![],
+                annotations: Vec::new(),
             },
         )
         .unwrap();
@@ -149,7 +183,8 @@ mod tests {
                 SchemaEntry {
                     name: "B".into(),
                     has_timestamp: true,
-                    fields: vec![]
+                    fields: vec![],
+                    annotations: Vec::new(),
                 }
             )
             .is_err()
@@ -166,6 +201,7 @@ mod tests {
                 name: "A".into(),
                 has_timestamp: true,
                 fields: vec![],
+                annotations: Vec::new(),
             },
         )
         .unwrap();
@@ -176,6 +212,7 @@ mod tests {
                 name: "B".into(),
                 has_timestamp: true,
                 fields: vec![],
+                annotations: Vec::new(),
             },
         )
         .unwrap();

--- a/dial9-trace-format/src/schema.rs
+++ b/dial9-trace-format/src/schema.rs
@@ -6,6 +6,7 @@
 use crate::codec::WireTypeId;
 use crate::encoder::FxHashMap;
 use crate::types::FieldType;
+use std::borrow::Cow;
 
 /// A per-field annotation carrying arbitrary key-value metadata.
 ///
@@ -15,23 +16,39 @@ use crate::types::FieldType;
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldAnnotation {
-    /// Index of the field this annotation applies to (0-based, matching the
-    /// field order in [`SchemaEntry::fields`]).
-    pub field_index: u16,
-    /// Annotation key (e.g. `"metrique.unit"`).
-    pub key: String,
-    /// Annotation value (e.g. `"microseconds"`).
-    pub value: String,
+    field_index: u16,
+    key: Cow<'static, str>,
+    value: Cow<'static, str>,
 }
 
 impl FieldAnnotation {
     /// Create a new field annotation.
-    pub fn new(field_index: u16, key: impl Into<String>, value: impl Into<String>) -> Self {
+    pub fn new(
+        field_index: u16,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
         Self {
             field_index,
-            key: key.into(),
-            value: value.into(),
+            key: Cow::Owned(key.into()),
+            value: Cow::Owned(value.into()),
         }
+    }
+
+    /// Index of the field this annotation applies to (0-based, matching the
+    /// field order in [`SchemaEntry::fields`]).
+    pub fn field_index(&self) -> u16 {
+        self.field_index
+    }
+
+    /// Annotation key (e.g. `"metrique.unit"`).
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Annotation value (e.g. `"microseconds"`).
+    pub fn value(&self) -> &str {
+        &self.value
     }
 }
 

--- a/dial9-trace-format/tests/annotations.rs
+++ b/dial9-trace-format/tests/annotations.rs
@@ -59,15 +59,15 @@ fn annotations_round_trip() {
             } => {
                 assert_eq!(*type_id, WireTypeId(0));
                 assert_eq!(annotations.len(), 3);
-                assert_eq!(annotations[0].field_index, 0);
-                assert_eq!(annotations[0].key, "metrique.unit");
-                assert_eq!(annotations[0].value, "microseconds");
-                assert_eq!(annotations[1].field_index, 1);
-                assert_eq!(annotations[1].key, "dial9.display");
-                assert_eq!(annotations[1].value, "label");
-                assert_eq!(annotations[2].field_index, 0);
-                assert_eq!(annotations[2].key, "dial9.kpi");
-                assert_eq!(annotations[2].value, "true");
+                assert_eq!(annotations[0].field_index(), 0);
+                assert_eq!(annotations[0].key(), "metrique.unit");
+                assert_eq!(annotations[0].value(), "microseconds");
+                assert_eq!(annotations[1].field_index(), 1);
+                assert_eq!(annotations[1].key(), "dial9.display");
+                assert_eq!(annotations[1].value(), "label");
+                assert_eq!(annotations[2].field_index(), 0);
+                assert_eq!(annotations[2].key(), "dial9.kpi");
+                assert_eq!(annotations[2].value(), "true");
                 saw_annotations = true;
             }
             _ => {}
@@ -79,7 +79,7 @@ fn annotations_round_trip() {
     // Verify annotations are merged into the registry
     let registry_entry = dec.registry().get(WireTypeId(0)).unwrap();
     assert_eq!(registry_entry.annotations.len(), 3);
-    assert_eq!(registry_entry.annotations[0].key, "metrique.unit");
+    assert_eq!(registry_entry.annotations[0].key(), "metrique.unit");
 }
 
 #[test]
@@ -95,11 +95,15 @@ fn no_annotations_no_frame() {
     .unwrap();
 
     let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let frames = dec.decode_all();
 
-    // With no annotations, the byte stream should not contain tag 0x07
+    // With no annotations, no annotation frame should be emitted
     assert!(
-        !data.contains(&0x07),
-        "annotation frame tag should not appear when annotations are empty"
+        !frames
+            .iter()
+            .any(|f| matches!(f, DecodedFrame::SchemaAnnotations { .. })),
+        "annotation frame should not appear when annotations are empty"
     );
 }
 
@@ -172,7 +176,7 @@ fn annotations_silent_truncation() {
     // Find the annotation frame tag and truncate just before it
     let ann_pos = data
         .iter()
-        .position(|&b| b == 0x07)
+        .position(|&b| b == 0x06)
         .expect("annotation frame should exist");
     let truncated = &data[..ann_pos];
 
@@ -211,12 +215,12 @@ fn annotations_unknown_type_id_skipped() {
     let mut data = enc.finish();
 
     // Manually append an annotation frame for type_id 99 (never registered)
-    // Format: tag(1) | type_id(2 LE) | count(2 LE) | entries...
+    // Format: tag(1) | type_id(varint) | count(2 LE) | entries...
     // Entry: field_index(2 LE) | key_len(2 LE) | key | value_len(4 LE) | value
     let key = b"ghost";
     let value = b"annotation";
-    data.push(0x07); // TAG_SCHEMA_ANNOTATIONS
-    data.extend_from_slice(&99u16.to_le_bytes()); // type_id = 99
+    data.push(0x06); // TAG_SCHEMA_ANNOTATIONS
+    data.push(99); // type_id = 99 (varint, fits in 1 byte)
     data.extend_from_slice(&1u16.to_le_bytes()); // count = 1
     data.extend_from_slice(&0u16.to_le_bytes()); // field_index = 0
     data.extend_from_slice(&(key.len() as u16).to_le_bytes());
@@ -270,8 +274,8 @@ fn annotations_round_trip_ref() {
     assert!(ann_frame.is_some());
     if let Some(DecodedFrameRef::SchemaAnnotations { annotations, .. }) = ann_frame {
         assert_eq!(annotations.len(), 1);
-        assert_eq!(annotations[0].key, "key");
-        assert_eq!(annotations[0].value, "val");
+        assert_eq!(annotations[0].key(), "key");
+        assert_eq!(annotations[0].value(), "val");
     }
 }
 
@@ -303,7 +307,7 @@ fn annotations_for_each_event_works() {
         assert_eq!(ev.name, "Metric");
         // Annotations should be visible on the schema
         assert_eq!(ev.schema.annotations.len(), 1);
-        assert_eq!(ev.schema.annotations[0].key, "unit");
+        assert_eq!(ev.schema.annotations[0].key(), "unit");
         event_count += 1;
     })
     .unwrap();

--- a/dial9-trace-format/tests/annotations.rs
+++ b/dial9-trace-format/tests/annotations.rs
@@ -1,0 +1,311 @@
+use dial9_trace_format::codec::WireTypeId;
+use dial9_trace_format::decoder::{DecodedFrame, DecodedFrameRef, Decoder};
+use dial9_trace_format::encoder::{Encoder, Schema};
+use dial9_trace_format::schema::{FieldAnnotation, FieldDef, SchemaEntry};
+use dial9_trace_format::types::{FieldType, FieldValue};
+
+#[test]
+fn annotations_round_trip() {
+    let mut enc = Encoder::new();
+    let entry = SchemaEntry {
+        name: "Latency".into(),
+        has_timestamp: true,
+        fields: vec![
+            FieldDef {
+                name: "duration_us".into(),
+                field_type: FieldType::Varint,
+            },
+            FieldDef {
+                name: "endpoint".into(),
+                field_type: FieldType::PooledString,
+            },
+        ],
+        annotations: vec![
+            FieldAnnotation::new(0, "metrique.unit", "microseconds"),
+            FieldAnnotation::new(1, "dial9.display", "label"),
+            FieldAnnotation::new(0, "dial9.kpi", "true"),
+        ],
+    };
+    let schema = Schema::from_entry(entry);
+    enc.register_existing(&schema).unwrap();
+
+    let endpoint_id = enc.intern_string("/api/health").unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(1_000_000),
+            FieldValue::Varint(42),
+            FieldValue::PooledString(endpoint_id),
+        ],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let frames = dec.decode_all();
+
+    // Should see: Schema, SchemaAnnotations, StringPool, Event
+    let mut saw_schema = false;
+    let mut saw_annotations = false;
+    for frame in &frames {
+        match frame {
+            DecodedFrame::Schema(s) => {
+                assert_eq!(s.name, "Latency");
+                saw_schema = true;
+            }
+            DecodedFrame::SchemaAnnotations {
+                type_id,
+                annotations,
+            } => {
+                assert_eq!(*type_id, WireTypeId(0));
+                assert_eq!(annotations.len(), 3);
+                assert_eq!(annotations[0].field_index, 0);
+                assert_eq!(annotations[0].key, "metrique.unit");
+                assert_eq!(annotations[0].value, "microseconds");
+                assert_eq!(annotations[1].field_index, 1);
+                assert_eq!(annotations[1].key, "dial9.display");
+                assert_eq!(annotations[1].value, "label");
+                assert_eq!(annotations[2].field_index, 0);
+                assert_eq!(annotations[2].key, "dial9.kpi");
+                assert_eq!(annotations[2].value, "true");
+                saw_annotations = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(saw_schema);
+    assert!(saw_annotations);
+
+    // Verify annotations are merged into the registry
+    let registry_entry = dec.registry().get(WireTypeId(0)).unwrap();
+    assert_eq!(registry_entry.annotations.len(), 3);
+    assert_eq!(registry_entry.annotations[0].key, "metrique.unit");
+}
+
+#[test]
+fn no_annotations_no_frame() {
+    let mut enc = Encoder::new();
+    enc.register_schema(
+        "Simple",
+        vec![FieldDef {
+            name: "x".into(),
+            field_type: FieldType::Varint,
+        }],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+
+    // With no annotations, the byte stream should not contain tag 0x07
+    assert!(
+        !data.contains(&0x07),
+        "annotation frame tag should not appear when annotations are empty"
+    );
+}
+
+#[test]
+fn multiple_schemas_with_mixed_annotations() {
+    let mut enc = Encoder::new();
+
+    let annotated = SchemaEntry {
+        name: "Annotated".into(),
+        has_timestamp: true,
+        fields: vec![FieldDef {
+            name: "val".into(),
+            field_type: FieldType::Varint,
+        }],
+        annotations: vec![FieldAnnotation::new(0, "unit", "ms")],
+    };
+    let plain = SchemaEntry {
+        name: "Plain".into(),
+        has_timestamp: true,
+        fields: vec![FieldDef {
+            name: "val".into(),
+            field_type: FieldType::Varint,
+        }],
+        annotations: Vec::new(),
+    };
+
+    let schema_a = Schema::from_entry(annotated);
+    let schema_b = Schema::from_entry(plain);
+    enc.register_existing(&schema_a).unwrap();
+    enc.register_existing(&schema_b).unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let frames = dec.decode_all();
+
+    // Only one annotation frame (for "Annotated")
+    let annotation_frames: Vec<_> = frames
+        .iter()
+        .filter(|f| matches!(f, DecodedFrame::SchemaAnnotations { .. }))
+        .collect();
+    assert_eq!(annotation_frames.len(), 1);
+
+    // Annotations attached to the right schema
+    let annotated_entry = dec.registry().get(WireTypeId(0)).unwrap();
+    assert_eq!(annotated_entry.name, "Annotated");
+    assert_eq!(annotated_entry.annotations.len(), 1);
+
+    let plain_entry = dec.registry().get(WireTypeId(1)).unwrap();
+    assert_eq!(plain_entry.name, "Plain");
+    assert!(plain_entry.annotations.is_empty());
+}
+
+#[test]
+fn annotations_silent_truncation() {
+    // Encode a trace with annotations, then truncate before the annotation frame.
+    let mut enc = Encoder::new();
+    let entry = SchemaEntry {
+        name: "Ev".into(),
+        has_timestamp: true,
+        fields: vec![FieldDef {
+            name: "x".into(),
+            field_type: FieldType::Varint,
+        }],
+        annotations: vec![FieldAnnotation::new(0, "key", "value")],
+    };
+    let schema = Schema::from_entry(entry);
+    enc.register_existing(&schema).unwrap();
+    let data = enc.finish();
+
+    // Find the annotation frame tag and truncate just before it
+    let ann_pos = data
+        .iter()
+        .position(|&b| b == 0x07)
+        .expect("annotation frame should exist");
+    let truncated = &data[..ann_pos];
+
+    // Decoder should halt cleanly at end-of-stream (no error, just fewer frames)
+    let mut dec = Decoder::new(truncated).unwrap();
+    let frames = dec.decode_all();
+    // Should have the schema but not the annotations
+    assert!(frames.iter().any(|f| matches!(f, DecodedFrame::Schema(_))));
+    assert!(
+        !frames
+            .iter()
+            .any(|f| matches!(f, DecodedFrame::SchemaAnnotations { .. }))
+    );
+}
+
+#[test]
+fn annotations_unknown_type_id_skipped() {
+    // Build a valid trace, then manually append an annotation frame for an unknown type_id.
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "Real",
+            vec![FieldDef {
+                name: "x".into(),
+                field_type: FieldType::Varint,
+            }],
+        )
+        .unwrap();
+
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(1_000_000), FieldValue::Varint(42)],
+    )
+    .unwrap();
+
+    let mut data = enc.finish();
+
+    // Manually append an annotation frame for type_id 99 (never registered)
+    // Format: tag(1) | type_id(2 LE) | count(2 LE) | entries...
+    // Entry: field_index(2 LE) | key_len(2 LE) | key | value_len(4 LE) | value
+    let key = b"ghost";
+    let value = b"annotation";
+    data.push(0x07); // TAG_SCHEMA_ANNOTATIONS
+    data.extend_from_slice(&99u16.to_le_bytes()); // type_id = 99
+    data.extend_from_slice(&1u16.to_le_bytes()); // count = 1
+    data.extend_from_slice(&0u16.to_le_bytes()); // field_index = 0
+    data.extend_from_slice(&(key.len() as u16).to_le_bytes());
+    data.extend_from_slice(key);
+    data.extend_from_slice(&(value.len() as u32).to_le_bytes());
+    data.extend_from_slice(value);
+
+    // Decoder should handle the unknown type_id leniently
+    let mut dec = Decoder::new(&data).unwrap();
+    let frames = dec.decode_all();
+
+    // Should have Schema, Event, and SchemaAnnotations (for unknown type_id)
+    let has_event = frames
+        .iter()
+        .any(|f| matches!(f, DecodedFrame::Event { .. }));
+    assert!(has_event, "decoder should continue past unknown annotation");
+
+    // The "Real" schema should have no annotations
+    let real_entry = dec.registry().get(WireTypeId(0)).unwrap();
+    assert!(real_entry.annotations.is_empty());
+}
+
+#[test]
+fn annotations_round_trip_ref() {
+    // Verify the zero-copy path also works
+    let mut enc = Encoder::new();
+    let entry = SchemaEntry {
+        name: "Ev".into(),
+        has_timestamp: true,
+        fields: vec![FieldDef {
+            name: "x".into(),
+            field_type: FieldType::Varint,
+        }],
+        annotations: vec![FieldAnnotation::new(0, "key", "val")],
+    };
+    let schema = Schema::from_entry(entry);
+    enc.register_existing(&schema).unwrap();
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(1_000_000), FieldValue::Varint(7)],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let frames = dec.decode_all_ref();
+
+    let ann_frame = frames
+        .iter()
+        .find(|f| matches!(f, DecodedFrameRef::SchemaAnnotations { .. }));
+    assert!(ann_frame.is_some());
+    if let Some(DecodedFrameRef::SchemaAnnotations { annotations, .. }) = ann_frame {
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0].key, "key");
+        assert_eq!(annotations[0].value, "val");
+    }
+}
+
+#[test]
+fn annotations_for_each_event_works() {
+    // Verify that for_each_event processes events correctly when annotations are present
+    let mut enc = Encoder::new();
+    let entry = SchemaEntry {
+        name: "Metric".into(),
+        has_timestamp: true,
+        fields: vec![FieldDef {
+            name: "val".into(),
+            field_type: FieldType::Varint,
+        }],
+        annotations: vec![FieldAnnotation::new(0, "unit", "bytes")],
+    };
+    let schema = Schema::from_entry(entry);
+    enc.register_existing(&schema).unwrap();
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(1_000_000), FieldValue::Varint(1024)],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let mut event_count = 0;
+    dec.for_each_event(|ev| {
+        assert_eq!(ev.name, "Metric");
+        // Annotations should be visible on the schema
+        assert_eq!(ev.schema.annotations.len(), 1);
+        assert_eq!(ev.schema.annotations[0].key, "unit");
+        event_count += 1;
+    })
+    .unwrap();
+    assert_eq!(event_count, 1);
+}


### PR DESCRIPTION
Related: dial9-rs/dial9-tokio-telemetry#346 (metrique integration design)

### Summary

Adds wire-format support for schema-level annotations, the first of two trace-format extensions needed for metrique integration. Annotations carry `(field_index, key, value)` tuples that decoders can surface as per-field metadata: units today (`metrique.unit` = `microseconds`), display hints, semantic-convention labels, privacy tiers, and similar additions tomorrow. Fields without annotations cost zero bytes on the wire.

The annotation payload rides in a new top-level frame tag (`TAG_SCHEMA_ANNOTATIONS = 0x07`) that follows the schema frame it annotates. Framing decisions:

1. Annotations live in a separate frame rather than inside the schema frame body. We could inline them (new decoders handle both old and new formats fine), but a separate frame keeps the schema frame codec unchanged, avoids touching the JS parser's schema decode path, and allows multiple annotation frames per schema (the decoder accumulates). The separation also cleanly models the concern split: schema defines structure, annotations carry metadata.

2. Multiple annotation frames per schema are permitted. The decoder accumulates; the encoder emits one frame per schema registration but the format does not mandate it. I suspect that this will prove useful over time if we want to do clever things around metadata stickiness.

3. `FieldAnnotation` is intentionally generic (`String` key, `String` value) so one mechanism serves units, display hints, semantic conventions, privacy labels, and future metadata without further format churn.

### Tradeoffs

- **Separate frame vs inlined**: a separate frame adds a tag to the format but keeps the schema codec simple and the JS parser untouched. Since the viewer ships in lockstep with producers, backward compat with old decoders is not a concern; the real constraint is new decoders reading old traces (which works: no annotation frame means empty annotations).

- **Generic key-value strings**: flexible at the cost of being untyped. Consumers interpret by key (`metrique.unit`, `dial9.kpi`, etc.). A typed hierarchy was considered but would lock us into today's uses and fight the "add new metadata without format churn" requirement.

- **Breaking change**: This will need to go in `0.4.x` due to the new `annotations` field on `SchemaEntry` and various other places. I plan pull off the bandaid and tag that `#[non_exhaustive] and provide some better constructors, but I'll do it in a separate PR that adds support for non-stringly maps and lists.

### Testing

Round-trip of a schema with annotations; verify annotations attach to the right schema and field index. Empty-annotation schemas produce byte-parity output with the existing format. Interleaving scenarios: two schemas in one trace, one annotated, one not; decoder routes annotations correctly. Silent truncation: truncate the byte stream before the annotation frame; decoder halts cleanly at end of stream. Unknown type_id in an annotation frame: decoder skips leniently and continues. All existing trace-format round-trips continue to pass.

### Out of scope

- Annotation rendering in the dial9 viewer (follow-up).
- `#[non_exhaustive]` on `FieldType`, `FieldDef`, `SchemaEntry`: these land with the field-types PR.
- TraceField impls, metrique adapter.
- Format version bump, Cargo.toml change, CHANGELOG entry (handled at release time).
