### PR TITLE
fix(test): make test_schedstat_fd_closed_on_thread_exit not flaky

### DIFF
--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -649,9 +649,9 @@ mod tests {
                 // fd was closed and the slot was reused for an unrelated open
                 // in another thread. That still means our OwnedFd was dropped.
             }
-            Some(now) => panic!(
-                "schedstat fd {fd} leaked after thread exit (still points at {now:?})"
-            ),
+            Some(now) => {
+                panic!("schedstat fd {fd} leaked after thread exit (still points at {now:?})")
+            }
         }
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -609,19 +609,49 @@ mod tests {
     #[test]
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn test_schedstat_fd_closed_on_thread_exit() {
-        // fcntl(fd, F_GETFD) returns -1 with errno=EBADF for closed fds.
-        // SAFETY: F_GETFD with a raw fd is side-effect free.
-        fn fd_is_open(fd: std::os::fd::RawFd) -> bool {
-            unsafe { libc::fcntl(fd, libc::F_GETFD) != -1 }
+        // We cannot just check `fcntl(fd, F_GETFD) != -1` after the thread
+        // exits: the kernel readily recycles fd numbers, and other tests in the
+        // suite open many files (including their own per-thread schedstat fds)
+        // concurrently. A closed fd may immediately be reused by an unrelated
+        // open in another thread, making a naive open-check flaky.
+        //
+        // Instead, record the path the fd points at (via /proc/self/fd/<fd>)
+        // *inside* the spawned thread, and after join check whether the fd is
+        // either closed or now points at a different file. Each thread opens
+        // schedstat for its own tid, so the captured path
+        // `/proc/self/task/<spawned_tid>/schedstat` is unique to the spawned
+        // thread's open: no other thread will ever open that exact path. If the
+        // fd is still open and still points at it, the OwnedFd was leaked.
+
+        fn fd_target(fd: std::os::fd::RawFd) -> Option<std::path::PathBuf> {
+            std::fs::read_link(format!("/proc/self/fd/{fd}")).ok()
         }
 
-        let fd = std::thread::spawn(|| SchedStat::read_current().unwrap().fd)
-            .join()
-            .unwrap();
+        let (fd, opened_path) = std::thread::spawn(|| {
+            let fd = SchedStat::read_current().unwrap().fd;
+            let path = fd_target(fd).expect("readlink /proc/self/fd/<fd> in live thread");
+            (fd, path)
+        })
+        .join()
+        .unwrap();
 
+        // Sanity-check: confirm we actually captured a schedstat path so the
+        // assertion below is meaningful (rather than passing because we read
+        // the wrong link).
         assert!(
-            !fd_is_open(fd),
-            "schedstat fd {fd} leaked after thread exit"
+            opened_path.to_string_lossy().ends_with("/schedstat"),
+            "expected schedstat path, got {opened_path:?}"
         );
+
+        match fd_target(fd) {
+            None => { /* fd is closed - good. */ }
+            Some(now) if now != opened_path => {
+                // fd was closed and the slot was reused for an unrelated open
+                // in another thread. That still means our OwnedFd was dropped.
+            }
+            Some(now) => panic!(
+                "schedstat fd {fd} leaked after thread exit (still points at {now:?})"
+            ),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`test_schedstat_fd_closed_on_thread_exit` (added in 5e905e8) was flaky under the parallel test suite — failing roughly 3/10 runs of `cargo test -p dial9-tokio-telemetry --lib`, but passing every time when run in isolation.

**Root cause.** The test spawned a thread, called `SchedStat::read_current()` (which opens `/proc/self/task/<tid>/schedstat` and stores the `OwnedFd` in a thread-local), captured the raw fd number, joined, and then asserted `fcntl(fd, F_GETFD) != -1`. The kernel readily recycles fd numbers, and other tests in the same binary open many files concurrently — including their own per-thread schedstat fds opened from tokio worker poll callbacks (`runtime_context.rs`). If a sibling test opened any file in the small window after our spawned thread's `OwnedFd` was dropped, the fd number got reused and `fcntl(F_GETFD)` returned success on a totally unrelated fd, falsely reporting a leak.

**Fix.** Inside the spawned thread, also record what the fd points at via `readlink("/proc/self/fd/<fd>")`. After join, check whether the fd is either closed (readlink fails) or now points at a different file (slot was reused for an unrelated open — which itself proves our `OwnedFd` was dropped). The captured path `/proc/self/task/<spawned_tid>/schedstat` is unique to the spawned thread's open: each thread opens schedstat for its own tid, so no concurrent test can possibly hold an open fd for that exact path. If the fd is still open AND still points at it, that's a real leak — the assertion still fires.

The schedstat fd-cleanup invariant is unchanged; only the way the test observes it is hardened.

## Test plan

- [x] Reproduce the flake on `main`: 3/10 full-suite runs failed.
- [x] Apply the fix and run the full suite 13 times in a row — all 228 tests pass every time.
- [x] Verify the test still catches a real leak by temporarily replacing `*cell.borrow_mut() = Some(owned)` with `std::mem::forget(owned)` in the production path: test fails with `schedstat fd 3 leaked after thread exit (still points at "/proc/.../task/.../schedstat")`. Reverted before commit.
- [x] `cargo clippy -p dial9-tokio-telemetry --lib --tests` clean.