### PR TITLE
task dumps: Switch to poisson sampling & libunwind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,7 +1490,6 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-sdk-s3-transfer-manager",
- "backtrace",
  "bon",
  "bytes",
  "clap",

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -41,7 +41,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smallvec = "1"
 bytes = "1"
-backtrace = { version = "0.3", optional = true }
 dial9-perf-self-profile = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, features = ["serde"] }
 tracing = "0.1.44"
@@ -78,7 +77,7 @@ _shuttle = [
 ## (aarch64/x86/x86_64): tokio's upstream `taskdump` feature refuses to
 ## compile on other targets. Enabling this feature on an unsupported target
 ## is a hard compile error from tokio.
-taskdump = ["tokio/taskdump", "dep:backtrace"]
+taskdump = ["tokio/taskdump"]
 tracing-layer = ["dep:tracing-subscriber"]
 worker-s3 = [
     "dep:aws-sdk-s3-transfer-manager",

--- a/dial9-tokio-telemetry/src/lib.rs
+++ b/dial9-tokio-telemetry/src/lib.rs
@@ -21,6 +21,8 @@ pub(crate) mod task_dumped;
 /// Core telemetry types, recording, and trace I/O.
 pub mod telemetry;
 pub(crate) mod traced;
+#[cfg(feature = "taskdump")]
+pub(crate) mod unwind;
 
 #[cfg(feature = "tracing-layer")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tracing-layer")))]

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -1,5 +1,5 @@
 //! `TaskDumped<F>` wraps a future and captures async backtraces at yield
-//! points when the task stays idle longer than the configured threshold.
+//! points using geometric (Poisson) sampling keyed on idle duration.
 //!
 //! This wrapper is intentionally separate from [`crate::traced::Traced`]: the
 //! wake-event capture in `Traced` runs on every instrumented spawn regardless
@@ -7,20 +7,25 @@
 //! `taskdump` feature and its own runtime toggle.  Typical stacking is
 //! `Traced<TaskDumped<F>>`.
 //!
-//! # Capture model
+//! # Sampling model
 //!
-//! On each poll, the wrapper inspects the elapsed time since the last capture
-//! point (i.e., the task's idle duration leading up to this poll). If that
-//! idle exceeded the configured threshold, frames captured at the *previous*
-//! yield point are emitted as `TaskDump` events. If the current poll returns
-//! `Pending`, a fresh capture is taken via [`tokio::runtime::dump::trace_with`]
-//! so that the next poll's decision has fresh data.
+//! Instead of a hard time cutoff, each task maintains a byte-counter–style
+//! `next_sample_ns` drawn from an exponential distribution with mean equal to
+//! the configured `idle_threshold`. On each poll, the preceding idle duration
+//! is subtracted from the counter. When the counter reaches zero or below, the
+//! captured frames are emitted and a new gap is drawn. This gives unbiased
+//! Poisson sampling: longer idles are more likely to trigger a dump, but even
+//! short idles have a non-zero (if small) probability.
 //!
-//! The capture runs a second `poll` of the inner future under a no-op waker
-//! inside `trace_with`. Tokio yield points use the *inner* context's waker
-//! (noop) rather than the real executor waker, so this does not produce a
-//! duplicate `WakeEvent`, and the `PollStart`/`PollEnd` hooks run only on the
-//! outer scheduler call, not on the trace_with sub-poll.
+//! # Capture mechanics
+//!
+//! If the current poll returns `Pending`, a fresh capture is taken via
+//! [`tokio::runtime::dump::trace_with`] so that the next poll's sampling
+//! decision has fresh data. The capture runs a second `poll` of the inner
+//! future under a no-op waker inside `trace_with`. Tokio yield points use the
+//! *inner* context's waker (noop) rather than the real executor waker, so this
+//! does not produce a duplicate `WakeEvent`, and the `PollStart`/`PollEnd`
+//! hooks run only on the outer scheduler call, not on the trace_with sub-poll.
 //!
 //! # Allocation
 //!
@@ -44,9 +49,41 @@ use std::task::{Context, Poll, Waker};
 /// Initial heap reservation for the instruction-pointer buffer on first capture.
 const FRAME_BUF_INITIAL_CAPACITY: usize = 256;
 
+// ─── Minimal PRNG (splitmix64) ──────────────────────────────────────────────
+
+/// Minimal splitmix64 PRNG. Fast, no dependencies, good enough for sampling.
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e3779b97f4a7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
+        z ^ (z >> 31)
+    }
+
+    /// Draw from exponential distribution with given mean (in nanoseconds).
+    /// Returns at least 1 to avoid immediate re-trigger.
+    fn draw_exponential_ns(&mut self, mean_ns: u64) -> i64 {
+        // Generate a uniform float in (0, 1] — avoid exact 0 to prevent ln(0).
+        let u = (self.next_u64() >> 11) as f64 / ((1u64 << 53) as f64);
+        let u = if u == 0.0 { f64::MIN_POSITIVE } else { u };
+        let sample = -u.ln() * (mean_ns as f64);
+        // Clamp to at least 1ns so we never immediately re-trigger.
+        (sample as i64).max(1)
+    }
+}
+
+// ─── TaskDumped future wrapper ──────────────────────────────────────────────
+
 pin_project! {
-    /// Future wrapper that captures async backtraces at yield points when
-    /// the enclosing task has been idle longer than the configured threshold.
+    /// Future wrapper that captures async backtraces at yield points using
+    /// geometric (Poisson) sampling keyed on idle duration.
     pub(crate) struct TaskDumped<F> {
         #[pin]
         inner: F,
@@ -56,22 +93,34 @@ pin_project! {
         // Monotonic nanoseconds when the frames in `frames` were captured.
         // Only meaningful when `frames.has_data()`.
         pending_capture_ts: Option<NonZeroU64>,
-        // Snapshot of SharedState::task_dump_idle_threshold_ns at construction;
-        // promotes the atomic load off the poll hot path.
-        idle_threshold_ns: u64,
+        // Geometric sampling state: remaining nanoseconds of idle time before
+        // the next sample triggers. Signed so subtracting a large idle from a
+        // small remaining value goes negative rather than wrapping.
+        next_sample_ns: i64,
+        // Mean of the exponential distribution (nanoseconds).
+        sample_mean_ns: u64,
+        // Per-task PRNG for drawing exponential gaps.
+        rng: SplitMix64,
     }
 }
 
 impl<F> TaskDumped<F> {
     pub(crate) fn new(inner: F, shared: Arc<SharedState>, task_id: TaskId) -> Self {
-        let idle_threshold_ns = shared.task_dump_idle_threshold_ns.load(Ordering::Relaxed);
+        let sample_mean_ns = shared.task_dump_idle_threshold_ns.load(Ordering::Relaxed);
+        // Seed the PRNG from the task ID + a timestamp for uniqueness across tasks.
+        let seed = (task_id.to_u64()).wrapping_mul(0x517cc1b727220a95)
+            ^ crate::telemetry::events::clock_monotonic_ns();
+        let mut rng = SplitMix64::new(seed);
+        let next_sample_ns = rng.draw_exponential_ns(sample_mean_ns);
         Self {
             inner,
             shared,
             task_id,
             frames: FrameBuf::new(),
             pending_capture_ts: None,
-            idle_threshold_ns,
+            next_sample_ns,
+            sample_mean_ns,
+            rng,
         }
     }
 }
@@ -83,13 +132,8 @@ impl<F: Future> Future for TaskDumped<F> {
         let mut this = self.project();
 
         // Fast path: forward without any capture work when either task dumps
-        // are disabled, or telemetry as a whole is paused. Checking both here
-        // skips the re-poll under `trace_with` (not just the emit), so a
-        // paused guard imposes no overhead beyond two relaxed atomic loads.
+        // are disabled, or telemetry as a whole is paused.
         if !this.shared.task_dumps_enabled.load(Ordering::Relaxed) || !this.shared.is_enabled() {
-            // Stale pending frames become meaningless if we stopped capturing —
-            // drop them so we don't emit a dump attributed to an old idle gap
-            // after capture resumes.
             if this.frames.has_data() {
                 this.frames.clear();
                 *this.pending_capture_ts = None;
@@ -97,12 +141,14 @@ impl<F: Future> Future for TaskDumped<F> {
             return this.inner.poll(cx);
         }
 
-        // If we have captured frames from a previous idle, decide whether
-        // that idle was long enough to emit.
+        // Geometric sampling: subtract the idle duration from the counter.
+        // If it goes to zero or below, we should emit.
         let poll_start = crate::telemetry::recorder::poll_start_ts_or_now();
         let should_emit = match *this.pending_capture_ts {
             Some(ts) if this.frames.has_data() => {
-                poll_start.saturating_sub(ts.get()) > *this.idle_threshold_ns
+                let idle_ns = poll_start.saturating_sub(ts.get()) as i64;
+                *this.next_sample_ns -= idle_ns;
+                *this.next_sample_ns <= 0
             }
             _ => false,
         };
@@ -115,17 +161,19 @@ impl<F: Future> Future for TaskDumped<F> {
                 *this.task_id,
                 this.pending_capture_ts.unwrap().get(),
             );
+            // Redraw: loop in case the draw is smaller than the deficit
+            // (rare, but possible for very large idles / small means).
+            while *this.next_sample_ns <= 0 {
+                *this.next_sample_ns += this.rng.draw_exponential_ns(*this.sample_mean_ns);
+            }
         }
 
         match &result {
             Poll::Ready(_) => {
-                // Terminal. Nothing more to capture; discard stale frames.
                 this.frames.clear();
                 *this.pending_capture_ts = None;
             }
             Poll::Pending => {
-                // Capture the yield point we just landed on, for the next
-                // poll's threshold check.
                 this.frames.capture(this.inner.as_mut());
                 *this.pending_capture_ts = NonZeroU64::new(poll_start);
             }

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -205,39 +205,15 @@ impl FrameBuf {
     }
 }
 
-/// Walk the stack via [`backtrace::trace`], skipping frames at or below
-/// `leaf_addr` (tokio's `trace_leaf` function — any frames at or below it
-/// are internal plumbing) and stopping at `root_addr` (tokio's `Root::poll`
-/// boundary). `root_addr` is always `None` today because we don't wrap
-/// spawned tasks in `Root`, but we keep the check defensively in case that
-/// changes — unwrapping the whole stack otherwise walks through scheduler
-/// internals that the caller has no use for.
-///
-/// Held behind the `backtrace` crate's process-wide mutex. This will be optimized in
-/// https://github.com/dial9-rs/dial9-tokio-telemetry/issues/357. This is not a
-/// complete blocker for the MvP because no code is utilizing the symbolizing from
-/// `backtrace` so the mutex is not actually held for long periods of time. Nevertheless,
-/// this will be a fast follow.
+/// Walk the stack, collecting instruction pointers between `leaf_addr` and
+/// `root_addr`. Calls `_Unwind_Backtrace` directly via [`crate::unwind`],
+/// bypassing the `backtrace` crate's process-wide mutex.
 fn capture_frames(
     ips: &mut Vec<u64>,
     root_addr: Option<*const core::ffi::c_void>,
     leaf_addr: *const core::ffi::c_void,
 ) {
-    let mut above_leaf = false;
-    backtrace::trace(|frame| {
-        let sym = frame.symbol_address();
-        let below_root = root_addr.is_none_or(|root| !std::ptr::eq(sym, root));
-
-        if above_leaf && below_root {
-            ips.push(frame.ip() as u64);
-        }
-
-        if std::ptr::eq(sym, leaf_addr) {
-            above_leaf = true;
-        }
-
-        below_root
-    });
+    crate::unwind::collect_frames(ips, root_addr, leaf_addr);
 }
 
 /// Borrowed-callchain view of a task-dump event that implements [`Encodable`]

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -133,10 +133,8 @@ impl<F> TaskDumped<F> {
 
 impl<F: Future> Future for TaskDumped<F> {
     type Output = F::Output;
-
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
         let mut this = self.project();
-
         // Fast path: forward without any capture work when either task dumps
         // are disabled, or telemetry as a whole is paused.
         if !this.shared.task_dumps_enabled.load(Ordering::Relaxed) || !this.shared.is_enabled() {
@@ -146,9 +144,11 @@ impl<F: Future> Future for TaskDumped<F> {
             }
             return this.inner.poll(cx);
         }
-
-        // Poisson sampling: subtract the idle duration from the counter.
-        // If it goes to zero or below, we should emit.
+        // Poisson sampling over idle time: subtract the idle duration from
+        // the counter. If it goes to zero or below, emit and redraw a fresh
+        // interval. Short idles have a small but nonzero chance of being
+        // sampled (~ idle / mean); long idles are sampled with probability
+        // approaching 1. At most one emission per poll.
         let poll_start = crate::telemetry::recorder::poll_start_ts_or_now();
         let should_emit = match *this.pending_capture_ts {
             Some(ts) if this.frames.has_data() => {
@@ -158,22 +158,15 @@ impl<F: Future> Future for TaskDumped<F> {
             }
             _ => false,
         };
-
         let result = this.inner.as_mut().poll(cx);
-
         if should_emit {
-            this.frames.emit(
-                this.shared,
-                *this.task_id,
-                this.pending_capture_ts.unwrap().get(),
-            );
-            // Redraw: loop in case the draw is smaller than the deficit
-            // (rare, but possible for very large idles / small means).
-            while *this.next_sample_ns <= 0 {
-                *this.next_sample_ns += this.rng.draw_exponential_ns(*this.sample_mean_ns);
-            }
+            let ts = this
+                .pending_capture_ts
+                .expect("checked in match above")
+                .get();
+            this.frames.emit(this.shared, *this.task_id, ts);
+            *this.next_sample_ns = this.rng.draw_exponential_ns(*this.sample_mean_ns);
         }
-
         match &result {
             Poll::Ready(_) => {
                 this.frames.clear();
@@ -181,10 +174,10 @@ impl<F: Future> Future for TaskDumped<F> {
             }
             Poll::Pending => {
                 this.frames.capture(this.inner.as_mut());
-                *this.pending_capture_ts = NonZeroU64::new(poll_start);
+                let poll_end = crate::telemetry::recorder::poll_start_ts_or_now();
+                *this.pending_capture_ts = NonZeroU64::new(poll_end);
             }
         }
-
         result
     }
 }

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -107,9 +107,16 @@ pin_project! {
 impl<F> TaskDumped<F> {
     pub(crate) fn new(inner: F, shared: Arc<SharedState>, task_id: TaskId) -> Self {
         let sample_mean_ns = shared.task_dump_idle_threshold_ns.load(Ordering::Relaxed);
-        // Seed the PRNG from the task ID + a timestamp for uniqueness across tasks.
-        let seed = (task_id.to_u64()).wrapping_mul(0x517cc1b727220a95)
-            ^ crate::telemetry::events::clock_monotonic_ns();
+        let base_seed = shared.task_dump_rng_seed.load(Ordering::Relaxed);
+        // When a fixed seed is configured (non-zero), use it directly for
+        // deterministic tests. Otherwise use task_id + timestamp for
+        // production uniqueness across tasks.
+        let seed = if base_seed != 0 {
+            base_seed
+        } else {
+            (task_id.to_u64()).wrapping_mul(0x517cc1b727220a95)
+                ^ crate::telemetry::events::clock_monotonic_ns()
+        };
         let mut rng = SplitMix64::new(seed);
         let next_sample_ns = rng.draw_exponential_ns(sample_mean_ns);
         Self {

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -1,5 +1,5 @@
 //! `TaskDumped<F>` wraps a future and captures async backtraces at yield
-//! points using geometric (Poisson) sampling keyed on idle duration.
+//! points using Poisson sampling keyed on idle duration.
 //!
 //! This wrapper is intentionally separate from [`crate::traced::Traced`]: the
 //! wake-event capture in `Traced` runs on every instrumented spawn regardless
@@ -83,7 +83,7 @@ impl SplitMix64 {
 
 pin_project! {
     /// Future wrapper that captures async backtraces at yield points using
-    /// geometric (Poisson) sampling keyed on idle duration.
+    /// Poisson sampling keyed on idle duration.
     pub(crate) struct TaskDumped<F> {
         #[pin]
         inner: F,
@@ -93,7 +93,7 @@ pin_project! {
         // Monotonic nanoseconds when the frames in `frames` were captured.
         // Only meaningful when `frames.has_data()`.
         pending_capture_ts: Option<NonZeroU64>,
-        // Geometric sampling state: remaining nanoseconds of idle time before
+        // Sampling state: remaining nanoseconds of idle time before
         // the next sample triggers. Signed so subtracting a large idle from a
         // small remaining value goes negative rather than wrapping.
         next_sample_ns: i64,
@@ -107,15 +107,14 @@ pin_project! {
 impl<F> TaskDumped<F> {
     pub(crate) fn new(inner: F, shared: Arc<SharedState>, task_id: TaskId) -> Self {
         let sample_mean_ns = shared.task_dump_idle_threshold_ns.load(Ordering::Relaxed);
-        let base_seed = shared.task_dump_rng_seed.load(Ordering::Relaxed);
-        // When a fixed seed is configured (non-zero), use it directly for
-        // deterministic tests. Otherwise use task_id + timestamp for
-        // production uniqueness across tasks.
-        let seed = if base_seed != 0 {
-            base_seed
-        } else {
-            (task_id.to_u64()).wrapping_mul(0x517cc1b727220a95)
-                ^ crate::telemetry::events::clock_monotonic_ns()
+        // When a fixed seed is configured, use it directly for deterministic
+        // tests. Otherwise use task_id + timestamp for production uniqueness.
+        let seed = match shared.task_dump_rng_seed {
+            Some(s) => s,
+            None => {
+                (task_id.to_u64()).wrapping_mul(0x517cc1b727220a95)
+                    ^ crate::telemetry::events::clock_monotonic_ns()
+            }
         };
         let mut rng = SplitMix64::new(seed);
         let next_sample_ns = rng.draw_exponential_ns(sample_mean_ns);
@@ -148,7 +147,7 @@ impl<F: Future> Future for TaskDumped<F> {
             return this.inner.poll(cx);
         }
 
-        // Geometric sampling: subtract the idle duration from the counter.
+        // Poisson sampling: subtract the idle duration from the counter.
         // If it goes to zero or below, we should emit.
         let poll_start = crate::telemetry::recorder::poll_start_ts_or_now();
         let should_emit = match *this.pending_capture_ts {
@@ -287,5 +286,45 @@ impl Encodable for TaskDumpData<'_> {
             task_id: self.task_id,
             callchain: interned_callchain,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SplitMix64;
+
+    #[test]
+    fn splitmix64_deterministic() {
+        let mut rng = SplitMix64::new(42);
+        let a = rng.next_u64();
+        let b = rng.next_u64();
+
+        let mut rng2 = SplitMix64::new(42);
+        assert_eq!(a, rng2.next_u64());
+        assert_eq!(b, rng2.next_u64());
+    }
+
+    #[test]
+    fn draw_exponential_ns_mean_is_reasonable() {
+        let mut rng = SplitMix64::new(123);
+        let mean_ns: u64 = 10_000_000; // 10ms
+        let n = 10_000;
+        let sum: f64 = (0..n)
+            .map(|_| rng.draw_exponential_ns(mean_ns) as f64)
+            .sum();
+        let observed_mean = sum / n as f64;
+        // Within 10% of the configured mean.
+        assert!(
+            (observed_mean - mean_ns as f64).abs() < mean_ns as f64 * 0.1,
+            "observed mean {observed_mean} too far from expected {mean_ns}"
+        );
+    }
+
+    #[test]
+    fn draw_exponential_ns_always_positive() {
+        let mut rng = SplitMix64::new(0);
+        for _ in 0..10_000 {
+            assert!(rng.draw_exponential_ns(1_000_000) >= 1);
+        }
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1479,6 +1479,9 @@ impl TelemetryCore {
             shared
                 .task_dump_idle_threshold_ns
                 .store(cfg.idle_threshold().as_nanos() as u64, Ordering::Relaxed);
+            if let Some(seed) = cfg.rng_seed() {
+                shared.task_dump_rng_seed.store(seed, Ordering::Relaxed);
+            }
         }
         #[allow(unused_mut)]
         let mut event_writer = EventWriter::new(Box::new(writer));

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1473,15 +1473,13 @@ impl TelemetryCore {
         worker_metrics_sink: Option<metrique_writer::BoxEntrySink>,
     ) -> std::io::Result<TelemetryGuard> {
         let start_mono_ns = crate::telemetry::events::clock_monotonic_ns();
-        let shared = Arc::new(SharedState::new(start_mono_ns));
+        let rng_seed = task_dump_config.as_ref().and_then(|cfg| cfg.rng_seed());
+        let shared = Arc::new(SharedState::new(start_mono_ns, rng_seed));
         if let Some(cfg) = task_dump_config.as_ref() {
             shared.task_dumps_enabled.store(true, Ordering::Relaxed);
             shared
                 .task_dump_idle_threshold_ns
                 .store(cfg.idle_threshold().as_nanos() as u64, Ordering::Relaxed);
-            if let Some(seed) = cfg.rng_seed() {
-                shared.task_dump_rng_seed.store(seed, Ordering::Relaxed);
-            }
         }
         #[allow(unused_mut)]
         let mut event_writer = EventWriter::new(Box::new(writer));
@@ -2130,7 +2128,7 @@ mod tests {
 
     #[test]
     fn test_shared_state_no_spawn_location_fields() {
-        let _shared = SharedState::new(crate::telemetry::events::clock_monotonic_ns());
+        let _shared = SharedState::new(crate::telemetry::events::clock_monotonic_ns(), None);
     }
 
     #[test]

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -32,6 +32,8 @@ pub(crate) struct SharedState {
     /// each `TaskDumped` instance at construction time so the hot poll path
     /// does not need an atomic load.
     pub(crate) task_dump_idle_threshold_ns: AtomicU64,
+    /// Fixed RNG seed for deterministic task dump sampling (0 = use timestamp).
+    pub(crate) task_dump_rng_seed: AtomicU64,
     pub(crate) collector: Arc<CentralCollector>,
     /// Absolute `CLOCK_MONOTONIC` nanosecond timestamp captured at trace start.
     pub(crate) start_time_ns: u64,
@@ -63,6 +65,7 @@ impl SharedState {
             enabled: AtomicBool::new(false),
             task_dumps_enabled: AtomicBool::new(false),
             task_dump_idle_threshold_ns: AtomicU64::new(0),
+            task_dump_rng_seed: AtomicU64::new(0),
             collector: Arc::new(CentralCollector::new()),
             start_time_ns,
             next_worker_id: AtomicU64::new(0),

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -32,8 +32,9 @@ pub(crate) struct SharedState {
     /// each `TaskDumped` instance at construction time so the hot poll path
     /// does not need an atomic load.
     pub(crate) task_dump_idle_threshold_ns: AtomicU64,
-    /// Fixed RNG seed for deterministic task dump sampling (0 = use timestamp).
-    pub(crate) task_dump_rng_seed: AtomicU64,
+    /// Fixed RNG seed for deterministic task dump sampling. Set once at
+    /// construction before the `Arc` is shared; read-only thereafter.
+    pub(crate) task_dump_rng_seed: Option<u64>,
     pub(crate) collector: Arc<CentralCollector>,
     /// Absolute `CLOCK_MONOTONIC` nanosecond timestamp captured at trace start.
     pub(crate) start_time_ns: u64,
@@ -60,12 +61,12 @@ pub(crate) struct SharedState {
 }
 
 impl SharedState {
-    pub(super) fn new(start_time_ns: u64) -> Self {
+    pub(super) fn new(start_time_ns: u64, task_dump_rng_seed: Option<u64>) -> Self {
         Self {
             enabled: AtomicBool::new(false),
             task_dumps_enabled: AtomicBool::new(false),
             task_dump_idle_threshold_ns: AtomicU64::new(0),
-            task_dump_rng_seed: AtomicU64::new(0),
+            task_dump_rng_seed,
             collector: Arc::new(CentralCollector::new()),
             start_time_ns,
             next_worker_id: AtomicU64::new(0),
@@ -252,7 +253,7 @@ mod tests {
 
     /// Helper: create a SharedState with recording enabled.
     fn enabled_shared_state() -> SharedState {
-        let ss = SharedState::new(0);
+        let ss = SharedState::new(0, None);
         ss.enabled.store(true, Ordering::Relaxed);
         ss
     }

--- a/dial9-tokio-telemetry/src/telemetry/task_dump_config.rs
+++ b/dial9-tokio-telemetry/src/telemetry/task_dump_config.rs
@@ -1,7 +1,8 @@
 //! Configuration for task dump capture.
 //!
 //! Task dumps capture async backtraces at yield points for tasks that have
-//! been idle longer than the configured threshold. Use [`TaskDumpConfig`] with
+//! been idle, using geometric (Poisson) sampling keyed on idle duration.
+//! Use [`TaskDumpConfig`] with
 //! [`TracedRuntimeBuilder::with_task_dumps`](crate::telemetry::TracedRuntimeBuilder::with_task_dumps)
 //! or [`TelemetryCoreBuilder::task_dump_config`](crate::telemetry::TelemetryCoreBuilder::task_dump_config).
 //!
@@ -11,14 +12,16 @@
 
 use std::time::Duration;
 
-/// Default idle threshold after which a task dump is emitted.
+/// Default mean idle duration for geometric sampling.
 const DEFAULT_IDLE_THRESHOLD: Duration = Duration::from_millis(10);
 
 /// Configuration for task dump capture.
 #[derive(Debug, Clone, bon::Builder)]
 pub struct TaskDumpConfig {
-    /// Minimum time a task must have been idle between polls before a task
-    /// dump is emitted on the next poll. Defaults to 10ms.
+    /// Mean idle duration for geometric (Poisson) sampling. On average, one
+    /// task dump is emitted per this amount of cumulative idle time. Shorter
+    /// idles have a lower (but non-zero) probability of triggering a dump;
+    /// longer idles are very likely to trigger. Defaults to 10ms.
     #[builder(default = DEFAULT_IDLE_THRESHOLD)]
     idle_threshold: Duration,
 }
@@ -30,7 +33,7 @@ impl Default for TaskDumpConfig {
 }
 
 impl TaskDumpConfig {
-    /// Minimum idle duration between polls before a dump is emitted.
+    /// Mean idle duration for geometric sampling.
     pub fn idle_threshold(&self) -> Duration {
         self.idle_threshold
     }

--- a/dial9-tokio-telemetry/src/telemetry/task_dump_config.rs
+++ b/dial9-tokio-telemetry/src/telemetry/task_dump_config.rs
@@ -24,6 +24,12 @@ pub struct TaskDumpConfig {
     /// longer idles are very likely to trigger. Defaults to 10ms.
     #[builder(default = DEFAULT_IDLE_THRESHOLD)]
     idle_threshold: Duration,
+
+    /// Optional fixed seed for the per-task PRNG. When set, task dump sampling
+    /// becomes deterministic (given the same task IDs and idle durations).
+    /// Intended for testing. When `None` (default), each task seeds its PRNG
+    /// from a timestamp for production uniqueness.
+    rng_seed: Option<u64>,
 }
 
 impl Default for TaskDumpConfig {
@@ -36,5 +42,10 @@ impl TaskDumpConfig {
     /// Mean idle duration for geometric sampling.
     pub fn idle_threshold(&self) -> Duration {
         self.idle_threshold
+    }
+
+    /// Optional fixed RNG seed for deterministic sampling.
+    pub fn rng_seed(&self) -> Option<u64> {
+        self.rng_seed
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/task_dump_config.rs
+++ b/dial9-tokio-telemetry/src/telemetry/task_dump_config.rs
@@ -1,7 +1,7 @@
 //! Configuration for task dump capture.
 //!
 //! Task dumps capture async backtraces at yield points for tasks that have
-//! been idle, using geometric (Poisson) sampling keyed on idle duration.
+//! been idle, using Poisson sampling keyed on idle duration.
 //! Use [`TaskDumpConfig`] with
 //! [`TracedRuntimeBuilder::with_task_dumps`](crate::telemetry::TracedRuntimeBuilder::with_task_dumps)
 //! or [`TelemetryCoreBuilder::task_dump_config`](crate::telemetry::TelemetryCoreBuilder::task_dump_config).
@@ -12,13 +12,13 @@
 
 use std::time::Duration;
 
-/// Default mean idle duration for geometric sampling.
+/// Default mean idle duration for Poisson sampling.
 const DEFAULT_IDLE_THRESHOLD: Duration = Duration::from_millis(10);
 
 /// Configuration for task dump capture.
 #[derive(Debug, Clone, bon::Builder)]
 pub struct TaskDumpConfig {
-    /// Mean idle duration for geometric (Poisson) sampling. On average, one
+    /// Mean idle duration for Poisson sampling. On average, one
     /// task dump is emitted per this amount of cumulative idle time. Shorter
     /// idles have a lower (but non-zero) probability of triggering a dump;
     /// longer idles are very likely to trigger. Defaults to 10ms.
@@ -39,7 +39,7 @@ impl Default for TaskDumpConfig {
 }
 
 impl TaskDumpConfig {
-    /// Mean idle duration for geometric sampling.
+    /// Mean idle duration for Poisson sampling.
     pub fn idle_threshold(&self) -> Duration {
         self.idle_threshold
     }

--- a/dial9-tokio-telemetry/src/unwind.rs
+++ b/dial9-tokio-telemetry/src/unwind.rs
@@ -1,0 +1,73 @@
+//! Direct libunwind FFI for lock-free stack walking.
+//!
+//! Bypasses the `backtrace` crate's global mutex by calling `_Unwind_Backtrace`
+//! directly. Adapted from backtrace-0.3.76/src/backtrace/libunwind.rs (Apache-2.0/MIT).
+
+use core::ffi::c_void;
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+enum UnwindReasonCode {
+    NoReason = 0,
+    Failure = 9,
+}
+
+#[allow(non_camel_case_types)]
+enum UnwindContext {}
+
+type UnwindTraceFn = extern "C" fn(ctx: *mut UnwindContext, arg: *mut c_void) -> UnwindReasonCode;
+
+unsafe extern "C" {
+    fn _Unwind_Backtrace(trace: UnwindTraceFn, trace_argument: *mut c_void) -> UnwindReasonCode;
+    fn _Unwind_GetIP(ctx: *mut UnwindContext) -> libc::uintptr_t;
+    fn _Unwind_FindEnclosingFunction(pc: *mut c_void) -> *mut c_void;
+}
+
+struct CallbackData<'a> {
+    frame_ips: &'a mut Vec<u64>,
+    above_leaf: bool,
+    root_addr: Option<*const c_void>,
+    leaf_addr: *const c_void,
+}
+
+extern "C" fn trace_fn(ctx: *mut UnwindContext, arg: *mut c_void) -> UnwindReasonCode {
+    let data = unsafe { &mut *arg.cast::<CallbackData<'_>>() };
+    let ip = unsafe { _Unwind_GetIP(ctx) } as *mut c_void;
+    let symbol_address = unsafe { _Unwind_FindEnclosingFunction(ip) };
+
+    let below_root = data
+        .root_addr
+        .is_none_or(|root| !std::ptr::eq(symbol_address, root));
+
+    if data.above_leaf && below_root {
+        data.frame_ips.push(ip as u64);
+    }
+
+    if std::ptr::eq(symbol_address, data.leaf_addr) {
+        data.above_leaf = true;
+    }
+
+    if below_root {
+        UnwindReasonCode::NoReason
+    } else {
+        UnwindReasonCode::Failure
+    }
+}
+
+/// Walk the call stack, collecting instruction pointers between `leaf_addr` and
+/// `root_addr`. This calls `_Unwind_Backtrace` directly without any global lock.
+pub(crate) fn collect_frames(
+    frame_ips: &mut Vec<u64>,
+    root_addr: Option<*const c_void>,
+    leaf_addr: *const c_void,
+) {
+    let mut data = CallbackData {
+        frame_ips,
+        above_leaf: false,
+        root_addr,
+        leaf_addr,
+    };
+    unsafe {
+        _Unwind_Backtrace(trace_fn, core::ptr::addr_of_mut!(data).cast());
+    }
+}

--- a/dial9-tokio-telemetry/src/unwind.rs
+++ b/dial9-tokio-telemetry/src/unwind.rs
@@ -68,6 +68,6 @@ pub(crate) fn collect_frames(
         leaf_addr,
     };
     unsafe {
-        _Unwind_Backtrace(trace_fn, core::ptr::addr_of_mut!(data).cast());
+        _Unwind_Backtrace(trace_fn, (&raw mut data).cast());
     }
 }

--- a/dial9-tokio-telemetry/tests/task_dump.rs
+++ b/dial9-tokio-telemetry/tests/task_dump.rs
@@ -15,7 +15,7 @@ fn task_dump_emitted_for_long_sleep() {
     builder.enable_all();
     let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
-        .with_task_dumps(TaskDumpConfig::default())
+        .with_task_dumps(TaskDumpConfig::builder().rng_seed(42).build())
         .build_and_start(builder, writer)
         .unwrap();
 
@@ -64,6 +64,7 @@ fn no_task_dump_for_short_sleep() {
         .with_task_dumps(
             TaskDumpConfig::builder()
                 .idle_threshold(Duration::from_secs(1))
+                .rng_seed(42)
                 .build(),
         )
         .build_and_start(builder, writer)
@@ -102,7 +103,7 @@ fn task_dump_does_not_produce_extra_events() {
         builder.enable_all();
         let mut tb = TracedRuntime::builder().with_task_tracking(true);
         if enable {
-            tb = tb.with_task_dumps(TaskDumpConfig::default());
+            tb = tb.with_task_dumps(TaskDumpConfig::builder().rng_seed(42).build());
         }
         let (runtime, guard) = tb.build_and_start(builder, writer).unwrap();
 


### PR DESCRIPTION
Two improvements from the first cut:
1. Switch to poisson sampling (we'll also use this in memory profiling)
2. use libunwind directly instead of backtrace::trace