### PR TITLE
feat: add symposium keyword to dial9-tokio-telemetry

### DIFF
--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 publish = true
 readme = "README.md"
 description = "Low-overhead runtime telemetry for Tokio with poll timing, wake events, and CPU profiling"
-keywords = ["tokio", "telemetry", "profiling", "async", "tracing"]
+keywords = ["tokio", "telemetry", "profiling", "tracing", "symposium"]
 categories = ["asynchronous", "development-tools::profiling"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
We're still figuring out the "discover crates with symposium skills that you don't already have" story, but probably v1 will involve crates.io keywords.

I imagine we want dial9 to pop up on the discovery list as Niko is getting eyes on Symposium, so adding our tag.