### PR TITLE
feat: add ring-buffer scaffold for memory profiling

### DIFF
--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -79,6 +79,8 @@ _shuttle = [
 ## is a hard compile error from tokio.
 taskdump = ["tokio/taskdump"]
 tracing-layer = ["dep:tracing-subscriber"]
+## Sampled memory allocation profiling via ring buffers.
+memory-profiling = []
 worker-s3 = [
     "dep:aws-sdk-s3-transfer-manager",
     "dep:aws-sdk-s3",
@@ -92,6 +94,7 @@ unstable-events = []
 __nonlinux_all_features = [
     "analysis",
     "cpu-profiling",
+    "memory-profiling",
     "tracing-layer",
     "worker-s3",
 ]
@@ -99,6 +102,7 @@ __nonlinux_all_features = [
 [dev-dependencies]
 dial9-tokio-telemetry = { path = ".", features = [
     "analysis",
+    "memory-profiling",
     "tracing-layer",
     "unstable-events",
     "worker-s3",
@@ -134,6 +138,7 @@ iai-callgrind = "=0.16.1"
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 dial9-tokio-telemetry = { path = ".", features = [
     "cpu-profiling",
+    "memory-profiling",
     "worker-s3",
     "analysis",
     "taskdump",

--- a/dial9-tokio-telemetry/src/lib.rs
+++ b/dial9-tokio-telemetry/src/lib.rs
@@ -13,6 +13,8 @@
 pub mod analysis_unstable;
 /// Background worker pipeline for processing sealed trace segments.
 pub mod background_task;
+#[cfg(feature = "memory-profiling")]
+pub(crate) mod memory_profiling;
 pub(crate) mod metrics;
 pub(crate) mod primitives;
 pub(crate) mod rate_limit;

--- a/dial9-tokio-telemetry/src/memory_profiling/mod.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/mod.rs
@@ -1,0 +1,44 @@
+//! Memory profiling — sampled allocation tracking via ring buffers.
+//!
+//! See `docs/design/memory-profiling.md` for the full design. The
+//! architecture (design §5, §6, §9):
+//!
+//! 1. The allocator hook (later commit) does the bare minimum on the
+//!    allocating thread: sampling decision, stack capture, push a
+//!    fixed-size POD record into one of two process-global lock-free
+//!    queues.
+//! 2. The flush thread (consolidator) drains both queues every flush cycle
+//!    via the `Source` trait, interns stacks, and emits `AllocEvent`s and
+//!    `FreeEvent`s into the central collector.
+//!
+//! ## Why two queues
+//!
+//! Allocs and frees have very different rates and record sizes:
+//! - `RawAlloc` (~1 KiB at 128 frames) is pushed only on sampled
+//!   allocations, ~2K/sec at default sample rate.
+//! - `RawFree` (~32 B) is pushed on every dealloc when liveset tracking is
+//!   on, potentially 15M/sec.
+//!
+//! A unified queue would either over-size the alloc queue or under-size
+//! the free queue. Splitting the queues lets us size each independently:
+//! at default capacities the alloc queue is ~4 MiB and the free queue is
+//! ~1 MiB (8× the slot count of the alloc queue, but each slot is ~32× smaller).
+//!
+//! Gated behind the `memory-profiling` cargo feature.
+
+mod ring;
+mod source;
+
+#[expect(
+    unused_imports,
+    reason = "wired up by allocator hook in a later commit"
+)]
+pub(crate) use ring::{
+    DEFAULT_ALLOC_QUEUE_CAPACITY, DEFAULT_FREE_QUEUE_CAPACITY, DEFAULT_MAX_FRAMES, RawAlloc,
+    RawFree, RingBuffers,
+};
+#[expect(
+    unused_imports,
+    reason = "wired up by allocator hook in a later commit"
+)]
+pub(crate) use source::MemoryProfileSource;

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -1,0 +1,76 @@
+//! Two lock-free MPMC queues — one for sampled allocations, one for frees.
+
+use crossbeam_queue::ArrayQueue;
+use std::sync::atomic::AtomicU64;
+
+/// Default maximum frames captured per allocation. 128 × 8 B = 1 KiB stack budget.
+pub(crate) const DEFAULT_MAX_FRAMES: usize = 128;
+
+/// Default number of `RawAlloc` slots. ~4 MiB total at 128 frames (design §5).
+pub(crate) const DEFAULT_ALLOC_QUEUE_CAPACITY: usize = 4096;
+
+/// Default number of `RawFree` slots. 8× the alloc queue (design §9).
+#[expect(dead_code, reason = "wired up by allocator hook in a later commit")]
+pub(crate) const DEFAULT_FREE_QUEUE_CAPACITY: usize = DEFAULT_ALLOC_QUEUE_CAPACITY * 8;
+
+/// One sampled allocation captured on the producer thread.
+///
+/// `MAX_FRAMES` controls the size of the inline stack buffer. The default
+/// (128) gives a 1 KiB stack budget for the frames field.
+#[derive(Debug, Clone)]
+pub(crate) struct RawAlloc<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
+    pub(crate) tid: u32,
+    pub(crate) size: u64,
+    pub(crate) addr: u64,
+    pub(crate) ts_ns: u64,
+    pub(crate) frames: [u64; MAX_FRAMES],
+    pub(crate) frame_count: u8,
+}
+
+impl<const MAX_FRAMES: usize> RawAlloc<MAX_FRAMES> {
+    pub(crate) fn frames(&self) -> &[u64] {
+        &self.frames[..self.frame_count as usize]
+    }
+}
+
+/// One free captured on the producer thread when liveset tracking is on.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RawFree {
+    pub(crate) tid: u32,
+    pub(crate) addr: u64,
+    #[expect(
+        dead_code,
+        reason = "consolidator uses size from the liveset entry, not from RawFree; the field is here so the producer doesn't have to do a separate lookup"
+    )]
+    pub(crate) size: u64,
+    pub(crate) ts_ns: u64,
+}
+
+/// Process-global pair of lock-free queues for the memory profiler.
+///
+/// Producers (allocator hook) and the consumer (`MemoryProfileSource`) both
+/// hold `Arc<RingBuffers<N>>` and access the queues via `&self` — no inner
+/// `Arc`s, so the `&Arc<...>` smell is contained to the outer borrow.
+pub(crate) struct RingBuffers<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
+    pub(crate) alloc_queue: ArrayQueue<RawAlloc<MAX_FRAMES>>,
+    pub(crate) free_queue: ArrayQueue<RawFree>,
+    #[expect(dead_code, reason = "incremented by allocator hook in a later commit")]
+    pub(crate) dropped_allocs: AtomicU64,
+    #[expect(dead_code, reason = "incremented by allocator hook in a later commit")]
+    pub(crate) dropped_frees: AtomicU64,
+}
+
+// `RingBuffers::new` is only called from tests in this commit. The allocator
+// hook in a later commit will call it from a non-test path; at that point
+// this `allow(dead_code)` becomes inert.
+#[cfg_attr(not(test), allow(dead_code))]
+impl<const MAX_FRAMES: usize> RingBuffers<MAX_FRAMES> {
+    pub(crate) fn new(alloc_capacity: usize, free_capacity: usize) -> Self {
+        Self {
+            alloc_queue: ArrayQueue::new(alloc_capacity),
+            free_queue: ArrayQueue::new(free_capacity),
+            dropped_allocs: AtomicU64::new(0),
+            dropped_frees: AtomicU64::new(0),
+        }
+    }
+}

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -28,10 +28,7 @@ pub(crate) struct RawAlloc<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
 }
 
 impl<const MAX_FRAMES: usize> RawAlloc<MAX_FRAMES> {
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by allocator hook in a later commit")
-    )]
+    #[expect(dead_code, reason = "used by allocator hook in a later commit")]
     pub(crate) fn frames(&self) -> &[u64] {
         const { assert!(MAX_FRAMES <= u8::MAX as usize, "MAX_FRAMES must fit in u8") };
         &self.frames[..self.frame_count as usize]

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -1,7 +1,7 @@
 //! Two lock-free MPMC queues — one for sampled allocations, one for frees.
 
+use crate::primitives::sync::atomic::AtomicU64;
 use crossbeam_queue::ArrayQueue;
-use std::sync::atomic::AtomicU64;
 
 /// Default maximum frames captured per allocation. 128 × 8 B = 1 KiB stack budget.
 pub(crate) const DEFAULT_MAX_FRAMES: usize = 128;
@@ -28,7 +28,12 @@ pub(crate) struct RawAlloc<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
 }
 
 impl<const MAX_FRAMES: usize> RawAlloc<MAX_FRAMES> {
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by allocator hook in a later commit")
+    )]
     pub(crate) fn frames(&self) -> &[u64] {
+        const { assert!(MAX_FRAMES <= u8::MAX as usize, "MAX_FRAMES must fit in u8") };
         &self.frames[..self.frame_count as usize]
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -451,4 +451,52 @@ mod tests {
         assert_eq!(entry.size, 512);
         assert_eq!(entry.timestamp_ns, 300);
     }
+
+    /// Demonstrates that `poll_start_ts_or_now` produces strictly ordered
+    /// timestamps even for events that would otherwise share a clock tick —
+    /// the scenario that occurs during a realloc (free old + alloc new at
+    /// same address).
+    #[test]
+    fn monotonic_ts_solves_realloc_ordering() {
+        use crate::telemetry::recorder::poll_start_ts_monotonic;
+
+        // Simulate a realloc: alloc, free, alloc — all at the "same instant".
+        // poll_start_ts_or_now guarantees each gets a distinct, increasing timestamp.
+        let t1 = poll_start_ts_monotonic();
+        let t2 = poll_start_ts_monotonic();
+        let t3 = poll_start_ts_monotonic();
+        assert!(t1 < t2 && t2 < t3, "timestamps must be strictly ordered");
+
+        let rings = rings(16, 16);
+        rings.alloc_queue.push(make_raw_alloc(0x6000, 256, t1)).ok();
+        rings.free_queue.push(make_raw_free(0x6000, t2)).ok();
+        rings.alloc_queue.push(make_raw_alloc(0x6000, 512, t3)).ok();
+
+        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+        let events = flush_and_collect(&mut source);
+
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(frees.len(), 1);
+        match frees[0] {
+            TelemetryEvent::Free {
+                size,
+                alloc_timestamp_nanos,
+                ..
+            } => {
+                assert_eq!(*size, 256, "free should match the first alloc");
+                assert_eq!(*alloc_timestamp_nanos, t1);
+            }
+            _ => unreachable!(),
+        }
+
+        // Second alloc remains live.
+        let liveset = source.liveset.as_ref().unwrap();
+        assert_eq!(liveset.len(), 1);
+        let entry = liveset.get(&0x6000).unwrap();
+        assert_eq!(entry.size, 512);
+        assert_eq!(entry.timestamp_ns, t3);
+    }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -153,8 +153,8 @@ impl<const MAX_FRAMES: usize> Source for MemoryProfileSource<MAX_FRAMES> {
 mod tests {
     use super::*;
     use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree, RingBuffers};
-    use crate::primitives::sync::atomic::AtomicU64;
     use crate::primitives::sync::Arc;
+    use crate::primitives::sync::atomic::AtomicU64;
     use crate::telemetry::buffer::drain_to_collector;
     use crate::telemetry::collector::CentralCollector;
     use crate::telemetry::events::{TelemetryEvent, ThreadRole};

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -1,11 +1,11 @@
 //! `Source` impl that drains the alloc and free queues each flush cycle.
 
 use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree, RingBuffers};
+use crate::primitives::sync::Arc;
 use crate::telemetry::buffer::with_encoder;
 use crate::telemetry::format::{AllocEvent, FreeEvent};
 use crate::telemetry::recorder::source::{FlushContext, Source};
 use std::collections::HashMap;
-use std::sync::Arc;
 
 /// Liveset entry tracking a live sampled allocation, kept by the consolidator
 /// (flush thread). Only `size` and `timestamp_ns` are needed: both are
@@ -48,17 +48,18 @@ impl<const MAX_FRAMES: usize> MemoryProfileSource<MAX_FRAMES> {
     }
 
     fn handle_alloc(&mut self, a: RawAlloc<MAX_FRAMES>, ctx: &FlushContext<'_>) {
-        let frames = a.frames().to_vec();
+        let frame_count = a.frame_count as usize;
         let RawAlloc {
             tid,
             size,
             addr,
             ts_ns,
+            frames,
             ..
         } = a;
         with_encoder(
             |enc| {
-                let callchain = enc.intern_stack_frames(&frames);
+                let callchain = enc.intern_stack_frames(&frames[..frame_count]);
                 enc.encode(&AllocEvent {
                     timestamp_ns: ts_ns,
                     tid,
@@ -152,14 +153,14 @@ impl<const MAX_FRAMES: usize> Source for MemoryProfileSource<MAX_FRAMES> {
 mod tests {
     use super::*;
     use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree, RingBuffers};
+    use crate::primitives::sync::atomic::AtomicU64;
+    use crate::primitives::sync::Arc;
     use crate::telemetry::buffer::drain_to_collector;
     use crate::telemetry::collector::CentralCollector;
     use crate::telemetry::events::{TelemetryEvent, ThreadRole};
     use crate::telemetry::format::decode_events;
     use crate::telemetry::recorder::source::FlushContext;
     use std::collections::HashMap;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicU64;
 
     fn make_raw_alloc(addr: u64, size: u64, ts_ns: u64) -> RawAlloc {
         let mut frames = [0u64; DEFAULT_MAX_FRAMES];

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -1,0 +1,453 @@
+//! `Source` impl that drains the alloc and free queues each flush cycle.
+
+use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree, RingBuffers};
+use crate::telemetry::buffer::with_encoder;
+use crate::telemetry::format::{AllocEvent, FreeEvent};
+use crate::telemetry::recorder::source::{FlushContext, Source};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Liveset entry tracking a live sampled allocation, kept by the consolidator
+/// (flush thread). Only `size` and `timestamp_ns` are needed: both are
+/// denormalized onto `FreeEvent` so leak analysis stays useful when the
+/// matching `AllocEvent` has been evicted by trace rotation. Storing the stack
+/// here would bloat the liveset (see design §8).
+#[derive(Debug, Clone, Copy)]
+struct LivesetEntry {
+    size: u64,
+    timestamp_ns: u64,
+}
+
+/// Drains the alloc and free queues into the trace each flush cycle.
+///
+/// The drain is timestamp-ordered: at each step we look at the head of each
+/// queue and process the older one first. This matters for liveset
+/// correctness when the producer reuses an address within a single flush
+/// cycle (alloc → free → alloc-with-same-addr); naive "drain all allocs,
+/// then all frees" would race and corrupt the liveset.
+pub(crate) struct MemoryProfileSource<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
+    rings: Arc<RingBuffers<MAX_FRAMES>>,
+    liveset: Option<HashMap<u64, LivesetEntry>>,
+}
+
+impl<const MAX_FRAMES: usize> MemoryProfileSource<MAX_FRAMES> {
+    /// Create a new source that drains the supplied ring buffers.
+    ///
+    /// `track_liveset = true` enables `FreeEvent` emission (matched against
+    /// previously-sampled allocations); `false` means frees are silently
+    /// dropped on the consumer side.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired up by allocator hook in a later commit")
+    )]
+    pub(crate) fn new(rings: Arc<RingBuffers<MAX_FRAMES>>, track_liveset: bool) -> Self {
+        Self {
+            rings,
+            liveset: track_liveset.then(HashMap::new),
+        }
+    }
+
+    fn handle_alloc(&mut self, a: RawAlloc<MAX_FRAMES>, ctx: &FlushContext<'_>) {
+        let frames = a.frames().to_vec();
+        let RawAlloc {
+            tid,
+            size,
+            addr,
+            ts_ns,
+            ..
+        } = a;
+        with_encoder(
+            |enc| {
+                let callchain = enc.intern_stack_frames(&frames);
+                enc.encode(&AllocEvent {
+                    timestamp_ns: ts_ns,
+                    tid,
+                    size,
+                    addr,
+                    callchain,
+                });
+            },
+            ctx.collector,
+            ctx.drain_epoch,
+        );
+        if let Some(liveset) = self.liveset.as_mut() {
+            liveset.insert(
+                addr,
+                LivesetEntry {
+                    size,
+                    timestamp_ns: ts_ns,
+                },
+            );
+        }
+    }
+
+    fn handle_free(&mut self, f: RawFree, ctx: &FlushContext<'_>) {
+        let Some(liveset) = self.liveset.as_mut() else {
+            return;
+        };
+        let Some(entry) = liveset.remove(&f.addr) else {
+            return;
+        };
+        with_encoder(
+            |enc| {
+                enc.encode(&FreeEvent {
+                    timestamp_ns: f.ts_ns,
+                    tid: f.tid,
+                    addr: f.addr,
+                    size: entry.size,
+                    alloc_timestamp_ns: entry.timestamp_ns,
+                });
+            },
+            ctx.collector,
+            ctx.drain_epoch,
+        );
+    }
+}
+
+impl<const MAX_FRAMES: usize> Source for MemoryProfileSource<MAX_FRAMES> {
+    fn flush(&mut self, ctx: &FlushContext<'_>) {
+        // Merge-sort drain by timestamp. Hold one peeked element from each
+        // queue and emit the older one. `crossbeam_queue::ArrayQueue` has no
+        // peek API, so we pop into local slots and only refill after we
+        // emit. The producer can race in between; that's fine — anything it
+        // pushes during this loop has a timestamp later than anything we've
+        // already emitted, and we either pick it up this cycle (if our last
+        // pop sees it) or next cycle.
+        let mut next_alloc: Option<RawAlloc<MAX_FRAMES>> = self.rings.alloc_queue.pop();
+        let mut next_free: Option<RawFree> = self.rings.free_queue.pop();
+        loop {
+            match (&next_alloc, &next_free) {
+                (None, None) => break,
+                (Some(_), None) => {
+                    let a = next_alloc.take().expect("checked Some above");
+                    self.handle_alloc(a, ctx);
+                    next_alloc = self.rings.alloc_queue.pop();
+                }
+                (None, Some(_)) => {
+                    let f = next_free.take().expect("checked Some above");
+                    self.handle_free(f, ctx);
+                    next_free = self.rings.free_queue.pop();
+                }
+                (Some(a), Some(f)) => {
+                    if a.ts_ns <= f.ts_ns {
+                        let a = next_alloc.take().expect("checked Some above");
+                        self.handle_alloc(a, ctx);
+                        next_alloc = self.rings.alloc_queue.pop();
+                    } else {
+                        let f = next_free.take().expect("checked Some above");
+                        self.handle_free(f, ctx);
+                        next_free = self.rings.free_queue.pop();
+                    }
+                }
+            }
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "memory"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree, RingBuffers};
+    use crate::telemetry::buffer::drain_to_collector;
+    use crate::telemetry::collector::CentralCollector;
+    use crate::telemetry::events::{TelemetryEvent, ThreadRole};
+    use crate::telemetry::format::decode_events;
+    use crate::telemetry::recorder::source::FlushContext;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+
+    fn make_raw_alloc(addr: u64, size: u64, ts_ns: u64) -> RawAlloc {
+        let mut frames = [0u64; DEFAULT_MAX_FRAMES];
+        frames[0] = 0xAAAA;
+        frames[1] = 0xBBBB;
+        frames[2] = 0xCCCC;
+        RawAlloc {
+            tid: 1,
+            size,
+            addr,
+            ts_ns,
+            frames,
+            frame_count: 3,
+        }
+    }
+
+    fn make_raw_free(addr: u64, ts_ns: u64) -> RawFree {
+        RawFree {
+            tid: 2,
+            addr,
+            size: 0, // size on the free side is informational; consolidator uses liveset
+            ts_ns,
+        }
+    }
+
+    fn rings(alloc_cap: usize, free_cap: usize) -> Arc<RingBuffers> {
+        Arc::new(RingBuffers::new(alloc_cap, free_cap))
+    }
+
+    fn flush_and_collect(source: &mut MemoryProfileSource) -> Vec<TelemetryEvent> {
+        let collector = Arc::new(CentralCollector::new());
+        let drain_epoch = AtomicU64::new(0);
+        let thread_roles: HashMap<u32, ThreadRole> = HashMap::new();
+        let ctx = FlushContext {
+            collector: &collector,
+            drain_epoch: &drain_epoch,
+            thread_roles: &thread_roles,
+        };
+        source.flush(&ctx);
+        drain_to_collector(&collector);
+        let mut events = Vec::new();
+        while let Some(batch) = collector.next() {
+            if let Ok(decoded) = decode_events(&batch.encoded_bytes) {
+                events.extend(decoded);
+            }
+        }
+        events
+    }
+
+    #[test]
+    fn source_emits_alloc_event() {
+        let rings = rings(16, 16);
+        rings
+            .alloc_queue
+            .push(make_raw_alloc(0x1000, 4096, 100))
+            .ok();
+
+        let mut source = MemoryProfileSource::new(Arc::clone(&rings), false);
+
+        let events = flush_and_collect(&mut source);
+        let allocs: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+            .collect();
+        assert_eq!(allocs.len(), 1);
+        match &allocs[0] {
+            TelemetryEvent::Alloc {
+                timestamp_nanos,
+                tid,
+                size,
+                addr,
+                callchain,
+            } => {
+                assert_eq!(*timestamp_nanos, 100);
+                assert_eq!(*tid, 1);
+                assert_eq!(*size, 4096);
+                assert_eq!(*addr, 0x1000);
+                assert_eq!(callchain, &[0xAAAA, 0xBBBB, 0xCCCC]);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn source_emits_free_event_for_matching_alloc() {
+        let rings = rings(16, 16);
+        rings
+            .alloc_queue
+            .push(make_raw_alloc(0x2000, 512, 200))
+            .ok();
+        rings.free_queue.push(make_raw_free(0x2000, 300)).ok();
+
+        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+
+        let events = flush_and_collect(&mut source);
+        let allocs: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+            .collect();
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(allocs.len(), 1);
+        assert_eq!(frees.len(), 1);
+        match &frees[0] {
+            TelemetryEvent::Free {
+                timestamp_nanos,
+                tid,
+                addr,
+                size,
+                alloc_timestamp_nanos,
+            } => {
+                assert_eq!(*timestamp_nanos, 300);
+                assert_eq!(*tid, 2);
+                assert_eq!(*addr, 0x2000);
+                assert_eq!(*size, 512);
+                assert_eq!(*alloc_timestamp_nanos, 200);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn free_without_alloc_is_silently_dropped() {
+        let rings = rings(16, 16);
+        rings.free_queue.push(make_raw_free(0x9999, 400)).ok();
+
+        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+
+        let events = flush_and_collect(&mut source);
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(frees.len(), 0);
+    }
+
+    #[test]
+    fn liveset_off_drops_all_frees() {
+        let rings = rings(16, 16);
+        rings
+            .alloc_queue
+            .push(make_raw_alloc(0x3000, 128, 500))
+            .ok();
+        rings.free_queue.push(make_raw_free(0x3000, 600)).ok();
+
+        let mut source = MemoryProfileSource::new(Arc::clone(&rings), false);
+
+        let events = flush_and_collect(&mut source);
+        let allocs: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+            .collect();
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(allocs.len(), 1);
+        assert_eq!(frees.len(), 0);
+    }
+
+    #[test]
+    fn alloc_then_free_in_separate_flush_cycles() {
+        let rings = rings(16, 16);
+        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+
+        // First flush: only the alloc
+        rings
+            .alloc_queue
+            .push(make_raw_alloc(0x4000, 256, 700))
+            .ok();
+        let events = flush_and_collect(&mut source);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+                .count(),
+            0
+        );
+
+        // Second flush: the free arrives
+        rings.free_queue.push(make_raw_free(0x4000, 800)).ok();
+        let events = flush_and_collect(&mut source);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+                .count(),
+            0
+        );
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(frees.len(), 1);
+        match &frees[0] {
+            TelemetryEvent::Free {
+                size,
+                alloc_timestamp_nanos,
+                ..
+            } => {
+                assert_eq!(*size, 256);
+                assert_eq!(*alloc_timestamp_nanos, 700);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Regression test for the address-reuse race during a single flush cycle.
+    ///
+    /// Sequence at the producer (timestamps strictly increasing):
+    ///   t=100  alloc 0x5000 (size 256)   → alloc_queue
+    ///   t=200  free  0x5000              → free_queue
+    ///   t=300  alloc 0x5000 (size 512)   → alloc_queue
+    ///
+    /// Naïve "drain all allocs, then all frees" emits:
+    ///   alloc(t=100, size=256), alloc(t=300, size=512), free(t=200)
+    /// and the free incorrectly evicts the *second* alloc (size=512, t=300)
+    /// from the liveset — the second allocation looks freed even though it's
+    /// still live.
+    ///
+    /// Timestamp-ordered drain emits alloc, free, alloc and the second
+    /// allocation correctly remains in the liveset.
+    #[test]
+    fn address_reuse_within_flush_cycle_preserves_liveset() {
+        let rings = rings(16, 16);
+        rings
+            .alloc_queue
+            .push(make_raw_alloc(0x5000, 256, 100))
+            .ok();
+        rings.free_queue.push(make_raw_free(0x5000, 200)).ok();
+        rings
+            .alloc_queue
+            .push(make_raw_alloc(0x5000, 512, 300))
+            .ok();
+
+        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+
+        let events = flush_and_collect(&mut source);
+        let allocs: Vec<&TelemetryEvent> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+            .collect();
+        let frees: Vec<&TelemetryEvent> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(allocs.len(), 2, "both allocs should be emitted");
+        assert_eq!(
+            frees.len(),
+            1,
+            "the matching free should be emitted exactly once"
+        );
+
+        // The single free must match the *first* allocation (size=256, t=100).
+        // If drain order is wrong, the free would match alloc2 (size=512).
+        match frees[0] {
+            TelemetryEvent::Free {
+                size,
+                alloc_timestamp_nanos,
+                addr,
+                ..
+            } => {
+                assert_eq!(*addr, 0x5000);
+                assert_eq!(*size, 256, "free should report size from first alloc");
+                assert_eq!(
+                    *alloc_timestamp_nanos, 100,
+                    "free should reference timestamp of first alloc"
+                );
+            }
+            _ => unreachable!(),
+        }
+
+        // The second allocation must remain live in the liveset.
+        let liveset = source.liveset.as_ref().expect("liveset is on");
+        assert_eq!(liveset.len(), 1, "second alloc should still be live");
+        let entry = liveset
+            .get(&0x5000)
+            .expect("addr 0x5000 should be in liveset");
+        assert_eq!(entry.size, 512);
+        assert_eq!(entry.timestamp_ns, 300);
+    }
+}

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -125,7 +125,7 @@ impl<F: Future> Future for TaskDumped<F> {
         // interval. Short idles have a small but nonzero chance of being
         // sampled (~ idle / mean); long idles are sampled with probability
         // approaching 1. At most one emission per poll.
-        let poll_start = crate::telemetry::recorder::poll_start_ts_or_now();
+        let poll_start = crate::telemetry::recorder::poll_start_ts_monotonic();
         let should_emit = match *this.pending_capture_ts {
             Some(ts) if this.frames.has_data() => {
                 let idle_ns = poll_start.saturating_sub(ts.get()) as i64;
@@ -157,7 +157,7 @@ impl<F: Future> Future for TaskDumped<F> {
                 } else {
                     this.frames.capture(this.inner.as_mut(), cx);
                     *this.just_captured = true;
-                    let poll_end = crate::telemetry::recorder::poll_start_ts_or_now();
+                    let poll_end = crate::telemetry::recorder::poll_start_ts_monotonic();
                     *this.pending_capture_ts = NonZeroU64::new(poll_end);
                 }
             }

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -694,4 +694,19 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn poll_start_ts_or_now_is_strictly_increasing() {
+        use crate::telemetry::recorder::poll_start_ts_monotonic;
+        // Rapid-fire calls should never return the same value twice.
+        let mut prev = poll_start_ts_monotonic();
+        for _ in 0..10_000 {
+            let next = poll_start_ts_monotonic();
+            assert!(
+                next > prev,
+                "poll_start_ts_or_now must be strictly increasing: got {next} after {prev}"
+            );
+            prev = next;
+        }
+    }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -5,8 +5,6 @@ pub(crate) mod source;
 
 pub(crate) use runtime_context::RuntimeContext;
 pub use runtime_context::current_worker_id;
-#[cfg(feature = "taskdump")]
-pub(crate) use runtime_context::poll_start_ts_or_now;
 pub(crate) use shared_state::SharedState;
 
 use event_writer::EventWriter;
@@ -28,6 +26,8 @@ use std::cell::Cell;
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::time::Duration;
+
+pub(crate) use runtime_context::poll_start_ts_monotonic;
 
 crate::primitives::thread_local! {
     /// Per-thread [`TelemetryHandle`], populated in `on_thread_start` and

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -7,7 +7,6 @@ use crate::telemetry::format::{
 use crate::telemetry::task_metadata::TaskId;
 use std::cell::Cell;
 use std::collections::HashMap;
-#[cfg(feature = "taskdump")]
 use std::num::NonZeroU64;
 use std::sync::OnceLock;
 use std::sync::RwLock;
@@ -39,19 +38,31 @@ thread_local! {
     static TID_REGISTERED: Cell<bool> = const { Cell::new(false) };
     /// Monotonic timestamp captured in `on_before_task_poll`, cleared in
     /// `on_after_task_poll`. Allows code running inside a poll (e.g.
-    /// `TaskDumped`) to reuse the timestamp without an extra clock read.
-    #[cfg(feature = "taskdump")]
+    /// `TaskDumped`, memory profiler) to reuse the timestamp without an extra
+    /// clock read.
     static POLL_START_TS: Cell<Option<NonZeroU64>> = const { Cell::new(None) };
+    /// Last timestamp returned by `poll_start_ts_or_now`. Ensures strictly
+    /// increasing values within a thread by bumping +1ns on ties.
+    static LAST_TS: Cell<u64> = const { Cell::new(0) };
 }
 
-/// Returns the poll-start timestamp if we're inside a poll, otherwise reads
-/// the clock.
-#[cfg(feature = "taskdump")]
-pub(crate) fn poll_start_ts_or_now() -> u64 {
-    POLL_START_TS.with(|c| c.get()).map_or_else(
+/// Returns a strictly monotonic timestamp for this thread.
+///
+/// Uses the cached poll-start timestamp if inside a poll, otherwise reads
+/// the clock. Guarantees the returned value is always greater than the
+/// previous call on this thread (bumps by 1ns on ties). This ensures
+/// correct ordering for events that share a clock tick (e.g. a realloc
+/// producing free + alloc at the same address within one poll).
+pub(crate) fn poll_start_ts_monotonic() -> u64 {
+    let raw = POLL_START_TS.with(|c| c.get()).map_or_else(
         crate::telemetry::events::clock_monotonic_ns,
         NonZeroU64::get,
-    )
+    );
+    LAST_TS.with(|last| {
+        let next = last.get().wrapping_add(1).max(raw);
+        last.set(next);
+        next
+    })
 }
 
 impl RuntimeContext {
@@ -231,7 +242,6 @@ pub(super) fn make_poll_start(
         .map(|(_, idx)| ctx.local_queue_depth(idx))
         .unwrap_or(0);
     let timestamp_ns = crate::telemetry::events::clock_monotonic_ns();
-    #[cfg(feature = "taskdump")]
     POLL_START_TS.with(|c| c.set(NonZeroU64::new(timestamp_ns)));
     PollStart {
         timestamp_ns,
@@ -243,7 +253,6 @@ pub(super) fn make_poll_start(
 }
 
 pub(super) fn make_poll_end(ctx: &RuntimeContext, shared: &SharedState) -> PollEndEvent {
-    #[cfg(feature = "taskdump")]
     POLL_START_TS.with(|c| c.set(None));
     let resolved = ctx.resolve_worker(shared);
     PollEndEvent {


### PR DESCRIPTION
Adds `pub(crate) mod memory_profiling` (gated on the new `memory-profiling` cargo feature) with:
- RawAlloc<MAX_FRAMES> and RawFree fixed-size POD records.
- RingBuffers<MAX_FRAMES> wrapping two `crossbeam_queue::ArrayQueue`s — alloc queue (default 4096 slots × 1056 B = ~4 MiB at 128 frames) and free queue (default 32K slots × 32 B = ~1 MiB; 8× the alloc slot count per design §9 because frees are pushed unconditionally and allocs only when sampled).
- MemoryProfileSource<MAX_FRAMES> implementing the existing Source trait, draining both queues each flush cycle and emitting AllocEvent / FreeEvent into the trace via the consolidator's ThreadLocalEncoder.

Drain is timestamp-ordered: at each step we emit whichever queue head has the older timestamp. Naive 'all allocs, then all frees' would corrupt the liveset under address reuse within a single flush cycle (alloc → free → alloc-with-same-addr); see the `address_reuse_within_flush_cycle_preserves_liveset` test.

Liveset tracking (HashMap<u64, LivesetEntry>) is wired in but only activates when MemoryProfileSource is constructed with `MemoryProfileSource::new(rings, true)`.

No allocator hook yet (later commit). Tests push synthetic RawAllocs and RawFrees directly into the queues and verify AllocEvents and FreeEvents come out the other end.