### PR TITLE
fix(viewer): correct kernel scheduling delay POI in viewer

### DIFF
--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -335,8 +335,7 @@
       if (filterType === "sched") {
         for (const s of spans.parks) {
           if (hasSchedWait && s.schedWait > 100) {
-            const schedWaitNs = s.schedWait * 1000;
-            const wakeupShouldBe = s.end - schedWaitNs;
+            const wakeupShouldBe = s.end - s.schedWait;
             points.push({
               time: wakeupShouldBe,
               worker: w,


### PR DESCRIPTION
## Summary

The `sched` filter in `filterPointsOfInterest` multiplied `s.schedWait` by 1000, treating it as microseconds. It is already in nanoseconds (parsed from `sched_wait_ns`), so the computed `wakeupShouldBe` timestamp was 1000x too far back — causing "worst first" navigation to jump to the wrong part of the trace instead of the actual scheduling delay.

## Fix

Remove the erroneous `* 1000` to match the rendering code in viewer.html which correctly uses `s.end - s.schedWait`.

## Testing

- JS tests pass (`node test_trace_analysis.js`)
- `cargo build -p dial9-viewer` succeeds
- Manually verified in browser

Closes #422