### PR TITLE
ci: drop dial9-viewer from semver-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,8 +240,7 @@ jobs:
             -p dial9-trace-format \
             -p dial9-perf-self-profile \
             -p dial9-macro \
-            -p dial9-tokio-telemetry \
-            -p dial9-viewer
+            -p dial9-tokio-telemetry
 
   package:
     name: Cargo package


### PR DESCRIPTION
dial9-viewer is an application binary, not a library with downstream semver consumers. Its build.rs generates code from files that aren't available in the semver-checks baseline checkout, causing spurious failures on every PR.