### PR TITLE
chore(release): prepare dial9-trace-format 0.4.0 breaking release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/dial9-rs/dial9-tokio-telemetry/compare/dial9-tokio-telemetry-v0.3.7...dial9-tokio-telemetry-v0.3.8) - 2026-05-08
+
+### Added
+
+- Add task dump capture behind `taskdump` feature ([#354](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/354))
+- Task dumps: switch to Poisson sampling and libunwind ([#369](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/369))
+- Taskdump viewer and expand inline frames in flamegraphs ([#378](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/378))
+- Expose runtime pipeline ([#355](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/355), [#365](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/365))
+- Add typed list and map FieldTypes ([#367](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/367))
+- Add TAG_SCHEMA_ANNOTATIONS frame and SchemaEntry::annotations ([#366](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/366))
+- *(viewer)* Adopt agent skills spec, Symposium integration, lightweight benchmark ([#370](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/370))
+- *(toolkit)* Task dumps in recipes, bugfixes ([#380](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/380))
+- Document task dumps, other README improvements ([#379](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/379))
+
+### Fixed
+
+- Use real waker in task dump capture to prevent lost wakes ([#372](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/372))
+- Eliminate task dump busy loop and move dl_iterate_phdr off hot path ([#375](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/375))
+- Redo tracing UI and add span close events ([#342](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/342))
+
+### Other
+
+- *(design)* metrique to dial9 integration ([#346](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/346))
+- Memory profiling design ([#362](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/362))
+- Add iai-callgrind PR gate, retire criterion CI ([#360](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/360))
+- Write dial9 crate README ([#374](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/374))
+- Add symposium keyword to dial9-tokio-telemetry ([#376](https://github.com/dial9-rs/dial9-tokio-telemetry/pull/376))
+- update Cargo.lock dependencies
+
 ## [0.3.7](https://github.com/dial9-rs/dial9-tokio-telemetry/compare/dial9-tokio-telemetry-v0.3.6...dial9-tokio-telemetry-v0.3.7) - 2026-05-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-perf-self-profile"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blazesym",
  "criterion",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-tokio-telemetry"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "arc-swap",
  "assert2",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-trace-format"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "dial9-trace-format-derive",
  "flate2",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-trace-format-derive"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "insta",
  "prettyplease",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "dial9-viewer"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "assert2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ repository = "https://github.com/dial9-rs/dial9-tokio-telemetry"
 
 [workspace.dependencies]
 libc = "0.2"
-dial9-perf-self-profile = { version = "0.4.0", path = "perf-self-profile" }
-dial9-trace-format = { version = "0.3.6", path = "dial9-trace-format" }
-dial9-trace-format-derive = { version = "0.3.5", path = "dial9-trace-format-derive" }
+dial9-perf-self-profile = { version = "0.4.1", path = "perf-self-profile" }
+dial9-trace-format = { version = "0.4.0", path = "dial9-trace-format" }
+dial9-trace-format-derive = { version = "0.4.0", path = "dial9-trace-format-derive" }
 dial9-macro = { version = "0.3.6", path = "dial9-macro" }
 assert2 = "0.4"
 

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-tokio-telemetry"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dial9-trace-format-derive/Cargo.toml
+++ b/dial9-trace-format-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-trace-format-derive"
-version = "0.3.5"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dial9-trace-format/Cargo.toml
+++ b/dial9-trace-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-trace-format"
-version = "0.3.6"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-viewer"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/perf-self-profile/Cargo.toml
+++ b/perf-self-profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dial9-perf-self-profile"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 repository.workspace = true
 description = "Minimal self-profiling via Linux perf_event_open with frame-pointer-based stack traces"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,6 +12,7 @@ changelog_include = [
     "dial9-trace-format",
     "dial9-trace-format-derive",
     "dial9-viewer",
+    "dial9",
 ]
 
 [[package]]
@@ -25,10 +26,12 @@ changelog_update = false
 [[package]]
 name = "dial9-trace-format"
 changelog_update = false
+version_group = "trace-format"
 
 [[package]]
 name = "dial9-trace-format-derive"
 changelog_update = false
+version_group = "trace-format"
 
 [[package]]
 name = "dial9-viewer"


### PR DESCRIPTION
Cutting a release that has `dial9-trace-format` breaking, and everything else un-breaking. We did a bunch of semver cleanup along with adding new types (though adding new types won't be breaking in the future).

I figure we don't want to keep our main in a confusing state with breaking cargo semver staged in it any longer than we had to.

Though, I'd like to link in #370 if anybody has time for a review, in which case i'll update the changelog accordingly.