### PR TITLE
fix: make build.rs resilient to missing README_TELEMETRY.md

### DIFF
--- a/dial9-viewer/build.rs
+++ b/dial9-viewer/build.rs
@@ -269,8 +269,10 @@ const SETUP_SECTIONS: &[&str] = &[
 /// Generate the setup skill from the crate README.
 fn generate_setup_from_readme(manifest_dir: &str, out_dir: &str) -> String {
     let readme_path = Path::new(manifest_dir).join("README_TELEMETRY.md");
-    let readme = fs::read_to_string(&readme_path)
-        .unwrap_or_else(|e| panic!("failed to read {}: {e}", readme_path.display()));
+    let readme = match fs::read_to_string(&readme_path) {
+        Ok(content) => content,
+        Err(_) => return String::new(),
+    };
 
     let mut body = String::from("# Instrumenting your app with dial9\n\n");
 


### PR DESCRIPTION
When `cargo-semver-checks` builds the baseline from origin/main, the checkout may not include `README_TELEMETRY.md`, causing `build.rs` to panic at line 273. This fix returns an empty string instead of panicking when the file is missing, allowing the semver checks CI job to succeed.

## Changes
- `dial9-viewer/build.rs`: Replace `unwrap_or_else(panic)` with a `match` that returns an empty string on file-read failure.