### PR TITLE
ci: disable cache-bin to fix flaky macOS builds

### DIFF
--- a/.github/actions/rust-build/action.yml
+++ b/.github/actions/rust-build/action.yml
@@ -18,6 +18,7 @@ runs:
         - uses: Swatinem/rust-cache@v2
           with:
               save-if: ${{ inputs.save-if }}
+              cache-bin: "false"
         - name: Enable perf_event_open and kallsyms for tests
           if: runner.os == 'Linux'
           shell: bash


### PR DESCRIPTION
## Problem

The macOS CI job flakes with:

```
error: unexpected argument 'test' found
Usage: rustup-init[EXE] [OPTIONS]
```

This happens because `Swatinem/rust-cache@v2` with `cache-bin: true` (the default) caches `~/.cargo/bin`. On macOS, `dtolnay/rust-toolchain` sets `RUSTUP_PERMIT_COPY_RENAME=1`, so rustup proxy binaries (`cargo`, `rustc`, etc.) are **copies** of the rustup binary rather than hardlinks.

When the cache restores these stale copies after a rustup version change on the runner image, the `cargo` binary resolves to `rustup-init` instead of the proper proxy, breaking all cargo commands.

## Fix

Set `cache-bin: "false"` so `Swatinem/rust-cache` no longer caches `~/.cargo/bin`. Rustup manages its own proxy binaries; they should not be cached.

This is a [documented known issue](https://github.com/Swatinem/rust-cache#known-issues) in rust-cache.

## Impact

- Fixes the flaky macOS CI failure
- Negligible CI time impact: the bin directory only contains rustup proxies (tiny files), not compiled binaries
- No change to Linux behavior (same root cause exists but is less likely to manifest since Linux uses hardlinks)