### PR TITLE
feat: composable user hooks for Tokio runtime callbacks (#297)

### DIFF
--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -318,6 +318,35 @@ record_event(
 # }
 ```
 
+### Custom Runtime Hooks
+
+dial9 installs callbacks on all 8 Tokio runtime hooks to collect telemetry. If you need to run your own logic alongside dial9's instrumentation, use `with_tokio_hooks`:
+
+```rust,no_run
+use dial9_tokio_telemetry::telemetry::{TracedRuntime, NullWriter};
+
+let mut builder = tokio::runtime::Builder::new_multi_thread();
+builder.worker_threads(4).enable_all();
+
+let (runtime, guard) = TracedRuntime::builder()
+    .with_tokio_hooks(|hooks| {
+        hooks.on_thread_start(|| {
+            println!("Worker thread started");
+        });
+        hooks.on_thread_stop(|| {
+            println!("Worker thread stopping");
+        });
+        // Also available: on_thread_park, on_thread_unpark,
+        // on_task_spawn, on_task_terminate, on_before_task_poll, on_after_task_poll
+    })
+    .build_and_start_with_writer(builder, NullWriter)
+    .unwrap();
+```
+
+dial9's internal hooks always run first, then your callbacks fire. This ensures `TelemetryHandle::current()` is available in your `on_thread_start` callback.
+
+**Important:** Do not set hooks directly via `tokio::runtime::Builder::on_thread_start()` etc. — dial9 will overwrite them. Always use `with_tokio_hooks` to compose your callbacks with dial9's instrumentation.
+
 ## Getting data out of dial9
 
 dial9 is recording data to in memory buffers and eventually to disk. For most applications, they would like the data to go somewhere else. `dial9` has a built in exporter for S3 and it is also possible to write your own exporter.

--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -343,7 +343,7 @@ let (runtime, guard) = TracedRuntime::builder()
     .unwrap();
 ```
 
-dial9's internal hooks always run first, then your callbacks fire. This ensures `TelemetryHandle::current()` is available in your `on_thread_start` callback.
+dial9's internal hooks always run first, then your callbacks fire in registration order. This ensures `TelemetryHandle::current()` is available in your `on_thread_start` callback. Registering the same hook multiple times stacks the callbacks — all of them will fire.
 
 **Important:** Do not set hooks directly via `tokio::runtime::Builder::on_thread_start()` etc. — dial9 will overwrite them. Always use `with_tokio_hooks` to compose your callbacks with dial9's instrumentation.
 

--- a/dial9-tokio-telemetry/src/config.rs
+++ b/dial9-tokio-telemetry/src/config.rs
@@ -817,6 +817,16 @@ impl<S: dial9_config_builder::State> Dial9ConfigBuilder<S> {
     /// `Fn + Send + Sync + 'static` so that
     /// [`build_or_disabled`](Self::build_or_disabled) can preserve the
     /// configurators on the disabled-fallback variant.
+    ///
+    /// # Warning
+    ///
+    /// Setting any of the 8 Tokio runtime hooks (`on_thread_start`,
+    /// `on_thread_stop`, `on_thread_park`, `on_thread_unpark`,
+    /// `on_task_spawn`, `on_task_terminate`, `on_before_task_poll`,
+    /// `on_after_task_poll`) via this closure will be silently overwritten
+    /// by dial9's internal hooks. Use
+    /// [`with_runtime`](Self::with_runtime) + [`TracedRuntimeBuilder::with_tokio_hooks`]
+    /// to compose user callbacks with dial9's hooks instead.
     pub fn with_tokio<F>(mut self, f: F) -> Self
     where
         F: Fn(&mut tokio::runtime::Builder) + Send + Sync + 'static,

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -27,7 +27,8 @@ pub use format::{
 pub use recorder::{
     HasTracePath, NoTracePath, PipelineCustom, PipelineS3, PipelineUnset, RuntimeTelemetryHandle,
     TelemetryCore, TelemetryCoreBuilder, TelemetryGuard, TelemetryHandle, TelemetryRuntimeError,
-    TraceRuntimeCoreBuilder, TracedRuntime, TracedRuntimeBuilder, current_worker_id, spawn,
+    TokioHooks, TraceRuntimeCoreBuilder, TracedRuntime, TracedRuntimeBuilder, current_worker_id,
+    spawn,
 };
 pub use task_dump_config::TaskDumpConfig;
 pub use task_metadata::{TaskId, UNKNOWN_TASK_ID};

--- a/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
@@ -172,13 +172,12 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
 
     /// Configure user-provided callbacks to run alongside dial9's internal
     /// Tokio runtime hooks. dial9's logic always runs first, then the user
-    /// callback fires.
+    /// callbacks fire in registration order.
     ///
     /// This method can be called multiple times; each call receives a mutable
-    /// reference to the same `TokioHooks` instance. Setting the same hook
+    /// reference to the same `TokioHooks` instance. Registering the same hook
     /// multiple times (either within one closure or across multiple calls)
-    /// will overwrite the previous callback — only the last one registered
-    /// will fire.
+    /// stacks the callbacks — all registered callbacks will fire.
     pub fn with_tokio_hooks<F>(mut self, f: F) -> Self
     where
         F: FnOnce(&mut super::TokioHooks),

--- a/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
@@ -65,6 +65,7 @@ pub struct TracedRuntimeBuilder<P = NoTracePath, M = PipelineUnset> {
     pub(super) segment_metadata: Vec<(String, String)>,
     pub(super) worker_poll_interval: Option<Duration>,
     pub(super) worker_metrics_sink: Option<metrique_writer::BoxEntrySink>,
+    pub(super) tokio_hooks: super::TokioHooks,
     pub(super) _marker: std::marker::PhantomData<(P, M)>,
 }
 
@@ -169,6 +170,17 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
         self
     }
 
+    /// Configure user-provided callbacks to run alongside dial9's internal
+    /// Tokio runtime hooks. dial9's logic always runs first, then the user
+    /// callback fires.
+    pub fn with_tokio_hooks<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut super::TokioHooks),
+    {
+        f(&mut self.tokio_hooks);
+        self
+    }
+
     /// Attach a new runtime to an existing telemetry session.
     ///
     /// This reuses the `SharedState`, flush thread, writer, and CPU profiler
@@ -191,6 +203,7 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
             self.runtime_name,
             control_tx,
             self.task_tracking_enabled,
+            self.tokio_hooks,
         )
     }
 
@@ -209,6 +222,7 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
             segment_metadata: self.segment_metadata,
             worker_poll_interval: self.worker_poll_interval,
             worker_metrics_sink: self.worker_metrics_sink,
+            tokio_hooks: self.tokio_hooks,
             _marker: std::marker::PhantomData,
         }
     }
@@ -449,6 +463,7 @@ impl<M> TracedRuntimeBuilder<HasTracePath, M> {
             self.runtime_name,
             &control_tx,
             self.task_tracking_enabled,
+            self.tokio_hooks,
         )?;
         Ok((runtime, guard))
     }
@@ -791,6 +806,7 @@ impl TracedRuntime {
             segment_metadata: Vec::new(),
             worker_poll_interval: None,
             worker_metrics_sink: None,
+            tokio_hooks: super::TokioHooks::default(),
             _marker: std::marker::PhantomData,
         }
     }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
@@ -173,6 +173,12 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
     /// Configure user-provided callbacks to run alongside dial9's internal
     /// Tokio runtime hooks. dial9's logic always runs first, then the user
     /// callback fires.
+    ///
+    /// This method can be called multiple times; each call receives a mutable
+    /// reference to the same `TokioHooks` instance. Setting the same hook
+    /// multiple times (either within one closure or across multiple calls)
+    /// will overwrite the previous callback — only the last one registered
+    /// will fire.
     pub fn with_tokio_hooks<F>(mut self, f: F) -> Self
     where
         F: FnOnce(&mut super::TokioHooks),

--- a/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
@@ -150,6 +150,7 @@ impl TelemetryGuard {
             guard: self,
             name: name.into(),
             task_tracking: false,
+            tokio_hooks: super::TokioHooks::default(),
         }
     }
 
@@ -257,6 +258,7 @@ pub struct TraceRuntimeCoreBuilder<'a> {
     guard: &'a TelemetryGuard,
     name: String,
     task_tracking: bool,
+    tokio_hooks: super::TokioHooks,
 }
 
 impl<'a> TraceRuntimeCoreBuilder<'a> {
@@ -264,6 +266,17 @@ impl<'a> TraceRuntimeCoreBuilder<'a> {
     /// Defaults to `false`.
     pub fn task_tracking(mut self, enabled: bool) -> Self {
         self.task_tracking = enabled;
+        self
+    }
+
+    /// Configure user-provided callbacks to run alongside dial9's internal
+    /// Tokio runtime hooks. dial9's logic always runs first, then the user
+    /// callback fires.
+    pub fn with_tokio_hooks<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut super::TokioHooks),
+    {
+        f(&mut self.tokio_hooks);
         self
     }
 
@@ -296,6 +309,7 @@ impl<'a> TraceRuntimeCoreBuilder<'a> {
             Some(self.name),
             control_tx,
             self.task_tracking,
+            self.tokio_hooks,
         )?;
         let handle = RuntimeTelemetryHandle {
             runtime: runtime.handle().clone(),

--- a/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
@@ -271,7 +271,7 @@ impl<'a> TraceRuntimeCoreBuilder<'a> {
 
     /// Configure user-provided callbacks to run alongside dial9's internal
     /// Tokio runtime hooks. dial9's logic always runs first, then the user
-    /// callback fires.
+    /// callbacks fire in registration order.
     pub fn with_tokio_hooks<F>(mut self, f: F) -> Self
     where
         F: FnOnce(&mut super::TokioHooks),

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -18,6 +18,9 @@ pub use builder::{
 pub use guard::{TelemetryGuard, TraceRuntimeCoreBuilder};
 pub use handle::{RuntimeTelemetryHandle, TelemetryHandle, spawn};
 
+mod tokio_hooks;
+pub use tokio_hooks::TokioHooks;
+
 pub(crate) use flush_loop::FlushStats;
 
 // Re-exports for internal test access
@@ -46,6 +49,38 @@ pub(crate) enum ControlCommand {
     FinalizeAndStop(crate::primitives::sync::mpsc::SyncSender<()>),
 }
 
+/// Register a tokio hook, composing with an optional user callback.
+/// When `$user_hook` is None, registers only the dial9 closure (zero-cost).
+/// When Some, registers a closure that runs dial9 logic first, then the user callback.
+macro_rules! register_hook {
+    // For hooks with no arguments: on_thread_park, on_thread_unpark, on_thread_start, on_thread_stop
+    ($builder:expr, $method:ident, $user_hook:expr, $dial9_body:expr) => {
+        if let Some(user_cb) = $user_hook {
+            $builder.$method(move || {
+                $dial9_body;
+                user_cb();
+            });
+        } else {
+            $builder.$method(move || {
+                $dial9_body;
+            });
+        }
+    };
+    // For hooks with a TaskMeta argument: on_before_task_poll, on_after_task_poll, on_task_spawn, on_task_terminate
+    (meta: $builder:expr, $method:ident, $user_hook:expr, |$meta:ident| $dial9_body:expr) => {
+        if let Some(user_cb) = $user_hook {
+            $builder.$method(move |$meta| {
+                $dial9_body;
+                user_cb($meta);
+            });
+        } else {
+            $builder.$method(move |$meta| {
+                $dial9_body;
+            });
+        }
+    };
+}
+
 /// Register telemetry callbacks on a runtime builder.
 /// Closures capture `Arc<RuntimeContext>` (runtime-specific) and `Arc<SharedState>` (recording core).
 ///
@@ -63,6 +98,7 @@ fn register_hooks(
     shared: &Arc<SharedState>,
     control_tx: &crate::primitives::sync::mpsc::SyncSender<ControlCommand>,
     task_tracking_enabled: bool,
+    tokio_hooks: TokioHooks,
 ) {
     // TODO: these should rely on public APIs instead of utilizing `SharedState`
 
@@ -75,37 +111,49 @@ fn register_hooks(
     let c4 = ctx.clone();
     let s4 = shared.clone();
 
-    builder
-        .on_thread_park(move || {
-            s1.if_enabled(|buf| {
-                let event = make_worker_park(&c1, &s1);
-                buf.record_encodable_event(&event);
-            });
+    register_hook!(builder, on_thread_park, tokio_hooks.on_thread_park, {
+        s1.if_enabled(|buf| {
+            let event = make_worker_park(&c1, &s1);
+            buf.record_encodable_event(&event);
         })
-        .on_thread_unpark(move || {
-            s2.if_enabled(|buf| {
-                let event = make_worker_unpark(&c2, &s2);
-                buf.record_encodable_event(&event);
-            });
+    });
+
+    register_hook!(builder, on_thread_unpark, tokio_hooks.on_thread_unpark, {
+        s2.if_enabled(|buf| {
+            let event = make_worker_unpark(&c2, &s2);
+            buf.record_encodable_event(&event);
         })
-        .on_before_task_poll(move |meta| {
+    });
+
+    register_hook!(
+        meta: builder,
+        on_before_task_poll,
+        tokio_hooks.on_before_task_poll,
+        |meta| {
             s3.if_enabled(|buf| {
                 let task_id = TaskId::from(meta.id());
                 let location = meta.spawned_at();
                 let event = make_poll_start(&c3, &s3, location, task_id);
                 buf.record_encodable_event(&event);
-            });
-        })
-        .on_after_task_poll(move |_meta| {
+            })
+        }
+    );
+
+    register_hook!(
+        meta: builder,
+        on_after_task_poll,
+        tokio_hooks.on_after_task_poll,
+        |_meta| {
             s4.if_enabled(|buf| {
                 let event = make_poll_end(&c4, &s4);
                 buf.record_encodable_event(&event);
-            });
-        });
+            })
+        }
+    );
 
     if task_tracking_enabled {
         let s5 = shared.clone();
-        builder.on_task_spawn(move |meta| {
+        register_hook!(meta: builder, on_task_spawn, tokio_hooks.on_task_spawn, |meta| {
             s5.if_enabled(|buf| {
                 let task_id = TaskId::from(meta.id());
                 let location = meta.spawned_at();
@@ -117,18 +165,35 @@ fn register_hooks(
                     location,
                     instrumented,
                 });
-            });
+            })
         });
         let s6 = shared.clone();
-        builder.on_task_terminate(move |meta| {
-            s6.if_enabled(|buf| {
+        register_hook!(
+            meta: builder,
+            on_task_terminate,
+            tokio_hooks.on_task_terminate,
+            |meta| {
                 let task_id = TaskId::from(meta.id());
-                buf.record_encodable_event(&TaskTerminateEvent {
-                    timestamp_ns: crate::telemetry::events::clock_monotonic_ns(),
-                    task_id,
-                });
+                s6.if_enabled(|buf| {
+                    buf.record_encodable_event(&TaskTerminateEvent {
+                        timestamp_ns: crate::telemetry::events::clock_monotonic_ns(),
+                        task_id,
+                    });
+                })
+            }
+        );
+    } else {
+        // When task tracking is disabled, still register user hooks if provided
+        if let Some(user_cb) = tokio_hooks.on_task_spawn {
+            builder.on_task_spawn(move |meta| {
+                user_cb(meta);
             });
-        });
+        }
+        if let Some(user_cb) = tokio_hooks.on_task_terminate {
+            builder.on_task_terminate(move |meta| {
+                user_cb(meta);
+            });
+        }
     }
 
     // Unified on_thread_start / on_thread_stop. Tokio only stores one
@@ -140,52 +205,52 @@ fn register_hooks(
     #[cfg(feature = "cpu-profiling")]
     let s_stop = shared.clone();
 
-    builder
-        .on_thread_start(move || {
-            // Install this thread's TelemetryHandle so user code can call
-            // `TelemetryHandle::current()` from anywhere on this thread.
-            CURRENT_HANDLE.with(|cell| {
-                *cell.borrow_mut() = Some(handle_for_tl.clone());
-            });
-
-            #[cfg(feature = "cpu-profiling")]
-            {
-                // Register as Blocking initially; worker threads will
-                // overwrite this to Worker(i) in resolve_worker_id.
-                // NOTE: `tokio::runtime::worker_index()` will always return `None` at this point
-                // so we can't utilize that here.
-                let tid = crate::telemetry::events::current_tid();
-                s_start
-                    .thread_roles
-                    .lock()
-                    .unwrap()
-                    .insert(tid, crate::telemetry::events::ThreadRole::Blocking);
-                // Sched event sampling is deferred to register_tid_if_needed(),
-                // which runs only for worker threads on their first poll/park.
-                // This avoids opening perf fds for blocking pool threads.
-
-                // Registers the current thread for the CPU-profiling fallback (ctimer).
-                // No-op when perf is the active backend (perf uses inherit).
-                let _ = dial9_perf_self_profile::register_current_thread();
-            }
-        })
-        .on_thread_stop(move || {
-            CURRENT_HANDLE.with(|cell| {
-                *cell.borrow_mut() = None;
-            });
-
-            #[cfg(feature = "cpu-profiling")]
-            {
-                let tid = crate::telemetry::events::current_tid();
-                s_stop.thread_roles.lock().unwrap().remove(&tid);
-                if let Ok(mut sources) = s_stop.sources.lock() {
-                    for source in sources.iter_mut() {
-                        source.on_thread_stop();
-                    }
-                }
-                dial9_perf_self_profile::unregister_current_thread();
-            }
+    register_hook!(builder, on_thread_start, tokio_hooks.on_thread_start, {
+        // Install this thread's TelemetryHandle so user code can call
+        // `TelemetryHandle::current()` from anywhere on this thread.
+        CURRENT_HANDLE.with(|cell| {
+            *cell.borrow_mut() = Some(handle_for_tl.clone());
         });
+
+        #[cfg(feature = "cpu-profiling")]
+        {
+            // Register as Blocking initially; worker threads will
+            // overwrite this to Worker(i) in resolve_worker_id.
+            // NOTE: `tokio::runtime::worker_index()` will always return `None` at this point
+            // so we can't utilize that here.
+            let tid = crate::telemetry::events::current_tid();
+            s_start
+                .thread_roles
+                .lock()
+                .unwrap()
+                .insert(tid, crate::telemetry::events::ThreadRole::Blocking);
+            // Sched event sampling is deferred to register_tid_if_needed(),
+            // which runs only for worker threads on their first poll/park.
+            // This avoids opening perf fds for blocking pool threads.
+
+            // Registers the current thread for the CPU-profiling fallback (ctimer).
+            // No-op when perf is the active backend (perf uses inherit).
+            let _ = dial9_perf_self_profile::register_current_thread();
+        }
+    });
+
+    register_hook!(builder, on_thread_stop, tokio_hooks.on_thread_stop, {
+        CURRENT_HANDLE.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+
+        #[cfg(feature = "cpu-profiling")]
+        {
+            let tid = crate::telemetry::events::current_tid();
+            s_stop.thread_roles.lock().unwrap().remove(&tid);
+            if let Ok(mut sources) = s_stop.sources.lock() {
+                for source in sources.iter_mut() {
+                    source.on_thread_stop();
+                }
+            }
+            dial9_perf_self_profile::unregister_current_thread();
+        }
+    });
 }
 
 /// Attach a runtime to an existing telemetry session: register hooks, build
@@ -196,6 +261,7 @@ fn attach_runtime(
     runtime_name: Option<String>,
     control_tx: &crate::primitives::sync::mpsc::SyncSender<ControlCommand>,
     task_tracking_enabled: bool,
+    tokio_hooks: TokioHooks,
 ) -> std::io::Result<tokio::runtime::Runtime> {
     let ctx = Arc::new(RuntimeContext::new(runtime_name));
     register_hooks(
@@ -204,6 +270,7 @@ fn attach_runtime(
         shared,
         control_tx,
         task_tracking_enabled,
+        tokio_hooks,
     );
 
     let runtime = builder.build()?;

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -51,14 +51,14 @@ pub(crate) enum ControlCommand {
 
 /// Register a tokio hook, composing with an optional user callback.
 /// When `$user_hook` is None, registers only the dial9 closure (zero-cost).
-/// When Some, registers a closure that runs dial9 logic first, then the user callback.
+/// When Some, registers a closure that runs dial9 logic first, then the user callbacks.
 macro_rules! register_hook {
     // For hooks with no arguments: on_thread_park, on_thread_unpark, on_thread_start, on_thread_stop
     ($builder:expr, $method:ident, $user_hook:expr, $dial9_body:expr) => {
-        if let Some(user_cb) = $user_hook {
+        if let Some(user_hook) = $user_hook {
             $builder.$method(move || {
                 $dial9_body;
-                user_cb();
+                user_hook.execute();
             });
         } else {
             $builder.$method(move || {
@@ -68,10 +68,10 @@ macro_rules! register_hook {
     };
     // For hooks with a TaskMeta argument: on_before_task_poll, on_after_task_poll, on_task_spawn, on_task_terminate
     (meta: $builder:expr, $method:ident, $user_hook:expr, |$meta:ident| $dial9_body:expr) => {
-        if let Some(user_cb) = $user_hook {
+        if let Some(user_hook) = $user_hook {
             $builder.$method(move |$meta| {
                 $dial9_body;
-                user_cb($meta);
+                user_hook.execute($meta);
             });
         } else {
             $builder.$method(move |$meta| {
@@ -184,14 +184,14 @@ fn register_hooks(
         );
     } else {
         // When task tracking is disabled, still register user hooks if provided
-        if let Some(user_cb) = tokio_hooks.on_task_spawn {
+        if let Some(user_hook) = tokio_hooks.on_task_spawn {
             builder.on_task_spawn(move |meta| {
-                user_cb(meta);
+                user_hook.execute(meta);
             });
         }
-        if let Some(user_cb) = tokio_hooks.on_task_terminate {
+        if let Some(user_hook) = tokio_hooks.on_task_terminate {
             builder.on_task_terminate(move |meta| {
-                user_cb(meta);
+                user_hook.execute(meta);
             });
         }
     }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -173,8 +173,8 @@ fn register_hooks(
             on_task_terminate,
             tokio_hooks.on_task_terminate,
             |meta| {
-                let task_id = TaskId::from(meta.id());
                 s6.if_enabled(|buf| {
+                    let task_id = TaskId::from(meta.id());
                     buf.record_encodable_event(&TaskTerminateEvent {
                         timestamp_ns: crate::telemetry::events::clock_monotonic_ns(),
                         task_id,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/tokio_hooks.rs
@@ -1,12 +1,63 @@
 use crate::primitives::sync::Arc;
+use smallvec::SmallVec;
 
-type NoArgHook = Option<Arc<dyn Fn() + Send + Sync>>;
-type TaskMetaHook = Option<Arc<dyn Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync>>;
+type NoArgCb = Arc<dyn Fn() + Send + Sync>;
+type TaskMetaCb = Arc<dyn Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync>;
+
+/// A collection of stacked callbacks for a single Tokio runtime hook.
+///
+/// When executed, callbacks fire in registration order.
+#[derive(Clone)]
+pub(crate) struct TokioHook<H> {
+    callbacks: SmallVec<[H; 1]>,
+}
+
+impl<H> TokioHook<H> {
+    fn new(cb: H) -> Self {
+        Self {
+            callbacks: SmallVec::from_buf_and_len([cb], 1),
+        }
+    }
+
+    fn push(&mut self, cb: H) {
+        self.callbacks.push(cb);
+    }
+
+    /// Number of registered callbacks.
+    pub(crate) fn len(&self) -> usize {
+        self.callbacks.len()
+    }
+}
+
+impl TokioHook<NoArgCb> {
+    /// Execute all registered no-arg callbacks in registration order.
+    #[inline]
+    pub(crate) fn execute(&self) {
+        for cb in &self.callbacks {
+            cb();
+        }
+    }
+}
+
+impl TokioHook<TaskMetaCb> {
+    /// Execute all registered task-meta callbacks in registration order.
+    #[inline]
+    pub(crate) fn execute(&self, meta: &tokio::runtime::TaskMeta<'_>) {
+        for cb in &self.callbacks {
+            cb(meta);
+        }
+    }
+}
 
 /// User-provided callbacks to run alongside dial9's internal Tokio runtime hooks.
 ///
 /// All callbacks are composed with dial9's internal hooks: dial9 always runs
-/// first, then the user callback fires. This applies to all 8 hooks.
+/// first, then the user callbacks fire in registration order. This applies to
+/// all 8 hooks.
+///
+/// Registering the same hook multiple times (either within one closure or
+/// across multiple `with_tokio_hooks` calls) stacks the callbacks — all
+/// registered callbacks will fire.
 ///
 /// # Example
 ///
@@ -26,74 +77,114 @@ type TaskMetaHook = Option<Arc<dyn Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sy
 #[derive(Clone, Default)]
 #[non_exhaustive]
 pub struct TokioHooks {
-    pub(crate) on_thread_start: NoArgHook,
-    pub(crate) on_thread_stop: NoArgHook,
-    pub(crate) on_thread_park: NoArgHook,
-    pub(crate) on_thread_unpark: NoArgHook,
-    pub(crate) on_task_spawn: TaskMetaHook,
-    pub(crate) on_task_terminate: TaskMetaHook,
-    pub(crate) on_before_task_poll: TaskMetaHook,
-    pub(crate) on_after_task_poll: TaskMetaHook,
+    pub(crate) on_thread_start: Option<TokioHook<NoArgCb>>,
+    pub(crate) on_thread_stop: Option<TokioHook<NoArgCb>>,
+    pub(crate) on_thread_park: Option<TokioHook<NoArgCb>>,
+    pub(crate) on_thread_unpark: Option<TokioHook<NoArgCb>>,
+    pub(crate) on_task_spawn: Option<TokioHook<TaskMetaCb>>,
+    pub(crate) on_task_terminate: Option<TokioHook<TaskMetaCb>>,
+    pub(crate) on_before_task_poll: Option<TokioHook<TaskMetaCb>>,
+    pub(crate) on_after_task_poll: Option<TokioHook<TaskMetaCb>>,
 }
 
 impl TokioHooks {
-    /// Set a callback to run when a runtime worker thread starts.
+    /// Register a callback to run when a runtime worker thread starts.
+    ///
+    /// Multiple callbacks can be registered; they fire in registration order.
     pub fn on_thread_start(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
-        self.on_thread_start = Some(Arc::new(f));
+        match &mut self.on_thread_start {
+            Some(hook) => hook.push(Arc::new(f)),
+            slot => *slot = Some(TokioHook::new(Arc::new(f))),
+        }
         self
     }
 
-    /// Set a callback to run when a runtime worker thread stops.
+    /// Register a callback to run when a runtime worker thread stops.
+    ///
+    /// Multiple callbacks can be registered; they fire in registration order.
     pub fn on_thread_stop(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
-        self.on_thread_stop = Some(Arc::new(f));
+        match &mut self.on_thread_stop {
+            Some(hook) => hook.push(Arc::new(f)),
+            slot => *slot = Some(TokioHook::new(Arc::new(f))),
+        }
         self
     }
 
-    /// Set a callback to run when a runtime worker thread parks.
+    /// Register a callback to run when a runtime worker thread parks.
+    ///
+    /// Multiple callbacks can be registered; they fire in registration order.
     pub fn on_thread_park(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
-        self.on_thread_park = Some(Arc::new(f));
+        match &mut self.on_thread_park {
+            Some(hook) => hook.push(Arc::new(f)),
+            slot => *slot = Some(TokioHook::new(Arc::new(f))),
+        }
         self
     }
 
-    /// Set a callback to run when a runtime worker thread unparks.
+    /// Register a callback to run when a runtime worker thread unparks.
+    ///
+    /// Multiple callbacks can be registered; they fire in registration order.
     pub fn on_thread_unpark(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
-        self.on_thread_unpark = Some(Arc::new(f));
+        match &mut self.on_thread_unpark {
+            Some(hook) => hook.push(Arc::new(f)),
+            slot => *slot = Some(TokioHook::new(Arc::new(f))),
+        }
         self
     }
 
-    /// Set a callback to run when a task is spawned.
+    /// Register a callback to run when a task is spawned.
+    ///
+    /// Multiple callbacks can be registered; they fire in registration order.
     pub fn on_task_spawn(
         &mut self,
         f: impl Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync + 'static,
     ) -> &mut Self {
-        self.on_task_spawn = Some(Arc::new(f));
+        match &mut self.on_task_spawn {
+            Some(hook) => hook.push(Arc::new(f)),
+            slot => *slot = Some(TokioHook::new(Arc::new(f))),
+        }
         self
     }
 
-    /// Set a callback to run when a task terminates.
+    /// Register a callback to run when a task terminates.
+    ///
+    /// Multiple callbacks can be registered; they fire in registration order.
     pub fn on_task_terminate(
         &mut self,
         f: impl Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync + 'static,
     ) -> &mut Self {
-        self.on_task_terminate = Some(Arc::new(f));
+        match &mut self.on_task_terminate {
+            Some(hook) => hook.push(Arc::new(f)),
+            slot => *slot = Some(TokioHook::new(Arc::new(f))),
+        }
         self
     }
 
-    /// Set a callback to run before a task is polled.
+    /// Register a callback to run before a task is polled.
+    ///
+    /// Multiple callbacks can be registered; they fire in registration order.
     pub fn on_before_task_poll(
         &mut self,
         f: impl Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync + 'static,
     ) -> &mut Self {
-        self.on_before_task_poll = Some(Arc::new(f));
+        match &mut self.on_before_task_poll {
+            Some(hook) => hook.push(Arc::new(f)),
+            slot => *slot = Some(TokioHook::new(Arc::new(f))),
+        }
         self
     }
 
-    /// Set a callback to run after a task is polled.
+    /// Register a callback to run after a task is polled.
+    ///
+    /// Multiple callbacks can be registered; they fire in registration order.
     pub fn on_after_task_poll(
         &mut self,
         f: impl Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync + 'static,
     ) -> &mut Self {
-        self.on_after_task_poll = Some(Arc::new(f));
+        match &mut self.on_after_task_poll {
+            Some(hook) => hook.push(Arc::new(f)),
+            slot => *slot = Some(TokioHook::new(Arc::new(f))),
+        }
         self
     }
 }
@@ -101,14 +192,38 @@ impl TokioHooks {
 impl std::fmt::Debug for TokioHooks {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TokioHooks")
-            .field("on_thread_start", &self.on_thread_start.is_some())
-            .field("on_thread_stop", &self.on_thread_stop.is_some())
-            .field("on_thread_park", &self.on_thread_park.is_some())
-            .field("on_thread_unpark", &self.on_thread_unpark.is_some())
-            .field("on_task_spawn", &self.on_task_spawn.is_some())
-            .field("on_task_terminate", &self.on_task_terminate.is_some())
-            .field("on_before_task_poll", &self.on_before_task_poll.is_some())
-            .field("on_after_task_poll", &self.on_after_task_poll.is_some())
+            .field(
+                "on_thread_start",
+                &self.on_thread_start.as_ref().map(|h| h.len()),
+            )
+            .field(
+                "on_thread_stop",
+                &self.on_thread_stop.as_ref().map(|h| h.len()),
+            )
+            .field(
+                "on_thread_park",
+                &self.on_thread_park.as_ref().map(|h| h.len()),
+            )
+            .field(
+                "on_thread_unpark",
+                &self.on_thread_unpark.as_ref().map(|h| h.len()),
+            )
+            .field(
+                "on_task_spawn",
+                &self.on_task_spawn.as_ref().map(|h| h.len()),
+            )
+            .field(
+                "on_task_terminate",
+                &self.on_task_terminate.as_ref().map(|h| h.len()),
+            )
+            .field(
+                "on_before_task_poll",
+                &self.on_before_task_poll.as_ref().map(|h| h.len()),
+            )
+            .field(
+                "on_after_task_poll",
+                &self.on_after_task_poll.as_ref().map(|h| h.len()),
+            )
             .finish()
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/tokio_hooks.rs
@@ -1,0 +1,114 @@
+use crate::primitives::sync::Arc;
+
+type NoArgHook = Option<Arc<dyn Fn() + Send + Sync>>;
+type TaskMetaHook = Option<Arc<dyn Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync>>;
+
+/// User-provided callbacks to run alongside dial9's internal Tokio runtime hooks.
+///
+/// All callbacks are composed with dial9's internal hooks: dial9 always runs
+/// first, then the user callback fires. This applies to all 8 hooks.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use dial9_tokio_telemetry::telemetry::{TokioHooks, TracedRuntime, NullWriter};
+///
+/// let mut builder = tokio::runtime::Builder::new_multi_thread();
+/// builder.worker_threads(4).enable_all();
+/// let (runtime, guard) = TracedRuntime::builder()
+///     .with_tokio_hooks(|h| {
+///         h.on_thread_start(|| println!("started"));
+///         h.on_thread_stop(|| println!("stopping"));
+///     })
+///     .build_and_start_with_writer(builder, NullWriter)
+///     .unwrap();
+/// ```
+#[derive(Clone, Default)]
+#[non_exhaustive]
+pub struct TokioHooks {
+    pub(crate) on_thread_start: NoArgHook,
+    pub(crate) on_thread_stop: NoArgHook,
+    pub(crate) on_thread_park: NoArgHook,
+    pub(crate) on_thread_unpark: NoArgHook,
+    pub(crate) on_task_spawn: TaskMetaHook,
+    pub(crate) on_task_terminate: TaskMetaHook,
+    pub(crate) on_before_task_poll: TaskMetaHook,
+    pub(crate) on_after_task_poll: TaskMetaHook,
+}
+
+impl TokioHooks {
+    /// Set a callback to run when a runtime worker thread starts.
+    pub fn on_thread_start(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
+        self.on_thread_start = Some(Arc::new(f));
+        self
+    }
+
+    /// Set a callback to run when a runtime worker thread stops.
+    pub fn on_thread_stop(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
+        self.on_thread_stop = Some(Arc::new(f));
+        self
+    }
+
+    /// Set a callback to run when a runtime worker thread parks.
+    pub fn on_thread_park(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
+        self.on_thread_park = Some(Arc::new(f));
+        self
+    }
+
+    /// Set a callback to run when a runtime worker thread unparks.
+    pub fn on_thread_unpark(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
+        self.on_thread_unpark = Some(Arc::new(f));
+        self
+    }
+
+    /// Set a callback to run when a task is spawned.
+    pub fn on_task_spawn(
+        &mut self,
+        f: impl Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.on_task_spawn = Some(Arc::new(f));
+        self
+    }
+
+    /// Set a callback to run when a task terminates.
+    pub fn on_task_terminate(
+        &mut self,
+        f: impl Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.on_task_terminate = Some(Arc::new(f));
+        self
+    }
+
+    /// Set a callback to run before a task is polled.
+    pub fn on_before_task_poll(
+        &mut self,
+        f: impl Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.on_before_task_poll = Some(Arc::new(f));
+        self
+    }
+
+    /// Set a callback to run after a task is polled.
+    pub fn on_after_task_poll(
+        &mut self,
+        f: impl Fn(&tokio::runtime::TaskMeta<'_>) + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.on_after_task_poll = Some(Arc::new(f));
+        self
+    }
+}
+
+impl std::fmt::Debug for TokioHooks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokioHooks")
+            .field("on_thread_start", &self.on_thread_start.is_some())
+            .field("on_thread_stop", &self.on_thread_stop.is_some())
+            .field("on_thread_park", &self.on_thread_park.is_some())
+            .field("on_thread_unpark", &self.on_thread_unpark.is_some())
+            .field("on_task_spawn", &self.on_task_spawn.is_some())
+            .field("on_task_terminate", &self.on_task_terminate.is_some())
+            .field("on_before_task_poll", &self.on_before_task_poll.is_some())
+            .field("on_after_task_poll", &self.on_after_task_poll.is_some())
+            .finish()
+    }
+}

--- a/dial9-tokio-telemetry/tests/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/tests/tokio_hooks.rs
@@ -343,3 +343,86 @@ fn task_spawn_hook_fires_when_task_tracking_disabled() {
         spawn_count.load(Ordering::Relaxed)
     );
 }
+
+#[test]
+fn task_terminate_hook_fires_when_task_tracking_disabled() {
+    let terminate_count = Arc::new(AtomicUsize::new(0));
+    let tc = terminate_count.clone();
+
+    let num_tasks = 5;
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(false)
+        .with_tokio_hooks(|h| {
+            h.on_task_terminate(move |_meta| {
+                tc.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        let mut handles = Vec::new();
+        for _ in 0..num_tasks {
+            handles.push(tokio::spawn(async {
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    assert!(
+        terminate_count.load(Ordering::Relaxed) >= num_tasks,
+        "expected on_task_terminate to fire at least {num_tasks} times even with task_tracking disabled, got {}",
+        terminate_count.load(Ordering::Relaxed)
+    );
+}
+
+#[test]
+fn dial9_hooks_run_before_user_hooks() {
+    use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+
+    let hook_fired = Arc::new(AtomicUsize::new(0));
+    let hf = hook_fired.clone();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_thread_start(move || {
+                // dial9's hook must have already run and installed TelemetryHandle
+                let handle = TelemetryHandle::current();
+                assert!(
+                    handle.is_enabled(),
+                    "TelemetryHandle should be installed by dial9 before user hook runs"
+                );
+                hf.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::spawn(async {
+            tokio::task::yield_now().await;
+        })
+        .await
+        .unwrap();
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    assert!(
+        hook_fired.load(Ordering::Relaxed) > 0,
+        "user on_thread_start hook should have fired"
+    );
+}

--- a/dial9-tokio-telemetry/tests/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/tests/tokio_hooks.rs
@@ -424,3 +424,177 @@ fn dial9_hooks_run_before_user_hooks() {
         "user on_thread_start hook should have fired"
     );
 }
+
+#[test]
+fn hook_stacking_single_callback_fires() {
+    let log = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+    let log_c = log.clone();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_thread_park(move || {
+                log_c.lock().unwrap().push("park_a");
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        // Sleep to let the worker park at least once
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let entries = log.lock().unwrap();
+    assert!(
+        entries.contains(&"park_a"),
+        "expected single callback to fire, got: {entries:?}"
+    );
+}
+
+#[test]
+fn hook_stacking_multiple_callbacks_fire_in_order() {
+    let log = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+    let log_a = log.clone();
+    let log_b = log.clone();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_thread_park(move || {
+                log_a.lock().unwrap().push("park_a");
+            });
+            h.on_thread_park(move || {
+                log_b.lock().unwrap().push("park_b");
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let entries = log.lock().unwrap();
+    assert!(
+        entries.contains(&"park_a"),
+        "expected first callback to fire, got: {entries:?}"
+    );
+    assert!(
+        entries.contains(&"park_b"),
+        "expected second callback to fire, got: {entries:?}"
+    );
+    // Verify ordering: every "park_a" should appear before its corresponding "park_b"
+    let first_a = entries.iter().position(|e| *e == "park_a").unwrap();
+    let first_b = entries.iter().position(|e| *e == "park_b").unwrap();
+    assert!(
+        first_a < first_b,
+        "expected park_a before park_b, got: {entries:?}"
+    );
+}
+
+#[test]
+fn hook_stacking_multiple_with_tokio_hooks_calls() {
+    let log = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+    let log_a = log.clone();
+    let log_b = log.clone();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_thread_park(move || {
+                log_a.lock().unwrap().push("call_1");
+            });
+        })
+        .with_tokio_hooks(|h| {
+            h.on_thread_park(move || {
+                log_b.lock().unwrap().push("call_2");
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let entries = log.lock().unwrap();
+    assert!(
+        entries.contains(&"call_1"),
+        "expected first with_tokio_hooks callback to fire, got: {entries:?}"
+    );
+    assert!(
+        entries.contains(&"call_2"),
+        "expected second with_tokio_hooks callback to fire, got: {entries:?}"
+    );
+    let first_1 = entries.iter().position(|e| *e == "call_1").unwrap();
+    let first_2 = entries.iter().position(|e| *e == "call_2").unwrap();
+    assert!(
+        first_1 < first_2,
+        "expected call_1 before call_2, got: {entries:?}"
+    );
+}
+
+#[test]
+fn hook_stacking_task_meta_hooks_fire_in_order() {
+    let log = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+    let log_a = log.clone();
+    let log_b = log.clone();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_before_task_poll(move |_meta| {
+                log_a.lock().unwrap().push("poll_a");
+            });
+            h.on_before_task_poll(move |_meta| {
+                log_b.lock().unwrap().push("poll_b");
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::spawn(async {
+            tokio::task::yield_now().await;
+        })
+        .await
+        .unwrap();
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let entries = log.lock().unwrap();
+    assert!(
+        entries.contains(&"poll_a"),
+        "expected first task meta callback to fire, got: {entries:?}"
+    );
+    assert!(
+        entries.contains(&"poll_b"),
+        "expected second task meta callback to fire, got: {entries:?}"
+    );
+    let first_a = entries.iter().position(|e| *e == "poll_a").unwrap();
+    let first_b = entries.iter().position(|e| *e == "poll_b").unwrap();
+    assert!(
+        first_a < first_b,
+        "expected poll_a before poll_b, got: {entries:?}"
+    );
+}

--- a/dial9-tokio-telemetry/tests/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/tests/tokio_hooks.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use dial9_tokio_telemetry::telemetry::{NullWriter, TelemetryCore, TracedRuntime};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/dial9-tokio-telemetry/tests/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/tests/tokio_hooks.rs
@@ -1,0 +1,345 @@
+mod common;
+
+use dial9_tokio_telemetry::telemetry::{NullWriter, TelemetryCore, TracedRuntime};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn on_thread_start_and_stop_fire() {
+    let start_count = Arc::new(AtomicUsize::new(0));
+    let stop_count = Arc::new(AtomicUsize::new(0));
+    let sc = start_count.clone();
+    let stc = stop_count.clone();
+
+    let num_workers = 4;
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(num_workers).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_thread_start(move || {
+                sc.fetch_add(1, Ordering::Relaxed);
+            });
+            h.on_thread_stop(move || {
+                stc.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        // Ensure all workers have started by spawning work on each.
+        let mut handles = Vec::new();
+        for _ in 0..num_workers * 4 {
+            handles.push(tokio::spawn(async {
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    assert!(
+        start_count.load(Ordering::Relaxed) >= num_workers,
+        "expected on_thread_start to fire at least {num_workers} times, got {}",
+        start_count.load(Ordering::Relaxed)
+    );
+    assert!(
+        stop_count.load(Ordering::Relaxed) >= num_workers,
+        "expected on_thread_stop to fire at least {num_workers} times, got {}",
+        stop_count.load(Ordering::Relaxed)
+    );
+}
+
+#[test]
+fn each_runtime_gets_own_hooks() {
+    let count_a = Arc::new(AtomicUsize::new(0));
+    let count_b = Arc::new(AtomicUsize::new(0));
+    let ca = count_a.clone();
+    let cb = count_b.clone();
+
+    let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+    guard.enable();
+
+    let mut builder_a = tokio::runtime::Builder::new_multi_thread();
+    builder_a.worker_threads(2).enable_all();
+    let (runtime_a, _handle_a) = guard
+        .trace_runtime("a")
+        .with_tokio_hooks(|h| {
+            h.on_before_task_poll(move |_meta| {
+                ca.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build(builder_a)
+        .unwrap();
+
+    let mut builder_b = tokio::runtime::Builder::new_multi_thread();
+    builder_b.worker_threads(2).enable_all();
+    let (runtime_b, _handle_b) = guard
+        .trace_runtime("b")
+        .with_tokio_hooks(|h| {
+            h.on_before_task_poll(move |_meta| {
+                cb.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build(builder_b)
+        .unwrap();
+
+    // Generate work only on runtime A
+    runtime_a.block_on(async {
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            handles.push(tokio::spawn(async {
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    });
+
+    let a_polls = count_a.load(Ordering::Relaxed);
+    let b_polls_before = count_b.load(Ordering::Relaxed);
+
+    // Generate work only on runtime B
+    runtime_b.block_on(async {
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            handles.push(tokio::spawn(async {
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    });
+
+    let b_polls_after = count_b.load(Ordering::Relaxed);
+
+    assert!(a_polls > 0, "expected runtime A poll hook to fire");
+    assert_eq!(
+        b_polls_before, 0,
+        "expected runtime B poll hook to NOT fire during A's work"
+    );
+    assert!(
+        b_polls_after > 0,
+        "expected runtime B poll hook to fire during B's work"
+    );
+
+    drop(runtime_a);
+    drop(runtime_b);
+    let _ = guard.graceful_shutdown(std::time::Duration::from_secs(1));
+}
+
+#[test]
+fn on_thread_park_fires() {
+    let park_count = Arc::new(AtomicUsize::new(0));
+    let pc = park_count.clone();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_thread_park(move || {
+                pc.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        // Sleep to let workers park
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    assert!(
+        park_count.load(Ordering::Relaxed) > 0,
+        "expected on_thread_park to fire at least once"
+    );
+}
+
+#[test]
+fn on_thread_unpark_fires() {
+    let unpark_count = Arc::new(AtomicUsize::new(0));
+    let uc = unpark_count.clone();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_thread_unpark(move || {
+                uc.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        // Generate work to trigger unparks
+        let mut handles = Vec::new();
+        for _ in 0..20 {
+            handles.push(tokio::spawn(async {
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    assert!(
+        unpark_count.load(Ordering::Relaxed) > 0,
+        "expected on_thread_unpark to fire at least once"
+    );
+}
+
+#[test]
+fn task_poll_hooks_fire() {
+    let before_count = Arc::new(AtomicUsize::new(0));
+    let after_count = Arc::new(AtomicUsize::new(0));
+    let bc = before_count.clone();
+    let ac = after_count.clone();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_tokio_hooks(|h| {
+            h.on_before_task_poll(move |_meta| {
+                bc.fetch_add(1, Ordering::Relaxed);
+            });
+            h.on_after_task_poll(move |_meta| {
+                ac.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        let handle = tokio::spawn(async {
+            tokio::task::yield_now().await;
+        });
+        handle.await.unwrap();
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    assert!(
+        before_count.load(Ordering::Relaxed) > 0,
+        "expected on_before_task_poll to fire"
+    );
+    assert!(
+        after_count.load(Ordering::Relaxed) > 0,
+        "expected on_after_task_poll to fire"
+    );
+    assert_eq!(
+        before_count.load(Ordering::Relaxed),
+        after_count.load(Ordering::Relaxed),
+        "before and after poll counts should match"
+    );
+}
+
+#[test]
+fn task_lifecycle_hooks_fire() {
+    let spawn_count = Arc::new(AtomicUsize::new(0));
+    let terminate_count = Arc::new(AtomicUsize::new(0));
+    let sc = spawn_count.clone();
+    let tc = terminate_count.clone();
+
+    let num_tasks = 10;
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .with_tokio_hooks(|h| {
+            h.on_task_spawn(move |_meta| {
+                sc.fetch_add(1, Ordering::Relaxed);
+            });
+            h.on_task_terminate(move |_meta| {
+                tc.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        let mut handles = Vec::new();
+        for _ in 0..num_tasks {
+            handles.push(tokio::spawn(async {
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    assert!(
+        spawn_count.load(Ordering::Relaxed) >= num_tasks,
+        "expected on_task_spawn to fire at least {num_tasks} times, got {}",
+        spawn_count.load(Ordering::Relaxed)
+    );
+    assert!(
+        terminate_count.load(Ordering::Relaxed) >= num_tasks,
+        "expected on_task_terminate to fire at least {num_tasks} times, got {}",
+        terminate_count.load(Ordering::Relaxed)
+    );
+}
+
+#[test]
+fn task_spawn_hook_fires_when_task_tracking_disabled() {
+    let spawn_count = Arc::new(AtomicUsize::new(0));
+    let sc = spawn_count.clone();
+
+    let num_tasks = 5;
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(false)
+        .with_tokio_hooks(|h| {
+            h.on_task_spawn(move |_meta| {
+                sc.fetch_add(1, Ordering::Relaxed);
+            });
+        })
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    runtime.block_on(async {
+        let mut handles = Vec::new();
+        for _ in 0..num_tasks {
+            handles.push(tokio::spawn(async {
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    assert!(
+        spawn_count.load(Ordering::Relaxed) >= num_tasks,
+        "expected on_task_spawn to fire at least {num_tasks} times even with task_tracking disabled, got {}",
+        spawn_count.load(Ordering::Relaxed)
+    );
+}


### PR DESCRIPTION
Fixes #297 

```rust
  // Single runtime
  let (runtime, guard) = TracedRuntime::builder()
      .with_tokio_hooks(|h| {
          h.on_thread_start(|| install_my_thread_local_subscriber());
          h.on_thread_stop(|| cleanup_my_thread_local());
      })
      .build_and_start(builder, writer)?;

  // Multi-runtime via TelemetryCore
  let (rt, handle) = guard
      .trace_runtime("io")
      .with_tokio_hooks(|h| {
          h.on_thread_start(|| set_io_thread_priority());
      })
      .build(builder)?;

  // Via Dial9Config
  Dial9Config::builder()
      .with_runtime(|r| r.with_tokio_hooks(|h| {
          h.on_thread_start(|| { /* ... */ });
      }))
      .build_or_disabled()

```