### PR TITLE
feat: instrumented joinsets and other custom spawns

### DIFF
--- a/dial9-tokio-telemetry/src/lib.rs
+++ b/dial9-tokio-telemetry/src/lib.rs
@@ -43,4 +43,4 @@ pub use current_config::{
     Dial9Config, Dial9ConfigBuilder, Dial9ConfigBuilderError, ValidationError,
 };
 pub use dial9_macro::main;
-pub use telemetry::{TelemetryRuntimeError, TracedRuntime, spawn};
+pub use telemetry::{TelemetryRuntimeError, TracedFuture, TracedRuntime, spawn};

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -1,11 +1,10 @@
 //! `TaskDumped<F>` wraps a future and captures async backtraces at yield
 //! points using Poisson sampling keyed on idle duration.
 //!
-//! This wrapper is intentionally separate from [`crate::traced::Traced`]: the
-//! wake-event capture in `Traced` runs on every instrumented spawn regardless
-//! of the `taskdump` feature, while task-dump capture is gated behind the
-//! `taskdump` feature and its own runtime toggle.  Typical stacking is
-//! `Traced<TaskDumped<F>>`.
+//! This wrapper is intentionally separate from the wake-event wrapper: wake
+//! capture runs on every instrumented spawn regardless of the `taskdump`
+//! feature, while task-dump capture is gated behind the `taskdump` feature and
+//! its own runtime toggle. Typical stacking is `WakeTracked<TaskDumped<F>>`.
 //!
 //! # Sampling model
 //!

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -4,7 +4,7 @@
 //! This wrapper is intentionally separate from the wake-event wrapper: wake
 //! capture runs on every instrumented spawn regardless of the `taskdump`
 //! feature, while task-dump capture is gated behind the `taskdump` feature and
-//! its own runtime toggle. Typical stacking is `WakeTracked<TaskDumped<F>>`.
+//! its own runtime toggle. Typical stacking is `WakeTraced<TaskDumped<F>>`.
 //!
 //! # Sampling model
 //!

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -17,6 +17,7 @@ pub mod task_dump_config;
 pub(crate) mod task_metadata;
 pub(crate) mod writer;
 
+pub use crate::traced::TracedFuture;
 pub use buffer::{Encodable, ThreadLocalEncoder};
 pub use events::{CpuSampleSource, TelemetryEvent, clock_monotonic_ns};
 pub use format::{

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -33,9 +33,9 @@ crate::primitives::thread_local! {
     /// cleared in `on_thread_stop`. Enables [`TelemetryHandle::current`].
     static CURRENT_HANDLE: RefCell<Option<TelemetryHandle>> = const { RefCell::new(None) };
 
-    /// Set by `TelemetryHandle::spawn()` before calling `tokio::spawn()`,
-    /// so the `on_task_spawn` hook can distinguish instrumented from raw spawns.
-    static INSTRUMENTED_SPAWN: Cell<bool> = const { Cell::new(false) };
+    /// Nest count for [`InstrumentedSpawnGuard`]. `on_task_spawn` treats
+    /// any value `> 0` as an instrumented spawn.
+    static INSTRUMENTED_SPAWN: Cell<u32> = const { Cell::new(0) };
 }
 
 // ---------------------------------------------------------------------------
@@ -204,7 +204,7 @@ fn register_hooks(
             s5.if_enabled(|buf| {
                 let task_id = TaskId::from(meta.id());
                 let location = meta.spawned_at();
-                let instrumented = INSTRUMENTED_SPAWN.with(|f| f.get());
+                let instrumented = INSTRUMENTED_SPAWN.with(|f| f.get()) > 0;
                 let timestamp_ns = crate::telemetry::events::clock_monotonic_ns();
                 buf.record_encodable_event(&runtime_context::TaskSpawn {
                     timestamp_ns,
@@ -506,42 +506,73 @@ impl TelemetryHandle {
     {
         match self.traced_handle() {
             Some(traced_handle) => {
-                let _guard = InstrumentedSpawnGuard::set();
-                tokio::spawn(async move {
-                    let task_id = tokio::task::try_id().map(TaskId::from).unwrap_or_default();
-                    let inner = wrap_task_dumped(future, traced_handle.shared.clone(), task_id);
-                    crate::traced::Traced::new(inner, traced_handle, task_id).await
-                })
+                let _guard = InstrumentedSpawnGuard::enter();
+                tokio::spawn(crate::telemetry::TracedFuture::new(
+                    future,
+                    Some(traced_handle),
+                ))
             }
             None => tokio::spawn(future),
         }
     }
-}
 
-/// If the `taskdump` feature is on, wrap `future` in `TaskDumped<F>`; otherwise
-/// pass through unchanged. Factored so `TelemetryHandle::spawn` stays readable.
-#[cfg(feature = "taskdump")]
-fn wrap_task_dumped<F>(
-    future: F,
-    shared: Arc<crate::telemetry::recorder::SharedState>,
-    task_id: TaskId,
-) -> crate::task_dumped::TaskDumped<F>
-where
-    F: std::future::Future,
-{
-    crate::task_dumped::TaskDumped::new(future, shared, task_id)
-}
-
-#[cfg(not(feature = "taskdump"))]
-fn wrap_task_dumped<F>(
-    future: F,
-    _shared: Arc<crate::telemetry::recorder::SharedState>,
-    _task_id: TaskId,
-) -> F
-where
-    F: std::future::Future,
-{
-    future
+    /// Spawn an instrumented future through a user-supplied spawn function.
+    ///
+    /// `spawn_fn` is invoked synchronously with a [`TracedFuture<F>`] that
+    /// the caller is expected to spawn immediately. The closure's return
+    /// value is forwarded back to the caller, so you can keep the
+    /// [`tokio::task::JoinHandle`], [`tokio::task::AbortHandle`], or
+    /// whatever the spawn function returns.
+    ///
+    /// # Examples
+    ///
+    /// Spawn into a [`tokio::task::JoinSet`]:
+    ///
+    /// ```rust,no_run
+    /// # use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+    /// # use tokio::task::JoinSet;
+    /// # async fn work() {}
+    /// # async fn demo() {
+    /// let handle = TelemetryHandle::current();
+    /// let mut set: JoinSet<()> = JoinSet::new();
+    /// handle.spawn_with(work(), |f| set.spawn(f));
+    /// # }
+    /// ```
+    ///
+    /// Spawn into a [`tokio::task::JoinSet`] on a specific runtime:
+    ///
+    /// ```rust,no_run
+    /// # use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+    /// # use tokio::runtime::Runtime;
+    /// # use tokio::task::JoinSet;
+    /// # async fn work() {}
+    /// # fn demo(runtime: &Runtime) {
+    /// let handle = TelemetryHandle::current();
+    /// let mut set: JoinSet<()> = JoinSet::new();
+    /// handle.spawn_with(work(), |f| set.spawn_on(f, runtime.handle()));
+    /// # }
+    /// ```
+    ///
+    /// [`TracedFuture<F>`]: crate::telemetry::TracedFuture
+    pub fn spawn_with<F, S>(
+        &self,
+        future: F,
+        spawn_fn: impl FnOnce(crate::telemetry::TracedFuture<F>) -> S,
+    ) -> S
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let traced_handle = self.traced_handle();
+        let future = crate::telemetry::TracedFuture::new(future, traced_handle.clone());
+        match traced_handle {
+            Some(_) => {
+                let _guard = InstrumentedSpawnGuard::enter();
+                spawn_fn(future)
+            }
+            None => spawn_fn(future),
+        }
+    }
 }
 
 /// Spawn a traced task on the current tokio runtime.
@@ -565,24 +596,24 @@ where
     TelemetryHandle::current().spawn(future)
 }
 
-/// RAII guard that sets `INSTRUMENTED_SPAWN` to `true` on creation and
-/// resets it to `false` on drop, even if `tokio::spawn` panics.
+/// RAII guard that increments `INSTRUMENTED_SPAWN` on creation and
+/// decrements it on drop, even if the protected closure panics.
 struct InstrumentedSpawnGuard;
 
 impl InstrumentedSpawnGuard {
-    fn set() -> Self {
-        INSTRUMENTED_SPAWN.with(|c| c.set(true));
+    fn enter() -> Self {
+        INSTRUMENTED_SPAWN.with(|c| c.set(c.get().saturating_add(1)));
         Self
     }
 }
 
 impl Drop for InstrumentedSpawnGuard {
     fn drop(&mut self) {
-        INSTRUMENTED_SPAWN.with(|c| c.set(false));
+        INSTRUMENTED_SPAWN.with(|c| c.set(c.get().saturating_sub(1)));
     }
 }
 
-/// Handle for spawning wake-tracked futures on a specific runtime.
+/// Handle for spawning instrumented futures on a specific runtime.
 ///
 /// Returned by [`TraceRuntimeCoreBuilder::build`]. Unlike [`TelemetryHandle::spawn`]
 /// which uses `tokio::spawn()` (requiring an ambient runtime context), this type
@@ -606,16 +637,58 @@ impl RuntimeTelemetryHandle {
         F: std::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        match &self.traced {
-            Some(traced) => {
-                let traced = traced.clone();
-                let _guard = InstrumentedSpawnGuard::set();
-                self.runtime.spawn(async move {
-                    let task_id = tokio::task::try_id().map(TaskId::from).unwrap_or_default();
-                    crate::traced::Traced::new(future, traced, task_id).await
-                })
+        match self.traced.clone() {
+            Some(traced_handle) => {
+                let _guard = InstrumentedSpawnGuard::enter();
+                self.runtime.spawn(crate::telemetry::TracedFuture::new(
+                    future,
+                    Some(traced_handle),
+                ))
             }
             None => self.runtime.spawn(future),
+        }
+    }
+
+    /// Spawn an instrumented future through a user-supplied spawn function.
+    ///
+    /// Mirrors [`TelemetryHandle::spawn_with`] but does not require an
+    /// ambient tokio runtime context — `spawn_fn` is invoked on the
+    /// calling thread, so it is the closure's responsibility to target
+    /// this handle's runtime (typically via
+    /// [`tokio::task::JoinSet::spawn_on`] passing the appropriate
+    /// [`tokio::runtime::Handle`]).
+    ///
+    /// # Examples
+    ///
+    /// Spawn into a [`tokio::task::JoinSet`] on a specific runtime:
+    ///
+    /// ```rust,no_run
+    /// # use dial9_tokio_telemetry::telemetry::RuntimeTelemetryHandle;
+    /// # use tokio::runtime::Runtime;
+    /// # use tokio::task::JoinSet;
+    /// # async fn work() {}
+    /// # fn demo(runtime: &Runtime, handle: RuntimeTelemetryHandle, set: &mut JoinSet<()>) {
+    /// handle.spawn_with(work(), |f| set.spawn_on(f, runtime.handle()));
+    /// # }
+    /// ```
+    ///
+    /// [`TracedFuture<F>`]: crate::telemetry::TracedFuture
+    pub fn spawn_with<F, S>(
+        &self,
+        future: F,
+        spawn_fn: impl FnOnce(crate::telemetry::TracedFuture<F>) -> S,
+    ) -> S
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let future = crate::telemetry::TracedFuture::new(future, self.traced.clone());
+        match self.traced {
+            Some(_) => {
+                let _guard = InstrumentedSpawnGuard::enter();
+                spawn_fn(future)
+            }
+            None => spawn_fn(future),
         }
     }
 }
@@ -1378,7 +1451,7 @@ impl<'a> TraceRuntimeCoreBuilder<'a> {
     /// Install telemetry hooks, build the runtime, and reserve worker IDs.
     ///
     /// Returns the runtime and a [`RuntimeTelemetryHandle`] for spawning
-    /// wake-tracked futures via [`RuntimeTelemetryHandle::spawn`].
+    /// instrumented futures via [`RuntimeTelemetryHandle::spawn`].
     pub fn build(
         self,
         mut builder: tokio::runtime::Builder,
@@ -2079,6 +2152,23 @@ mod tests {
             Ok(())
         }
     }
+
+    /// Nested `InstrumentedSpawnGuard`s must compose: inner drop must not
+    /// clear the outer scope. Counter, not flag.
+    #[test]
+    fn instrumented_spawn_guard_nests() {
+        assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 0);
+        let outer = InstrumentedSpawnGuard::enter();
+        assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 1);
+        {
+            let _inner = InstrumentedSpawnGuard::enter();
+            assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 2);
+        }
+        assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 1);
+        drop(outer);
+        assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 0);
+    }
+
     #[test]
     fn current_thread_runtime_resolves_worker_ids() {
         let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
@@ -2489,7 +2579,7 @@ mod tests {
             .build_and_attach_to_telemetry(builder_b, &guard)
             .unwrap();
 
-        // Use handle.spawn on runtime B to get Traced waker wrapping → wake events.
+        // Use handle.spawn on runtime B to get wake-tracked wrapping → wake events.
         let handle = guard.handle();
         runtime_b.block_on(async {
             let mut handles = Vec::new();
@@ -2907,7 +2997,7 @@ mod tests {
         drop(runtime);
         drop(guard);
 
-        // Verify wake events were recorded (handle.spawn wraps with Traced)
+        // Verify wake events were recorded (handle.spawn wraps with wake tracking)
         let raw = data.lock().unwrap();
         let events = crate::telemetry::format::decode_events(&raw).unwrap();
         let wake_count = events

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -518,11 +518,13 @@ impl TelemetryHandle {
 
     /// Spawn an instrumented future through a user-supplied spawn function.
     ///
-    /// `spawn_fn` is invoked synchronously with a [`TracedFuture<F>`] that
-    /// the caller is expected to spawn immediately. The closure's return
-    /// value is forwarded back to the caller, so you can keep the
-    /// [`tokio::task::JoinHandle`], [`tokio::task::AbortHandle`], or
-    /// whatever the spawn function returns.
+    /// `spawn_fn` must synchronously perform a real Tokio spawn (or an
+    /// equivalent operation) before returning; do not defer the future or run
+    /// it with `block_on`. To record the resulting task as instrumented, spawn
+    /// on a dial9-traced runtime with task tracking enabled. The closure's
+    /// return value is forwarded back to the caller, so you can keep the
+    /// [`tokio::task::JoinHandle`], [`tokio::task::AbortHandle`], or whatever
+    /// the spawn function returns.
     ///
     /// # Examples
     ///
@@ -651,12 +653,13 @@ impl RuntimeTelemetryHandle {
 
     /// Spawn an instrumented future through a user-supplied spawn function.
     ///
-    /// Mirrors [`TelemetryHandle::spawn_with`] but does not require an
-    /// ambient tokio runtime context — `spawn_fn` is invoked on the
-    /// calling thread, so it is the closure's responsibility to target
-    /// this handle's runtime (typically via
-    /// [`tokio::task::JoinSet::spawn_on`] passing the appropriate
-    /// [`tokio::runtime::Handle`]).
+    /// Mirrors [`TelemetryHandle::spawn_with`] for callers that already hold a
+    /// [`RuntimeTelemetryHandle`]. `spawn_fn` must synchronously perform a real
+    /// Tokio spawn (or an equivalent operation) before returning; do not defer
+    /// the future or run it with `block_on`. To record the resulting task as
+    /// instrumented, target a dial9-traced runtime with task tracking enabled,
+    /// typically via [`tokio::task::JoinSet::spawn_on`] with the appropriate
+    /// [`tokio::runtime::Handle`].
     ///
     /// # Examples
     ///

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -34,6 +34,7 @@ pub(crate) struct SharedState {
     pub(crate) task_dump_idle_threshold_ns: AtomicU64,
     /// Fixed RNG seed for deterministic task dump sampling. Set once at
     /// construction before the `Arc` is shared; read-only thereafter.
+    #[cfg_attr(not(feature = "taskdump"), allow(dead_code))]
     pub(crate) task_dump_rng_seed: Option<u64>,
     pub(crate) collector: Arc<CentralCollector>,
     /// Absolute `CLOCK_MONOTONIC` nanosecond timestamp captured at trace start.
@@ -85,7 +86,7 @@ impl SharedState {
     }
 
     /// Create a wake event. Pragmatic exception: calls `tokio::task::try_id()`
-    /// because `Traced` is inherently tokio-specific.
+    /// because the wake-tracking future is inherently tokio-specific.
     pub(crate) fn create_wake_event(
         &self,
         woken_task_id: TaskId,
@@ -106,7 +107,7 @@ impl SharedState {
     /// provides an [`EventBuffer`] that makes it structurally impossible to
     /// record without checking first. Use `is_enabled()` only for
     /// control-flow decisions that don't directly record events (e.g.
-    /// deciding whether to wrap a waker in `Traced::poll`).
+    /// deciding whether to wrap a waker in wake-tracking polls).
     pub(crate) fn is_enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
     }

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -1,5 +1,6 @@
-//! `Traced<F>` future wrapper for wake event capture and task dump collection.
+//! Future wrappers for task instrumentation.
 
+use crate::rate_limit::rate_limited;
 use crate::telemetry::recorder::SharedState;
 use crate::telemetry::task_metadata::TaskId;
 use futures_util::task::{ArcWake, AtomicWaker, waker as arc_waker};
@@ -8,8 +9,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
+use std::time::Duration;
 
-/// Handle used by `Traced<F>` to emit events into the telemetry system.
+/// Handle used by instrumented futures to emit events into the telemetry system.
 #[derive(Clone)]
 pub(crate) struct TracedHandle {
     pub(crate) shared: Arc<SharedState>,
@@ -21,30 +23,78 @@ impl std::fmt::Debug for TracedHandle {
     }
 }
 
+#[cfg(feature = "taskdump")]
+type MaybeTaskDumped<F> = crate::task_dumped::TaskDumped<F>;
+
+#[cfg(not(feature = "taskdump"))]
+type MaybeTaskDumped<F> = F;
+
+type InstrumentedFuture<F> = WakeTracked<MaybeTaskDumped<F>>;
+
 pin_project! {
-    /// Future wrapper that captures wake events (and later, task dumps).
-    pub struct Traced<F> {
+    /// Future wrapper produced by `spawn_with` for custom spawn APIs.
+    ///
+    /// On first poll, `TracedFuture<F>` resolves the surrounding Tokio task ID
+    /// and uses it for task instrumentation. If the future is polled outside a
+    /// Tokio task context, it runs as a transparent passthrough without wake
+    /// tracking or task dumps.
+    pub struct TracedFuture<F> {
+        #[pin]
+        state: TracedFutureState<F>,
+    }
+}
+
+impl<F> std::fmt::Debug for TracedFuture<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TracedFuture").finish_non_exhaustive()
+    }
+}
+
+impl<F> TracedFuture<F> {
+    pub(crate) fn new(inner: F, handle: Option<TracedHandle>) -> Self {
+        Self {
+            state: TracedFutureState::Init { inner, handle },
+        }
+    }
+}
+
+pin_project! {
+    #[project = TracedFutureStateProj]
+    #[project_replace = TracedFutureStateProjReplace]
+    enum TracedFutureState<F> {
+        Init {
+            inner: F,
+            handle: Option<TracedHandle>,
+        },
+        Passthrough {
+            #[pin]
+            inner: F,
+        },
+        Instrumented {
+            #[pin]
+            inner: InstrumentedFuture<F>,
+        },
+        Empty,
+    }
+}
+
+pin_project! {
+    /// Future wrapper that captures wake events for a known Tokio task.
+    pub(crate) struct WakeTracked<F> {
         #[pin]
         inner: F,
-        handle: TracedHandle,
-        task_id: TaskId,
         waker_data: Arc<TracedWakerData>, // reused across polls to avoid a per-poll Arc allocation
     }
 }
 
-impl<F> Traced<F> {
+impl<F> WakeTracked<F> {
     pub(crate) fn new(inner: F, handle: TracedHandle, task_id: TaskId) -> Self {
         let waker_data = Arc::new(TracedWakerData {
             inner: AtomicWaker::new(),
             woken_task_id: task_id,
             shared: handle.shared.clone(),
         });
-        Self {
-            inner,
-            handle,
-            task_id,
-            waker_data,
-        }
+        Self { inner, waker_data }
     }
 }
 
@@ -91,12 +141,69 @@ fn make_traced_waker(data: Arc<TracedWakerData>) -> Waker {
     arc_waker(data)
 }
 
-impl<F: Future> Future for Traced<F> {
+fn make_instrumented<F>(inner: F, handle: TracedHandle, task_id: TaskId) -> InstrumentedFuture<F>
+where
+    F: Future,
+{
+    let shared = handle.shared.clone();
+    #[cfg(feature = "taskdump")]
+    let inner = crate::task_dumped::TaskDumped::new(inner, shared, task_id);
+    #[cfg(not(feature = "taskdump"))]
+    let _ = shared;
+
+    WakeTracked::new(inner, handle, task_id)
+}
+
+impl<F: Future> Future for TracedFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.project().state;
+
+        loop {
+            match state.as_mut().project() {
+                TracedFutureStateProj::Init { .. } => {}
+                TracedFutureStateProj::Passthrough { inner } => return inner.poll(cx),
+                TracedFutureStateProj::Instrumented { inner } => return inner.poll(cx),
+                TracedFutureStateProj::Empty => {
+                    unreachable!("TracedFutureState::Empty is only used during state transitions")
+                }
+            }
+
+            let TracedFutureStateProjReplace::Init { inner, handle } =
+                state.as_mut().project_replace(TracedFutureState::Empty)
+            else {
+                unreachable!("Init was matched immediately before project_replace")
+            };
+
+            let Some(handle) = handle else {
+                state.set(TracedFutureState::Passthrough { inner });
+                continue;
+            };
+
+            let Some(task_id) = tokio::task::try_id().map(TaskId::from) else {
+                rate_limited!(Duration::from_secs(60), {
+                    tracing::warn!(
+                        "Traced future polled outside a Tokio task context; running future without instrumentation"
+                    );
+                });
+                state.set(TracedFutureState::Passthrough { inner });
+                continue;
+            };
+
+            let inner = make_instrumented(inner, handle, task_id);
+            state.set(TracedFutureState::Instrumented { inner });
+        }
+    }
+}
+
+impl<F: Future> Future for WakeTracked<F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        if !this.handle.shared.is_enabled() {
+
+        if !this.waker_data.shared.is_enabled() {
             return this.inner.poll(cx);
         }
 
@@ -117,13 +224,44 @@ mod tests {
     use super::*;
     use crate::telemetry::buffer;
     use crate::telemetry::events::TelemetryEvent;
-    use crate::telemetry::recorder::TracedRuntime;
+    use crate::telemetry::recorder::{TelemetryCore, TracedRuntime};
     use crate::telemetry::task_metadata::UNKNOWN_TASK_ID;
-    use crate::telemetry::writer::RotatingWriter;
+    use crate::telemetry::writer::{NullWriter, RotatingWriter};
+    use futures_util::task::noop_waker;
+    use std::pin::Pin;
     use std::sync::{Arc, Mutex};
+    use std::task::Context;
     use tempfile::TempDir;
 
-    /// Verify that `Traced<F>` records a `WakeEvent` whose `woken_task_id`
+    #[test]
+    fn traced_future_falls_back_after_missing_task_context() {
+        let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+        let handle = guard
+            .handle()
+            .traced_handle()
+            .expect("enabled handle yields TracedHandle");
+
+        let mut future = TracedFuture::new(std::future::pending::<()>(), Some(handle));
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(Pin::new(&mut future).poll(&mut cx).is_pending());
+        assert!(matches!(
+            future.state,
+            TracedFutureState::Passthrough { .. }
+        ));
+
+        // This is important to ensure the missing-task fallback is one-way:
+        // after the first failed task-id lookup, later polls go straight
+        // through without retrying `try_id()` or warning again.
+        assert!(Pin::new(&mut future).poll(&mut cx).is_pending());
+        assert!(matches!(
+            future.state,
+            TracedFutureState::Passthrough { .. }
+        ));
+    }
+
+    /// Verify that the wake-tracking wrapper records a `WakeEvent` whose `woken_task_id`
     /// matches the spawned task when a `Notify` wakes it.
     ///
     /// This is an integration test: events are written to a real file via
@@ -153,7 +291,7 @@ mod tests {
         let spawned_id_write = spawned_id.clone();
 
         runtime.block_on(async {
-            // Spawn a task wrapped in Traced that blocks on a Notify.
+            // Spawn a traced task that blocks on a Notify.
             let join = handle.spawn(async move {
                 *spawned_id_write.lock().unwrap() = tokio::task::try_id()
                     .map(TaskId::from)

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -29,7 +29,7 @@ type MaybeTaskDumped<F> = crate::task_dumped::TaskDumped<F>;
 #[cfg(not(feature = "taskdump"))]
 type MaybeTaskDumped<F> = F;
 
-type InstrumentedFuture<F> = WakeTracked<MaybeTaskDumped<F>>;
+type InstrumentedFuture<F> = WakeTraced<MaybeTaskDumped<F>>;
 
 pin_project! {
     /// Future wrapper produced by `spawn_with` for custom spawn APIs.
@@ -80,14 +80,14 @@ pin_project! {
 
 pin_project! {
     /// Future wrapper that captures wake events for a known Tokio task.
-    pub(crate) struct WakeTracked<F> {
+    pub(crate) struct WakeTraced<F> {
         #[pin]
         inner: F,
         waker_data: Arc<TracedWakerData>, // reused across polls to avoid a per-poll Arc allocation
     }
 }
 
-impl<F> WakeTracked<F> {
+impl<F> WakeTraced<F> {
     pub(crate) fn new(inner: F, handle: TracedHandle, task_id: TaskId) -> Self {
         let waker_data = Arc::new(TracedWakerData {
             inner: AtomicWaker::new(),
@@ -151,7 +151,7 @@ where
     #[cfg(not(feature = "taskdump"))]
     let _ = shared;
 
-    WakeTracked::new(inner, handle, task_id)
+    WakeTraced::new(inner, handle, task_id)
 }
 
 impl<F: Future> Future for TracedFuture<F> {
@@ -197,7 +197,7 @@ impl<F: Future> Future for TracedFuture<F> {
     }
 }
 
-impl<F: Future> Future for WakeTracked<F> {
+impl<F: Future> Future for WakeTraced<F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/dial9-tokio-telemetry/tests/spawn_with.rs
+++ b/dial9-tokio-telemetry/tests/spawn_with.rs
@@ -1,0 +1,202 @@
+//! Integration tests for the custom-spawn tracing API:
+//! - [`TelemetryHandle::spawn_with`]
+//! - [`RuntimeTelemetryHandle::spawn_with`]
+//!
+//! `spawn_with(fut, |f| spawn_fn(f))` is the way to spawn an instrumented
+//! future through APIs other than `TelemetryHandle::spawn` (e.g.
+//! `tokio::task::JoinSet::spawn`, `JoinSet::spawn_on`, etc.). It must:
+//!   - emit `WakeEvent`s for the polled future, and
+//!   - mark the resulting `TaskSpawn` as `instrumented = true`,
+//!   - while preserving the user's call site as `spawn_loc`.
+
+mod common;
+
+use dial9_tokio_telemetry::analysis_unstable::TraceReader;
+use dial9_tokio_telemetry::telemetry::{
+    RotatingWriter, TaskId, TelemetryEvent, TelemetryGuard, TraceWriter, TracedRuntime,
+};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::task::JoinSet;
+
+/// Standard 2-worker multi_thread runtime with task tracking enabled.
+fn build_traced_runtime<W: TraceWriter + 'static>(writer: W) -> (Runtime, TelemetryGuard) {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+    TracedRuntime::builder()
+        .with_task_tracking(true)
+        .build_and_start(builder, writer)
+        .unwrap()
+}
+
+/// `spawn_with(fut, |f| set.spawn(f))` produces `WakeEvent`s for the
+/// spawned task — the same as `handle.spawn(fut)` would.
+#[test]
+fn spawn_with_joinset_emits_wake_events() {
+    let (writer, events) = common::CapturingWriter::new();
+    let (runtime, guard) = build_traced_runtime(writer);
+
+    let handle = guard.handle();
+    let spawned_id: Arc<Mutex<Option<TaskId>>> = Arc::new(Mutex::new(None));
+    let id_w = spawned_id.clone();
+
+    runtime.block_on(async move {
+        let mut set: JoinSet<()> = JoinSet::new();
+        // `yield_now().await` self-wakes through the active waker, which
+        // here is our wake-tracking waker — so a `WakeEvent` fires without
+        // depending on cross-task scheduling order.
+        handle.spawn_with(
+            async move {
+                *id_w.lock().unwrap() = tokio::task::try_id().map(TaskId::from);
+                tokio::task::yield_now().await;
+            },
+            |f| set.spawn(f),
+        );
+        while set.join_next().await.is_some() {}
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let events = events.lock().unwrap();
+    let expected = spawned_id.lock().unwrap().expect("task id captured");
+    let saw_wake = events.iter().any(|e| {
+        matches!(e, TelemetryEvent::WakeEvent { woken_task_id, .. } if *woken_task_id == expected)
+    });
+    assert!(saw_wake, "expected WakeEvent for joinset task {expected:?}");
+}
+
+/// `spawn_with` flips the `TaskSpawn` `instrumented` flag for the spawn
+/// performed inside the closure, AND because `JoinSet::spawn` is called
+/// from that closure, its `#[track_caller]` resolves `spawn_loc` to the
+/// closure call site (NOT the library).
+#[test]
+fn spawn_with_marks_taskspawn_and_preserves_caller() {
+    let dir = tempfile::tempdir().unwrap();
+    let trace_path = dir.path().join("trace.bin");
+    let writer = RotatingWriter::single_file(&trace_path).unwrap();
+    let (runtime, guard) = build_traced_runtime(writer);
+
+    let handle = guard.handle();
+
+    runtime.block_on(async move {
+        let mut set: JoinSet<()> = JoinSet::new();
+
+        // Inside `spawn_with`: marked instrumented, caller = this file.
+        handle.spawn_with(async {}, |f| set.spawn(f));
+
+        // Outside `spawn_with`: NOT instrumented.
+        tokio::spawn(async {}).await.unwrap();
+
+        while set.join_next().await.is_some() {}
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let sealed = dir.path().join("trace.0.bin");
+    let reader = TraceReader::new(sealed.to_str().unwrap()).unwrap();
+
+    let mut instrumented_user_loc = 0;
+    let mut raw = 0;
+    for event in &reader.all_events {
+        if let TelemetryEvent::TaskSpawn {
+            spawn_loc,
+            instrumented,
+            ..
+        } = event
+        {
+            match instrumented {
+                Some(true) => {
+                    let loc = reader
+                        .spawn_locations
+                        .get(spawn_loc)
+                        .expect("spawn_loc should resolve");
+                    assert!(
+                        loc.contains("spawn_with.rs"),
+                        "instrumented spawn caller should resolve to the closure call site, got {loc}"
+                    );
+                    instrumented_user_loc += 1;
+                }
+                Some(false) => raw += 1,
+                None => {}
+            }
+        }
+    }
+    assert_eq!(
+        instrumented_user_loc, 1,
+        "expected 1 instrumented TaskSpawn pointing to the closure call site"
+    );
+    assert!(raw >= 1, "expected at least 1 raw TaskSpawn, got {raw}");
+}
+
+/// `spawn_with` returns whatever the closure returns. Useful so callers
+/// can keep the `JoinHandle` / `AbortHandle` / etc. produced by their
+/// spawn function.
+#[test]
+fn spawn_with_returns_closure_value() {
+    let (writer, _events) = common::CapturingWriter::new();
+    let (runtime, guard) = build_traced_runtime(writer);
+
+    let handle = guard.handle();
+
+    runtime.block_on(async move {
+        let join = handle.spawn_with(async { 42u32 }, tokio::spawn);
+        let value = join.await.unwrap();
+        assert_eq!(value, 42);
+    });
+
+    drop(runtime);
+    drop(guard);
+}
+
+/// `RuntimeTelemetryHandle::spawn_with` composes with `JoinSet::spawn_on`
+/// to target a specific runtime even when called from outside any
+/// runtime context, while still emitting wake events and marking the
+/// `TaskSpawn` instrumented.
+#[test]
+fn runtime_handle_spawn_with_targets_correct_runtime() {
+    use dial9_tokio_telemetry::telemetry::{NullWriter, TelemetryCore};
+
+    let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+    guard.enable();
+
+    let mut builder_a = tokio::runtime::Builder::new_multi_thread();
+    builder_a.worker_threads(1).enable_all().thread_name("rt-a");
+    let (rt_a, handle_a) = guard.trace_runtime("a").build(builder_a).unwrap();
+
+    let mut builder_b = tokio::runtime::Builder::new_multi_thread();
+    builder_b.worker_threads(1).enable_all().thread_name("rt-b");
+    let (rt_b, handle_b) = guard.trace_runtime("b").build(builder_b).unwrap();
+
+    let mut set_a: JoinSet<String> = JoinSet::new();
+    handle_a.spawn_with(
+        async {
+            tokio::task::yield_now().await;
+            std::thread::current().name().unwrap_or("?").to_string()
+        },
+        |f| set_a.spawn_on(f, rt_a.handle()),
+    );
+
+    let mut set_b: JoinSet<String> = JoinSet::new();
+    handle_b.spawn_with(
+        async {
+            tokio::task::yield_now().await;
+            std::thread::current().name().unwrap_or("?").to_string()
+        },
+        |f| set_b.spawn_on(f, rt_b.handle()),
+    );
+
+    let name_a = rt_a.block_on(async move { set_a.join_next().await.unwrap().unwrap() });
+    let name_b = rt_b.block_on(async move { set_b.join_next().await.unwrap().unwrap() });
+
+    assert!(name_a.starts_with("rt-a"), "got {name_a}");
+    assert!(name_b.starts_with("rt-b"), "got {name_b}");
+
+    drop(rt_a);
+    drop(rt_b);
+    let _ = guard.graceful_shutdown(Duration::from_secs(1));
+}

--- a/dial9-tokio-telemetry/tests/spawn_with.rs
+++ b/dial9-tokio-telemetry/tests/spawn_with.rs
@@ -159,22 +159,36 @@ fn spawn_with_returns_closure_value() {
 /// `TaskSpawn` instrumented.
 #[test]
 fn runtime_handle_spawn_with_targets_correct_runtime() {
-    use dial9_tokio_telemetry::telemetry::{NullWriter, TelemetryCore};
+    use dial9_tokio_telemetry::telemetry::TelemetryCore;
 
-    let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+    let (writer, events) = common::CapturingWriter::new();
+    let guard = TelemetryCore::builder().writer(writer).build().unwrap();
     guard.enable();
 
     let mut builder_a = tokio::runtime::Builder::new_multi_thread();
     builder_a.worker_threads(1).enable_all().thread_name("rt-a");
-    let (rt_a, handle_a) = guard.trace_runtime("a").build(builder_a).unwrap();
+    let (rt_a, handle_a) = guard
+        .trace_runtime("a")
+        .task_tracking(true)
+        .build(builder_a)
+        .unwrap();
 
     let mut builder_b = tokio::runtime::Builder::new_multi_thread();
     builder_b.worker_threads(1).enable_all().thread_name("rt-b");
-    let (rt_b, handle_b) = guard.trace_runtime("b").build(builder_b).unwrap();
+    let (rt_b, handle_b) = guard
+        .trace_runtime("b")
+        .task_tracking(true)
+        .build(builder_b)
+        .unwrap();
+
+    let task_id_a: Arc<Mutex<Option<TaskId>>> = Arc::new(Mutex::new(None));
+    let task_id_b: Arc<Mutex<Option<TaskId>>> = Arc::new(Mutex::new(None));
 
     let mut set_a: JoinSet<String> = JoinSet::new();
+    let id_a = task_id_a.clone();
     handle_a.spawn_with(
-        async {
+        async move {
+            *id_a.lock().unwrap() = tokio::task::try_id().map(TaskId::from);
             tokio::task::yield_now().await;
             std::thread::current().name().unwrap_or("?").to_string()
         },
@@ -182,8 +196,10 @@ fn runtime_handle_spawn_with_targets_correct_runtime() {
     );
 
     let mut set_b: JoinSet<String> = JoinSet::new();
+    let id_b = task_id_b.clone();
     handle_b.spawn_with(
-        async {
+        async move {
+            *id_b.lock().unwrap() = tokio::task::try_id().map(TaskId::from);
             tokio::task::yield_now().await;
             std::thread::current().name().unwrap_or("?").to_string()
         },
@@ -199,4 +215,33 @@ fn runtime_handle_spawn_with_targets_correct_runtime() {
     drop(rt_a);
     drop(rt_b);
     let _ = guard.graceful_shutdown(Duration::from_secs(1));
+
+    let task_id_a = task_id_a.lock().unwrap().expect("task id a captured");
+    let task_id_b = task_id_b.lock().unwrap().expect("task id b captured");
+    let events = events.lock().unwrap();
+
+    for expected in [task_id_a, task_id_b] {
+        let saw_instrumented_spawn = events.iter().any(|event| {
+            matches!(
+                event,
+                TelemetryEvent::TaskSpawn {
+                    task_id,
+                    instrumented: Some(true),
+                    ..
+                } if *task_id == expected
+            )
+        });
+        assert!(
+            saw_instrumented_spawn,
+            "expected instrumented TaskSpawn for runtime handle task {expected:?}"
+        );
+
+        let saw_wake = events.iter().any(|event| {
+            matches!(event, TelemetryEvent::WakeEvent { woken_task_id, .. } if *woken_task_id == expected)
+        });
+        assert!(
+            saw_wake,
+            "expected WakeEvent for runtime handle task {expected:?}"
+        );
+    }
 }

--- a/dial9-tokio-telemetry/tests/task_dump.rs
+++ b/dial9-tokio-telemetry/tests/task_dump.rs
@@ -4,6 +4,7 @@ mod common;
 
 use dial9_tokio_telemetry::telemetry::{TaskDumpConfig, TelemetryEvent, TracedRuntime};
 use std::time::Duration;
+use tokio::task::JoinSet;
 
 /// A task that stays idle longer than the threshold between polls should
 /// produce at least one `TaskDump` event.
@@ -141,5 +142,51 @@ fn task_dump_does_not_produce_extra_events() {
     assert_eq!(
         baseline, with_dumps,
         "enabling task dumps changed PollStart/PollEnd/WakeEvent counts: {baseline:?} vs {with_dumps:?}"
+    );
+}
+
+/// Custom spawn APIs should get the same task-dump instrumentation as
+/// [`TelemetryHandle::spawn`](dial9_tokio_telemetry::telemetry::TelemetryHandle::spawn).
+#[test]
+fn spawn_with_joinset_emits_task_dump() {
+    let (writer, events) = common::CapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_current_thread();
+    builder.enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .with_task_dumps(TaskDumpConfig::builder().rng_seed(42).build())
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    runtime.block_on(async {
+        let mut set: JoinSet<()> = JoinSet::new();
+        handle.spawn_with(
+            async {
+                // Well above the 10ms default threshold.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            },
+            |f| set.spawn(f),
+        );
+        while set.join_next().await.is_some() {}
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let events = events.lock().unwrap();
+    let dumps: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, TelemetryEvent::TaskDump { .. }))
+        .collect();
+
+    assert!(
+        !dumps.is_empty(),
+        "expected TaskDump events from spawn_with JoinSet task; got: {:?}",
+        events
+            .iter()
+            .map(std::mem::discriminant)
+            .collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
## Current solution

Exposes a `handle.spawn_with(fut, |f: TracedFuture| { ... })` to allow spawning instrumented/traced futures through custom spawn APIs (like `JoinSet::spawn`).

## Example

```rust
let handle = TelemetryHandle::current();
let mut set: JoinSet<()> = JoinSet::new();
handle.spawn_with(fut, |f| set.spawn(f));
```

## For reviewers

Most important changes are at `recorder/mod.rs` and `traced.rs`.

## Other
Closes #301 