### PR TITLE
ci: baseline semver-checks against origin/main instead of crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,9 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Need full history so cargo-semver-checks can use origin/main as the baseline.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ env.STABLE_TOOLCHAIN }}
@@ -225,8 +228,14 @@ jobs:
       - name: Check semver compliance
         env:
           RUSTFLAGS: "--cfg tokio_unstable"
+        # Compare against origin/main rather than the latest crates.io release. This
+        # surfaces only breaking changes introduced *by this PR* — accumulated breaks
+        # already on main don't relitigate on every PR. release-plz's own
+        # semver_check (at release time) is the gate that ensures a major bump
+        # before publishing.
         run: |
           cargo semver-checks \
+            --baseline-rev origin/main \
             -p dial9-trace-format-derive \
             -p dial9-trace-format \
             -p dial9-perf-self-profile \


### PR DESCRIPTION
Switch the `Semver checks` CI job to use `--baseline-rev origin/main` instead of the default crates.io baseline.

## Why

By default, `cargo-semver-checks` compares the PR against the latest crates.io release. That's good for "must I bump major before publishing?" but noisy for per-PR review:

- Every PR sees every accumulated breaking change since the last release, drowning out what *this* PR introduced.
- Stacked PRs relitigate the same advisory warnings.

`--baseline-rev origin/main` makes the per-PR check report only what the PR itself introduces. The "must I bump major?" check is already separately handled at release time by `release-plz`'s own `semver_check = true` (per CONTRIBUTING.md), so we don't lose any release safety.

## Changes

- `actions/checkout`: `fetch-depth: 0` (need full history for the baseline rev).
- `cargo semver-checks`: add `--baseline-rev origin/main`.

Reference: <https://github.com/obi1kenobi/cargo-semver-checks#does-the-crate-im-checking-have-to-be-published-on-cratesio>

## Expected effect on this PR

This PR itself touches only `.github/workflows/ci.yml`, so the new semver-checks job has nothing to compare and should pass.