### PR TITLE
fix: stress test inherits RUSTFLAGS from .cargo/config.toml

### DIFF
--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -24,10 +24,9 @@ jobs:
     timeout-minutes: 75
     env:
       RUST_BACKTRACE: 1
-      RUSTFLAGS: "--cfg tokio_unstable"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
       - name: Enable perf_event_open and kallsyms
         run: |


### PR DESCRIPTION
The stress test was setting `RUSTFLAGS: "--cfg tokio_unstable"` as an env var, which completely overrides `.cargo/config.toml` and drops `-C force-frame-pointers=yes`. Without frame pointers, the unwinder walks garbage frames, causing `capture_and_symbolize` to fail.

Fix: remove the explicit `RUSTFLAGS` env var so Cargo picks up the config from `.cargo/config.toml`. Also pin the toolchain to 1.94.1 to match CI.

Fixes https://github.com/dial9-rs/dial9/actions/runs/25910215043