### PR TITLE
feat!: Add dynamic list and map FieldTypes

### DIFF
--- a/dial9-tokio-telemetry/design/metrique-integration.md
+++ b/dial9-tokio-telemetry/design/metrique-integration.md
@@ -17,7 +17,7 @@ This design depends on the entry descriptor system in metrique (see `docs/entry-
 - **`dial9::Context`**: a `#[doc(hidden)]` dial9-internal field tag carried by `Dial9Context`'s own fields. Users do not interact with it directly; they flatten `Dial9Context` into their entry, and the sink walks the descriptor on first-use to find fields tagged `Context`. The name is not a stable guarantee; a future typed source-extraction mechanism would replace this tag-based discovery.
 - **`Dial9EntryWriter`**: the dial9 adapter that walks `Entry::write` on the flush thread. Uses the cached context- and payload-field index sets to route each callback to either the event header (context) or the payload encoder (Emit), or to skip.
 - **First-use per-descriptor**: the moment a `Dial9Stream` first sees an entry with a given `DescriptorId`. Dial9 walks the descriptor once, caches the index sets and any diagnostics, and uses the cache for every subsequent entry of that type.
-- **Trace format**: dial9's wire format, defined in `dial9-trace-format/SPEC.md`. Carries schema frames (one per entry type), event frames (one per emission), pool frames (deduplicated strings and stack frames), and schema-annotation frames (per-field metadata). This design relies on two format features that ship independently of the integration: `TAG_SCHEMA_ANNOTATIONS` and the `List` / `Map` field types.
+- **Trace format**: dial9's wire format, defined in `dial9-trace-format/SPEC.md`. Carries schema frames (one per entry type), event frames (one per emission), pool frames (deduplicated strings and stack frames), and schema-annotation frames (per-field metadata). This design relies on two format features that ship independently of the integration: `TAG_SCHEMA_ANNOTATIONS` and the `DynamicList` / `DynamicMap` field types.
 
 ## User-facing API
 
@@ -156,8 +156,8 @@ The builder and manual composition paths are unchanged from the original design.
 │       encode according to FieldShape:                          │
 │            Known   : encode scalar                             │
 │            Optional: encode presence byte + inner              │
-│            List    : encode <count> <repeated element>         │
-│            Flex    : encode map<key, value>                    │
+│            List    : encode <count> <tag + value per element>   │
+│            Flex    : encode <count> <key_tag+key+val_tag+val>  │
 │            Opaque  : report + skip (sink-side validation)      │
 │                                                                │
 │     if field is tagged Interned and carries string data:       │
@@ -229,7 +229,7 @@ Per entry:
 3. First-use per `DescriptorId`: walk the descriptor to compute the context-field indices (fields tagged `dial9::Context`) and payload-field indices (tagged `dial9::Emit`). Build the wire schema with annotations for units.
 4. Walk `entry.write(..)` with a `Dial9EntryWriter` that uses the cached index sets to route each callback to either the event header (context) or the payload encoder (Emit), or to skip. `Interned` fields have their string data routed through the dial9 string pool. Relies on the metrique contract that `Entry::write` emits `value` callbacks in descriptor order.
 
-`Dial9EntryWriter` overrides `ValueWriter::values()` (the default implementation comma-joins elements into a string) to preserve the typed list wire encoding for `Vec<T>` fields.
+`Dial9EntryWriter` overrides `ValueWriter::values()` (the default implementation comma-joins elements into a string) to preserve the self-describing list wire encoding for `Vec<T>` fields.
 
 A `catch_unwind(AssertUnwindSafe(..))` guard around the `Entry::write` walk drops offending events (rate-limited log) without poisoning the flush thread's state.
 

--- a/dial9-tokio-telemetry/src/background_task/sealed.rs
+++ b/dial9-tokio-telemetry/src/background_task/sealed.rs
@@ -86,7 +86,7 @@ fn parse_segment_timestamp(data: &[u8]) -> Result<u64, ParseTimestampError> {
                 let name = dec
                     .registry()
                     .get(type_id)
-                    .map(|s| s.name.as_str())
+                    .map(|s| s.name())
                     .ok_or(ParseTimestampError::UnknownTypeId(type_id.0))?;
                 if name == "ClockSyncEvent" {
                     return match values.first() {

--- a/dial9-tokio-telemetry/src/telemetry/format.rs
+++ b/dial9-tokio-telemetry/src/telemetry/format.rs
@@ -322,7 +322,7 @@ pub(crate) fn decode_ref<'a>(
     schema: &SchemaEntry,
 ) -> Option<TelemetryEventRef<'a>> {
     use dial9_trace_format::TraceEvent as _;
-    let field_defs = &schema.fields;
+    let field_defs = schema.fields();
     Some(match name {
         "PollStartEvent" => {
             TelemetryEventRef::PollStart(PollStartEvent::decode(timestamp_ns, fields, field_defs)?)

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -553,9 +553,9 @@ mod shuttle_tests {
         };
         let mut out = Vec::new();
         dec.for_each_event(|ev| {
-            if ev.name == "ValidationEvent"
+            if ev.name() == "ValidationEvent"
                 && let Some(decoded) =
-                    ValidationEvent::decode(ev.timestamp_ns, ev.fields, &ev.schema.fields)
+                    ValidationEvent::decode(ev.timestamp_ns, ev.fields, &ev.schema.fields())
             {
                 out.push(ValidationEvent {
                     timestamp_ns: decoded.timestamp_ns,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -553,7 +553,7 @@ mod shuttle_tests {
         };
         let mut out = Vec::new();
         dec.for_each_event(|ev| {
-            if ev.name() == "ValidationEvent"
+            if ev.name == "ValidationEvent"
                 && let Some(decoded) =
                     ValidationEvent::decode(ev.timestamp_ns, ev.fields, &ev.schema.fields())
             {

--- a/dial9-tokio-telemetry/src/tracing_layer.rs
+++ b/dial9-tokio-telemetry/src/tracing_layer.rs
@@ -94,36 +94,15 @@ fn build_callsite_schemas(meta: &'static tracing::Metadata<'static>) -> Callsite
 
     // Base fields present on all span events
     let mut enter_fields = vec![
-        FieldDef {
-            name: "worker_id".into(),
-            field_type: FieldType::Varint,
-        },
-        FieldDef {
-            name: "span_id".into(),
-            field_type: FieldType::Varint,
-        },
-        FieldDef {
-            name: "parent_span_id".into(),
-            field_type: FieldType::OptionalVarint,
-        },
-        FieldDef {
-            name: "span_name".into(),
-            field_type: FieldType::PooledString,
-        },
+        FieldDef::new("worker_id", FieldType::Varint),
+        FieldDef::new("span_id", FieldType::Varint),
+        FieldDef::new("parent_span_id", FieldType::OptionalVarint),
+        FieldDef::new("span_name", FieldType::PooledString),
     ];
     let mut exit_fields = vec![
-        FieldDef {
-            name: "worker_id".into(),
-            field_type: FieldType::Varint,
-        },
-        FieldDef {
-            name: "span_id".into(),
-            field_type: FieldType::Varint,
-        },
-        FieldDef {
-            name: "span_name".into(),
-            field_type: FieldType::PooledString,
-        },
+        FieldDef::new("worker_id", FieldType::Varint),
+        FieldDef::new("span_id", FieldType::Varint),
+        FieldDef::new("span_name", FieldType::PooledString),
     ];
 
     // Add user-defined fields as optional interned strings
@@ -131,10 +110,7 @@ fn build_callsite_schemas(meta: &'static tracing::Metadata<'static>) -> Callsite
     for field in meta.fields() {
         let name = field.name();
         field_names.push(name);
-        let def = FieldDef {
-            name: name.to_string(),
-            field_type: FieldType::OptionalPooledString,
-        };
+        let def = FieldDef::new(name.to_string(), FieldType::OptionalPooledString);
         enter_fields.push(def.clone());
         exit_fields.push(def);
     }

--- a/dial9-tokio-telemetry/tests/tracing_layer.rs
+++ b/dial9-tokio-telemetry/tests/tracing_layer.rs
@@ -55,56 +55,56 @@ fn decode_span_events(path: &std::path::Path) -> SpanEvents {
             if ev.name.starts_with("SpanEnter:") {
                 result.enter_count += 1;
                 result.enter_schema_names.insert(ev.name.to_owned());
-                for (field_def, field_val) in ev.schema.fields.iter().zip(ev.fields.iter()) {
-                    if field_def.name == "span_name"
+                for (field_def, field_val) in ev.schema.fields().iter().zip(ev.fields.iter()) {
+                    if field_def.name() == "span_name"
                         && let FieldValueRef::PooledString(id) = field_val
                         && let Some(name) = ev.string_pool.get(*id)
                     {
                         result.enter_names.push(name.to_owned());
                     }
-                    if field_def.name == "span_id"
+                    if field_def.name() == "span_id"
                         && let FieldValueRef::Varint(v) = field_val
                     {
                         result.entered_span_ids.insert(*v);
                     }
-                    if field_def.name == "parent_span_id"
+                    if field_def.name() == "parent_span_id"
                         && let FieldValueRef::Varint(v) = field_val
                         && *v > 0
                     {
                         result.saw_parent_span_id = true;
                     }
-                    if field_def.name == "worker_id"
+                    if field_def.name() == "worker_id"
                         && let FieldValueRef::Varint(v) = field_val
                     {
                         result.worker_ids.insert(*v);
                     }
                     // User-defined fields are optional pooled strings
                     if !["worker_id", "span_id", "parent_span_id", "span_name"]
-                        .contains(&field_def.name.as_str())
+                        .contains(&field_def.name())
                         && let FieldValueRef::PooledString(id) = field_val
                         && let Some(v) = ev.string_pool.get(*id)
                     {
                         result
                             .enter_fields
-                            .push((field_def.name.clone(), v.to_owned()));
+                            .push((field_def.name().to_owned(), v.to_owned()));
                     }
                 }
             } else if ev.name.starts_with("SpanExit:") {
                 result.exit_count += 1;
-                for (field_def, field_val) in ev.schema.fields.iter().zip(ev.fields.iter()) {
-                    if !["worker_id", "span_id", "span_name"].contains(&field_def.name.as_str())
+                for (field_def, field_val) in ev.schema.fields().iter().zip(ev.fields.iter()) {
+                    if !["worker_id", "span_id", "span_name"].contains(&field_def.name())
                         && let FieldValueRef::PooledString(id) = field_val
                         && let Some(v) = ev.string_pool.get(*id)
                     {
                         result
                             .exit_fields
-                            .push((field_def.name.clone(), v.to_owned()));
+                            .push((field_def.name().to_owned(), v.to_owned()));
                     }
                 }
             } else if ev.name == "SpanCloseEvent" {
                 result.close_count += 1;
-                for (field_def, field_val) in ev.schema.fields.iter().zip(ev.fields.iter()) {
-                    if field_def.name == "span_id"
+                for (field_def, field_val) in ev.schema.fields().iter().zip(ev.fields.iter()) {
+                    if field_def.name() == "span_id"
                         && let FieldValueRef::Varint(v) = field_val
                     {
                         result.closed_span_ids.insert(*v);

--- a/dial9-trace-format-derive/src/lib.rs
+++ b/dial9-trace-format-derive/src/lib.rs
@@ -59,10 +59,10 @@ fn derive_trace_event_impl(input: DeriveInput) -> proc_macro2::TokenStream {
 
         let field_name_str = field_name.to_string();
         field_def_tokens.push(quote! {
-            ::dial9_trace_format::schema::FieldDef {
-                name: #field_name_str.to_string(),
-                field_type: <#ty as ::dial9_trace_format::TraceField>::field_type(),
-            }
+            ::dial9_trace_format::schema::FieldDef::new(
+                #field_name_str,
+                <#ty as ::dial9_trace_format::TraceField>::field_type(),
+            )
         });
         encode_tokens.push(quote! {
             <#ty as ::dial9_trace_format::TraceField>::encode(&self.#field_name, enc)?;

--- a/dial9-trace-format-derive/src/lib.rs
+++ b/dial9-trace-format-derive/src/lib.rs
@@ -80,7 +80,7 @@ fn derive_trace_event_impl(input: DeriveInput) -> proc_macro2::TokenStream {
         decode_tokens.push(quote! {
             #field_name: {
                 let val = field_defs.iter().zip(fields.iter())
-                    .find(|(f, _)| f.name == #field_name_str)
+                    .find(|(f, _)| f.name() == #field_name_str)
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <#ty as ::dial9_trace_format::TraceField>::decode_ref(v)?,

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__all_field_types.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__all_field_types.snap
@@ -88,7 +88,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "a_u8")
+                    .find(|(f, _)| f.name() == "a_u8")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u8 as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -99,7 +99,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "b_u16")
+                    .find(|(f, _)| f.name() == "b_u16")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u16 as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -110,7 +110,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "c_u32")
+                    .find(|(f, _)| f.name() == "c_u32")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u32 as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -121,7 +121,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "d_u64")
+                    .find(|(f, _)| f.name() == "d_u64")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u64 as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -132,7 +132,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "e_i64")
+                    .find(|(f, _)| f.name() == "e_i64")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <i64 as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -143,7 +143,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "f_f64")
+                    .find(|(f, _)| f.name() == "f_f64")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <f64 as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -154,7 +154,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "g_bool")
+                    .find(|(f, _)| f.name() == "g_bool")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <bool as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -165,7 +165,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "h_string")
+                    .find(|(f, _)| f.name() == "h_string")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => {
@@ -180,7 +180,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "i_bytes")
+                    .find(|(f, _)| f.name() == "i_bytes")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => {
@@ -195,7 +195,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "j_interned")
+                    .find(|(f, _)| f.name() == "j_interned")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => {
@@ -212,7 +212,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "k_frames")
+                    .find(|(f, _)| f.name() == "k_frames")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => {
@@ -227,7 +227,7 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "l_map")
+                    .find(|(f, _)| f.name() == "l_map")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => {

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__all_field_types.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__all_field_types.snap
@@ -25,32 +25,30 @@ impl ::dial9_trace_format::TraceEvent for AllFieldTypes {
     }
     fn field_defs() -> Vec<::dial9_trace_format::schema::FieldDef> {
         vec![
-            ::dial9_trace_format::schema::FieldDef { name : "a_u8".to_string(),
-            field_type : < u8 as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "b_u16".to_string(),
-            field_type : < u16 as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "c_u32".to_string(),
-            field_type : < u32 as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "d_u64".to_string(),
-            field_type : < u64 as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "e_i64".to_string(),
-            field_type : < i64 as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "f_f64".to_string(),
-            field_type : < f64 as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "g_bool".to_string(),
-            field_type : < bool as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "h_string".to_string(),
-            field_type : < String as ::dial9_trace_format::TraceField > ::field_type(),
-            }, ::dial9_trace_format::schema::FieldDef { name : "i_bytes".to_string(),
-            field_type : < Vec < u8 > as ::dial9_trace_format::TraceField >
-            ::field_type(), }, ::dial9_trace_format::schema::FieldDef { name :
-            "j_interned".to_string(), field_type : < InternedString as
-            ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "k_frames".to_string(),
-            field_type : < StackFrames as ::dial9_trace_format::TraceField >
-            ::field_type(), }, ::dial9_trace_format::schema::FieldDef { name : "l_map"
-            .to_string(), field_type : < Vec < (String, String) > as
-            ::dial9_trace_format::TraceField > ::field_type(), }
+            ::dial9_trace_format::schema::FieldDef::new("a_u8", < u8 as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("b_u16", < u16 as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("c_u32", < u32 as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("d_u64", < u64 as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("e_i64", < i64 as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("f_f64", < f64 as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("g_bool", < bool as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("h_string", < String as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("i_bytes", < Vec < u8 > as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("j_interned", < InternedString as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("k_frames", < StackFrames as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("l_map", < Vec < (String, String)
+            > as ::dial9_trace_format::TraceField > ::field_type(),)
         ]
     }
     fn timestamp(&self) -> u64 {

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__doc_comments_copied_to_ref_fields.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__doc_comments_copied_to_ref_fields.snap
@@ -19,10 +19,10 @@ impl ::dial9_trace_format::TraceEvent for DocEvent {
     }
     fn field_defs() -> Vec<::dial9_trace_format::schema::FieldDef> {
         vec![
-            ::dial9_trace_format::schema::FieldDef { name : "worker_id".to_string(),
-            field_type : < u64 as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "local_queue".to_string(),
-            field_type : < u8 as ::dial9_trace_format::TraceField > ::field_type(), }
+            ::dial9_trace_format::schema::FieldDef::new("worker_id", < u64 as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("local_queue", < u8 as
+            ::dial9_trace_format::TraceField > ::field_type(),)
         ]
     }
     fn timestamp(&self) -> u64 {

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__doc_comments_copied_to_ref_fields.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__doc_comments_copied_to_ref_fields.snap
@@ -47,7 +47,7 @@ impl ::dial9_trace_format::TraceEvent for DocEvent {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "worker_id")
+                    .find(|(f, _)| f.name() == "worker_id")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u64 as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -58,7 +58,7 @@ impl ::dial9_trace_format::TraceEvent for DocEvent {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "local_queue")
+                    .find(|(f, _)| f.name() == "local_queue")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u8 as ::dial9_trace_format::TraceField>::decode_ref(v)?,

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__simple_event.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__simple_event.snap
@@ -39,7 +39,7 @@ impl ::dial9_trace_format::TraceEvent for SimpleEvent {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "value")
+                    .find(|(f, _)| f.name() == "value")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u32 as ::dial9_trace_format::TraceField>::decode_ref(v)?,

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__simple_event.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__simple_event.snap
@@ -14,8 +14,8 @@ impl ::dial9_trace_format::TraceEvent for SimpleEvent {
     }
     fn field_defs() -> Vec<::dial9_trace_format::schema::FieldDef> {
         vec![
-            ::dial9_trace_format::schema::FieldDef { name : "value".to_string(),
-            field_type : < u32 as ::dial9_trace_format::TraceField > ::field_type(), }
+            ::dial9_trace_format::schema::FieldDef::new("value", < u32 as
+            ::dial9_trace_format::TraceField > ::field_type(),)
         ]
     }
     fn timestamp(&self) -> u64 {

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__timestamp_attribute.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__timestamp_attribute.snap
@@ -15,10 +15,10 @@ impl ::dial9_trace_format::TraceEvent for PollStart {
     }
     fn field_defs() -> Vec<::dial9_trace_format::schema::FieldDef> {
         vec![
-            ::dial9_trace_format::schema::FieldDef { name : "worker_id".to_string(),
-            field_type : < u64 as ::dial9_trace_format::TraceField > ::field_type(), },
-            ::dial9_trace_format::schema::FieldDef { name : "task_id".to_string(),
-            field_type : < u64 as ::dial9_trace_format::TraceField > ::field_type(), }
+            ::dial9_trace_format::schema::FieldDef::new("worker_id", < u64 as
+            ::dial9_trace_format::TraceField > ::field_type(),),
+            ::dial9_trace_format::schema::FieldDef::new("task_id", < u64 as
+            ::dial9_trace_format::TraceField > ::field_type(),)
         ]
     }
     fn timestamp(&self) -> u64 {

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__timestamp_attribute.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__timestamp_attribute.snap
@@ -43,7 +43,7 @@ impl ::dial9_trace_format::TraceEvent for PollStart {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "worker_id")
+                    .find(|(f, _)| f.name() == "worker_id")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u64 as ::dial9_trace_format::TraceField>::decode_ref(v)?,
@@ -54,7 +54,7 @@ impl ::dial9_trace_format::TraceEvent for PollStart {
                 let val = field_defs
                     .iter()
                     .zip(fields.iter())
-                    .find(|(f, _)| f.name == "task_id")
+                    .find(|(f, _)| f.name() == "task_id")
                     .map(|(_, v)| v);
                 match val {
                     Some(v) => <u64 as ::dial9_trace_format::TraceField>::decode_ref(v)?,

--- a/dial9-trace-format/SPEC.md
+++ b/dial9-trace-format/SPEC.md
@@ -192,6 +192,8 @@ A decoder that encounters an annotation frame referencing an unknown `type_id` m
 | 11 | U8 | 1-byte unsigned | 1 |
 | 12 | U16 | 2-byte little-endian unsigned | 2 |
 | 13 | U32 | 4-byte little-endian unsigned | 4 |
+| 14 | DynamicList | u32 count + count × (u8 tag + value) | variable |
+| 15 | DynamicMap | u32 count + count × (u8 key_tag + key + u8 value_tag + value) | variable |
 
 ### Optional Field Modifier (`0x80`)
 
@@ -240,6 +242,24 @@ A string map carries an ordered list of key-value pairs (both UTF-8 strings):
 
 1. Write `count` as u32 (number of pairs).
 2. For each pair, write `key_len` as u32, then key bytes, then `val_len` as u32, then value bytes.
+
+### DynamicList Encoding
+
+A self-describing list where each element carries its own type tag:
+
+1. Write `count` as u32 (number of elements).
+2. For each element, write the element's field type tag as u8, then encode the element value according to that tag.
+
+Elements may be heterogeneous (different types in the same list). Nested containers are supported: an element tag of `0x0E` (DynamicList) or `0x0F` (DynamicMap) is followed by the recursive encoding of that container.
+
+### DynamicMap Encoding
+
+A self-describing map where each entry carries type tags for both key and value:
+
+1. Write `count` as u32 (number of entries).
+2. For each entry, write the key's field type tag as u8, encode the key value, then write the value's field type tag as u8, encode the value.
+
+Entries may be heterogeneous. Both keys and values can be any field type including nested containers.
 
 ### LEB128
 

--- a/dial9-trace-format/fuzz/fuzz_targets/fuzz_round_trip.rs
+++ b/dial9-trace-format/fuzz/fuzz_targets/fuzz_round_trip.rs
@@ -18,14 +18,8 @@ fuzz_target!(|data: &[u8]| {
         .register_schema(
             "FuzzEvent",
             vec![
-                FieldDef {
-                    name: "a".into(),
-                    field_type: FieldType::Varint,
-                },
-                FieldDef {
-                    name: "b".into(),
-                    field_type: FieldType::Varint,
-                },
+                FieldDef::new("a", FieldType::Varint),
+                FieldDef::new("b", FieldType::Varint),
             ],
         )
         .unwrap();

--- a/dial9-trace-format/fuzz/fuzz_targets/fuzz_structured_round_trip.rs
+++ b/dial9-trace-format/fuzz/fuzz_targets/fuzz_structured_round_trip.rs
@@ -188,10 +188,7 @@ fuzz_target!(|data: &[u8]| {
                 } else {
                     base
                 };
-                FieldDef {
-                    name: format!("f{j}"),
-                    field_type,
-                }
+                FieldDef::new(format!("f{j}"), field_type)
             })
             .collect();
         schemas.push(enc.register_schema(names[i], fields).unwrap());

--- a/dial9-trace-format/js/decode.js
+++ b/dial9-trace-format/js/decode.js
@@ -12,6 +12,7 @@ const FieldType = {
   I64: 1, F64: 2, Bool: 3, String: 4,
   Bytes: 5, PooledStackFrames: 6, PooledString: 7, StackFrames: 8, Varint: 9,
   StringMap: 10, U8: 11, U16: 12, U32: 13,
+  DynamicList: 14, DynamicMap: 15,
 };
 
 function decodeULEB128(view, offset) {
@@ -85,6 +86,33 @@ function decodeFieldValue(view, offset, fieldType) {
     case FieldType.U8: return [view.getUint8(offset), 1];
     case FieldType.U16: return [view.getUint16(offset, true), 2];
     case FieldType.U32: return [view.getUint32(offset, true), 4];
+    case FieldType.DynamicList: {
+      const count = view.getUint32(offset, true);
+      let pos = 4;
+      const items = [];
+      for (let i = 0; i < count; i++) {
+        const tag = view.getUint8(offset + pos); pos += 1;
+        const [val, consumed] = decodeFieldValue(view, offset + pos, tag);
+        items.push(val);
+        pos += consumed;
+      }
+      return [items, pos];
+    }
+    case FieldType.DynamicMap: {
+      const count = view.getUint32(offset, true);
+      let pos = 4;
+      const entries = [];
+      for (let i = 0; i < count; i++) {
+        const keyTag = view.getUint8(offset + pos); pos += 1;
+        const [key, keySize] = decodeFieldValue(view, offset + pos, keyTag);
+        pos += keySize;
+        const valTag = view.getUint8(offset + pos); pos += 1;
+        const [val, valSize] = decodeFieldValue(view, offset + pos, valTag);
+        pos += valSize;
+        entries.push([key, val]);
+      }
+      return [entries, pos];
+    }
     default: throw new Error(`Unknown field type: ${fieldType}`);
   }
 }

--- a/dial9-trace-format/src/lib.rs
+++ b/dial9-trace-format/src/lib.rs
@@ -24,6 +24,8 @@ pub mod schema;
 pub mod types;
 
 pub use dial9_trace_format_derive::TraceEvent;
+pub use types::DynamicListRef;
+pub use types::DynamicMapRef;
 pub use types::EventEncoder;
 pub use types::FieldValue;
 pub use types::InternedStackFrames;

--- a/dial9-trace-format/src/schema.rs
+++ b/dial9-trace-format/src/schema.rs
@@ -49,6 +49,7 @@ impl FieldAnnotation {
 }
 
 /// A single field within a schema: a name and a [`FieldType`].
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldDef {
     /// Field name (e.g. `"worker_id"`).
@@ -59,8 +60,26 @@ pub struct FieldDef {
     pub field_type: FieldType,
 }
 
+impl FieldDef {
+    /// Construct a field definition with the given name and type.
+    ///
+    /// ```
+    /// # use dial9_trace_format::schema::FieldDef;
+    /// # use dial9_trace_format::types::FieldType;
+    /// FieldDef::new("worker_id", FieldType::Varint);
+    /// FieldDef::new("tags", FieldType::DynamicList);
+    /// ```
+    pub fn new(name: impl Into<String>, field_type: FieldType) -> Self {
+        Self {
+            name: name.into(),
+            field_type,
+        }
+    }
+}
+
 /// Describes the layout of an event type. Does not carry a wire type ID —
 /// the ID is assigned by the encoder and tracked externally by the registry.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaEntry {
     /// Event type name (e.g. `"PollStart"`).
@@ -72,6 +91,33 @@ pub struct SchemaEntry {
     /// Per-field annotations (metadata such as units, display hints).
     /// Empty by default; carried in a separate wire frame.
     pub annotations: Vec<FieldAnnotation>,
+}
+
+impl SchemaEntry {
+    /// Construct a new schema entry.
+    pub fn new(name: impl Into<String>, has_timestamp: bool, fields: Vec<FieldDef>) -> Self {
+        Self {
+            name: name.into(),
+            has_timestamp,
+            fields,
+            annotations: Vec::new(),
+        }
+    }
+
+    /// Construct a schema entry with annotations.
+    pub fn with_annotations(
+        name: impl Into<String>,
+        has_timestamp: bool,
+        fields: Vec<FieldDef>,
+        annotations: Vec<FieldAnnotation>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            has_timestamp,
+            fields,
+            annotations,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/dial9-trace-format/src/schema.rs
+++ b/dial9-trace-format/src/schema.rs
@@ -52,12 +52,8 @@ impl FieldAnnotation {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldDef {
-    /// Field name (e.g. `"worker_id"`).
-    pub name: String,
-    /// Wire type used to encode this field. Optional variants (e.g.
-    /// `FieldType::OptionalPooledString`) indicate the field uses the
-    /// high-bit optional encoding on the wire.
-    pub field_type: FieldType,
+    pub(crate) name: String,
+    pub(crate) field_type: FieldType,
 }
 
 impl FieldDef {
@@ -75,6 +71,16 @@ impl FieldDef {
             field_type,
         }
     }
+
+    /// Field name (e.g. `"worker_id"`).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Wire type used to encode this field.
+    pub fn field_type(&self) -> FieldType {
+        self.field_type
+    }
 }
 
 /// Describes the layout of an event type. Does not carry a wire type ID —
@@ -82,24 +88,23 @@ impl FieldDef {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaEntry {
-    /// Event type name (e.g. `"PollStart"`).
-    pub name: String,
-    /// Whether events of this type carry a packed u24 nanosecond timestamp in the event header.
-    pub has_timestamp: bool,
-    /// Ordered list of fields (excluding the timestamp, which is in the header).
-    pub fields: Vec<FieldDef>,
-    /// Per-field annotations (metadata such as units, display hints).
-    /// Empty by default; carried in a separate wire frame.
-    pub annotations: Vec<FieldAnnotation>,
+    pub(crate) name: String,
+    pub(crate) has_timestamp: bool,
+    pub(crate) fields: Vec<FieldDef>,
+    pub(crate) annotations: Vec<FieldAnnotation>,
 }
 
 impl SchemaEntry {
     /// Construct a new schema entry.
-    pub fn new(name: impl Into<String>, has_timestamp: bool, fields: Vec<FieldDef>) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        has_timestamp: bool,
+        fields: impl IntoIterator<Item = FieldDef>,
+    ) -> Self {
         Self {
             name: name.into(),
             has_timestamp,
-            fields,
+            fields: fields.into_iter().collect(),
             annotations: Vec::new(),
         }
     }
@@ -108,15 +113,35 @@ impl SchemaEntry {
     pub fn with_annotations(
         name: impl Into<String>,
         has_timestamp: bool,
-        fields: Vec<FieldDef>,
-        annotations: Vec<FieldAnnotation>,
+        fields: impl IntoIterator<Item = FieldDef>,
+        annotations: impl IntoIterator<Item = FieldAnnotation>,
     ) -> Self {
         Self {
             name: name.into(),
             has_timestamp,
-            fields,
-            annotations,
+            fields: fields.into_iter().collect(),
+            annotations: annotations.into_iter().collect(),
         }
+    }
+
+    /// Event type name (e.g. `"PollStart"`).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Whether events of this type carry a packed timestamp in the event header.
+    pub fn has_timestamp(&self) -> bool {
+        self.has_timestamp
+    }
+
+    /// Ordered list of fields (excluding the timestamp).
+    pub fn fields(&self) -> &[FieldDef] {
+        &self.fields
+    }
+
+    /// Per-field annotations.
+    pub fn annotations(&self) -> &[FieldAnnotation] {
+        &self.annotations
     }
 }
 

--- a/dial9-trace-format/src/types.rs
+++ b/dial9-trace-format/src/types.rs
@@ -471,10 +471,10 @@ pub enum FieldValueRef<'a> {
     PooledStackFrames(InternedStackFrames),
     Varint(u64),
     StringMap(StringMapRef<'a>),
-    /// Self-describing list. Elements are decoded eagerly since each carries its own tag.
-    List(Vec<FieldValueRef<'a>>),
-    /// Self-describing map. Entries are decoded eagerly since each carries its own tags.
-    Map(Vec<(FieldValueRef<'a>, FieldValueRef<'a>)>),
+    /// Self-describing list. Use [`DynamicListRef::iter`] to access elements.
+    List(DynamicListRef<'a>),
+    /// Self-describing map. Use [`DynamicMapRef::iter`] to access entries.
+    Map(DynamicMapRef<'a>),
     /// Absent optional field.
     None,
 }
@@ -534,6 +534,48 @@ impl<'a> StringMapRef<'a> {
     /// Raw packed bytes (length-prefixed key-value pairs). Used for zero-copy re-encoding.
     pub fn raw_data(&self) -> &'a [u8] {
         self.data
+    }
+}
+
+/// Opaque wrapper for a decoded dynamic list. Access elements via [`Self::iter`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct DynamicListRef<'a>(Vec<FieldValueRef<'a>>);
+
+impl<'a> DynamicListRef<'a> {
+    /// Iterate the list elements.
+    pub fn iter(&self) -> impl Iterator<Item = &FieldValueRef<'a>> {
+        self.0.iter()
+    }
+
+    /// Number of elements.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Opaque wrapper for a decoded dynamic map. Access entries via [`Self::iter`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct DynamicMapRef<'a>(Vec<(FieldValueRef<'a>, FieldValueRef<'a>)>);
+
+impl<'a> DynamicMapRef<'a> {
+    /// Iterate the map entries as `(key, value)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&FieldValueRef<'a>, &FieldValueRef<'a>)> {
+        self.0.iter().map(|(k, v)| (k, v))
+    }
+
+    /// Number of entries.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the map is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 
@@ -627,7 +669,7 @@ impl<'a> FieldValueRef<'a> {
                     pos += consumed;
                     items.push(val);
                 }
-                Some((FieldValueRef::List(items), pos))
+                Some((FieldValueRef::List(DynamicListRef(items)), pos))
             }
             FieldType::DynamicMap | FieldType::OptionalDynamicMap => {
                 let count = u32::from_le_bytes(d.get(..4)?.try_into().ok()?) as usize;
@@ -648,7 +690,7 @@ impl<'a> FieldValueRef<'a> {
 
                     pairs.push((key, val));
                 }
-                Some((FieldValueRef::Map(pairs), pos))
+                Some((FieldValueRef::Map(DynamicMapRef(pairs)), pos))
             }
             // Optional variants: decode using the inner type.
             _ => Self::decode(field_type.inner(), data, offset),
@@ -672,12 +714,9 @@ impl<'a> FieldValueRef<'a> {
                     .map(|(k, v)| (k.as_bytes().to_vec(), v.as_bytes().to_vec()))
                     .collect(),
             ),
-            FieldValueRef::List(items) => {
-                FieldValue::List(items.iter().map(|v| v.to_owned()).collect())
-            }
-            FieldValueRef::Map(pairs) => FieldValue::Map(
-                pairs
-                    .iter()
+            FieldValueRef::List(lr) => FieldValue::List(lr.iter().map(|v| v.to_owned()).collect()),
+            FieldValueRef::Map(mr) => FieldValue::Map(
+                mr.iter()
                     .map(|(k, v)| (k.to_owned(), v.to_owned()))
                     .collect(),
             ),

--- a/dial9-trace-format/src/types.rs
+++ b/dial9-trace-format/src/types.rs
@@ -15,6 +15,7 @@ use std::io::{self, Write};
 /// absent (decoded as [`FieldValueRef::None`]), `0x01` means present (followed
 /// by the inner type's normal encoding). The inner type tag is `tag & 0x7F`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum FieldType {
     I64 = 1,

--- a/dial9-trace-format/src/types.rs
+++ b/dial9-trace-format/src/types.rs
@@ -30,6 +30,8 @@ pub enum FieldType {
     U8 = 11,
     U16 = 12,
     U32 = 13,
+    DynamicList = 14,
+    DynamicMap = 15,
     // Optional variants (inner tag | 0x80).
     OptionalI64 = 0x81,
     OptionalF64 = 0x82,
@@ -44,6 +46,8 @@ pub enum FieldType {
     OptionalU8 = 0x8B,
     OptionalU16 = 0x8C,
     OptionalU32 = 0x8D,
+    OptionalDynamicList = 0x8E,
+    OptionalDynamicMap = 0x8F,
 }
 
 /// Newtype for stack frame addresses (leaf-first).
@@ -149,6 +153,10 @@ pub enum FieldValue {
     PooledStackFrames(InternedStackFrames),
     Varint(u64),
     StringMap(Vec<(Vec<u8>, Vec<u8>)>),
+    /// Self-describing list: each element carries its own type tag.
+    List(Vec<FieldValue>),
+    /// Self-describing map: each entry carries type tags for key and value.
+    Map(Vec<(FieldValue, FieldValue)>),
     /// Absent optional field.
     None,
 }
@@ -177,6 +185,8 @@ impl serde::Serialize for FieldValue {
                 }
                 map.end()
             }
+            FieldValue::List(items) => items.serialize(serializer),
+            FieldValue::Map(pairs) => pairs.serialize(serializer),
             FieldValue::None => serializer.serialize_none(),
         }
     }
@@ -185,6 +195,26 @@ impl serde::Serialize for FieldValue {
 impl FieldValue {
     pub fn string(s: &str) -> Self {
         FieldValue::String(s.to_string())
+    }
+
+    /// Returns the `FieldType` wire tag corresponding to this value's type.
+    /// Used for self-describing encoding in DynamicList/DynamicMap.
+    pub fn field_type_tag(&self) -> u8 {
+        match self {
+            FieldValue::I64(_) => FieldType::I64 as u8,
+            FieldValue::F64(_) => FieldType::F64 as u8,
+            FieldValue::Bool(_) => FieldType::Bool as u8,
+            FieldValue::String(_) => FieldType::String as u8,
+            FieldValue::Bytes(_) => FieldType::Bytes as u8,
+            FieldValue::PooledString(_) => FieldType::PooledString as u8,
+            FieldValue::StackFrames(_) => FieldType::StackFrames as u8,
+            FieldValue::PooledStackFrames(_) => FieldType::PooledStackFrames as u8,
+            FieldValue::Varint(_) => FieldType::Varint as u8,
+            FieldValue::StringMap(_) => FieldType::StringMap as u8,
+            FieldValue::List(_) => FieldType::DynamicList as u8,
+            FieldValue::Map(_) => FieldType::DynamicMap as u8,
+            FieldValue::None => 0x00,
+        }
     }
 }
 
@@ -207,6 +237,8 @@ impl FieldType {
             11 => Some(FieldType::U8),
             12 => Some(FieldType::U16),
             13 => Some(FieldType::U32),
+            14 => Some(FieldType::DynamicList),
+            15 => Some(FieldType::DynamicMap),
             0x81 => Some(FieldType::OptionalI64),
             0x82 => Some(FieldType::OptionalF64),
             0x83 => Some(FieldType::OptionalBool),
@@ -220,6 +252,8 @@ impl FieldType {
             0x8B => Some(FieldType::OptionalU8),
             0x8C => Some(FieldType::OptionalU16),
             0x8D => Some(FieldType::OptionalU32),
+            0x8E => Some(FieldType::OptionalDynamicList),
+            0x8F => Some(FieldType::OptionalDynamicMap),
             _ => None,
         }
     }
@@ -268,6 +302,24 @@ impl FieldValue {
                     w.write_all(k)?;
                     w.write_all(&(v.len() as u32).to_le_bytes())?;
                     w.write_all(v)?;
+                }
+                Ok(())
+            }
+            FieldValue::List(items) => {
+                w.write_all(&(items.len() as u32).to_le_bytes())?;
+                for item in items {
+                    w.write_all(&[item.field_type_tag()])?;
+                    item.encode(w)?;
+                }
+                Ok(())
+            }
+            FieldValue::Map(pairs) => {
+                w.write_all(&(pairs.len() as u32).to_le_bytes())?;
+                for (k, v) in pairs {
+                    w.write_all(&[k.field_type_tag()])?;
+                    k.encode(w)?;
+                    w.write_all(&[v.field_type_tag()])?;
+                    v.encode(w)?;
                 }
                 Ok(())
             }
@@ -361,6 +413,41 @@ impl FieldValue {
                 }
                 Some((FieldValue::StringMap(pairs), &data[pos..]))
             }
+            FieldType::DynamicList | FieldType::OptionalDynamicList => {
+                let count = u32::from_le_bytes(data.get(..4)?.try_into().ok()?) as usize;
+                let mut pos = 4;
+                let mut items = Vec::with_capacity(count.min(data.len() / 2));
+                for _ in 0..count {
+                    let tag = *data.get(pos)?;
+                    pos += 1;
+                    let ft = FieldType::from_tag(tag)?;
+                    let (val, rest) = Self::decode(ft, &data[pos..])?;
+                    pos += data.len() - pos - rest.len();
+                    items.push(val);
+                }
+                Some((FieldValue::List(items), &data[pos..]))
+            }
+            FieldType::DynamicMap | FieldType::OptionalDynamicMap => {
+                let count = u32::from_le_bytes(data.get(..4)?.try_into().ok()?) as usize;
+                let mut pos = 4;
+                let mut pairs = Vec::with_capacity(count.min(data.len() / 4));
+                for _ in 0..count {
+                    let key_tag = *data.get(pos)?;
+                    pos += 1;
+                    let key_ft = FieldType::from_tag(key_tag)?;
+                    let (key, rest) = Self::decode(key_ft, &data[pos..])?;
+                    pos += data.len() - pos - rest.len();
+
+                    let val_tag = *data.get(pos)?;
+                    pos += 1;
+                    let val_ft = FieldType::from_tag(val_tag)?;
+                    let (val, rest) = Self::decode(val_ft, &data[pos..])?;
+                    pos += data.len() - pos - rest.len();
+
+                    pairs.push((key, val));
+                }
+                Some((FieldValue::Map(pairs), &data[pos..]))
+            }
             // Optional variants: decode using the inner type.
             _ => Self::decode(field_type.inner(), data),
         }
@@ -383,6 +470,10 @@ pub enum FieldValueRef<'a> {
     PooledStackFrames(InternedStackFrames),
     Varint(u64),
     StringMap(StringMapRef<'a>),
+    /// Self-describing list. Elements are decoded eagerly since each carries its own tag.
+    List(Vec<FieldValueRef<'a>>),
+    /// Self-describing map. Entries are decoded eagerly since each carries its own tags.
+    Map(Vec<(FieldValueRef<'a>, FieldValueRef<'a>)>),
     /// Absent optional field.
     None,
 }
@@ -523,6 +614,41 @@ impl<'a> FieldValueRef<'a> {
                     pos,
                 ))
             }
+            FieldType::DynamicList | FieldType::OptionalDynamicList => {
+                let count = u32::from_le_bytes(d.get(..4)?.try_into().ok()?) as usize;
+                let mut pos = 4;
+                let mut items = Vec::with_capacity(count.min(d.len() / 2));
+                for _ in 0..count {
+                    let tag = *d.get(pos)?;
+                    pos += 1;
+                    let ft = FieldType::from_tag(tag)?;
+                    let (val, consumed) = Self::decode(ft, data, offset + pos)?;
+                    pos += consumed;
+                    items.push(val);
+                }
+                Some((FieldValueRef::List(items), pos))
+            }
+            FieldType::DynamicMap | FieldType::OptionalDynamicMap => {
+                let count = u32::from_le_bytes(d.get(..4)?.try_into().ok()?) as usize;
+                let mut pos = 4;
+                let mut pairs = Vec::with_capacity(count.min(d.len() / 4));
+                for _ in 0..count {
+                    let key_tag = *d.get(pos)?;
+                    pos += 1;
+                    let key_ft = FieldType::from_tag(key_tag)?;
+                    let (key, key_consumed) = Self::decode(key_ft, data, offset + pos)?;
+                    pos += key_consumed;
+
+                    let val_tag = *d.get(pos)?;
+                    pos += 1;
+                    let val_ft = FieldType::from_tag(val_tag)?;
+                    let (val, val_consumed) = Self::decode(val_ft, data, offset + pos)?;
+                    pos += val_consumed;
+
+                    pairs.push((key, val));
+                }
+                Some((FieldValueRef::Map(pairs), pos))
+            }
             // Optional variants: decode using the inner type.
             _ => Self::decode(field_type.inner(), data, offset),
         }
@@ -543,6 +669,15 @@ impl<'a> FieldValueRef<'a> {
             FieldValueRef::StringMap(sm) => FieldValue::StringMap(
                 sm.iter()
                     .map(|(k, v)| (k.as_bytes().to_vec(), v.as_bytes().to_vec()))
+                    .collect(),
+            ),
+            FieldValueRef::List(items) => {
+                FieldValue::List(items.iter().map(|v| v.to_owned()).collect())
+            }
+            FieldValueRef::Map(pairs) => FieldValue::Map(
+                pairs
+                    .iter()
+                    .map(|(k, v)| (k.to_owned(), v.to_owned()))
                     .collect(),
             ),
             FieldValueRef::None => FieldValue::None,
@@ -1135,7 +1270,7 @@ mod tests {
             assert_eq!(ft as u8, tag);
         }
         assert!(FieldType::from_tag(0).is_none());
-        assert!(FieldType::from_tag(14).is_none());
+        assert!(FieldType::from_tag(14).is_some());
     }
 
     #[test]

--- a/dial9-trace-format/tests/annotations.rs
+++ b/dial9-trace-format/tests/annotations.rs
@@ -7,25 +7,19 @@ use dial9_trace_format::types::{FieldType, FieldValue};
 #[test]
 fn annotations_round_trip() {
     let mut enc = Encoder::new();
-    let entry = SchemaEntry {
-        name: "Latency".into(),
-        has_timestamp: true,
-        fields: vec![
-            FieldDef {
-                name: "duration_us".into(),
-                field_type: FieldType::Varint,
-            },
-            FieldDef {
-                name: "endpoint".into(),
-                field_type: FieldType::PooledString,
-            },
+    let entry = SchemaEntry::with_annotations(
+        "Latency",
+        true,
+        vec![
+            FieldDef::new("duration_us", FieldType::Varint),
+            FieldDef::new("endpoint", FieldType::PooledString),
         ],
-        annotations: vec![
+        vec![
             FieldAnnotation::new(0, "metrique.unit", "microseconds"),
             FieldAnnotation::new(1, "dial9.display", "label"),
             FieldAnnotation::new(0, "dial9.kpi", "true"),
         ],
-    };
+    );
     let schema = Schema::from_entry(entry);
     enc.register_existing(&schema).unwrap();
 
@@ -85,14 +79,8 @@ fn annotations_round_trip() {
 #[test]
 fn no_annotations_no_frame() {
     let mut enc = Encoder::new();
-    enc.register_schema(
-        "Simple",
-        vec![FieldDef {
-            name: "x".into(),
-            field_type: FieldType::Varint,
-        }],
-    )
-    .unwrap();
+    enc.register_schema("Simple", vec![FieldDef::new("x", FieldType::Varint)])
+        .unwrap();
 
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
@@ -111,24 +99,18 @@ fn no_annotations_no_frame() {
 fn multiple_schemas_with_mixed_annotations() {
     let mut enc = Encoder::new();
 
-    let annotated = SchemaEntry {
-        name: "Annotated".into(),
-        has_timestamp: true,
-        fields: vec![FieldDef {
-            name: "val".into(),
-            field_type: FieldType::Varint,
-        }],
-        annotations: vec![FieldAnnotation::new(0, "unit", "ms")],
-    };
-    let plain = SchemaEntry {
-        name: "Plain".into(),
-        has_timestamp: true,
-        fields: vec![FieldDef {
-            name: "val".into(),
-            field_type: FieldType::Varint,
-        }],
-        annotations: Vec::new(),
-    };
+    let annotated = SchemaEntry::with_annotations(
+        "Annotated",
+        true,
+        vec![FieldDef::new("val", FieldType::Varint)],
+        vec![FieldAnnotation::new(0, "unit", "ms")],
+    );
+    let plain = SchemaEntry::with_annotations(
+        "Plain",
+        true,
+        vec![FieldDef::new("val", FieldType::Varint)],
+        Vec::new(),
+    );
 
     let schema_a = Schema::from_entry(annotated);
     let schema_b = Schema::from_entry(plain);
@@ -160,15 +142,12 @@ fn multiple_schemas_with_mixed_annotations() {
 fn annotations_silent_truncation() {
     // Encode a trace with annotations, then truncate before the annotation frame.
     let mut enc = Encoder::new();
-    let entry = SchemaEntry {
-        name: "Ev".into(),
-        has_timestamp: true,
-        fields: vec![FieldDef {
-            name: "x".into(),
-            field_type: FieldType::Varint,
-        }],
-        annotations: vec![FieldAnnotation::new(0, "key", "value")],
-    };
+    let entry = SchemaEntry::with_annotations(
+        "Ev",
+        true,
+        vec![FieldDef::new("x", FieldType::Varint)],
+        vec![FieldAnnotation::new(0, "key", "value")],
+    );
     let schema = Schema::from_entry(entry);
     enc.register_existing(&schema).unwrap();
     let data = enc.finish();
@@ -197,13 +176,7 @@ fn annotations_unknown_type_id_skipped() {
     // Build a valid trace, then manually append an annotation frame for an unknown type_id.
     let mut enc = Encoder::new();
     let schema = enc
-        .register_schema(
-            "Real",
-            vec![FieldDef {
-                name: "x".into(),
-                field_type: FieldType::Varint,
-            }],
-        )
+        .register_schema("Real", vec![FieldDef::new("x", FieldType::Varint)])
         .unwrap();
 
     enc.write_event(
@@ -247,15 +220,12 @@ fn annotations_unknown_type_id_skipped() {
 fn annotations_round_trip_ref() {
     // Verify the zero-copy path also works
     let mut enc = Encoder::new();
-    let entry = SchemaEntry {
-        name: "Ev".into(),
-        has_timestamp: true,
-        fields: vec![FieldDef {
-            name: "x".into(),
-            field_type: FieldType::Varint,
-        }],
-        annotations: vec![FieldAnnotation::new(0, "key", "val")],
-    };
+    let entry = SchemaEntry::with_annotations(
+        "Ev",
+        true,
+        vec![FieldDef::new("x", FieldType::Varint)],
+        vec![FieldAnnotation::new(0, "key", "val")],
+    );
     let schema = Schema::from_entry(entry);
     enc.register_existing(&schema).unwrap();
     enc.write_event(
@@ -283,15 +253,12 @@ fn annotations_round_trip_ref() {
 fn annotations_for_each_event_works() {
     // Verify that for_each_event processes events correctly when annotations are present
     let mut enc = Encoder::new();
-    let entry = SchemaEntry {
-        name: "Metric".into(),
-        has_timestamp: true,
-        fields: vec![FieldDef {
-            name: "val".into(),
-            field_type: FieldType::Varint,
-        }],
-        annotations: vec![FieldAnnotation::new(0, "unit", "bytes")],
-    };
+    let entry = SchemaEntry::with_annotations(
+        "Metric",
+        true,
+        vec![FieldDef::new("val", FieldType::Varint)],
+        vec![FieldAnnotation::new(0, "unit", "bytes")],
+    );
     let schema = Schema::from_entry(entry);
     enc.register_existing(&schema).unwrap();
     enc.write_event(

--- a/dial9-trace-format/tests/annotations.rs
+++ b/dial9-trace-format/tests/annotations.rs
@@ -44,7 +44,7 @@ fn annotations_round_trip() {
     for frame in &frames {
         match frame {
             DecodedFrame::Schema(s) => {
-                assert_eq!(s.name, "Latency");
+                assert_eq!(s.name(), "Latency");
                 saw_schema = true;
             }
             DecodedFrame::SchemaAnnotations {
@@ -72,8 +72,8 @@ fn annotations_round_trip() {
 
     // Verify annotations are merged into the registry
     let registry_entry = dec.registry().get(WireTypeId(0)).unwrap();
-    assert_eq!(registry_entry.annotations.len(), 3);
-    assert_eq!(registry_entry.annotations[0].key(), "metrique.unit");
+    assert_eq!(registry_entry.annotations().len(), 3);
+    assert_eq!(registry_entry.annotations()[0].key(), "metrique.unit");
 }
 
 #[test]
@@ -130,12 +130,12 @@ fn multiple_schemas_with_mixed_annotations() {
 
     // Annotations attached to the right schema
     let annotated_entry = dec.registry().get(WireTypeId(0)).unwrap();
-    assert_eq!(annotated_entry.name, "Annotated");
-    assert_eq!(annotated_entry.annotations.len(), 1);
+    assert_eq!(annotated_entry.name(), "Annotated");
+    assert_eq!(annotated_entry.annotations().len(), 1);
 
     let plain_entry = dec.registry().get(WireTypeId(1)).unwrap();
-    assert_eq!(plain_entry.name, "Plain");
-    assert!(plain_entry.annotations.is_empty());
+    assert_eq!(plain_entry.name(), "Plain");
+    assert!(plain_entry.annotations().is_empty());
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn annotations_unknown_type_id_skipped() {
 
     // The "Real" schema should have no annotations
     let real_entry = dec.registry().get(WireTypeId(0)).unwrap();
-    assert!(real_entry.annotations.is_empty());
+    assert!(real_entry.annotations().is_empty());
 }
 
 #[test]
@@ -273,8 +273,8 @@ fn annotations_for_each_event_works() {
     dec.for_each_event(|ev| {
         assert_eq!(ev.name, "Metric");
         // Annotations should be visible on the schema
-        assert_eq!(ev.schema.annotations.len(), 1);
-        assert_eq!(ev.schema.annotations[0].key(), "unit");
+        assert_eq!(ev.schema.annotations().len(), 1);
+        assert_eq!(ev.schema.annotations()[0].key(), "unit");
         event_count += 1;
     })
     .unwrap();

--- a/dial9-trace-format/tests/container_round_trip.rs
+++ b/dial9-trace-format/tests/container_round_trip.rs
@@ -11,10 +11,7 @@ fn dynamic_list_round_trip() {
     let schema = enc
         .register_schema(
             "ListEvent",
-            vec![FieldDef {
-                name: "items".into(),
-                field_type: FieldType::DynamicList,
-            }],
+            vec![FieldDef::new("items", FieldType::DynamicList)],
         )
         .unwrap();
 
@@ -50,10 +47,7 @@ fn dynamic_map_round_trip() {
     let schema = enc
         .register_schema(
             "MapEvent",
-            vec![FieldDef {
-                name: "props".into(),
-                field_type: FieldType::DynamicMap,
-            }],
+            vec![FieldDef::new("props", FieldType::DynamicMap)],
         )
         .unwrap();
 
@@ -91,10 +85,7 @@ fn optional_dynamic_list_round_trip() {
     let schema = enc
         .register_schema(
             "OptListEvent",
-            vec![FieldDef {
-                name: "tags".into(),
-                field_type: FieldType::OptionalDynamicList,
-            }],
+            vec![FieldDef::new("tags", FieldType::OptionalDynamicList)],
         )
         .unwrap();
 
@@ -131,10 +122,7 @@ fn heterogeneous_list_round_trip() {
     let schema = enc
         .register_schema(
             "MixedList",
-            vec![FieldDef {
-                name: "data".into(),
-                field_type: FieldType::DynamicList,
-            }],
+            vec![FieldDef::new("data", FieldType::DynamicList)],
         )
         .unwrap();
 
@@ -172,10 +160,7 @@ fn nested_list_in_map_round_trip() {
     let schema = enc
         .register_schema(
             "NestedEvent",
-            vec![FieldDef {
-                name: "nested".into(),
-                field_type: FieldType::DynamicMap,
-            }],
+            vec![FieldDef::new("nested", FieldType::DynamicMap)],
         )
         .unwrap();
 
@@ -209,14 +194,8 @@ fn empty_list_and_map_round_trip() {
         .register_schema(
             "EmptyContainers",
             vec![
-                FieldDef {
-                    name: "list".into(),
-                    field_type: FieldType::DynamicList,
-                },
-                FieldDef {
-                    name: "map".into(),
-                    field_type: FieldType::DynamicMap,
-                },
+                FieldDef::new("list", FieldType::DynamicList),
+                FieldDef::new("map", FieldType::DynamicMap),
             ],
         )
         .unwrap();

--- a/dial9-trace-format/tests/container_round_trip.rs
+++ b/dial9-trace-format/tests/container_round_trip.rs
@@ -1,0 +1,248 @@
+//! Round-trip tests for DynamicList and DynamicMap field types.
+
+use dial9_trace_format::decoder::{DecodedFrame, Decoder};
+use dial9_trace_format::encoder::Encoder;
+use dial9_trace_format::schema::FieldDef;
+use dial9_trace_format::types::{FieldType, FieldValue};
+
+#[test]
+fn dynamic_list_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "ListEvent",
+            vec![FieldDef {
+                name: "items".into(),
+                field_type: FieldType::DynamicList,
+            }],
+        )
+        .unwrap();
+
+    let items = vec![
+        FieldValue::String("hello".into()),
+        FieldValue::String("world".into()),
+        FieldValue::Varint(42),
+    ];
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(1000), FieldValue::List(items.clone())],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let events: Vec<_> = dec
+        .decode_all()
+        .into_iter()
+        .filter_map(|f| match f {
+            DecodedFrame::Event { values, .. } => Some(values),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0][0], FieldValue::List(items));
+}
+
+#[test]
+fn dynamic_map_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "MapEvent",
+            vec![FieldDef {
+                name: "props".into(),
+                field_type: FieldType::DynamicMap,
+            }],
+        )
+        .unwrap();
+
+    let pairs = vec![
+        (FieldValue::String("count".into()), FieldValue::Varint(10)),
+        (
+            FieldValue::String("name".into()),
+            FieldValue::String("test".into()),
+        ),
+    ];
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(2000), FieldValue::Map(pairs.clone())],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let events: Vec<_> = dec
+        .decode_all()
+        .into_iter()
+        .filter_map(|f| match f {
+            DecodedFrame::Event { values, .. } => Some(values),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0][0], FieldValue::Map(pairs));
+}
+
+#[test]
+fn optional_dynamic_list_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "OptListEvent",
+            vec![FieldDef {
+                name: "tags".into(),
+                field_type: FieldType::OptionalDynamicList,
+            }],
+        )
+        .unwrap();
+
+    // Present
+    let items = vec![FieldValue::Varint(1), FieldValue::Varint(2)];
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(3000), FieldValue::List(items.clone())],
+    )
+    .unwrap();
+    // Absent
+    enc.write_event(&schema, &[FieldValue::Varint(3001), FieldValue::None])
+        .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let events: Vec<_> = dec
+        .decode_all()
+        .into_iter()
+        .filter_map(|f| match f {
+            DecodedFrame::Event { values, .. } => Some(values),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0][0], FieldValue::List(items));
+    assert_eq!(events[1][0], FieldValue::None);
+}
+
+#[test]
+fn heterogeneous_list_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "MixedList",
+            vec![FieldDef {
+                name: "data".into(),
+                field_type: FieldType::DynamicList,
+            }],
+        )
+        .unwrap();
+
+    let items = vec![
+        FieldValue::String("hello".into()),
+        FieldValue::Varint(42),
+        FieldValue::Bool(true),
+        FieldValue::F64(1.5),
+        FieldValue::I64(-1),
+    ];
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(4000), FieldValue::List(items.clone())],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let events: Vec<_> = dec
+        .decode_all()
+        .into_iter()
+        .filter_map(|f| match f {
+            DecodedFrame::Event { values, .. } => Some(values),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0][0], FieldValue::List(items));
+}
+
+#[test]
+fn nested_list_in_map_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "NestedEvent",
+            vec![FieldDef {
+                name: "nested".into(),
+                field_type: FieldType::DynamicMap,
+            }],
+        )
+        .unwrap();
+
+    let inner_list = FieldValue::List(vec![FieldValue::Varint(1), FieldValue::Varint(2)]);
+    let pairs = vec![(FieldValue::String("nums".into()), inner_list.clone())];
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(5000), FieldValue::Map(pairs.clone())],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let events: Vec<_> = dec
+        .decode_all()
+        .into_iter()
+        .filter_map(|f| match f {
+            DecodedFrame::Event { values, .. } => Some(values),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0][0], FieldValue::Map(pairs));
+}
+
+#[test]
+fn empty_list_and_map_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "EmptyContainers",
+            vec![
+                FieldDef {
+                    name: "list".into(),
+                    field_type: FieldType::DynamicList,
+                },
+                FieldDef {
+                    name: "map".into(),
+                    field_type: FieldType::DynamicMap,
+                },
+            ],
+        )
+        .unwrap();
+
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(6000),
+            FieldValue::List(vec![]),
+            FieldValue::Map(vec![]),
+        ],
+    )
+    .unwrap();
+
+    let data = enc.finish();
+    let mut dec = Decoder::new(&data).unwrap();
+    let events: Vec<_> = dec
+        .decode_all()
+        .into_iter()
+        .filter_map(|f| match f {
+            DecodedFrame::Event { values, .. } => Some(values),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0][0], FieldValue::List(vec![]));
+    assert_eq!(events[0][1], FieldValue::Map(vec![]));
+}

--- a/dial9-trace-format/tests/derive_round_trip.rs
+++ b/dial9-trace-format/tests/derive_round_trip.rs
@@ -126,7 +126,7 @@ fn kitchen_sink_all_field_types() {
         .unwrap();
 
     let schema = schema::<KitchenSink>();
-    let decoded = KitchenSink::decode(ts, event, &schema.fields).unwrap();
+    let decoded = KitchenSink::decode(ts, event, schema.fields()).unwrap();
 
     assert_eq!(decoded.a_u8, 255);
     assert_eq!(decoded.b_u16, 65535);
@@ -187,7 +187,7 @@ fn kitchen_sink_zero_and_empty_values() {
         .unwrap();
 
     let schema = schema::<KitchenSink>();
-    let decoded = KitchenSink::decode(ts, event, &schema.fields).unwrap();
+    let decoded = KitchenSink::decode(ts, event, schema.fields()).unwrap();
 
     assert_eq!(decoded.a_u8, 0);
     assert_eq!(decoded.b_u16, 0);
@@ -219,7 +219,7 @@ fn empty_struct_round_trip() {
     assert_eq!(events.len(), 2);
     let schema = schema::<Empty>();
     for (ts, values) in &events {
-        let decoded = Empty::decode(*ts, values, &schema.fields).unwrap();
+        let decoded = Empty::decode(*ts, values, schema.fields()).unwrap();
         let _ = decoded; // just verify it decodes
     }
 }
@@ -240,7 +240,7 @@ fn multi_event_stream_preserves_order() {
     assert_eq!(events.len(), 100);
     let schema = schema::<SingleVarint>();
     for (i, (ts, values)) in events.iter().enumerate() {
-        let decoded = SingleVarint::decode(*ts, values, &schema.fields).unwrap();
+        let decoded = SingleVarint::decode(*ts, values, schema.fields()).unwrap();
         assert_eq!(decoded.v, i as u64);
     }
 }
@@ -290,12 +290,12 @@ fn interleaved_event_types() {
     for i in 0..20 {
         let (tid, ts, vals) = &events[i * 2];
         assert_eq!(*tid, varint_tid);
-        let sv = SingleVarint::decode(*ts, vals, &sv_schema.fields).unwrap();
+        let sv = SingleVarint::decode(*ts, vals, sv_schema.fields()).unwrap();
         assert_eq!(sv.v, i as u64);
 
         let (tid, ts, vals) = &events[i * 2 + 1];
         assert_eq!(*tid, strings_tid);
-        let decoded = TwoStrings::decode(*ts, vals, &ts_schema.fields).unwrap();
+        let decoded = TwoStrings::decode(*ts, vals, ts_schema.fields()).unwrap();
         assert_eq!(decoded.a, format!("a{i}"));
         assert_eq!(decoded.b, format!("b{i}"));
     }
@@ -351,17 +351,17 @@ fn interleaved_string_pools() {
     assert_eq!(events.len(), 3);
 
     let schema = schema::<MultiPool>();
-    let e0 = MultiPool::decode(events[0].0, events[0].1, &schema.fields).unwrap();
+    let e0 = MultiPool::decode(events[0].0, events[0].1, schema.fields()).unwrap();
     assert_eq!(e0.x, id_a);
     assert_eq!(e0.y, id_a);
     assert_eq!(e0.z, id_a);
 
-    let e1 = MultiPool::decode(events[1].0, events[1].1, &schema.fields).unwrap();
+    let e1 = MultiPool::decode(events[1].0, events[1].1, schema.fields()).unwrap();
     assert_eq!(e1.x, id_a);
     assert_eq!(e1.y, id_b);
     assert_eq!(e1.z, id_a);
 
-    let e2 = MultiPool::decode(events[2].0, events[2].1, &schema.fields).unwrap();
+    let e2 = MultiPool::decode(events[2].0, events[2].1, schema.fields()).unwrap();
     assert_eq!(e2.x, id_c);
     assert_eq!(e2.y, id_b);
     assert_eq!(e2.z, id_a);
@@ -405,7 +405,7 @@ fn string_pool_deduplication() {
         .unwrap();
 
     let schema = schema::<MultiPool>();
-    let decoded = MultiPool::decode(ts, event, &schema.fields).unwrap();
+    let decoded = MultiPool::decode(ts, event, schema.fields()).unwrap();
     assert_eq!(decoded.x, decoded.y); // same pool ID
     assert_ne!(decoded.x, decoded.z);
 }
@@ -453,7 +453,7 @@ fn stack_frames_edge_cases() {
             .unwrap();
 
         let schema = schema::<FrameEvent>();
-        let decoded = FrameEvent::decode(ts, event, &schema.fields).unwrap();
+        let decoded = FrameEvent::decode(ts, event, schema.fields()).unwrap();
         let decoded_addrs: Vec<u64> = decoded.frames.iter().collect();
         assert_eq!(&decoded_addrs, addrs, "failed for input {addrs:?}");
     }
@@ -497,7 +497,7 @@ fn f64_special_values_round_trip() {
         .unwrap();
 
     let schema = schema::<Floats>();
-    let decoded = Floats::decode(ts, event, &schema.fields).unwrap();
+    let decoded = Floats::decode(ts, event, schema.fields()).unwrap();
     assert_eq!(decoded.a, f64::INFINITY);
     assert_eq!(decoded.b, f64::NEG_INFINITY);
     assert!(decoded.c.is_sign_negative() && decoded.c == 0.0);
@@ -536,7 +536,7 @@ fn f64_nan_round_trip() {
         .unwrap();
 
     let schema = schema::<NanEvent>();
-    let decoded = NanEvent::decode(ts, event, &schema.fields).unwrap();
+    let decoded = NanEvent::decode(ts, event, schema.fields()).unwrap();
     assert!(decoded.v.is_nan());
 }
 
@@ -566,7 +566,7 @@ fn unicode_string_round_trip() {
         .unwrap();
 
     let schema = schema::<TwoStrings>();
-    let decoded = TwoStrings::decode(ts, event, &schema.fields).unwrap();
+    let decoded = TwoStrings::decode(ts, event, schema.fields()).unwrap();
     assert_eq!(decoded.a, "日本語テスト 🎌");
     assert_eq!(decoded.b, "émojis: 🦀🔥💯 and ñ");
 }
@@ -604,7 +604,7 @@ fn large_bytes_field() {
         .unwrap();
 
     let schema = schema::<BlobEvent>();
-    let decoded = BlobEvent::decode(ts, event, &schema.fields).unwrap();
+    let decoded = BlobEvent::decode(ts, event, schema.fields()).unwrap();
     assert_eq!(decoded.data.len(), 64 * 1024);
     assert!(decoded.data.iter().all(|&b| b == 0xAB));
 }
@@ -653,16 +653,16 @@ fn varint_boundary_values() {
     assert_eq!(events.len(), 3);
 
     let schema = schema::<Boundaries>();
-    let d0 = Boundaries::decode(events[0].0, &events[0].1, &schema.fields).unwrap();
+    let d0 = Boundaries::decode(events[0].0, &events[0].1, schema.fields()).unwrap();
     assert_eq!((d0.a, d0.b, d0.c, d0.d), (127, 128, 16383, 16384));
 
-    let d1 = Boundaries::decode(events[1].0, &events[1].1, &schema.fields).unwrap();
+    let d1 = Boundaries::decode(events[1].0, &events[1].1, schema.fields()).unwrap();
     assert_eq!(
         (d1.a, d1.b, d1.c, d1.d),
         (u8::MAX, u16::MAX, u32::MAX, u64::MAX)
     );
 
-    let d2 = Boundaries::decode(events[2].0, &events[2].1, &schema.fields).unwrap();
+    let d2 = Boundaries::decode(events[2].0, &events[2].1, schema.fields()).unwrap();
     assert_eq!((d2.a, d2.b, d2.c, d2.d), (0, 0, 0, 0));
 }
 
@@ -672,10 +672,10 @@ fn decode_wrong_field_count_returns_none() {
     let vals: Vec<FieldValueRef<'_>> = vec![FieldValueRef::Varint(1)];
     let ts_schema = schema::<TwoStrings>();
     // TwoStrings expects 2 fields, giving it 1 should fail
-    assert!(TwoStrings::decode(None, &vals, &ts_schema.fields).is_none());
+    assert!(TwoStrings::decode(None, &vals, ts_schema.fields()).is_none());
     // Empty slice
     let sv_schema = schema::<SingleVarint>();
-    assert!(SingleVarint::decode(None, &[], &sv_schema.fields).is_none());
+    assert!(SingleVarint::decode(None, &[], sv_schema.fields()).is_none());
 }
 
 #[test]
@@ -715,7 +715,7 @@ fn string_map_round_trip() {
     assert_eq!(events.len(), 3);
 
     let schema = schema::<MapEvent>();
-    let d0 = MapEvent::decode(events[0].0, &events[0].1, &schema.fields).unwrap();
+    let d0 = MapEvent::decode(events[0].0, &events[0].1, schema.fields()).unwrap();
     let pairs0: Vec<_> = d0.tags.iter().collect();
     assert_eq!(
         pairs0,
@@ -726,10 +726,10 @@ fn string_map_round_trip() {
         ]
     );
 
-    let d1 = MapEvent::decode(events[1].0, &events[1].1, &schema.fields).unwrap();
+    let d1 = MapEvent::decode(events[1].0, &events[1].1, schema.fields()).unwrap();
     assert_eq!(d1.tags.count(), 0);
 
-    let d2 = MapEvent::decode(events[2].0, &events[2].1, &schema.fields).unwrap();
+    let d2 = MapEvent::decode(events[2].0, &events[2].1, schema.fields()).unwrap();
     let pairs2: Vec<_> = d2.tags.iter().collect();
     assert_eq!(pairs2, vec![("名前", "テスト")]);
 }
@@ -812,23 +812,23 @@ fn many_events_many_types_stress() {
     let c_schema = schema::<TypeC>();
 
     for (idx, (tid, ts, vals)) in events.iter().enumerate() {
-        let schema_name = &dec.registry().get(*tid).unwrap().name;
+        let schema_name = dec.registry().get(*tid).unwrap().name();
         match idx % 3 {
             0 => {
                 assert_eq!(schema_name, a_name);
-                let d = TypeA::decode(*ts, vals, &a_schema.fields).unwrap();
+                let d = TypeA::decode(*ts, vals, a_schema.fields()).unwrap();
                 assert_eq!(d.ts, idx as u64 * 1000);
                 assert_eq!(d.val, idx as u32);
             }
             1 => {
                 assert_eq!(schema_name, b_name);
-                let d = TypeB::decode(*ts, vals, &b_schema.fields).unwrap();
+                let d = TypeB::decode(*ts, vals, b_schema.fields()).unwrap();
                 assert_eq!(d.name, format!("ev{idx}"));
                 assert_eq!(d.flag, idx % 2 == 0);
             }
             2 => {
                 assert_eq!(schema_name, c_name);
-                let d = TypeC::decode(*ts, vals, &c_schema.fields).unwrap();
+                let d = TypeC::decode(*ts, vals, c_schema.fields()).unwrap();
                 assert!((d.x - idx as f64 * 0.1).abs() < f64::EPSILON);
                 assert!((d.y - -(idx as f64)).abs() < f64::EPSILON);
             }
@@ -899,7 +899,7 @@ fn encoder_new_to_with_preallocated_buffer() {
     let (_, events) = decode_events(&data);
     assert_eq!(events.len(), 1);
     let schema = schema::<SingleVarint>();
-    let decoded = SingleVarint::decode(events[0].0, &events[0].1, &schema.fields).unwrap();
+    let decoded = SingleVarint::decode(events[0].0, &events[0].1, schema.fields()).unwrap();
     assert_eq!(decoded.v, 42);
 }
 
@@ -984,7 +984,7 @@ fn for_each_event_with_derive_types() {
     let mut dec = Decoder::new(&bytes).unwrap();
     let mut results = Vec::new();
     dec.for_each_event(|ev| {
-        let decoded = Ev::decode(ev.timestamp_ns, ev.fields, &ev.schema.fields).unwrap();
+        let decoded = Ev::decode(ev.timestamp_ns, ev.fields, ev.schema.fields()).unwrap();
         results.push((
             decoded.timestamp_ns,
             decoded.worker_id,
@@ -1035,7 +1035,7 @@ fn for_each_event_resolves_interned_strings() {
     let mut results = Vec::new();
     dec.for_each_event(|ev| {
         assert_eq!(ev.name, "TaskStart");
-        let decoded = TaskStart::decode(ev.timestamp_ns, ev.fields, &ev.schema.fields).unwrap();
+        let decoded = TaskStart::decode(ev.timestamp_ns, ev.fields, ev.schema.fields()).unwrap();
         // Resolve InternedString → &str via the string pool on RawEvent
         let location = ev.string_pool.get(decoded.spawn_location).unwrap();
         results.push((decoded.task_id, location.to_string()));
@@ -1068,12 +1068,12 @@ fn derive_event_name() {
 fn derive_field_defs() {
     let defs = SpanEvent::field_defs();
     assert_eq!(defs.len(), 3);
-    assert_eq!(defs[0].name, "parent_id");
-    assert_eq!(defs[0].field_type, FieldType::Varint);
-    assert_eq!(defs[1].name, "name");
-    assert_eq!(defs[1].field_type, FieldType::String);
-    assert_eq!(defs[2].name, "duration_ns");
-    assert_eq!(defs[2].field_type, FieldType::Varint);
+    assert_eq!(defs[0].name(), "parent_id");
+    assert_eq!(defs[0].field_type(), FieldType::Varint);
+    assert_eq!(defs[1].name(), "name");
+    assert_eq!(defs[1].field_type(), FieldType::String);
+    assert_eq!(defs[2].name(), "duration_ns");
+    assert_eq!(defs[2].field_type(), FieldType::Varint);
 }
 
 #[derive(TraceEvent)]
@@ -1089,11 +1089,11 @@ struct SmallTypes {
 #[test]
 fn derive_small_int_types_use_fixed_width() {
     let defs = SmallTypes::field_defs();
-    assert_eq!(defs[0].field_type, FieldType::U8, "u8 should be U8");
-    assert_eq!(defs[1].field_type, FieldType::U16, "u16 should be U16");
-    assert_eq!(defs[2].field_type, FieldType::U32, "u32 should be U32");
+    assert_eq!(defs[0].field_type(), FieldType::U8, "u8 should be U8");
+    assert_eq!(defs[1].field_type(), FieldType::U16, "u16 should be U16");
+    assert_eq!(defs[2].field_type(), FieldType::U32, "u32 should be U32");
     assert_eq!(
-        defs[3].field_type,
+        defs[3].field_type(),
         FieldType::Varint,
         "u64 should be Varint"
     );
@@ -1135,14 +1135,14 @@ struct WithOptionalStack {
 fn optional_field_schema_has_optional_flag() {
     let defs = WithOptionalString::field_defs();
     assert!(
-        !defs[0].field_type.is_optional(),
+        !defs[0].field_type().is_optional(),
         "required_id should not be optional"
     );
     assert!(
-        defs[1].field_type.is_optional(),
+        defs[1].field_type().is_optional(),
         "optional_name should be optional"
     );
-    assert_eq!(defs[1].field_type, FieldType::OptionalPooledString);
+    assert_eq!(defs[1].field_type(), FieldType::OptionalPooledString);
 }
 
 #[test]
@@ -1252,7 +1252,7 @@ fn optional_interned_stack_frames_round_trip() {
     assert_eq!(events, vec![(1000, Some(stack)), (2000, None)]);
 
     let defs = WithOptionalStack::field_defs();
-    assert_eq!(defs[0].field_type, FieldType::OptionalPooledStackFrames);
+    assert_eq!(defs[0].field_type(), FieldType::OptionalPooledStackFrames);
 }
 
 #[test]
@@ -1278,12 +1278,12 @@ fn named_decode_missing_optional_field_returns_none() {
         // This should fail because the wire data has field defs from WithoutOptional,
         // not WithOptionalString. The field defs from the wire are ["required_id"],
         // but we're passing WithOptionalString's defs ["required_id", "optional_name"].
-        // The named lookup finds "required_id" in ev.schema.fields, and "optional_name"
-        // is missing from ev.schema.fields, so it calls decode_missing() -> Some(None).
+        // The named lookup finds "required_id" in ev.schema.fields(), and "optional_name"
+        // is missing from ev.schema.fields(), so it calls decode_missing() -> Some(None).
         //
-        // Actually, ev.schema.fields comes from the wire schema (WithoutOptional),
+        // Actually, ev.schema.fields() comes from the wire schema (WithoutOptional),
         // which only has ["required_id"]. The defs we pass are the reader's expected
-        // defs. The decode zips ev.schema.fields with ev.fields, then looks up each
+        // defs. The decode zips ev.schema.fields() with ev.fields, then looks up each
         // expected name. "required_id" is found, "optional_name" is not -> None.
         let decoded = decoded.unwrap();
         assert_eq!(decoded.required_id, 77);

--- a/dial9-trace-format/tests/js_parser.rs
+++ b/dial9-trace-format/tests/js_parser.rs
@@ -364,3 +364,44 @@ fn js_decodes_optional_pooled_stack_frames() {
     );
     assert!(events[1]["values"]["callchain"].is_null());
 }
+
+#[test]
+fn js_decodes_dynamic_list_and_map() {
+    let mut enc = Encoder::new();
+    let tid = enc
+        .register_schema(
+            "Containers",
+            vec![
+                FieldDef::new("items", FieldType::DynamicList),
+                FieldDef::new("props", FieldType::DynamicMap),
+            ],
+        )
+        .unwrap();
+
+    let list = FieldValue::List(vec![
+        FieldValue::String("hello".into()),
+        FieldValue::Varint(42),
+    ]);
+    let map = FieldValue::Map(vec![(
+        FieldValue::String("key".into()),
+        FieldValue::Varint(99),
+    )]);
+    enc.write_event(&tid, &[FieldValue::Varint(1000), list, map])
+        .unwrap();
+
+    let data = enc.finish();
+    let json = js_decode(&data);
+
+    let frames = json["frames"].as_array().unwrap();
+    // schema + event = 2
+    assert_eq!(frames.len(), 2);
+
+    let vals = &frames[1]["values"];
+    let items = vals["items"].as_array().unwrap();
+    assert_eq!(items[0], "hello");
+    assert_eq!(items[1], "42");
+
+    let props = vals["props"].as_array().unwrap();
+    assert_eq!(props[0][0], "key");
+    assert_eq!(props[0][1], "99");
+}

--- a/dial9-trace-format/tests/js_parser.rs
+++ b/dial9-trace-format/tests/js_parser.rs
@@ -30,42 +30,15 @@ fn js_decodes_all_field_types() {
         .register_schema(
             "AllTypes",
             vec![
-                FieldDef {
-                    name: "a_u64".into(),
-                    field_type: FieldType::Varint,
-                },
-                FieldDef {
-                    name: "b_i64".into(),
-                    field_type: FieldType::I64,
-                },
-                FieldDef {
-                    name: "c_f64".into(),
-                    field_type: FieldType::F64,
-                },
-                FieldDef {
-                    name: "d_bool".into(),
-                    field_type: FieldType::Bool,
-                },
-                FieldDef {
-                    name: "e_string".into(),
-                    field_type: FieldType::String,
-                },
-                FieldDef {
-                    name: "f_bytes".into(),
-                    field_type: FieldType::Bytes,
-                },
-                FieldDef {
-                    name: "h_pooled".into(),
-                    field_type: FieldType::PooledString,
-                },
-                FieldDef {
-                    name: "i_stack".into(),
-                    field_type: FieldType::StackFrames,
-                },
-                FieldDef {
-                    name: "j_varint".into(),
-                    field_type: FieldType::Varint,
-                },
+                FieldDef::new("a_u64", FieldType::Varint),
+                FieldDef::new("b_i64", FieldType::I64),
+                FieldDef::new("c_f64", FieldType::F64),
+                FieldDef::new("d_bool", FieldType::Bool),
+                FieldDef::new("e_string", FieldType::String),
+                FieldDef::new("f_bytes", FieldType::Bytes),
+                FieldDef::new("h_pooled", FieldType::PooledString),
+                FieldDef::new("i_stack", FieldType::StackFrames),
+                FieldDef::new("j_varint", FieldType::Varint),
             ],
         )
         .unwrap();
@@ -101,18 +74,9 @@ fn js_decodes_all_field_types() {
             .register_schema(
                 "SymbolTableEntry",
                 vec![
-                    FieldDef {
-                        name: "base_addr".into(),
-                        field_type: FieldType::Varint,
-                    },
-                    FieldDef {
-                        name: "size".into(),
-                        field_type: FieldType::Varint,
-                    },
-                    FieldDef {
-                        name: "symbol_name".into(),
-                        field_type: FieldType::PooledString,
-                    },
+                    FieldDef::new("base_addr", FieldType::Varint),
+                    FieldDef::new("size", FieldType::Varint),
+                    FieldDef::new("symbol_name", FieldType::PooledString),
                 ],
             )
             .unwrap();
@@ -171,13 +135,7 @@ fn js_decodes_empty_stream() {
 fn js_decodes_truncated_trace_gracefully() {
     let mut enc = Encoder::new();
     let tid = enc
-        .register_schema(
-            "Ping",
-            vec![FieldDef {
-                name: "seq".into(),
-                field_type: FieldType::Varint,
-            }],
-        )
+        .register_schema("Ping", vec![FieldDef::new("seq", FieldType::Varint)])
         .unwrap();
     // Write two events so the first one is fully decodable.
     for i in 0..2u64 {
@@ -212,13 +170,7 @@ fn js_decodes_truncated_trace_gracefully() {
 fn js_decodes_multiple_events() {
     let mut enc = Encoder::new();
     let tid = enc
-        .register_schema(
-            "Tick",
-            vec![FieldDef {
-                name: "ts".into(),
-                field_type: FieldType::Varint,
-            }],
-        )
+        .register_schema("Tick", vec![FieldDef::new("ts", FieldType::Varint)])
         .unwrap();
     for i in 0..5u64 {
         enc.write_event(
@@ -247,14 +199,8 @@ fn js_decodes_optional_pooled_string() {
         .register_schema(
             "OptionalStringEvent",
             vec![
-                FieldDef {
-                    name: "required_id".into(),
-                    field_type: FieldType::Varint,
-                },
-                FieldDef {
-                    name: "opt_name".into(),
-                    field_type: FieldType::OptionalPooledString,
-                },
+                FieldDef::new("required_id", FieldType::Varint),
+                FieldDef::new("opt_name", FieldType::OptionalPooledString),
             ],
         )
         .unwrap();
@@ -304,14 +250,8 @@ fn js_decodes_pooled_stack_frames() {
         .register_schema(
             "CpuSample",
             vec![
-                FieldDef {
-                    name: "worker".into(),
-                    field_type: FieldType::Varint,
-                },
-                FieldDef {
-                    name: "callchain".into(),
-                    field_type: FieldType::PooledStackFrames,
-                },
+                FieldDef::new("worker", FieldType::Varint),
+                FieldDef::new("callchain", FieldType::PooledStackFrames),
             ],
         )
         .unwrap();
@@ -389,10 +329,10 @@ fn js_decodes_optional_pooled_stack_frames() {
     let tid = enc
         .register_schema(
             "MaybeStack",
-            vec![FieldDef {
-                name: "callchain".into(),
-                field_type: FieldType::OptionalPooledStackFrames,
-            }],
+            vec![FieldDef::new(
+                "callchain",
+                FieldType::OptionalPooledStackFrames,
+            )],
         )
         .unwrap();
 

--- a/dial9-trace-format/tests/round_trip.rs
+++ b/dial9-trace-format/tests/round_trip.rs
@@ -84,8 +84,8 @@ fn full_round_trip() {
     // + 1 cpu sample + 1 pool("my_function") + 1 symbol event = 8
     assert_eq!(decoded.len(), 8, "got: {decoded:#?}");
 
-    assert!(matches!(&decoded[0], DecodedFrame::Schema(s) if s.name == "PollStart"));
-    assert!(matches!(&decoded[1], DecodedFrame::Schema(s) if s.name == "CpuSample"));
+    assert!(matches!(&decoded[0], DecodedFrame::Schema(s) if s.name() == "PollStart"));
+    assert!(matches!(&decoded[1], DecodedFrame::Schema(s) if s.name() == "CpuSample"));
 
     assert_eq!(dec.string_pool().get(thread_id), Some("worker-0"));
     assert_eq!(dec.string_pool().get(sym_name_id), Some("my_function"));
@@ -106,7 +106,7 @@ fn full_round_trip() {
     }
 
     // Verify symbol table event
-    assert!(matches!(&decoded[6], DecodedFrame::Schema(s) if s.name == "SymbolTableEntry"));
+    assert!(matches!(&decoded[6], DecodedFrame::Schema(s) if s.name() == "SymbolTableEntry"));
     if let DecodedFrame::Event { values, .. } = &decoded[7] {
         assert_eq!(values[0], FieldValue::Varint(0x5555_5555_0000));
         assert_eq!(values[1], FieldValue::Varint(0x2000));

--- a/dial9-trace-format/tests/round_trip.rs
+++ b/dial9-trace-format/tests/round_trip.rs
@@ -11,14 +11,8 @@ fn full_round_trip() {
         .register_schema(
             "PollStart",
             vec![
-                FieldDef {
-                    name: "worker".into(),
-                    field_type: FieldType::Varint,
-                },
-                FieldDef {
-                    name: "task_id".into(),
-                    field_type: FieldType::Varint,
-                },
+                FieldDef::new("worker", FieldType::Varint),
+                FieldDef::new("task_id", FieldType::Varint),
             ],
         )
         .unwrap();
@@ -26,14 +20,8 @@ fn full_round_trip() {
         .register_schema(
             "CpuSample",
             vec![
-                FieldDef {
-                    name: "thread_name".into(),
-                    field_type: FieldType::PooledString,
-                },
-                FieldDef {
-                    name: "frames".into(),
-                    field_type: FieldType::StackFrames,
-                },
+                FieldDef::new("thread_name", FieldType::PooledString),
+                FieldDef::new("frames", FieldType::StackFrames),
             ],
         )
         .unwrap();
@@ -68,18 +56,9 @@ fn full_round_trip() {
         .register_schema(
             "SymbolTableEntry",
             vec![
-                FieldDef {
-                    name: "base_addr".into(),
-                    field_type: FieldType::Varint,
-                },
-                FieldDef {
-                    name: "size".into(),
-                    field_type: FieldType::Varint,
-                },
-                FieldDef {
-                    name: "symbol_name".into(),
-                    field_type: FieldType::PooledString,
-                },
+                FieldDef::new("base_addr", FieldType::Varint),
+                FieldDef::new("size", FieldType::Varint),
+                FieldDef::new("symbol_name", FieldType::PooledString),
             ],
         )
         .unwrap();
@@ -144,38 +123,14 @@ fn round_trip_all_field_types() {
         .register_schema(
             "AllTypes",
             vec![
-                FieldDef {
-                    name: "a".into(),
-                    field_type: FieldType::Varint,
-                },
-                FieldDef {
-                    name: "b".into(),
-                    field_type: FieldType::I64,
-                },
-                FieldDef {
-                    name: "c".into(),
-                    field_type: FieldType::F64,
-                },
-                FieldDef {
-                    name: "d".into(),
-                    field_type: FieldType::Bool,
-                },
-                FieldDef {
-                    name: "e".into(),
-                    field_type: FieldType::String,
-                },
-                FieldDef {
-                    name: "f".into(),
-                    field_type: FieldType::Bytes,
-                },
-                FieldDef {
-                    name: "h".into(),
-                    field_type: FieldType::PooledString,
-                },
-                FieldDef {
-                    name: "i".into(),
-                    field_type: FieldType::StackFrames,
-                },
+                FieldDef::new("a", FieldType::Varint),
+                FieldDef::new("b", FieldType::I64),
+                FieldDef::new("c", FieldType::F64),
+                FieldDef::new("d", FieldType::Bool),
+                FieldDef::new("e", FieldType::String),
+                FieldDef::new("f", FieldType::Bytes),
+                FieldDef::new("h", FieldType::PooledString),
+                FieldDef::new("i", FieldType::StackFrames),
             ],
         )
         .unwrap();

--- a/dial9-trace-format/tests/spec_edge_cases.rs
+++ b/dial9-trace-format/tests/spec_edge_cases.rs
@@ -39,7 +39,7 @@ fn schema_max_type_id_via_encoder() {
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
     let frames = dec.decode_all();
-    assert!(matches!(&frames[0], DecodedFrame::Schema(s) if s.name == "Ev"));
+    assert!(matches!(&frames[0], DecodedFrame::Schema(s) if s.name() == "Ev"));
     if let DecodedFrame::Event { values, .. } = &frames[1] {
         assert_eq!(values[0], FieldValue::Varint(42));
     } else {
@@ -55,7 +55,7 @@ fn schema_empty_name_via_encoder() {
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
     let frames = dec.decode_all();
-    assert!(matches!(&frames[0], DecodedFrame::Schema(s) if s.name.is_empty()));
+    assert!(matches!(&frames[0], DecodedFrame::Schema(s) if s.name().is_empty()));
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn schema_many_fields_via_encoder() {
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
     let frames = dec.decode_all();
-    assert!(matches!(&frames[0], DecodedFrame::Schema(s) if s.fields.len() == 256));
+    assert!(matches!(&frames[0], DecodedFrame::Schema(s) if s.fields().len() == 256));
 }
 
 // --- Field type edge cases ---

--- a/dial9-trace-format/tests/spec_edge_cases.rs
+++ b/dial9-trace-format/tests/spec_edge_cases.rs
@@ -29,10 +29,7 @@ fn empty_stream_after_header() {
 fn schema_max_type_id_via_encoder() {
     // Register a schema and verify round-trip
     let mut enc = Encoder::new();
-    let fields = vec![FieldDef {
-        name: "v".into(),
-        field_type: FieldType::Varint,
-    }];
+    let fields = vec![FieldDef::new("v", FieldType::Varint)];
     let schema = enc.register_schema("Ev", fields).unwrap();
     enc.write_event(
         &schema,
@@ -65,10 +62,7 @@ fn schema_empty_name_via_encoder() {
 fn schema_many_fields_via_encoder() {
     let mut enc = Encoder::new();
     let fields: Vec<FieldDef> = (0..256)
-        .map(|i| FieldDef {
-            name: format!("f{i}"),
-            field_type: FieldType::Varint,
-        })
+        .map(|i| FieldDef::new(format!("f{i}"), FieldType::Varint))
         .collect();
     let schema = enc.register_schema("Wide", fields).unwrap();
     let mut values = vec![FieldValue::Varint(0)]; // timestamp
@@ -258,10 +252,7 @@ fn string_pool_many_entries_via_encoder() {
 #[test]
 fn multiple_schemas_then_events() {
     let mut enc = Encoder::new();
-    let fields = vec![FieldDef {
-        name: "v".into(),
-        field_type: FieldType::Varint,
-    }];
+    let fields = vec![FieldDef::new("v", FieldType::Varint)];
     let schemas: Vec<_> = (0..5)
         .map(|i| {
             enc.register_schema(&format!("Ev{i}"), fields.clone())
@@ -294,13 +285,7 @@ fn multiple_schemas_then_events() {
 fn interleaved_pool_and_events() {
     let mut enc = Encoder::new();
     let schema = enc
-        .register_schema(
-            "Ev",
-            vec![FieldDef {
-                name: "s".into(),
-                field_type: FieldType::PooledString,
-            }],
-        )
+        .register_schema("Ev", vec![FieldDef::new("s", FieldType::PooledString)])
         .unwrap();
     let id0 = enc.intern_string("first").unwrap();
     enc.write_event(

--- a/dial9-trace-format/tests/spec_edge_cases.rs
+++ b/dial9-trace-format/tests/spec_edge_cases.rs
@@ -342,7 +342,7 @@ fn field_type_tag_0_invalid() {
 
 #[test]
 fn field_type_tag_14_invalid() {
-    assert!(FieldType::from_tag(14).is_none());
+    assert!(FieldType::from_tag(14).is_some());
 }
 
 #[test]

--- a/perf-self-profile/src/offline_symbolize.rs
+++ b/perf-self-profile/src/offline_symbolize.rs
@@ -159,13 +159,7 @@ mod tests {
     fn symbolize_no_stack_frames_writes_nothing() {
         let mut enc = Encoder::new();
         let schema = enc
-            .register_schema(
-                "Ev",
-                vec![FieldDef {
-                    name: "count".into(),
-                    field_type: FieldType::Varint,
-                }],
-            )
+            .register_schema("Ev", vec![FieldDef::new("count", FieldType::Varint)])
             .unwrap();
         enc.write_event(&schema, &[FieldValue::Varint(0), FieldValue::Varint(42)])
             .unwrap();
@@ -186,13 +180,7 @@ mod tests {
     fn symbolize_empty_maps_writes_nothing() {
         let mut enc = Encoder::new();
         let schema = enc
-            .register_schema(
-                "Ev",
-                vec![FieldDef {
-                    name: "frames".into(),
-                    field_type: FieldType::StackFrames,
-                }],
-            )
+            .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
             .unwrap();
         enc.write_event(
             &schema,

--- a/perf-self-profile/src/sys/linux/offline_symbolize.rs
+++ b/perf-self-profile/src/sys/linux/offline_symbolize.rs
@@ -208,10 +208,7 @@ mod tests {
         let schema1 = enc1
             .register_schema(
                 "Ev",
-                vec![FieldDef {
-                    name: "frames".into(),
-                    field_type: FieldType::PooledStackFrames,
-                }],
+                vec![FieldDef::new("frames", FieldType::PooledStackFrames)],
             )
             .unwrap();
         let id_a = enc1.intern_stack_frames(&[addr_a]).unwrap();
@@ -227,10 +224,7 @@ mod tests {
         let schema2 = enc2
             .register_schema(
                 "Ev",
-                vec![FieldDef {
-                    name: "frames".into(),
-                    field_type: FieldType::PooledStackFrames,
-                }],
+                vec![FieldDef::new("frames", FieldType::PooledStackFrames)],
             )
             .unwrap();
         let id_b = enc2.intern_stack_frames(&[addr_b]).unwrap();
@@ -270,13 +264,7 @@ mod tests {
 
         let mut enc = Encoder::new();
         let schema = enc
-            .register_schema(
-                "Ev",
-                vec![FieldDef {
-                    name: "frames".into(),
-                    field_type: FieldType::StackFrames,
-                }],
-            )
+            .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
             .unwrap();
         enc.write_event(
             &schema,
@@ -326,13 +314,7 @@ mod tests {
         // Build a minimal trace containing a single StackFrames event with our address.
         let mut enc = Encoder::new();
         let schema = enc
-            .register_schema(
-                "Ev",
-                vec![FieldDef {
-                    name: "frames".into(),
-                    field_type: FieldType::StackFrames,
-                }],
-            )
+            .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
             .unwrap();
         enc.write_event(
             &schema,

--- a/perf-self-profile/src/sys/linux/offline_symbolize.rs
+++ b/perf-self-profile/src/sys/linux/offline_symbolize.rs
@@ -188,7 +188,7 @@ mod tests {
                 type_id, values, ..
             } = frame
                 && let Some(entry) = dec.registry().get(*type_id)
-                && entry.name == SymbolTableEntry::event_name()
+                && entry.name() == SymbolTableEntry::event_name()
                 && let Some(FieldValue::Varint(addr)) = values.first()
             {
                 out.push(*addr);
@@ -289,7 +289,7 @@ mod tests {
             .iter()
             .any(|f| matches!(f, DecodedFrame::StringPool(_)));
         let has_symbol_schema = frames.iter().any(
-            |f| matches!(f, DecodedFrame::Schema(s) if s.name == SymbolTableEntry::event_name()),
+            |f| matches!(f, DecodedFrame::Schema(s) if s.name() == SymbolTableEntry::event_name()),
         );
         assert!(has_string_pool, "expected StringPool frame in output");
         assert!(
@@ -338,7 +338,7 @@ mod tests {
         let frames = dec.decode_all();
 
         let has_symbol_schema = frames.iter().any(
-            |f| matches!(f, DecodedFrame::Schema(s) if s.name == SymbolTableEntry::event_name()),
+            |f| matches!(f, DecodedFrame::Schema(s) if s.name() == SymbolTableEntry::event_name()),
         );
         assert!(
             has_symbol_schema,

--- a/perf-self-profile/src/tracepoint.rs
+++ b/perf-self-profile/src/tracepoint.rs
@@ -396,10 +396,7 @@ fn kernel_field_to_trace_format(field: &TracepointField) -> FieldDef {
     } else {
         kernel_type_to_field_type(&field.field_type, field.size, field.signed)
     };
-    FieldDef {
-        name: field.name.clone(),
-        field_type,
-    }
+    FieldDef::new(field.name.clone(), field_type)
 }
 
 fn kernel_type_to_field_type(type_str: &str, size: usize, signed: bool) -> FieldType {

--- a/perf-self-profile/src/tracepoint.rs
+++ b/perf-self-profile/src/tracepoint.rs
@@ -556,20 +556,20 @@ print fmt: "prev_comm=%s prev_pid=%d prev_prio=%d prev_state=%s%s ==> next_comm=
         assert_eq!(defs.len(), 7);
 
         // char[16] → String
-        assert_eq!(defs[0].name, "prev_comm");
-        assert_eq!(defs[0].field_type, FieldType::String);
+        assert_eq!(defs[0].name(), "prev_comm");
+        assert_eq!(defs[0].field_type(), FieldType::String);
 
         // pid_t (4 bytes, signed) → I64
-        assert_eq!(defs[1].name, "prev_pid");
-        assert_eq!(defs[1].field_type, FieldType::I64);
+        assert_eq!(defs[1].name(), "prev_pid");
+        assert_eq!(defs[1].field_type(), FieldType::I64);
 
         // int (4 bytes, signed) → I64
-        assert_eq!(defs[2].name, "prev_prio");
-        assert_eq!(defs[2].field_type, FieldType::I64);
+        assert_eq!(defs[2].name(), "prev_prio");
+        assert_eq!(defs[2].field_type(), FieldType::I64);
 
         // long (8 bytes, signed) → I64
-        assert_eq!(defs[3].name, "prev_state");
-        assert_eq!(defs[3].field_type, FieldType::I64);
+        assert_eq!(defs[3].name(), "prev_state");
+        assert_eq!(defs[3].field_type(), FieldType::I64);
     }
 
     #[test]
@@ -633,10 +633,10 @@ print fmt: "prev_comm=%s prev_pid=%d prev_prio=%d prev_state=%s%s ==> next_comm=
         for frame in frames {
             match frame {
                 DecodedFrame::Schema(entry) => {
-                    assert_eq!(entry.name, "sched_switch");
-                    assert!(entry.has_timestamp);
-                    assert_eq!(entry.fields.len(), 7);
-                    assert_eq!(entry.fields[0].name, "prev_comm");
+                    assert_eq!(entry.name(), "sched_switch");
+                    assert!(entry.has_timestamp());
+                    assert_eq!(entry.fields().len(), 7);
+                    assert_eq!(entry.fields()[0].name(), "prev_comm");
                     found_schema = true;
                 }
                 DecodedFrame::Event {
@@ -819,7 +819,7 @@ format:
         let defs = tp.to_trace_format_fields();
 
         // __data_loc char[] → String
-        assert_eq!(defs[2].name, "name");
-        assert_eq!(defs[2].field_type, FieldType::String);
+        assert_eq!(defs[2].name(), "name");
+        assert_eq!(defs[2].field_type(), FieldType::String);
     }
 }

--- a/perf-self-profile/tests/tracepoint_e2e.rs
+++ b/perf-self-profile/tests/tracepoint_e2e.rs
@@ -90,9 +90,9 @@ fn tracepoint_sched_switch_e2e() {
     for frame in &frames {
         match frame {
             DecodedFrame::Schema(entry) => {
-                assert_eq!(entry.name, "sched_switch");
-                assert!(entry.has_timestamp);
-                assert_eq!(entry.fields.len(), tp.fields.len());
+                assert_eq!(entry.name(), "sched_switch");
+                assert!(entry.has_timestamp());
+                assert_eq!(entry.fields().len(), tp.fields.len());
                 schema_count += 1;
             }
             DecodedFrame::Event {


### PR DESCRIPTION
Related: dial9-rs/dial9-tokio-telemetry#346 (metrique integration design), groundwork for the metrique adapter

### Summary

Adds wire-format support for typed list and typed map fields, the second of two trace-format extensions needed for metrique integration. Lists model metrique `Vec<a[dial9-trace-format] Add List and Map field types with structural FieldType

Related: dial9-rs/dial9-tokio-telemetry#346 (metrique integration design), groundwork for the metrique adapter

### Summary

Adds wire-format support for typed list and typed map fields, the second of two trace-format extensions needed for metrique integration. Lists model metrique `Vec<T>`; maps model metrique `Flex<(String, T)>`. Both produce one schema per entry type regardless of runtime cardinality, which is the property the integration needs to avoid schema explosion.

Four new `FieldType` wire tags: `List = 0x0E`, `Map = 0x0F`, `OptionalList = 0x8E`, `OptionalMap = 0x8F`. Schema frame field-type bytes become variable-width and recursive: each container tag is followed by its inner type(s) using the same encoding. Event payloads encode list/map counts as `u32 LE` followed by elements in the declared inner type.

Inner optionals (`Vec<Option<T>>`, `Flex<(String, Option<T>)>`) are supported via the existing `OptionalX` scalar tags in the inner position. Nested containers (`Vec<Vec<T>>`, `Map<K, Map<...>>`) are supported: the recursive schema encoding and event codec handle arbitrary nesting depth.

### Tradeoffs and rationale

`FieldType` becomes structural for the new variants: `List(Box<ListSpec>)`, `Map(Box<MapSpec>)`, and their optional forms. Three representations were weighed.

The one I picked (B1) ultimately was not the minimal change, but preserved clearer semantics around FieldTypes vs FieldDefs and set us up for not having pain in the near future:


#### A: flat FieldType, sidecars on FieldDef (not chosen)

```rust
#[repr(u8)]
#[derive(Copy, Clone)]
pub enum FieldType {
    I64 = 1, ..., U32 = 13,
    OptionalI64 = 0x81, ..., OptionalU32 = 0x8D,
    List = 14, Map = 15,
    OptionalList = 0x8E, OptionalMap = 0x8F,
}

pub struct FieldDef {
    name: String,
    field_type: FieldType,
    list_element: Option<FieldType>,
    map_key_value: Option<(FieldType, FieldType)>,
}
```

Not chosen because: container shape invariants live on FieldDef sidecars (runtime-validated, not type-enforced), cannot express nested containers even in principle, and grows another Option sidecar per future container variant.

#### B1: structural FieldType with OptionalX variants kept (chosen)

```rust
pub enum FieldType {
    I64, ..., U32,
    OptionalI64, ..., OptionalU32,
    List(Box<ListSpec>),
    Map(Box<MapSpec>),
    OptionalList(Box<ListSpec>),
    OptionalMap(Box<MapSpec>),
}

pub struct ListSpec { element: FieldType }
pub struct MapSpec { key: FieldType, value: FieldType }

pub struct FieldDef {
    name: String,
    field_type: FieldType,
}
```

Chosen because: thin FieldDef, compile-time container shape, `Vec<Option<T>>` and `Flex<(String, Option<T>)>` compose via existing OptionalX variants without parallel flags, nested containers work naturally via recursive schema encoding.

#### B2: uniform is_optional on FieldDef, no OptionalX variants (not chosen)

```rust
pub enum FieldType {
    I64, ..., U32,
    List(Box<ListSpec>),
    Map(Box<MapSpec>),
}

pub struct ListSpec { element: FieldType }
pub struct MapSpec { key: FieldType, value: FieldType }

pub struct FieldDef {
    name: String,
    field_type: FieldType,
    is_optional: bool,
}
```

Not chosen because: inner optionals (`Vec<Option<T>>`, `Flex<(String, Option<T>)>`) would need parallel `_optional` bools inside `ListSpec` / `MapSpec` (`element_optional`, `key_optional`, `value_optional`), which is more boilerplate than B1's reuse of OptionalX variants. Also the largest total diff of the three.


### Breaking changes

This is a breaking release for `dial9-trace-format`:

- `FieldType` loses `Copy` and `#[repr(u8)]`. `ft as u8` is replaced by `ft.wire_tag() -> u8`. External exhaustive-match patterns need a wildcard arm (the type is now `#[non_exhaustive]`).
- `FieldType::from_tag(u8)` is replaced by `FieldType::from_scalar_tag(u8)` (scalar-only) plus `FieldType::read_from_bytes(&[u8])` for schema decoding with variable-width inner types.
- `FieldType`, `FieldDef`, `SchemaEntry`, `ListSpec`, `MapSpec` gain `#[non_exhaustive]`.
- External struct literal construction of `FieldDef` migrates to public constructors (`::new`, `::list`, `::list_optional`, `::map`, `::map_optional`). All external in-tree sites are migrated in this PR. Same-crate code continues to use struct literals where convenient.
- `SchemaEntry` gains `::new` constructor.
- Decoder-internal `SchemaCache::field_tags: Vec<u8>` becomes `field_types: Vec<FieldType>` (private).
- `FieldValue` and `FieldValueRef` gain `List` and `Map` variants (both already `#[non_exhaustive]`, so additive).

Version bump (0.3.x to 0.4.0), Cargo.toml changes, and CHANGELOG entries are handled at release time, not in this PR.

### Testing

Round-trip coverage for `Vec<T>`, `Option<Vec<T>>`, `Vec<Option<T>>`, `Flex<(String, T)>`, `Flex<(String, Option<T>)>`, optional maps, and nested `List<List<T>>`. Codec round-trip through the full encoder/decoder pipeline for every new combination. Zero-copy `ListRef`/`MapRef` iteration verified through `for_each_event`. Derive macro round-trip with `TypedList<String>` and `TypedMap<String, u64>` fields, plus insta snapshot of the macro expansion. All existing round-trip, derive, spec-edge-case, and snapshot tests continue to pass after insta acceptance.

### Out of scope

- Viewer updates (JS decoder, HTML viewer) for the new field types. Settled on the wire but not rendered yet.
- Demo trace regeneration. Current producers do not emit the new variants, so the demo trace stays unchanged.
- Format version bump, Cargo.toml change, CHANGELOG entry (handled at release time).T>`; maps model metrique `Flex<(String, T)>`. Both produce one schema per entry type regardless of runtime cardinality, which is the property the integration needs to avoid schema explosion.

Four new `FieldType` wire tags: `List = 0x0E`, `Map = 0x0F`, `OptionalList = 0x8E`, `OptionalMap = 0x8F`. Schema frame field-type bytes become variable-width and recursive: each container tag is followed by its inner type(s) using the same encoding. Event payloads encode list/map counts as `u32 LE` followed by elements in the declared inner type.

Inner optionals (`Vec<Option<T>>`, `Flex<(String, Option<T>)>`) are supported via the existing `OptionalX` scalar tags in the inner position. Nested containers (`Vec<Vec<T>>`, `Map<K, Map<...>>`) are supported: the recursive schema encoding and event codec handle arbitrary nesting depth.

### Tradeoffs and rationale

`FieldType` becomes structural for the new variants: `List(Box<ListSpec>)`, `Map(Box<MapSpec>)`, and their optional forms. Three representations were weighed.

The one I picked (A) ultimately was not the minimal change, but preserved clearer semantics around FieldTypes vs FieldDefs and set us up for not having pain in the near future:


#### A: flat FieldType, sidecars on FieldDef (not chosen)

```rust
#[repr(u8)]
#[derive(Copy, Clone)]
pub enum FieldType {
    I64 = 1, ..., U32 = 13,
    OptionalI64 = 0x81, ..., OptionalU32 = 0x8D,
    List = 14, Map = 15,
    OptionalList = 0x8E, OptionalMap = 0x8F,
}

pub struct FieldDef {
    name: String,
    field_type: FieldType,
    list_element: Option<FieldType>,
    map_key_value: Option<(FieldType, FieldType)>,
}
```

Not chosen because: container shape invariants live on FieldDef sidecars (runtime-validated, not type-enforced), cannot express nested containers even in principle, and grows another Option sidecar per future container variant.

#### B1: structural FieldType with OptionalX variants kept (chosen)

```rust
pub enum FieldType {
    I64, ..., U32,
    OptionalI64, ..., OptionalU32,
    List(Box<ListSpec>),
    Map(Box<MapSpec>),
    OptionalList(Box<ListSpec>),
    OptionalMap(Box<MapSpec>),
}

pub struct ListSpec { element: FieldType }
pub struct MapSpec { key: FieldType, value: FieldType }

pub struct FieldDef {
    name: String,
    field_type: FieldType,
}
```

Chosen because: thin FieldDef, compile-time container shape, `Vec<Option<T>>` and `Flex<(String, Option<T>)>` compose via existing OptionalX variants without parallel flags, nested containers work naturally via recursive schema encoding.

#### B2: uniform is_optional on FieldDef, no OptionalX variants (not chosen)

```rust
pub enum FieldType {
    I64, ..., U32,
    List(Box<ListSpec>),
    Map(Box<MapSpec>),
}

pub struct ListSpec { element: FieldType }
pub struct MapSpec { key: FieldType, value: FieldType }

pub struct FieldDef {
    name: String,
    field_type: FieldType,
    is_optional: bool,
}
```

Not chosen because: inner optionals (`Vec<Option<T>>`, `Flex<(String, Option<T>)>`) would need parallel `_optional` bools inside `ListSpec` / `MapSpec` (`element_optional`, `key_optional`, `value_optional`), which is more boilerplate than B1's reuse of OptionalX variants. Also the largest total diff of the three.


### Breaking changes

This is a breaking release for `dial9-trace-format`:

- `FieldType` loses `Copy` and `#[repr(u8)]`. `ft as u8` is replaced by `ft.wire_tag() -> u8`. External exhaustive-match patterns need a wildcard arm (the type is now `#[non_exhaustive]`).
- `FieldType::from_tag(u8)` is replaced by `FieldType::from_scalar_tag(u8)` (scalar-only) plus `FieldType::read_from_bytes(&[u8])` for schema decoding with variable-width inner types.
- `FieldType`, `FieldDef`, `SchemaEntry`, `ListSpec`, `MapSpec` gain `#[non_exhaustive]`.
- External struct literal construction of `FieldDef` migrates to public constructors (`::new`, `::list`, `::list_optional`, `::map`, `::map_optional`). All external in-tree sites are migrated in this PR. Same-crate code continues to use struct literals where convenient.
- `SchemaEntry` gains `::new` constructor.
- Decoder-internal `SchemaCache::field_tags: Vec<u8>` becomes `field_types: Vec<FieldType>` (private).
- `FieldValue` and `FieldValueRef` gain `List` and `Map` variants (both already `#[non_exhaustive]`, so additive).

Version bump (0.3.x to 0.4.0), Cargo.toml changes, and CHANGELOG entries are handled at release time, not in this PR.

### Testing

Round-trip coverage for `Vec<T>`, `Option<Vec<T>>`, `Vec<Option<T>>`, `Flex<(String, T)>`, `Flex<(String, Option<T>)>`, optional maps, and nested `List<List<T>>`. Codec round-trip through the full encoder/decoder pipeline for every new combination. Zero-copy `ListRef`/`MapRef` iteration verified through `for_each_event`. All existing round-trip, derive, spec-edge-case, and snapshot tests continue to pass after insta acceptance.

### Out of scope

- Viewer updates (JS decoder, HTML viewer) for the new field types. Settled on the wire but not rendered yet.
- Demo trace regeneration. Current producers do not emit the new variants, so the demo trace stays unchanged.
- `TraceField` blanket impls for `Vec<T>` / `HashMap<K, V>`. These land with the metrique adapter.
- Format version bump, Cargo.toml change, CHANGELOG entry (handled at release time).