### PR TITLE
feat: add `Dial9Allocator`, a profiling allocator that feeds events into dial9 traces

### DIFF
--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -80,7 +80,7 @@ _shuttle = [
 taskdump = ["tokio/taskdump"]
 tracing-layer = ["dep:tracing-subscriber"]
 ## Sampled memory allocation profiling via ring buffers.
-memory-profiling = []
+memory-profiling = ["dep:dial9-perf-self-profile"]
 worker-s3 = [
     "dep:aws-sdk-s3-transfer-manager",
     "dep:aws-sdk-s3",

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -154,6 +154,11 @@ harness = false
 name = "e2e_workload"
 harness = false
 
+[[bench]]
+name = "memory_profiling_bench"
+harness = false
+required-features = ["memory-profiling"]
+
 [[example]]
 name = "blocking_pool_tracking"
 required-features = ["cpu-profiling"]

--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -167,6 +167,7 @@ fn my_config() -> Dial9Config {
         })
         .build_or_disabled()
 }
+# }
 ```
 
 #### Instrumenting multiple runtimes
@@ -290,7 +291,7 @@ async fn main() { /* ... */ }
 
 You can emit your own application-level events into the trace alongside the built-in runtime events. Define a struct with `#[derive(TraceEvent)]` and call `record_event`:
 
-```rust
+```rust,no_run
 # fn main() {
 use dial9_trace_format::TraceEvent;
 use dial9_tokio_telemetry::telemetry::{record_event, clock_monotonic_ns, TelemetryHandle};

--- a/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
+++ b/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
@@ -21,7 +21,7 @@
 //!   BENCH_CONFIG=sampling_only cargo bench --bench memory_profiling_bench --features memory-profiling
 //!   BENCH_CONFIG=sampling_with_liveset cargo bench --bench memory_profiling_bench --features memory-profiling
 
-use criterion::{Criterion, Throughput, criterion_group};
+use criterion::{Criterion, Throughput};
 use dial9_tokio_telemetry::memory_profiling::Dial9Allocator;
 use std::alloc::{GlobalAlloc, Layout};
 
@@ -93,12 +93,6 @@ fn bench_mixed_sizes(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_tight_alloc,
-    bench_realloc_growth,
-    bench_mixed_sizes
-);
 
 fn install_profiler() {
     use dial9_tokio_telemetry::memory_profiling::{MemoryProfiler, MemoryProfilingConfig};
@@ -141,6 +135,9 @@ fn main() {
         _ => {} // no profiler — measures baseline OnceLock::get() cost
     }
 
-    benches();
-    Criterion::default().configure_from_args().final_summary();
+    let mut criterion = Criterion::default().configure_from_args();
+    bench_tight_alloc(&mut criterion);
+    bench_realloc_growth(&mut criterion);
+    bench_mixed_sizes(&mut criterion);
+    criterion.final_summary();
 }

--- a/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
+++ b/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
@@ -93,7 +93,6 @@ fn bench_mixed_sizes(c: &mut Criterion) {
     group.finish();
 }
 
-
 fn install_profiler() {
     use dial9_tokio_telemetry::memory_profiling::{MemoryProfiler, MemoryProfilingConfig};
     use dial9_tokio_telemetry::telemetry::{NullWriter, TracedRuntime};

--- a/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
+++ b/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
@@ -1,0 +1,146 @@
+//! Integration benchmark for memory profiling.
+//!
+//! Measures the overhead of the Dial9Allocator hook path by calling
+//! GlobalAlloc methods directly on a Dial9Allocator<System> instance.
+//!
+//! Usage: `cargo bench -p dial9-tokio-telemetry --features memory-profiling \
+//!     --bench memory_profiling_bench`
+//!
+//! Three groups (per design §10):
+//! - tight_alloc: high-frequency small allocs, measures fast-path cost.
+//! - realloc_growth: Vec::push pattern, exercises the realloc path.
+//! - mixed_sizes: varying sizes across the sample-rate boundary.
+//!
+//! NOTE: The profiler is installed once at process start via BENCH_CONFIG
+//! env var. Without it, we measure the "no profiler" baseline (just the
+//! OnceLock::get() check). With BENCH_CONFIG=sampling_only or
+//! BENCH_CONFIG=sampling_with_liveset, the full hook path is exercised.
+//!
+//! Run all three configs:
+//!   cargo bench --bench memory_profiling_bench --features memory-profiling
+//!   BENCH_CONFIG=sampling_only cargo bench --bench memory_profiling_bench --features memory-profiling
+//!   BENCH_CONFIG=sampling_with_liveset cargo bench --bench memory_profiling_bench --features memory-profiling
+
+use criterion::{Criterion, Throughput, criterion_group};
+use dial9_tokio_telemetry::memory_profiling::Dial9Allocator;
+use std::alloc::{GlobalAlloc, Layout};
+
+fn bench_tight_alloc(c: &mut Criterion) {
+    let allocator = Dial9Allocator::system();
+    let layout = Layout::from_size_align(64, 8).unwrap();
+
+    let mut group = c.benchmark_group("tight_alloc");
+    group.throughput(Throughput::Bytes(64));
+    group.bench_function("alloc_dealloc_64b", |b| {
+        b.iter(|| {
+            // SAFETY: layout is valid, we dealloc immediately.
+            let ptr = unsafe { allocator.alloc(layout) };
+            assert!(!ptr.is_null());
+            unsafe { allocator.dealloc(ptr, layout) };
+        });
+    });
+    group.finish();
+}
+
+fn bench_realloc_growth(c: &mut Criterion) {
+    let allocator = Dial9Allocator::system();
+
+    let mut group = c.benchmark_group("realloc_growth");
+    // Total bytes touched: 64+128+256+512+1024+2048+4096 = 8128
+    group.throughput(Throughput::Bytes(8128));
+    group.bench_function("64_to_4096", |b| {
+        b.iter(|| {
+            let layout = Layout::from_size_align(64, 8).unwrap();
+            // SAFETY: layout is valid.
+            let mut ptr = unsafe { allocator.alloc(layout) };
+            assert!(!ptr.is_null());
+            let mut current_layout = layout;
+            let mut size = 128usize;
+            while size <= 4096 {
+                // SAFETY: ptr was allocated with current_layout, new_size > 0.
+                let new_ptr = unsafe { allocator.realloc(ptr, current_layout, size) };
+                assert!(!new_ptr.is_null());
+                ptr = new_ptr;
+                current_layout = Layout::from_size_align(size, 8).unwrap();
+                size *= 2;
+            }
+            // SAFETY: ptr was allocated with current_layout.
+            unsafe { allocator.dealloc(ptr, current_layout) };
+        });
+    });
+    group.finish();
+}
+
+fn bench_mixed_sizes(c: &mut Criterion) {
+    let allocator = Dial9Allocator::system();
+    let sizes: &[usize] = &[8, 64, 256, 1024, 64, 16, 8192, 32, 512, 4096];
+    let total_bytes: u64 = sizes.iter().map(|&s| s as u64).sum();
+
+    let mut group = c.benchmark_group("mixed_sizes");
+    group.throughput(Throughput::Bytes(total_bytes));
+    group.bench_function("10_mixed_allocs", |b| {
+        b.iter(|| {
+            for &size in sizes {
+                let layout = Layout::from_size_align(size, 8).unwrap();
+                // SAFETY: layout is valid.
+                let ptr = unsafe { allocator.alloc(layout) };
+                assert!(!ptr.is_null());
+                // SAFETY: ptr was allocated with this layout.
+                unsafe { allocator.dealloc(ptr, layout) };
+            }
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_tight_alloc,
+    bench_realloc_growth,
+    bench_mixed_sizes
+);
+
+fn install_profiler() {
+    use dial9_tokio_telemetry::memory_profiling::{MemoryProfiler, MemoryProfilingConfig};
+    use dial9_tokio_telemetry::telemetry::{NullWriter, TracedRuntime};
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+
+    // We leak the runtime and guard so they live for the process lifetime.
+    // This is intentional — the profiler is process-permanent anyway.
+    let (runtime, guard) = TracedRuntime::builder()
+        .build_and_start(builder, NullWriter)
+        .unwrap();
+    let handle = guard.handle();
+
+    let track_liveset = matches!(
+        std::env::var("BENCH_CONFIG").as_deref(),
+        Ok("sampling_with_liveset")
+    );
+
+    let cfg = MemoryProfilingConfig::builder()
+        .sample_rate_bytes(512 * 1024)
+        .track_liveset(track_liveset)
+        .rng_seed(42)
+        .build();
+
+    let _mem_guard = MemoryProfiler::from_config(cfg)
+        .install(handle)
+        .expect("profiler install should succeed in bench");
+
+    // Leak everything to keep the profiler alive for the process.
+    std::mem::forget(runtime);
+    std::mem::forget(guard);
+    // _mem_guard doesn't implement Drop — dropping is fine.
+}
+
+fn main() {
+    match std::env::var("BENCH_CONFIG").as_deref() {
+        Ok("sampling_only") | Ok("sampling_with_liveset") => install_profiler(),
+        _ => {} // no profiler — measures baseline OnceLock::get() cost
+    }
+
+    benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/dial9-tokio-telemetry/src/analysis_unstable.rs
+++ b/dial9-tokio-telemetry/src/analysis_unstable.rs
@@ -6,6 +6,23 @@
 //! The API surface here is still evolving.
 //! Expect breaking changes between minor versions.
 //!
+//! # Memory profiling: scaling sampled `Alloc` events
+//!
+//! `Alloc` events in the trace are sampled with Poisson sampling at the
+//! configured `MemoryProfilingConfig::sample_rate_bytes` (`R`). The
+//! `size` field on each event is the raw bytes of *that one* allocation
+//! — it is **not** a scaled estimate. To recover unbiased totals from
+//! the sample stream:
+//!
+//! ```text
+//! total_bytes ≈ Σ s_i / (1 - exp(-s_i / R))
+//! total_count ≈ Σ   1 / (1 - exp(-s_i / R))
+//! ```
+//!
+//! Always weight each sample individually before summing. See
+//! `MemoryProfilingConfig::sample_rate_bytes` and
+//! `docs/design/memory-profiling.md` for worked examples.
+//!
 //! # Quick start
 //!
 //! ```no_run

--- a/dial9-tokio-telemetry/src/lib.rs
+++ b/dial9-tokio-telemetry/src/lib.rs
@@ -14,7 +14,7 @@ pub mod analysis_unstable;
 /// Background worker pipeline for processing sealed trace segments.
 pub mod background_task;
 #[cfg(feature = "memory-profiling")]
-pub(crate) mod memory_profiling;
+pub mod memory_profiling;
 pub(crate) mod metrics;
 pub(crate) mod primitives;
 pub(crate) mod rate_limit;

--- a/dial9-tokio-telemetry/src/memory_profiling/allocator.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/allocator.rs
@@ -90,6 +90,9 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: `layout` validity contract forwarded to the inner allocator.
         let ptr = unsafe { self.0.alloc(layout) };
+        // SAFETY: `on_alloc` is allocator-quiet (see hook module docs) — it
+        // performs no allocations, takes no locks, and only accesses lock-free
+        // data structures. `ptr` is non-null (checked below) and valid.
         if !ptr.is_null()
             && let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get()
         {
@@ -99,6 +102,9 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `on_dealloc` is allocator-quiet (see hook module docs) — it
+        // performs no allocations, takes no locks, and only accesses lock-free
+        // data structures. `ptr` is valid per the `dealloc` contract.
         if let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get() {
             crate::memory_profiling::hook::on_dealloc(inner, ptr, layout.size());
         }
@@ -113,6 +119,9 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
         // — otherwise the old pointer is still live and must not be
         // recorded as freed (design §3, "realloc handling").
         let new_ptr = unsafe { self.0.realloc(ptr, old_layout, new_size) };
+        // SAFETY: `on_realloc` is allocator-quiet (see hook module docs) — it
+        // performs no allocations, takes no locks, and only accesses lock-free
+        // data structures. `new_ptr` is non-null (checked below) and valid.
         if !new_ptr.is_null()
             && let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get()
         {
@@ -130,6 +139,9 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         // SAFETY: forwarded to the inner allocator.
         let ptr = unsafe { self.0.alloc_zeroed(layout) };
+        // SAFETY: `on_alloc` is allocator-quiet (see hook module docs) — it
+        // performs no allocations, takes no locks, and only accesses lock-free
+        // data structures. `ptr` is non-null (checked below) and valid.
         if !ptr.is_null()
             && let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get()
         {

--- a/dial9-tokio-telemetry/src/memory_profiling/allocator.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/allocator.rs
@@ -1,0 +1,188 @@
+//! `Dial9Allocator<A>` — a `GlobalAlloc` wrapper that hooks every allocation
+//! and deallocation to feed dial9's memory profiler.
+//!
+//! In this commit the wrapper is a **pure passthrough**: `alloc`, `dealloc`,
+//! `realloc`, and `alloc_zeroed` simply delegate to the inner `A`. The hook
+//! calls (the actual sampling + queue push) land in a later commit. We're
+//! shipping the wrapper as a separate commit so users can drop it in as a
+//! `#[global_allocator]` today and the hook becomes active later when
+//! `MemoryProfiler::install()` is called.
+//!
+//! See `docs/design/memory-profiling.md` §4 for the contract; in particular:
+//! realloc is treated as a free-of-old plus alloc-of-new, with the hooks only
+//! firing **after the inner realloc succeeds** (otherwise the old pointer is
+//! still live and must not be recorded as freed).
+
+use std::alloc::{GlobalAlloc, Layout};
+
+/// Generic `GlobalAlloc` wrapper that feeds dial9's memory profiler.
+///
+/// This type is designed to be installed as the process-global allocator
+/// via `#[global_allocator]`. Used in any other context (e.g. as a local
+/// allocator in `Box::new_in`) it will not enable memory profiling because
+/// the hook only intercepts allocations that route through the global
+/// allocator slot.
+///
+/// Defaults to wrapping `std::alloc::System`. Use `Dial9Allocator::system()`
+/// (no turbofish) for the common case, or `Dial9Allocator::new(inner)` to
+/// wrap a custom allocator like `tikv_jemallocator::Jemalloc` or
+/// `mimalloc::MiMalloc`.
+///
+/// # Examples
+///
+/// Wrap the system allocator:
+///
+/// ```no_run
+/// use dial9_tokio_telemetry::memory_profiling::Dial9Allocator;
+///
+/// #[global_allocator]
+/// static ALLOC: Dial9Allocator = Dial9Allocator::system();
+/// # fn main() {}
+/// ```
+///
+/// Wrap a custom allocator:
+///
+/// ```ignore
+/// use dial9_tokio_telemetry::memory_profiling::Dial9Allocator;
+///
+/// #[global_allocator]
+/// static ALLOC: Dial9Allocator<tikv_jemallocator::Jemalloc> =
+///     Dial9Allocator::new(tikv_jemallocator::Jemalloc);
+/// ```
+///
+/// # Cost
+///
+/// Until `MemoryProfiler::install()` has been called, this is a zero-cost
+/// passthrough — the hook (added in a later commit) checks an
+/// `OnceLock<MemoryProfilerInner>` which returns `None` and skips all
+/// profiling work. After install, ~99.9% of allocations take the unsampled
+/// fast path: ~5 ns total per allocation (one Acquire load, one TLS load,
+/// one subtract+compare on the per-thread sample counter). The remaining
+/// ~0.1% of sampled allocations pay ~1 µs for stack capture and event
+/// emission. See `docs/design/memory-profiling.md` §9 for the full
+/// overhead budget.
+#[derive(Debug)]
+pub struct Dial9Allocator<A = std::alloc::System>(A);
+
+impl Dial9Allocator {
+    /// Wrap the system allocator.
+    ///
+    /// Use this when you don't need a custom inner allocator (i.e. you
+    /// weren't otherwise setting `#[global_allocator]`).
+    pub const fn system() -> Self {
+        Self(std::alloc::System)
+    }
+}
+
+impl<A: GlobalAlloc> Dial9Allocator<A> {
+    /// Wrap a custom inner allocator (e.g. jemalloc, mimalloc).
+    pub const fn new(inner: A) -> Self {
+        Self(inner)
+    }
+}
+
+// SAFETY: forwarding to the inner `GlobalAlloc` impl. The `unsafe` contract on
+// each method is exactly the same as the inner allocator's. The hook
+// invocations (added in a later commit) must be allocator-quiet — see
+// design §6.
+unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: `layout` validity contract forwarded to the inner allocator.
+        unsafe { self.0.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr`/`layout` validity contract forwarded to the inner
+        // allocator.
+        unsafe { self.0.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, old_layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: forwarded to the inner allocator. When the hook is added
+        // (later commit), the free-of-old hook must only fire after
+        // confirming the inner realloc returned non-null — otherwise the
+        // old pointer is still live and must not be recorded as freed
+        // (design §3, "realloc handling").
+        unsafe { self.0.realloc(ptr, old_layout, new_size) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwarded to the inner allocator.
+        unsafe { self.0.alloc_zeroed(layout) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::alloc::{GlobalAlloc, Layout};
+
+    #[test]
+    fn dial9_allocator_default_constructible() {
+        let _: Dial9Allocator = Dial9Allocator::system();
+    }
+
+    #[test]
+    fn dial9_allocator_alloc_dealloc_roundtrip() {
+        let allocator = Dial9Allocator::system();
+        let layout = Layout::from_size_align(1024, 8).unwrap();
+        // SAFETY: layout is valid; we own the returned pointer.
+        let ptr = unsafe { allocator.alloc(layout) };
+        assert!(!ptr.is_null(), "alloc returned null");
+        // Touch the memory to make sure it's writable.
+        unsafe { ptr.write_bytes(0x42, 1024) };
+        // SAFETY: `ptr` was just allocated with this `layout`.
+        unsafe { allocator.dealloc(ptr, layout) };
+    }
+
+    #[test]
+    fn dial9_allocator_alloc_zeroed_returns_zero() {
+        let allocator = Dial9Allocator::system();
+        let layout = Layout::from_size_align(1024, 8).unwrap();
+        // SAFETY: layout is valid.
+        let ptr = unsafe { allocator.alloc_zeroed(layout) };
+        assert!(!ptr.is_null(), "alloc_zeroed returned null");
+        let slice = unsafe { std::slice::from_raw_parts(ptr, 1024) };
+        assert!(
+            slice.iter().all(|&b| b == 0),
+            "alloc_zeroed memory not zeroed"
+        );
+        // SAFETY: `ptr` was allocated with this `layout`.
+        unsafe { allocator.dealloc(ptr, layout) };
+    }
+
+    #[test]
+    fn dial9_allocator_realloc_grows() {
+        let allocator = Dial9Allocator::system();
+        let layout = Layout::from_size_align(64, 8).unwrap();
+        // SAFETY: layout is valid.
+        let ptr = unsafe { allocator.alloc(layout) };
+        assert!(!ptr.is_null(), "initial alloc returned null");
+        unsafe { ptr.write_bytes(0xAB, 64) };
+        // SAFETY: ptr was allocated with `layout`, new_size (256) > 0.
+        let new_ptr = unsafe { allocator.realloc(ptr, layout, 256) };
+        assert!(!new_ptr.is_null(), "realloc returned null");
+        // Verify original bytes preserved.
+        let slice = unsafe { std::slice::from_raw_parts(new_ptr, 64) };
+        assert!(
+            slice.iter().all(|&b| b == 0xAB),
+            "realloc didn't preserve data"
+        );
+        // Write to the grown region.
+        unsafe { new_ptr.add(64).write_bytes(0xCD, 192) };
+        // SAFETY: new_ptr was returned by realloc with new_size=256.
+        let new_layout = Layout::from_size_align(256, 8).unwrap();
+        unsafe { allocator.dealloc(new_ptr, new_layout) };
+    }
+
+    #[test]
+    fn dial9_allocator_with_custom_inner_compiles() {
+        let allocator = Dial9Allocator::new(std::alloc::System);
+        let layout = Layout::from_size_align(128, 8).unwrap();
+        // SAFETY: layout is valid.
+        let ptr = unsafe { allocator.alloc(layout) };
+        assert!(!ptr.is_null(), "alloc returned null");
+        // SAFETY: ptr was allocated with this layout.
+        unsafe { allocator.dealloc(ptr, layout) };
+    }
+}

--- a/dial9-tokio-telemetry/src/memory_profiling/allocator.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/allocator.rs
@@ -1,12 +1,13 @@
 //! `Dial9Allocator<A>` — a `GlobalAlloc` wrapper that hooks every allocation
 //! and deallocation to feed dial9's memory profiler.
 //!
-//! In this commit the wrapper is a **pure passthrough**: `alloc`, `dealloc`,
-//! `realloc`, and `alloc_zeroed` simply delegate to the inner `A`. The hook
-//! calls (the actual sampling + queue push) land in a later commit. We're
-//! shipping the wrapper as a separate commit so users can drop it in as a
-//! `#[global_allocator]` today and the hook becomes active later when
-//! `MemoryProfiler::install()` is called.
+//! The wrapper checks `ACTIVE.get()` on every alloc/dealloc/realloc. When
+//! `None` (profiler not installed), all methods are pure passthrough — one
+//! Acquire load + null check (~1 ns). When `Some`, the hook runs the
+//! geometric sampling decision and, on the sampled path (~0.1% of allocs
+//! at the default 512 KiB rate), captures a stack and pushes a fixed-size
+//! POD record into the alloc queue. Per-thread state lives in TLS; no
+//! locks, no allocation, no syscalls on the unsampled path.
 //!
 //! See `docs/design/memory-profiling.md` §4 for the contract; in particular:
 //! realloc is treated as a free-of-old plus alloc-of-new, with the hooks only
@@ -83,32 +84,58 @@ impl<A: GlobalAlloc> Dial9Allocator<A> {
 
 // SAFETY: forwarding to the inner `GlobalAlloc` impl. The `unsafe` contract on
 // each method is exactly the same as the inner allocator's. The hook
-// invocations (added in a later commit) must be allocator-quiet — see
-// design §6.
+// invocations are allocator-quiet by construction — see
+// [`crate::memory_profiling::hook`] module docs and design §6.
 unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: `layout` validity contract forwarded to the inner allocator.
-        unsafe { self.0.alloc(layout) }
+        let ptr = unsafe { self.0.alloc(layout) };
+        if !ptr.is_null()
+            && let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get()
+        {
+            crate::memory_profiling::hook::on_alloc(inner, ptr, layout.size());
+        }
+        ptr
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get() {
+            crate::memory_profiling::hook::on_dealloc(inner, ptr, layout.size());
+        }
         // SAFETY: `ptr`/`layout` validity contract forwarded to the inner
         // allocator.
-        unsafe { self.0.dealloc(ptr, layout) }
+        unsafe { self.0.dealloc(ptr, layout) };
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, old_layout: Layout, new_size: usize) -> *mut u8 {
-        // SAFETY: forwarded to the inner allocator. When the hook is added
-        // (later commit), the free-of-old hook must only fire after
-        // confirming the inner realloc returned non-null — otherwise the
-        // old pointer is still live and must not be recorded as freed
-        // (design §3, "realloc handling").
-        unsafe { self.0.realloc(ptr, old_layout, new_size) }
+        // SAFETY: forwarded to the inner allocator. The hook below only
+        // fires after we've confirmed the inner realloc returned non-null
+        // — otherwise the old pointer is still live and must not be
+        // recorded as freed (design §3, "realloc handling").
+        let new_ptr = unsafe { self.0.realloc(ptr, old_layout, new_size) };
+        if !new_ptr.is_null()
+            && let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get()
+        {
+            crate::memory_profiling::hook::on_realloc(
+                inner,
+                ptr,
+                old_layout.size(),
+                new_ptr,
+                new_size,
+            );
+        }
+        new_ptr
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         // SAFETY: forwarded to the inner allocator.
-        unsafe { self.0.alloc_zeroed(layout) }
+        let ptr = unsafe { self.0.alloc_zeroed(layout) };
+        if !ptr.is_null()
+            && let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get()
+        {
+            crate::memory_profiling::hook::on_alloc(inner, ptr, layout.size());
+        }
+        ptr
     }
 }
 

--- a/dial9-tokio-telemetry/src/memory_profiling/allocator.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/allocator.rs
@@ -1,18 +1,5 @@
-//! `Dial9Allocator<A>` — a `GlobalAlloc` wrapper that hooks every allocation
-//! and deallocation to feed dial9's memory profiler.
-//!
-//! The wrapper checks `ACTIVE.get()` on every alloc/dealloc/realloc. When
-//! `None` (profiler not installed), all methods are pure passthrough — one
-//! Acquire load + null check (~1 ns). When `Some`, the hook runs the
-//! geometric sampling decision and, on the sampled path (~0.1% of allocs
-//! at the default 512 KiB rate), captures a stack and pushes a fixed-size
-//! POD record into the alloc queue. Per-thread state lives in TLS; no
-//! locks, no allocation, no syscalls on the unsampled path.
-//!
-//! See `docs/design/memory-profiling.md` §4 for the contract; in particular:
-//! realloc is treated as a free-of-old plus alloc-of-new, with the hooks only
-//! firing **after the inner realloc succeeds** (otherwise the old pointer is
-//! still live and must not be recorded as freed).
+//! `Dial9Allocator<A>` — a `GlobalAlloc` wrapper that feeds dial9's memory
+//! profiler.
 
 use std::alloc::{GlobalAlloc, Layout};
 
@@ -53,15 +40,11 @@ use std::alloc::{GlobalAlloc, Layout};
 ///
 /// # Cost
 ///
-/// Until `MemoryProfiler::install()` has been called, this is a zero-cost
-/// passthrough — the hook (added in a later commit) checks an
-/// `OnceLock<MemoryProfilerInner>` which returns `None` and skips all
-/// profiling work. After install, ~99.9% of allocations take the unsampled
-/// fast path: ~5 ns total per allocation (one Acquire load, one TLS load,
-/// one subtract+compare on the per-thread sample counter). The remaining
-/// ~0.1% of sampled allocations pay ~1 µs for stack capture and event
-/// emission. See `docs/design/memory-profiling.md` §9 for the full
-/// overhead budget.
+/// Until [`MemoryProfiler::install()`](super::MemoryProfiler::install) has
+/// been called, this is a zero-cost passthrough (~1 ns Acquire load +
+/// null check). After install, ~99.9% of allocations take the unsampled
+/// fast path (~5 ns). The remaining ~0.1% of sampled allocations pay
+/// ~1 µs for stack capture and event emission.
 #[derive(Debug)]
 pub struct Dial9Allocator<A = std::alloc::System>(A);
 
@@ -84,13 +67,13 @@ impl<A: GlobalAlloc> Dial9Allocator<A> {
 
 // SAFETY: forwarding to the inner `GlobalAlloc` impl. The `unsafe` contract on
 // each method is exactly the same as the inner allocator's. The hook
-// invocations are allocator-quiet by construction — see
+// invocations are allocation-free by construction — see
 // [`crate::memory_profiling::hook`] module docs and design §6.
 unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: `layout` validity contract forwarded to the inner allocator.
         let ptr = unsafe { self.0.alloc(layout) };
-        // SAFETY: `on_alloc` is allocator-quiet (see hook module docs) — it
+        // SAFETY: `on_alloc` is allocation-free (see hook module docs) — it
         // performs no allocations, takes no locks, and only accesses lock-free
         // data structures. `ptr` is non-null (checked below) and valid.
         if !ptr.is_null()
@@ -102,7 +85,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        // SAFETY: `on_dealloc` is allocator-quiet (see hook module docs) — it
+        // SAFETY: `on_dealloc` is allocation-free (see hook module docs) — it
         // performs no allocations, takes no locks, and only accesses lock-free
         // data structures. `ptr` is valid per the `dealloc` contract.
         if let Some(inner) = crate::memory_profiling::profiler::ACTIVE.get() {
@@ -119,7 +102,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
         // — otherwise the old pointer is still live and must not be
         // recorded as freed (design §3, "realloc handling").
         let new_ptr = unsafe { self.0.realloc(ptr, old_layout, new_size) };
-        // SAFETY: `on_realloc` is allocator-quiet (see hook module docs) — it
+        // SAFETY: `on_realloc` is allocation-free (see hook module docs) — it
         // performs no allocations, takes no locks, and only accesses lock-free
         // data structures. `new_ptr` is non-null (checked below) and valid.
         if !new_ptr.is_null()
@@ -139,7 +122,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for Dial9Allocator<A> {
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         // SAFETY: forwarded to the inner allocator.
         let ptr = unsafe { self.0.alloc_zeroed(layout) };
-        // SAFETY: `on_alloc` is allocator-quiet (see hook module docs) — it
+        // SAFETY: `on_alloc` is allocation-free (see hook module docs) — it
         // performs no allocations, takes no locks, and only accesses lock-free
         // data structures. `ptr` is non-null (checked below) and valid.
         if !ptr.is_null()

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -1,0 +1,92 @@
+//! `MemoryProfilingConfig` and the `TimestampMode` enum (design §8).
+
+/// Default mean bytes-between-samples — geometric sampling rate.
+///
+/// At 512 KiB, a service doing 1 GB/s of allocation generates ~2000
+/// samples/sec — plenty of signal, trivial overhead. See design §1.
+pub const DEFAULT_SAMPLE_RATE_BYTES: u64 = 512 * 1024;
+
+/// Default number of `RawAlloc` slots in the producer-to-consolidator
+/// alloc ring. See design §5 "Sizing the ring".
+pub const DEFAULT_RING_CAPACITY: usize = 4096;
+
+/// How `AllocEvent.timestamp_ns` is populated.
+///
+/// See design §8 for the full motivation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum TimestampMode {
+    /// Reuse the timestamp from the most recent `PollStart` on this thread
+    /// (~2 ns TLS load). Falls back to `clock_monotonic_ns()` on threads
+    /// with no recorded `PollStart`.
+    #[default]
+    ReusePollStart,
+
+    /// Emit events with `timestamp_ns = 0`. Smallest on-disk size.
+    None,
+
+    /// Call `clock_monotonic_ns()` per sampled allocation (~25 ns via vDSO).
+    Precise,
+}
+
+/// Configuration for the memory profiler.
+///
+/// Built via `MemoryProfilingConfig::builder()...build()`. See design §8.
+#[derive(Debug, Clone, bon::Builder)]
+pub struct MemoryProfilingConfig {
+    /// Mean bytes between sampled allocations. Default 512 KiB.
+    #[builder(default = DEFAULT_SAMPLE_RATE_BYTES)]
+    sample_rate_bytes: u64,
+
+    /// Whether to track the liveset for leak detection. Default `false`.
+    #[builder(default = false)]
+    track_liveset: bool,
+
+    /// How `AllocEvent.timestamp_ns` is populated. See [`TimestampMode`].
+    #[builder(default)]
+    timestamp_mode: TimestampMode,
+
+    /// Cap the consolidator-side liveset. Default `None` (unbounded).
+    max_liveset_entries: Option<usize>,
+
+    /// Optional fixed seed for per-thread sampling PRNGs.
+    rng_seed: Option<u64>,
+
+    /// Number of slots in the alloc queue. Default 4096.
+    /// The free queue is sized 8× this.
+    #[builder(default = DEFAULT_RING_CAPACITY)]
+    ring_capacity: usize,
+}
+
+impl Default for MemoryProfilingConfig {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+impl MemoryProfilingConfig {
+    /// Mean bytes between sampled allocations.
+    pub fn sample_rate_bytes(&self) -> u64 {
+        self.sample_rate_bytes
+    }
+    /// Whether liveset tracking is enabled.
+    pub fn track_liveset(&self) -> bool {
+        self.track_liveset
+    }
+    /// Timestamp mode for alloc events.
+    pub fn timestamp_mode(&self) -> TimestampMode {
+        self.timestamp_mode
+    }
+    /// Maximum liveset entries cap.
+    pub fn max_liveset_entries(&self) -> Option<usize> {
+        self.max_liveset_entries
+    }
+    /// Optional fixed RNG seed.
+    pub fn rng_seed(&self) -> Option<u64> {
+        self.rng_seed
+    }
+    /// Ring capacity (alloc queue slots).
+    pub fn ring_capacity(&self) -> usize {
+        self.ring_capacity
+    }
+}

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -71,6 +71,15 @@ pub struct MemoryProfilingConfig {
     sample_rate_bytes: u64,
 
     /// Whether to track the liveset for leak detection. Default `false`.
+    ///
+    /// When enabled, a `RawFree` is pushed into the free queue on
+    /// **every** deallocation (not just sampled ones). At very high
+    /// dealloc rates the free queue can overflow; overflowed frees are
+    /// silently dropped (counted in `dropped_frees`). A dropped free
+    /// for a previously-sampled allocation means its liveset entry
+    /// persists, inflating the reported live set until the next flush
+    /// cycle or process exit. Size the `ring_capacity` accordingly for
+    /// high-throughput services.
     #[builder(default = false)]
     track_liveset: bool,
 

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -1,23 +1,20 @@
-//! `MemoryProfilingConfig` and the `TimestampMode` enum (design §8).
+//! Configuration types for the memory profiler.
 
 /// Default mean bytes-between-samples — geometric sampling rate.
 ///
 /// At 512 KiB, a service doing 1 GB/s of allocation generates ~2000
-/// samples/sec — plenty of signal, trivial overhead. See design §1.
+/// samples/sec — plenty of signal, trivial overhead.
 pub const DEFAULT_SAMPLE_RATE_BYTES: u64 = 512 * 1024;
 
-/// Default number of `RawAlloc` slots in the producer-to-consolidator
-/// alloc ring. See design §5 "Sizing the ring".
+/// Default number of slots in the producer-to-consolidator alloc ring.
 pub const DEFAULT_RING_CAPACITY: usize = 4096;
 
 /// How `AllocEvent.timestamp_ns` is populated.
-///
-/// See design §8 for the full motivation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum TimestampMode {
     /// Reuse the timestamp from the most recent `PollStart` on this thread
-    /// (~2 ns TLS load). Falls back to `clock_monotonic_ns()` when called
+    /// (~5 ns TLS load). Falls back to `clock_monotonic_ns()` when called
     /// outside a task poll (e.g., between polls, or on non-worker threads).
     #[default]
     ReusePollStart,
@@ -31,7 +28,7 @@ pub enum TimestampMode {
 
 /// Configuration for the memory profiler.
 ///
-/// Built via `MemoryProfilingConfig::builder()...build()`. See design §8.
+/// Built via `MemoryProfilingConfig::builder()...build()`.
 #[derive(Debug, Clone, bon::Builder)]
 #[non_exhaustive]
 pub struct MemoryProfilingConfig {

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -38,6 +38,33 @@ pub struct MemoryProfilingConfig {
     /// is a special "sample every allocation" mode: every call to the
     /// allocator is recorded, and the per-thread PRNG is bypassed
     /// entirely.
+    ///
+    /// # Going from sample sizes to estimated totals
+    ///
+    /// Each `Alloc` event in the trace carries the **raw size** of one
+    /// sampled allocation. Summing raw sizes will undercount because
+    /// only ~`s/R` allocations of size `s` are sampled. To recover
+    /// unbiased totals, weight each sample by the inverse Poisson
+    /// sampling probability:
+    ///
+    /// ```text
+    /// total_bytes ≈ Σ s_i / (1 - exp(-s_i / R))
+    /// total_count ≈ Σ   1 / (1 - exp(-s_i / R))
+    /// ```
+    ///
+    /// where `R` is the `sample_rate_bytes` value above. The same
+    /// formula handles all size regimes:
+    ///
+    /// - For `s << R`: each sample contributes ~`R` bytes (small
+    ///   samples are scaled up).
+    /// - For `s >> R`: each sample contributes ~`s` bytes (huge allocs
+    ///   are sampled with probability ~1, no scaling needed).
+    ///
+    /// **Aggregate per sample, not per group.** When grouping by call
+    /// site / task / type, weight each sample individually before
+    /// summing. Sum-then-unbias under-reports skewed groups.
+    ///
+    /// See `docs/design/memory-profiling.md` for worked examples.
     #[builder(default = DEFAULT_SAMPLE_RATE_BYTES)]
     sample_rate_bytes: u64,
 

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -30,14 +30,16 @@ pub enum TimestampMode {
 ///
 /// Built via `MemoryProfilingConfig::builder()...build()`.
 #[derive(Debug, Clone, bon::Builder)]
+#[builder(finish_fn = build_inner)]
 #[non_exhaustive]
 pub struct MemoryProfilingConfig {
     /// Mean bytes between sampled allocations. Default 512 KiB.
     ///
-    /// Lower values sample more allocations. `sample_rate_bytes <= 1`
-    /// is a special "sample every allocation" mode: every call to the
-    /// allocator is recorded, and the per-thread PRNG is bypassed
-    /// entirely.
+    /// Lower values sample more allocations. **`sample_rate_bytes = 1`
+    /// is a special "sample every allocation" mode**: every call to
+    /// the allocator is recorded and the per-thread PRNG is bypassed
+    /// entirely. `0` is rejected at build time — pass `1` for the
+    /// "sample everything" semantics.
     ///
     /// # Going from sample sizes to estimated totals
     ///
@@ -85,6 +87,26 @@ pub struct MemoryProfilingConfig {
     ring_capacity: usize,
 }
 
+impl<S: memory_profiling_config_builder::IsComplete> MemoryProfilingConfigBuilder<S> {
+    /// Finalise the config.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `sample_rate_bytes` was set to `0`. Use `1` for the
+    /// "sample every allocation" mode — `0` would mean "zero bytes
+    /// between samples", which is ambiguous (sample everything? sample
+    /// nothing?), so we require the explicit `1`.
+    pub fn build(self) -> MemoryProfilingConfig {
+        let config = self.build_inner();
+        assert!(
+            config.sample_rate_bytes >= 1,
+            "MemoryProfilingConfig::sample_rate_bytes must be >= 1; pass 1 for \
+             'sample every allocation' mode"
+        );
+        config
+    }
+}
+
 impl Default for MemoryProfilingConfig {
     fn default() -> Self {
         Self::builder().build()
@@ -111,5 +133,34 @@ impl MemoryProfilingConfig {
     /// Ring capacity (alloc queue slots).
     pub fn ring_capacity(&self) -> usize {
         self.ring_capacity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_accepts_one() {
+        let cfg = MemoryProfilingConfig::builder()
+            .sample_rate_bytes(1)
+            .build();
+        assert_eq!(cfg.sample_rate_bytes(), 1);
+    }
+
+    #[test]
+    fn build_accepts_default() {
+        // Default uses DEFAULT_SAMPLE_RATE_BYTES = 512 KiB.
+        let cfg = MemoryProfilingConfig::default();
+        assert_eq!(cfg.sample_rate_bytes(), DEFAULT_SAMPLE_RATE_BYTES);
+    }
+
+    #[test]
+    #[should_panic(expected = "sample_rate_bytes must be >= 1")]
+    fn build_rejects_zero() {
+        // `0` is ambiguous — pass `1` for "sample every allocation".
+        let _ = MemoryProfilingConfig::builder()
+            .sample_rate_bytes(0)
+            .build();
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -33,6 +33,11 @@ pub enum TimestampMode {
 #[non_exhaustive]
 pub struct MemoryProfilingConfig {
     /// Mean bytes between sampled allocations. Default 512 KiB.
+    ///
+    /// Lower values sample more allocations. `sample_rate_bytes <= 1`
+    /// is a special "sample every allocation" mode: every call to the
+    /// allocator is recorded, and the per-thread PRNG is bypassed
+    /// entirely.
     #[builder(default = DEFAULT_SAMPLE_RATE_BYTES)]
     sample_rate_bytes: u64,
 

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -17,8 +17,8 @@ pub const DEFAULT_RING_CAPACITY: usize = 4096;
 #[non_exhaustive]
 pub enum TimestampMode {
     /// Reuse the timestamp from the most recent `PollStart` on this thread
-    /// (~2 ns TLS load). Falls back to `clock_monotonic_ns()` on threads
-    /// with no recorded `PollStart`.
+    /// (~2 ns TLS load). Falls back to `clock_monotonic_ns()` when called
+    /// outside a task poll (e.g., between polls, or on non-worker threads).
     #[default]
     ReusePollStart,
 
@@ -33,6 +33,7 @@ pub enum TimestampMode {
 ///
 /// Built via `MemoryProfilingConfig::builder()...build()`. See design §8.
 #[derive(Debug, Clone, bon::Builder)]
+#[non_exhaustive]
 pub struct MemoryProfilingConfig {
     /// Mean bytes between sampled allocations. Default 512 KiB.
     #[builder(default = DEFAULT_SAMPLE_RATE_BYTES)]
@@ -45,9 +46,6 @@ pub struct MemoryProfilingConfig {
     /// How `AllocEvent.timestamp_ns` is populated. See [`TimestampMode`].
     #[builder(default)]
     timestamp_mode: TimestampMode,
-
-    /// Cap the consolidator-side liveset. Default `None` (unbounded).
-    max_liveset_entries: Option<usize>,
 
     /// Optional fixed seed for per-thread sampling PRNGs.
     rng_seed: Option<u64>,
@@ -76,10 +74,6 @@ impl MemoryProfilingConfig {
     /// Timestamp mode for alloc events.
     pub fn timestamp_mode(&self) -> TimestampMode {
         self.timestamp_mode
-    }
-    /// Maximum liveset entries cap.
-    pub fn max_liveset_entries(&self) -> Option<usize> {
-        self.max_liveset_entries
     }
     /// Optional fixed RNG seed.
     pub fn rng_seed(&self) -> Option<u64> {

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -14,12 +14,25 @@ pub const DEFAULT_RING_CAPACITY: usize = 4096;
 #[non_exhaustive]
 pub enum TimestampMode {
     /// Reuse the timestamp from the most recent `PollStart` on this thread
-    /// (~5 ns TLS load). Falls back to `clock_monotonic_ns()` when called
-    /// outside a task poll (e.g., between polls, or on non-worker threads).
+    /// (~5 ns TLS load), falling back to `clock_monotonic_ns()` when called
+    /// outside a task poll (e.g., between polls or on non-worker threads).
+    ///
+    /// In either case the returned timestamp is strictly greater than the
+    /// previous one this thread observed (a 1 ns bump on ties), so events
+    /// produced inside a single poll — including a free + alloc pair from
+    /// in-place realloc — always have distinct, ordered timestamps. This
+    /// is the default and the recommended mode when `track_liveset` is on.
     #[default]
     ReusePollStart,
 
     /// Emit events with `timestamp_ns = 0`. Smallest on-disk size.
+    ///
+    /// **Incompatible with `track_liveset(true)`** — the consolidator
+    /// relies on timestamp ordering to disambiguate same-address
+    /// free/alloc pairs (e.g. from in-place realloc). Use
+    /// [`TimestampMode::ReusePollStart`] or [`TimestampMode::Precise`]
+    /// instead when liveset tracking is on. The combination is rejected
+    /// at config build time.
     None,
 
     /// Call `clock_monotonic_ns()` per sampled allocation (~25 ns via vDSO).
@@ -105,12 +118,29 @@ impl<S: memory_profiling_config_builder::IsComplete> MemoryProfilingConfigBuilde
     /// "sample every allocation" mode — `0` would mean "zero bytes
     /// between samples", which is ambiguous (sample everything? sample
     /// nothing?), so we require the explicit `1`.
+    ///
+    /// Panics if `timestamp_mode == TimestampMode::None` is combined
+    /// with `track_liveset(true)`. The liveset matches `Free` events to
+    /// prior `Alloc` events by address, and relies on timestamp
+    /// ordering to disambiguate same-address free/alloc pairs (e.g.
+    /// in-place realloc). With every event at `ts = 0` the merge-sort
+    /// drain in `MemoryProfileSource` cannot order those pairs and
+    /// would corrupt the liveset.
     pub fn build(self) -> MemoryProfilingConfig {
         let config = self.build_inner();
         assert!(
             config.sample_rate_bytes >= 1,
             "MemoryProfilingConfig::sample_rate_bytes must be >= 1; pass 1 for \
              'sample every allocation' mode"
+        );
+        assert!(
+            !(config.track_liveset && matches!(config.timestamp_mode, TimestampMode::None)),
+            "MemoryProfilingConfig: TimestampMode::None is incompatible with \
+             track_liveset(true). With every event at ts=0 the consolidator's \
+             merge-sort drain cannot order same-address free/alloc pairs (e.g. \
+             from in-place realloc) and would corrupt the liveset. Choose \
+             TimestampMode::ReusePollStart (default) or TimestampMode::Precise \
+             when liveset tracking is on."
         );
         config
     }
@@ -171,5 +201,52 @@ mod tests {
         let _ = MemoryProfilingConfig::builder()
             .sample_rate_bytes(0)
             .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "TimestampMode::None")]
+    fn build_rejects_none_timestamp_with_liveset() {
+        // Liveset tracking matches Free→Alloc by addr AND requires
+        // timestamp ordering to disambiguate same-address free/alloc
+        // pairs (e.g. in-place realloc). With every event at ts=0, the
+        // merge-sort drain in `MemoryProfileSource` cannot tell which
+        // came first — see PR #442 review.
+        let _ = MemoryProfilingConfig::builder()
+            .timestamp_mode(TimestampMode::None)
+            .track_liveset(true)
+            .build();
+    }
+
+    #[test]
+    fn build_accepts_none_timestamp_without_liveset() {
+        // The None+!liveset combo is fine: free events are dropped,
+        // so there's no ordering hazard.
+        let cfg = MemoryProfilingConfig::builder()
+            .timestamp_mode(TimestampMode::None)
+            .track_liveset(false)
+            .build();
+        assert!(matches!(cfg.timestamp_mode(), TimestampMode::None));
+        assert!(!cfg.track_liveset());
+    }
+
+    #[test]
+    fn build_accepts_liveset_with_reuse_poll_start() {
+        // The intended liveset combo: ReusePollStart provides per-poll
+        // timestamps, falling back to clock_monotonic_ns elsewhere.
+        let cfg = MemoryProfilingConfig::builder()
+            .timestamp_mode(TimestampMode::ReusePollStart)
+            .track_liveset(true)
+            .build();
+        assert!(cfg.track_liveset());
+    }
+
+    #[test]
+    fn build_accepts_liveset_with_precise() {
+        // Precise also provides real timestamps.
+        let cfg = MemoryProfilingConfig::builder()
+            .timestamp_mode(TimestampMode::Precise)
+            .track_liveset(true)
+            .build();
+        assert!(cfg.track_liveset());
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::arithmetic_side_effects)]
 //! Allocator hook — the hot path called from `Dial9Allocator::alloc`/etc.
 //!
 //! # Soundness contract
@@ -33,7 +34,6 @@ use crate::memory_profiling::profiler::MemoryProfilerInner;
 use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree};
 use crate::sampling::SplitMix64;
 use crate::telemetry::events::current_tid;
-use std::sync::atomic::Ordering;
 
 /// Per-thread sampling state. Held in TLS so each thread reads/writes
 /// its own counter and PRNG without synchronization (design §1).
@@ -86,7 +86,8 @@ fn ensure_initialized(state: &mut SamplingState, inner: &MemoryProfilerInner) {
         }
     };
     state.rng = SplitMix64::new(seed);
-    state.next_sample_bytes = state.rng.draw_exponential(inner.sample_rate_bytes) as i64;
+    state.next_sample_bytes =
+        i64::try_from(state.rng.draw_exponential(inner.sample_rate_bytes)).unwrap_or(i64::MAX);
     state.initialized = true;
 }
 
@@ -117,7 +118,15 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         };
         ensure_initialized(&mut state, inner);
 
-        let remaining = state.next_sample_bytes - size as i64;
+        // Saturate at i64::MAX — allocations this large are unrealistic but we
+        // handle them defensively rather than wrapping.
+        let size_i64 = i64::try_from(size).unwrap_or(i64::MAX);
+
+        // OK: intentionally allowed to go negative — the design uses signed arithmetic
+        // so that a large allocation exceeding the remaining budget produces a negative value,
+        // which triggers sampling on the next line.
+        #[allow(clippy::arithmetic_side_effects)]
+        let remaining = state.next_sample_bytes - size_i64;
         if remaining > 0 {
             state.next_sample_bytes = remaining;
             return;
@@ -128,7 +137,10 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         // by more than one draw's worth (design §1).
         let mut next = remaining;
         while next <= 0 {
-            next = next.saturating_add(state.rng.draw_exponential(inner.sample_rate_bytes) as i64);
+            next = next.saturating_add(
+                i64::try_from(state.rng.draw_exponential(inner.sample_rate_bytes))
+                    .unwrap_or(i64::MAX),
+            );
         }
         state.next_sample_bytes = next;
 
@@ -153,9 +165,7 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
             frame_count: result.frames_written.min(DEFAULT_MAX_FRAMES) as u8,
         };
 
-        if inner.rings.alloc_queue.push(sample).is_err() {
-            inner.rings.dropped_allocs.fetch_add(1, Ordering::Relaxed);
-        }
+        inner.rings.push_alloc(sample);
     });
 }
 
@@ -174,9 +184,7 @@ pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize)
         size: size as u64,
         ts_ns: timestamp_ns,
     };
-    if inner.rings.free_queue.push(sample).is_err() {
-        inner.rings.dropped_frees.fetch_add(1, Ordering::Relaxed);
-    }
+    inner.rings.push_free(sample);
 }
 
 /// Allocator hook for realloc. Decomposes into free-of-old +

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -85,9 +85,27 @@ fn ensure_initialized(state: &mut SamplingState, inner: &MemoryProfilerInner) {
         }
     };
     state.rng = SplitMix64::new(seed);
-    state.next_sample_bytes =
-        i64::try_from(state.rng.draw_exponential(inner.sample_rate_bytes)).unwrap_or(i64::MAX);
+    state.next_sample_bytes = next_gap(&mut state.rng, inner.sample_rate_bytes);
     state.initialized = true;
+}
+
+/// Draw the next bytes-until-sample gap.
+///
+/// `sample_rate_bytes <= 1` means "sample every allocation": we return 0,
+/// which makes the next decision (`counter - size`) go ≤ 0 for any
+/// positive `size`, triggering a sample without consulting the PRNG.
+/// This avoids the surprise where `sample_rate_bytes = 1` would otherwise
+/// produce ~63% per-allocation sampling for `size = 1` allocations
+/// because of the exponential's variance around the mean.
+///
+/// For `sample_rate_bytes >= 2`, we draw from an exponential distribution
+/// with the given mean.
+#[inline]
+fn next_gap(rng: &mut SplitMix64, sample_rate_bytes: u64) -> i64 {
+    if sample_rate_bytes <= 1 {
+        return 0;
+    }
+    i64::try_from(rng.draw_exponential(sample_rate_bytes)).unwrap_or(i64::MAX)
 }
 
 #[inline]
@@ -131,17 +149,24 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
             return;
         }
 
-        // Sampled — redraw next gap. Loop guards against the rare case
-        // where a single huge allocation pushes the counter below zero
-        // by more than one draw's worth (design §1).
-        let mut next = remaining;
-        while next <= 0 {
-            next = next.saturating_add(
-                i64::try_from(state.rng.draw_exponential(inner.sample_rate_bytes))
-                    .unwrap_or(i64::MAX),
-            );
-        }
-        state.next_sample_bytes = next;
+        // Sampled this allocation. Draw the gap to the next sample.
+        //
+        // We deliberately do NOT loop to "consume" the deficit when a
+        // single allocation overshoots the counter by more than one
+        // draw. Each `RawAlloc` carries its own `size` field, so
+        // downstream rate estimators weight samples by allocation
+        // size — burning one PRNG draw vs. many doesn't change
+        // per-allocation sampling probability over the long run, and
+        // looping was a footgun: at `sample_rate_bytes = 1` and a
+        // 1 GiB allocation, a `while next <= 0 { next += draw(1); }`
+        // loop ran ~1 billion times inside the allocator hook. A
+        // single fresh draw avoids the pathological case while
+        // preserving unbiasedness of size-weighted rate estimates.
+        //
+        // `next_gap` short-circuits the draw entirely when
+        // `sample_rate_bytes <= 1`, so "sample every allocation" mode
+        // doesn't touch the PRNG.
+        state.next_sample_bytes = next_gap(&mut state.rng, inner.sample_rate_bytes);
 
         let timestamp_ns = stamp(inner.timestamp_mode);
 
@@ -208,4 +233,368 @@ pub(crate) fn on_realloc(
 ) {
     on_dealloc(inner, old_ptr, old_size);
     on_alloc(inner, new_ptr, new_size);
+}
+
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod tests {
+    use super::*;
+    use crate::memory_profiling::config::TimestampMode;
+    use crate::memory_profiling::profiler::MemoryProfilerInner;
+    use crate::memory_profiling::ring::RingBuffers;
+    use crate::sampling::SplitMix64;
+    use crate::telemetry::recorder::TelemetryHandle;
+    use dial9_perf_self_profile::unwinder::Unwinder;
+    use std::sync::Arc;
+
+    /// Reset this thread's sampling state to a deterministic seed.
+    ///
+    /// Test-only. Initialises TLS so subsequent `on_alloc` calls draw
+    /// from a known PRNG sequence regardless of `current_tid()` or
+    /// previous allocations on this thread.
+    fn seed_thread_sampling_state(seed: u64, sample_rate_bytes: u64) {
+        SAMPLE_STATE.with(|cell| {
+            let mut state = cell.borrow_mut();
+            state.rng = SplitMix64::new(seed);
+            state.next_sample_bytes = next_gap(&mut state.rng, sample_rate_bytes);
+            state.initialized = true;
+        });
+    }
+
+    /// Replay the production sampling logic in pure Rust to predict how
+    /// many samples a given sequence of allocation sizes will produce
+    /// against a freshly seeded counter.
+    ///
+    /// Mirrors `on_alloc`'s decision step exactly: subtract the size,
+    /// sample if the counter goes ≤ 0, redraw a fresh gap via `next_gap`.
+    fn predict_sample_count(
+        seed: u64,
+        sample_rate_bytes: u64,
+        sizes: impl IntoIterator<Item = u64>,
+    ) -> u64 {
+        let mut rng = SplitMix64::new(seed);
+        let mut counter = next_gap(&mut rng, sample_rate_bytes);
+        let mut samples = 0u64;
+        for size in sizes {
+            let size_i64 = i64::try_from(size).unwrap_or(i64::MAX);
+            counter = counter.saturating_sub(size_i64);
+            if counter > 0 {
+                continue;
+            }
+            samples = samples.saturating_add(1);
+            counter = next_gap(&mut rng, sample_rate_bytes);
+        }
+        samples
+    }
+
+    /// Build a `MemoryProfilerInner` for direct hook testing, bypassing
+    /// the install path and the global `ACTIVE` slot.
+    fn make_inner(sample_rate_bytes: u64, ring_capacity: usize) -> MemoryProfilerInner {
+        let unwinder = Unwinder::install().expect("unwinder install");
+        let rings = Arc::new(RingBuffers::new(ring_capacity, ring_capacity));
+        MemoryProfilerInner {
+            unwinder,
+            handle: TelemetryHandle::disabled(),
+            rings,
+            sample_rate_bytes,
+            track_liveset: false,
+            timestamp_mode: TimestampMode::None,
+            rng_seed: Some(0),
+        }
+    }
+
+    /// Drive `n` allocations of `size` bytes through `on_alloc` with a
+    /// freshly seeded counter, returning the number of samples that
+    /// landed in the alloc ring. Runs on a dedicated thread so the TLS
+    /// state is fresh per scenario.
+    fn run_scenario(seed: u64, sample_rate_bytes: u64, size: usize, n: usize) -> u64 {
+        let inner = Arc::new(make_inner(
+            sample_rate_bytes,
+            // Big enough that we never drop samples in the test.
+            n.max(16),
+        ));
+        let inner_for_thread = Arc::clone(&inner);
+        std::thread::spawn(move || {
+            seed_thread_sampling_state(seed, sample_rate_bytes);
+            // A bogus pointer is fine — `on_alloc` only stores it as `addr`.
+            let bogus_ptr = 0xDEAD_BEEF_usize as *mut u8;
+            for _ in 0..n {
+                on_alloc(&inner_for_thread, bogus_ptr, size);
+            }
+        })
+        .join()
+        .expect("scenario thread panicked");
+
+        let mut count = 0u64;
+        while inner.rings.alloc_queue.pop().is_some() {
+            count = count.saturating_add(1);
+        }
+        let dropped = inner
+            .rings
+            .dropped_allocs
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(dropped, 0, "ring overflowed: {dropped} samples dropped");
+        count
+    }
+
+    /// Drive a sequence of arbitrary allocation sizes through `on_alloc`
+    /// with a freshly seeded counter, returning the sizes (in bytes) of
+    /// every sampled allocation. Used by the cross-strategy estimator
+    /// tests.
+    fn run_scenario_with_sizes(
+        seed: u64,
+        sample_rate_bytes: u64,
+        sizes: Vec<u64>,
+        ring_capacity: usize,
+    ) -> Vec<u64> {
+        let inner = Arc::new(make_inner(sample_rate_bytes, ring_capacity));
+        let inner_for_thread = Arc::clone(&inner);
+        std::thread::spawn(move || {
+            seed_thread_sampling_state(seed, sample_rate_bytes);
+            let bogus_ptr = 0xDEAD_BEEF_usize as *mut u8;
+            for size in sizes {
+                // Cap at usize::MAX defensively; in practice sizes fit.
+                on_alloc(&inner_for_thread, bogus_ptr, size as usize);
+            }
+        })
+        .join()
+        .expect("scenario thread panicked");
+
+        let dropped = inner
+            .rings
+            .dropped_allocs
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(dropped, 0, "ring overflowed: {dropped} samples dropped");
+
+        let mut sample_sizes = Vec::new();
+        while let Some(raw) = inner.rings.alloc_queue.pop() {
+            sample_sizes.push(raw.size);
+        }
+        sample_sizes
+    }
+
+    /// Unbiased Horvitz–Thompson estimator of total allocated bytes
+    /// from a Poisson-sampled trace.
+    ///
+    /// Each sampled allocation of size `s` is weighted by
+    /// `1 / P(sample) = 1 / (1 - exp(-s / mean))`, so the estimate is
+    /// `Σ_sampled s_i / (1 - exp(-s_i / mean))`. For `s << mean` this
+    /// approaches `count * mean`; for `s >> mean` it approaches the raw
+    /// sum of sample sizes (since every alloc is sampled with
+    /// probability ~1).
+    fn estimate_total_bytes(samples: &[u64], sample_rate_bytes: u64) -> f64 {
+        let mean = sample_rate_bytes as f64;
+        samples
+            .iter()
+            .map(|&s| {
+                let p = 1.0 - (-(s as f64) / mean).exp();
+                (s as f64) / p
+            })
+            .sum()
+    }
+
+    #[test]
+    fn sample_count_matches_prediction_for_small_allocs() {
+        // Small: alloc size << sample rate. Most allocs miss; samples
+        // are sparse and statistical correctness depends on the gap
+        // distribution.
+        let seed = 0xABCD_EF01;
+        let sample_rate = 4096;
+        let size = 64;
+        let n = 10_000;
+
+        let predicted =
+            predict_sample_count(seed, sample_rate, std::iter::repeat_n(size as u64, n));
+        let actual = run_scenario(seed, sample_rate, size, n);
+
+        assert_eq!(
+            actual, predicted,
+            "small allocs: actual {actual} != predicted {predicted}"
+        );
+
+        // Sanity: roughly n*size/rate samples expected (here ~156).
+        let approx = (n as u64 * size as u64) / sample_rate;
+        assert!(
+            actual.abs_diff(approx) < approx,
+            "small allocs sanity: actual {actual} far from approx {approx}"
+        );
+    }
+
+    #[test]
+    fn sample_count_matches_prediction_for_large_allocs() {
+        // Large: alloc size ~= sample rate. Each alloc has ~63% chance
+        // of being sampled; roughly n samples expected for n allocs.
+        let seed = 0x1234_5678;
+        let sample_rate = 1024;
+        let size = 1024;
+        let n = 1_000;
+
+        let predicted =
+            predict_sample_count(seed, sample_rate, std::iter::repeat_n(size as u64, n));
+        let actual = run_scenario(seed, sample_rate, size, n);
+
+        assert_eq!(
+            actual, predicted,
+            "large allocs: actual {actual} != predicted {predicted}"
+        );
+        assert!(actual > 0, "large allocs should produce some samples");
+    }
+
+    #[test]
+    fn sample_count_matches_prediction_for_very_large_allocs() {
+        // Very large: alloc size >> sample rate. Every allocation
+        // samples (counter is always blown past zero).
+        let seed = 0xCAFE_BABE;
+        let sample_rate = 1024;
+        let size = 1024 * 1024; // 1 MiB
+        let n = 100;
+
+        let predicted =
+            predict_sample_count(seed, sample_rate, std::iter::repeat_n(size as u64, n));
+        let actual = run_scenario(seed, sample_rate, size, n);
+
+        assert_eq!(
+            actual, predicted,
+            "very large allocs: actual {actual} != predicted {predicted}"
+        );
+        // Every allocation should sample.
+        assert_eq!(actual, n as u64, "every very-large alloc should sample");
+    }
+
+    #[test]
+    fn sample_rate_one_samples_every_allocation() {
+        // sample_rate = 1 means "sample every allocation". This is the
+        // case that previously caused pathological loop iterations
+        // inside `on_alloc` for large allocations; with the single
+        // fresh draw the loop is gone.
+        let seed = 0x4242_4242;
+        let sample_rate = 1;
+        let n = 500;
+
+        // Mix of sizes including a 1 GiB-equivalent (capped to fit in
+        // the ring capacity test budget — 1 MiB is enough to confirm
+        // we don't burn cycles in a redraw loop).
+        for size in [1, 64, 4096, 1024 * 1024] {
+            let actual = run_scenario(seed, sample_rate, size, n);
+            assert_eq!(
+                actual, n as u64,
+                "sample_rate=1 with size={size}: every alloc should sample, got {actual}"
+            );
+        }
+    }
+
+    #[test]
+    fn sample_rate_one_with_huge_alloc_is_fast() {
+        // Regression test for the sample-rate-1 footgun: previously,
+        // `on_alloc(size = 1 GiB)` with `sample_rate_bytes = 1` ran a
+        // loop that called `draw_exponential` ~1 billion times to
+        // climb the counter back from -1 GiB. With the single-draw
+        // redraw + the `<= 1` short-circuit, even huge allocations
+        // complete in microseconds.
+        let seed = 0xFEED_FACE;
+        let sample_rate = 1;
+        let huge = 1024 * 1024 * 1024; // 1 GiB
+        let n = 16;
+
+        let start = std::time::Instant::now();
+        let actual = run_scenario(seed, sample_rate, huge, n);
+        let elapsed = start.elapsed();
+
+        assert_eq!(actual, n as u64);
+        assert!(
+            elapsed < std::time::Duration::from_millis(50),
+            "sample_rate=1 with 1 GiB allocs took {elapsed:?}; the redraw loop \
+             must have come back"
+        );
+    }
+
+    /// Demonstrates that the Horvitz–Thompson estimator recovers the
+    /// total bytes allocated regardless of allocation size distribution,
+    /// when sampled at a fixed rate.
+    ///
+    /// Strategies (each totalling 1 MiB):
+    ///   1. Tiny: 1B × 1,048,576 — far below sample rate.
+    ///   2. Small: 64B × 16,384.
+    ///   3. Medium: 1024B × 1024 — same scale as sample rate.
+    ///   4. Large: 64 KiB × 16 — well above sample rate.
+    ///   5. Huge: 1 MiB × 1 — single allocation.
+    ///   6. Random mix.
+    ///
+    /// Each strategy is run with `sample_rate_bytes = 512`. The estimated
+    /// total bytes from `Σ s_i / (1 - exp(-s_i/mean))` should equal 1 MiB
+    /// within ~10% (statistical noise). Naive `Σ s_i` would NOT — it
+    /// undercounts strategies dominated by small allocations.
+    #[test]
+    fn unbiased_estimator_recovers_total_bytes_across_strategies() {
+        let total_bytes = 1024u64 * 1024; // 1 MiB
+        let sample_rate: u64 = 512;
+        let seed = 0x5EED_5EED;
+
+        let strategies: Vec<(&str, Vec<u64>)> = vec![
+            ("tiny 1B", vec![1; total_bytes as usize]),
+            ("small 64B", vec![64; (total_bytes / 64) as usize]),
+            ("medium 1024B", vec![1024; (total_bytes / 1024) as usize]),
+            ("large 64 KiB", vec![65536; (total_bytes / 65536) as usize]),
+            ("huge 1 MiB", vec![total_bytes]),
+            ("random mix", random_mix_summing_to(seed, total_bytes)),
+        ];
+
+        // Ring needs to be big enough for the most-sampled strategy
+        // (tiny 1B): expected ~total_bytes / sample_rate ≈ 2048
+        // samples. Round up generously.
+        let ring_capacity = 1 << 14; // 16 384
+
+        for (label, sizes) in strategies {
+            // Sanity: every strategy sums to the same total.
+            let actual_total: u64 = sizes.iter().sum();
+            assert_eq!(actual_total, total_bytes, "{label} sum mismatch");
+
+            let samples = run_scenario_with_sizes(seed, sample_rate, sizes, ring_capacity);
+            assert!(!samples.is_empty(), "{label} produced no samples");
+
+            let estimate = estimate_total_bytes(&samples, sample_rate);
+            let truth = total_bytes as f64;
+            let relative_error = (estimate - truth).abs() / truth;
+
+            // 15% tolerance covers seed variance for the high-variance
+            // "huge 1 MiB" case (n=1, so the single sample IS the
+            // estimate). Other strategies converge tighter.
+            assert!(
+                relative_error < 0.15,
+                "{label}: estimated {estimate:.0} bytes, expected {truth:.0} \
+                 (rel err {:.2}%, samples: {})",
+                relative_error * 100.0,
+                samples.len()
+            );
+
+            eprintln!(
+                "{label}: {} samples, raw sum = {} B, estimate = {:.0} B \
+                 (rel err {:.2}%)",
+                samples.len(),
+                samples.iter().sum::<u64>(),
+                estimate,
+                relative_error * 100.0
+            );
+        }
+    }
+
+    /// Build a random sequence of allocation sizes summing to exactly
+    /// `total_bytes`. Uses `SplitMix64` seeded with `seed` so the test
+    /// is deterministic. Sizes are drawn from a log-uniform distribution
+    /// over [1, 8192] to exercise a wide dynamic range.
+    fn random_mix_summing_to(seed: u64, total_bytes: u64) -> Vec<u64> {
+        let mut rng = SplitMix64::new(seed);
+        let mut sizes = Vec::new();
+        let mut remaining = total_bytes;
+        while remaining > 0 {
+            // Log-uniform draw in [1, 8192]: 13 bit ranges.
+            let bits = rng.next_u64().rem_euclid(13).saturating_add(1);
+            let max = 1u64 << bits;
+            let size = rng.next_u64().rem_euclid(max).saturating_add(1);
+            let size = size.min(remaining);
+            sizes.push(size);
+            remaining = remaining.saturating_sub(size);
+        }
+        sizes
+    }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -1,0 +1,201 @@
+//! Allocator hook — the hot path called from `Dial9Allocator::alloc`/etc.
+//!
+//! # Soundness contract
+//!
+//! Every function in this module must be **allocator-quiet** — it must not
+//! allocate, deallocate, lock a mutex, call `tracing::warn!`, or do
+//! anything else that could trigger another allocation while we are
+//! inside `GlobalAlloc::alloc`. Any allocation here would re-enter our
+//! own hook and either deadlock or recurse without bound.
+//!
+//! Allowed operations:
+//! - `OnceLock::get` (Acquire load + null check, ~1 ns).
+//! - TLS access via `RefCell::try_borrow_mut`.
+//! - Stack-only `RawAlloc` / `RawFree` construction.
+//! - `Unwinder::capture` into a stack-resident `[u64; DEFAULT_MAX_FRAMES]`.
+//! - `ArrayQueue::push` (lock-free CAS, allocation-free).
+//! - `AtomicU64::fetch_add` (for the dropped-sample counter).
+//!
+//! Forbidden operations:
+//! - Any call that may allocate (`Vec::push`, `HashMap::insert`,
+//!   `String::from`, ...).
+//! - Any lock acquisition (`Mutex::lock`, `RwLock::read`, ...).
+//! - `record_encodable_event` / `record_event` / any encoder access — that
+//!   path allocates and is the consolidator's job, not ours.
+//! - `tracing::warn!` / `tracing::error!` — formatters allocate.
+//! - `current_tid()` IS allowed (it's either a vDSO syscall or a TLS
+//!   counter, no allocation).
+//!
+//! See design §6 (Reentrancy) for the full argument.
+
+use crate::memory_profiling::config::TimestampMode;
+use crate::memory_profiling::profiler::MemoryProfilerInner;
+use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree};
+use crate::sampling::SplitMix64;
+use crate::telemetry::events::current_tid;
+use std::sync::atomic::Ordering;
+
+/// Per-thread sampling state. Held in TLS so each thread reads/writes
+/// its own counter and PRNG without synchronization (design §1).
+struct SamplingState {
+    /// Remaining bytes until the next sample fires. Signed so subtracting
+    /// a large allocation from a small remaining value goes negative
+    /// rather than wrapping.
+    next_sample_bytes: i64,
+    /// Per-thread PRNG. Lazily seeded on first sample.
+    rng: SplitMix64,
+    /// Whether this thread's state has been initialized.
+    initialized: bool,
+}
+
+impl SamplingState {
+    const fn empty() -> Self {
+        Self {
+            next_sample_bytes: 0,
+            rng: SplitMix64::new(0),
+            initialized: false,
+        }
+    }
+}
+
+thread_local! {
+    /// Per-thread sampling state, wrapped in `RefCell` so we can detect
+    /// re-entrant calls via `try_borrow_mut`. If any code path inside
+    /// `on_alloc` somehow allocates while the borrow is held, the
+    /// re-entrant call gets `Err(BorrowMutError)` and silently skips
+    /// — the design's reentrancy guard (§6).
+    static SAMPLE_STATE: std::cell::RefCell<SamplingState> =
+        const { std::cell::RefCell::new(SamplingState::empty()) };
+}
+
+#[inline]
+fn ensure_initialized(state: &mut SamplingState, inner: &MemoryProfilerInner) {
+    if state.initialized {
+        return;
+    }
+    let nonce = current_tid() as u64;
+    let seed = match inner.rng_seed {
+        Some(s) => s.wrapping_add(nonce),
+        None => {
+            // Mix wall clock with the static address of the inner state
+            // and the thread nonce. The address contributes only at
+            // process startup; thread spawn variability comes from
+            // `clock_monotonic_ns` and `current_tid`.
+            let now = crate::telemetry::events::clock_monotonic_ns();
+            now.wrapping_mul(0x517cc1b727220a95) ^ nonce ^ (inner as *const _ as u64)
+        }
+    };
+    state.rng = SplitMix64::new(seed);
+    state.next_sample_bytes = state.rng.draw_exponential(inner.sample_rate_bytes) as i64;
+    state.initialized = true;
+}
+
+#[inline]
+fn stamp(mode: TimestampMode) -> u64 {
+    match mode {
+        TimestampMode::ReusePollStart => crate::telemetry::recorder::poll_start_ts_or_now(),
+        TimestampMode::None => 0,
+        TimestampMode::Precise => crate::telemetry::events::clock_monotonic_ns(),
+    }
+}
+
+/// Allocator hook: called from `Dial9Allocator::alloc` after the inner
+/// allocation succeeds (`ptr` is non-null).
+///
+/// SAFETY: must be allocator-quiet — see module docs.
+#[inline]
+pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
+    // `try_with` returns `Err` if the TLS slot is being destroyed during
+    // thread teardown — silently skip those allocations rather than
+    // risking UB.
+    let _ = SAMPLE_STATE.try_with(|cell| {
+        // `try_borrow_mut` is the reentrancy guard: if the current
+        // thread is already inside `on_alloc` higher up the stack,
+        // the borrow is already held and this call returns `Err`.
+        let Ok(mut state) = cell.try_borrow_mut() else {
+            return;
+        };
+        ensure_initialized(&mut state, inner);
+
+        let remaining = state.next_sample_bytes - size as i64;
+        if remaining > 0 {
+            state.next_sample_bytes = remaining;
+            return;
+        }
+
+        // Sampled — redraw next gap. Loop guards against the rare case
+        // where a single huge allocation pushes the counter below zero
+        // by more than one draw's worth (design §1).
+        let mut next = remaining;
+        while next <= 0 {
+            next = next.saturating_add(state.rng.draw_exponential(inner.sample_rate_bytes) as i64);
+        }
+        state.next_sample_bytes = next;
+
+        let timestamp_ns = stamp(inner.timestamp_mode);
+
+        // Stack capture into a stack-resident buffer. The `RefMut`
+        // is intentionally held across `capture` and the queue push:
+        // if those somehow allocated (they shouldn't — see module
+        // docs), the reentrancy guard would correctly trip.
+        // SAFETY: `Unwinder::install` was called in `MemoryProfiler::install`,
+        // which is the only code path that publishes `inner`. Not called
+        // from inside a SIGSEGV handler.
+        let mut frames = [0u64; DEFAULT_MAX_FRAMES];
+        let result = unsafe { inner.unwinder.capture(&mut frames) };
+
+        let sample = RawAlloc {
+            tid: current_tid(),
+            size: size as u64,
+            addr: ptr as u64,
+            ts_ns: timestamp_ns,
+            frames,
+            frame_count: result.frames_written.min(DEFAULT_MAX_FRAMES) as u8,
+        };
+
+        if inner.rings.alloc_queue.push(sample).is_err() {
+            inner.rings.dropped_allocs.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+}
+
+/// Allocator hook for dealloc. No-op when liveset tracking is off.
+///
+/// SAFETY: must be allocator-quiet — see module docs.
+#[inline]
+pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
+    if !inner.track_liveset {
+        return;
+    }
+    let timestamp_ns = stamp(inner.timestamp_mode);
+    let sample = RawFree {
+        tid: current_tid(),
+        addr: ptr as u64,
+        size: size as u64,
+        ts_ns: timestamp_ns,
+    };
+    if inner.rings.free_queue.push(sample).is_err() {
+        inner.rings.dropped_frees.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Allocator hook for realloc. Decomposes into free-of-old +
+/// alloc-of-new per design §3 ("realloc handling", matches jemalloc
+/// convention).
+///
+/// Only call AFTER the inner realloc returns a non-null `new_ptr` —
+/// otherwise the old pointer is still live and must not be recorded
+/// as freed.
+///
+/// SAFETY: must be allocator-quiet — see module docs.
+#[inline]
+pub(crate) fn on_realloc(
+    inner: &MemoryProfilerInner,
+    old_ptr: *mut u8,
+    old_size: usize,
+    new_ptr: *mut u8,
+    new_size: usize,
+) {
+    on_dealloc(inner, old_ptr, old_size);
+    on_alloc(inner, new_ptr, new_size);
+}

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -91,18 +91,21 @@ fn ensure_initialized(state: &mut SamplingState, inner: &MemoryProfilerInner) {
 
 /// Draw the next bytes-until-sample gap.
 ///
-/// `sample_rate_bytes <= 1` means "sample every allocation": we return 0,
-/// which makes the next decision (`counter - size`) go ≤ 0 for any
-/// positive `size`, triggering a sample without consulting the PRNG.
-/// This avoids the surprise where `sample_rate_bytes = 1` would otherwise
-/// produce ~63% per-allocation sampling for `size = 1` allocations
-/// because of the exponential's variance around the mean.
+/// `sample_rate_bytes == 1` is the magic "sample every allocation" mode:
+/// we return 0, which makes the next decision (`counter - size`) go ≤ 0
+/// for any positive `size`, triggering a sample without consulting the
+/// PRNG. This avoids the surprise where mean=1 exponential draws would
+/// otherwise produce ~63% per-allocation sampling for `size = 1`
+/// allocations due to the exponential's variance around its mean.
 ///
-/// For `sample_rate_bytes >= 2`, we draw from an exponential distribution
-/// with the given mean.
+/// `sample_rate_bytes == 0` is rejected at config build time, so this
+/// function only ever sees values `>= 1`.
+///
+/// For `sample_rate_bytes >= 2`, we draw from an exponential
+/// distribution with the given mean.
 #[inline]
 fn next_gap(rng: &mut SplitMix64, sample_rate_bytes: u64) -> i64 {
-    if sample_rate_bytes <= 1 {
+    if sample_rate_bytes == 1 {
         return 0;
     }
     i64::try_from(rng.draw_exponential(sample_rate_bytes)).unwrap_or(i64::MAX)
@@ -164,8 +167,9 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         // preserving unbiasedness of size-weighted rate estimates.
         //
         // `next_gap` short-circuits the draw entirely when
-        // `sample_rate_bytes <= 1`, so "sample every allocation" mode
-        // doesn't touch the PRNG.
+        // `sample_rate_bytes == 1` (the magic "sample every
+        // allocation" value), so that mode never touches the PRNG.
+        // `0` is rejected at config build time.
         state.next_sample_bytes = next_gap(&mut state.rng, inner.sample_rate_bytes);
 
         let timestamp_ns = stamp(inner.timestamp_mode);
@@ -489,8 +493,8 @@ mod tests {
         // `on_alloc(size = 1 GiB)` with `sample_rate_bytes = 1` ran a
         // loop that called `draw_exponential` ~1 billion times to
         // climb the counter back from -1 GiB. With the single-draw
-        // redraw + the `<= 1` short-circuit, even huge allocations
-        // complete in microseconds.
+        // redraw + the `== 1` magic-value short-circuit, even huge
+        // allocations complete in microseconds.
         let seed = 0xFEED_FACE;
         let sample_rate = 1;
         let huge = 1024 * 1024 * 1024; // 1 GiB

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -107,7 +107,7 @@ fn stamp(mode: TimestampMode) -> u64 {
 pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
     // `try_with` returns `Err` if the TLS slot is being destroyed during
     // thread teardown — silently skip those allocations rather than
-    // risking UB.
+    // risking UB. Logging is forbidden here (allocator-quiet contract).
     let _ = SAMPLE_STATE.try_with(|cell| {
         // `try_borrow_mut` is the reentrancy guard: if the current
         // thread is already inside `on_alloc` higher up the stack,
@@ -149,9 +149,13 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         // is intentionally held across `capture` and the queue push:
         // if those somehow allocated (they shouldn't — see module
         // docs), the reentrancy guard would correctly trip.
-        // SAFETY: `Unwinder::install` was called in `MemoryProfiler::install`,
-        // which is the only code path that publishes `inner`. Not called
-        // from inside a SIGSEGV handler.
+        // SAFETY: `Unwinder::install` was called and succeeded in
+        // `MemoryProfiler::install` before `inner` was published via
+        // `OnceLock::set`. The unwinder's SIGSEGV handler is installed.
+        // This is safe because:
+        // 1. We're not inside a signal handler (allocator hooks are not
+        //    signal-safe, so this is guaranteed by the allocator contract).
+        // 2. The stack is valid (normal allocation path, not corrupted).
         let mut frames = [0u64; DEFAULT_MAX_FRAMES];
         let result = unsafe { inner.unwinder.capture(&mut frames) };
 

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -176,7 +176,7 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
 ///
 /// SAFETY: must be allocator-quiet — see module docs.
 #[inline]
-pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
+pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize) {
     if !inner.track_liveset {
         return;
     }
@@ -184,7 +184,6 @@ pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize)
     let sample = RawFree {
         tid: current_tid(),
         addr: ptr as u64,
-        size: size as u64,
         ts_ns: timestamp_ns,
     };
     inner.rings.push_free(sample);

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -114,7 +114,7 @@ fn next_gap(rng: &mut SplitMix64, sample_rate_bytes: u64) -> i64 {
 #[inline]
 fn stamp(mode: TimestampMode) -> u64 {
     match mode {
-        TimestampMode::ReusePollStart => crate::telemetry::recorder::poll_start_ts_or_now(),
+        TimestampMode::ReusePollStart => crate::telemetry::recorder::poll_start_ts_monotonic(),
         TimestampMode::None => 0,
         TimestampMode::Precise => crate::telemetry::events::clock_monotonic_ns(),
     }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -142,11 +142,7 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         // handle them defensively rather than wrapping.
         let size_i64 = i64::try_from(size).unwrap_or(i64::MAX);
 
-        // OK: intentionally allowed to go negative — the design uses signed arithmetic
-        // so that a large allocation exceeding the remaining budget produces a negative value,
-        // which triggers sampling on the next line.
-        #[allow(clippy::arithmetic_side_effects)]
-        let remaining = state.next_sample_bytes - size_i64;
+        let remaining = state.next_sample_bytes.saturating_sub(size_i64);
         if remaining > 0 {
             state.next_sample_bytes = remaining;
             return;

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -77,10 +77,9 @@ fn ensure_initialized(state: &mut SamplingState, inner: &MemoryProfilerInner) {
     let seed = match inner.rng_seed {
         Some(s) => s.wrapping_add(nonce),
         None => {
-            // Mix wall clock with the static address of the inner state
-            // and the thread nonce. The address contributes only at
-            // process startup; thread spawn variability comes from
-            // `clock_monotonic_ns` and `current_tid`.
+            // Mix wall clock with the thread ID and the static address.
+            // `nonce` (= current_tid()) guarantees uniqueness across threads
+            // even if they initialize at the same nanosecond.
             let now = crate::telemetry::events::clock_monotonic_ns();
             now.wrapping_mul(0x517cc1b727220a95) ^ nonce ^ (inner as *const _ as u64)
         }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -3,7 +3,7 @@
 //!
 //! # Soundness contract
 //!
-//! Every function in this module must be **allocator-quiet** — it must not
+//! Every function in this module must be **allocation-free** — it must not
 //! allocate, deallocate, lock a mutex, call `tracing::warn!`, or do
 //! anything else that could trigger another allocation while we are
 //! inside `GlobalAlloc::alloc`. Any allocation here would re-enter our
@@ -102,12 +102,12 @@ fn stamp(mode: TimestampMode) -> u64 {
 /// Allocator hook: called from `Dial9Allocator::alloc` after the inner
 /// allocation succeeds (`ptr` is non-null).
 ///
-/// SAFETY: must be allocator-quiet — see module docs.
+/// SAFETY: must be allocation-free — see module docs.
 #[inline]
 pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
     // `try_with` returns `Err` if the TLS slot is being destroyed during
     // thread teardown — silently skip those allocations rather than
-    // risking UB. Logging is forbidden here (allocator-quiet contract).
+    // risking UB. Logging is forbidden here (allocation-free contract).
     let _ = SAMPLE_STATE.try_with(|cell| {
         // `try_borrow_mut` is the reentrancy guard: if the current
         // thread is already inside `on_alloc` higher up the stack,
@@ -174,7 +174,7 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
 
 /// Allocator hook for dealloc. No-op when liveset tracking is off.
 ///
-/// SAFETY: must be allocator-quiet — see module docs.
+/// SAFETY: must be allocation-free — see module docs.
 #[inline]
 pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize) {
     if !inner.track_liveset {
@@ -197,7 +197,7 @@ pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize
 /// otherwise the old pointer is still live and must not be recorded
 /// as freed.
 ///
-/// SAFETY: must be allocator-quiet — see module docs.
+/// SAFETY: must be allocation-free — see module docs.
 #[inline]
 pub(crate) fn on_realloc(
     inner: &MemoryProfilerInner,

--- a/dial9-tokio-telemetry/src/memory_profiling/mod.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/mod.rs
@@ -28,6 +28,7 @@
 
 mod allocator;
 mod config;
+mod hook;
 mod profiler;
 mod ring;
 mod source;

--- a/dial9-tokio-telemetry/src/memory_profiling/mod.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/mod.rs
@@ -1,9 +1,8 @@
 //! Memory profiling — sampled allocation tracking via ring buffers.
 //!
-//! See `docs/design/memory-profiling.md` for the full design. The
-//! architecture (design §5, §6, §9):
+//! The architecture:
 //!
-//! 1. The allocator hook (later commit) does the bare minimum on the
+//! 1. The allocator hook ([`Dial9Allocator`]) does the bare minimum on the
 //!    allocating thread: sampling decision, stack capture, push a
 //!    fixed-size POD record into one of two process-global lock-free
 //!    queues.
@@ -40,17 +39,3 @@ pub use config::{
 #[cfg(feature = "analysis")]
 pub use profiler::push_test_alloc;
 pub use profiler::{InstallError, MemoryProfiler, MemoryProfilerGuard, is_installed};
-
-#[expect(
-    unused_imports,
-    reason = "wired up by allocator hook in a later commit"
-)]
-pub(crate) use ring::{
-    DEFAULT_ALLOC_QUEUE_CAPACITY, DEFAULT_FREE_QUEUE_CAPACITY, DEFAULT_MAX_FRAMES, RawAlloc,
-    RawFree, RingBuffers,
-};
-#[expect(
-    unused_imports,
-    reason = "used by profiler.rs via direct import; re-export kept for consistency"
-)]
-pub(crate) use source::MemoryProfileSource;

--- a/dial9-tokio-telemetry/src/memory_profiling/mod.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/mod.rs
@@ -37,9 +37,9 @@ pub use allocator::Dial9Allocator;
 pub use config::{
     DEFAULT_RING_CAPACITY, DEFAULT_SAMPLE_RATE_BYTES, MemoryProfilingConfig, TimestampMode,
 };
-pub use profiler::{
-    InstallError, MemoryProfiler, MemoryProfilerGuard, is_installed, push_test_alloc,
-};
+#[cfg(feature = "analysis")]
+pub use profiler::push_test_alloc;
+pub use profiler::{InstallError, MemoryProfiler, MemoryProfilerGuard, is_installed};
 
 #[expect(
     unused_imports,

--- a/dial9-tokio-telemetry/src/memory_profiling/mod.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/mod.rs
@@ -27,10 +27,18 @@
 //! Gated behind the `memory-profiling` cargo feature.
 
 mod allocator;
+mod config;
+mod profiler;
 mod ring;
 mod source;
 
 pub use allocator::Dial9Allocator;
+pub use config::{
+    DEFAULT_RING_CAPACITY, DEFAULT_SAMPLE_RATE_BYTES, MemoryProfilingConfig, TimestampMode,
+};
+pub use profiler::{
+    InstallError, MemoryProfiler, MemoryProfilerGuard, is_installed, push_test_alloc,
+};
 
 #[expect(
     unused_imports,
@@ -42,6 +50,6 @@ pub(crate) use ring::{
 };
 #[expect(
     unused_imports,
-    reason = "wired up by allocator hook in a later commit"
+    reason = "used by profiler.rs via direct import; re-export kept for consistency"
 )]
 pub(crate) use source::MemoryProfileSource;

--- a/dial9-tokio-telemetry/src/memory_profiling/mod.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/mod.rs
@@ -26,8 +26,11 @@
 //!
 //! Gated behind the `memory-profiling` cargo feature.
 
+mod allocator;
 mod ring;
 mod source;
+
+pub use allocator::Dial9Allocator;
 
 #[expect(
     unused_imports,

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -1,0 +1,160 @@
+//! `MemoryProfiler::install()` — the install-once entry point per design §8.
+
+use crate::memory_profiling::config::{MemoryProfilingConfig, TimestampMode};
+use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RingBuffers};
+use crate::memory_profiling::source::MemoryProfileSource;
+use crate::telemetry::recorder::TelemetryHandle;
+use dial9_perf_self_profile::unwinder::Unwinder;
+use std::sync::{Arc, OnceLock};
+
+/// Process-global state for the active memory profiler.
+///
+/// Published via `OnceLock` exactly once per process. Never reclaimed
+/// (see design §8: any thread's allocator hook may be reading this).
+#[allow(dead_code)]
+pub(crate) struct MemoryProfilerInner {
+    pub(crate) unwinder: Unwinder,
+    pub(crate) handle: TelemetryHandle,
+    pub(crate) rings: Arc<RingBuffers<DEFAULT_MAX_FRAMES>>,
+    pub(crate) sample_rate_bytes: u64,
+    pub(crate) track_liveset: bool,
+    pub(crate) timestamp_mode: TimestampMode,
+    pub(crate) rng_seed: Option<u64>,
+}
+
+/// Process-global handle to the installed memory profiler.
+pub(crate) static ACTIVE: OnceLock<MemoryProfilerInner> = OnceLock::new();
+
+/// Returns `true` if the memory profiler has been installed in this process.
+pub fn is_installed() -> bool {
+    ACTIVE.get().is_some()
+}
+
+/// Push a synthetic `RawAlloc` into the installed profiler's queue.
+///
+/// Returns `false` if the profiler is not installed or the queue is full.
+/// Intended for integration tests that verify the source→trace pipeline.
+#[doc(hidden)]
+pub fn push_test_alloc(addr: u64, size: u64, ts_ns: u64) -> bool {
+    let Some(inner) = ACTIVE.get() else {
+        return false;
+    };
+    let mut frames = [0u64; DEFAULT_MAX_FRAMES];
+    frames[0] = 0xDEAD;
+    frames[1] = 0xBEEF;
+    let raw = RawAlloc {
+        tid: crate::telemetry::events::current_tid(),
+        size,
+        addr,
+        ts_ns,
+        frames,
+        frame_count: 2,
+    };
+    inner.rings.alloc_queue.push(raw).is_ok()
+}
+
+/// Errors that can occur during [`MemoryProfiler::install`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum InstallError {
+    /// `install()` was already called once for this process.
+    AlreadyInstalled,
+    /// The SIGSEGV handler used by the FP unwinder failed to install.
+    Unwinder(std::io::Error),
+}
+
+impl std::fmt::Display for InstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyInstalled => {
+                f.write_str("memory profiler already installed in this process")
+            }
+            Self::Unwinder(e) => write!(f, "failed to install SIGSEGV handler for unwinder: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for InstallError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::AlreadyInstalled => None,
+            Self::Unwinder(e) => Some(e),
+        }
+    }
+}
+
+/// Memory profiler entry point.
+///
+/// Use `MemoryProfiler::from_config(cfg).install(handle)` or
+/// `MemoryProfiler::with_defaults().install(handle)`.
+///
+/// Install is permanent for the life of the process (design §8).
+#[derive(Debug)]
+pub struct MemoryProfiler {
+    config: MemoryProfilingConfig,
+}
+
+impl MemoryProfiler {
+    /// Build a profiler from a [`MemoryProfilingConfig`].
+    pub fn from_config(config: MemoryProfilingConfig) -> Self {
+        Self { config }
+    }
+
+    /// Build a profiler with default configuration.
+    pub fn with_defaults() -> Self {
+        Self::from_config(MemoryProfilingConfig::default())
+    }
+
+    /// Install the profiler with the given handle.
+    ///
+    /// On a disabled handle, install is a no-op (returns `Ok` but does not
+    /// publish state). `ACTIVE.get()` remains `None` so the allocator hook
+    /// short-circuits.
+    pub fn install(self, handle: TelemetryHandle) -> Result<MemoryProfilerGuard, InstallError> {
+        if !handle.is_enabled() {
+            return Ok(MemoryProfilerGuard { _private: () });
+        }
+
+        let unwinder = Unwinder::install().map_err(InstallError::Unwinder)?;
+
+        let rings = Arc::new(RingBuffers::new(
+            self.config.ring_capacity(),
+            self.config.ring_capacity() * 8,
+        ));
+
+        let inner = MemoryProfilerInner {
+            unwinder,
+            handle: handle.clone(),
+            rings: Arc::clone(&rings),
+            sample_rate_bytes: self.config.sample_rate_bytes(),
+            track_liveset: self.config.track_liveset(),
+            timestamp_mode: self.config.timestamp_mode(),
+            rng_seed: self.config.rng_seed(),
+        };
+
+        ACTIVE
+            .set(inner)
+            .map_err(|_| InstallError::AlreadyInstalled)?;
+
+        let shared = handle.shared().expect("checked is_enabled above");
+        let source = MemoryProfileSource::new(rings, self.config.track_liveset());
+        shared.push_source(Box::new(source));
+
+        Ok(MemoryProfilerGuard { _private: () })
+    }
+}
+
+/// RAII guard returned by [`MemoryProfiler::install`].
+///
+/// Dropping does **NOT** uninstall the profiler — install is permanent.
+#[must_use = "dropping the guard does not uninstall the profiler; bind it to keep the install lifetime explicit"]
+pub struct MemoryProfilerGuard {
+    pub(crate) _private: (),
+}
+
+impl std::fmt::Debug for MemoryProfilerGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryProfilerGuard")
+            .finish_non_exhaustive()
+    }
+}

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -2,6 +2,7 @@
 
 use crate::memory_profiling::config::{MemoryProfilingConfig, TimestampMode};
 use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RingBuffers};
+
 use crate::memory_profiling::source::MemoryProfileSource;
 use crate::telemetry::recorder::TelemetryHandle;
 use dial9_perf_self_profile::unwinder::Unwinder;
@@ -15,7 +16,7 @@ use std::sync::{Arc, OnceLock};
 pub(crate) struct MemoryProfilerInner {
     pub(crate) unwinder: Unwinder,
     pub(crate) handle: TelemetryHandle,
-    pub(crate) rings: Arc<RingBuffers<DEFAULT_MAX_FRAMES>>,
+    pub(crate) rings: Arc<RingBuffers>,
     pub(crate) sample_rate_bytes: u64,
     pub(crate) track_liveset: bool,
     pub(crate) timestamp_mode: TimestampMode,

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -125,6 +125,8 @@ impl MemoryProfiler {
 
         let rings = Arc::new(RingBuffers::new(
             self.config.ring_capacity(),
+            // Free queue is sized 8× the alloc queue — see
+            // `DEFAULT_FREE_QUEUE_CAPACITY` in `ring.rs` for the rationale.
             self.config.ring_capacity() * 8,
         ));
 

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -38,6 +38,7 @@ pub fn is_installed() -> bool {
 ///
 /// Returns `false` if the profiler is not installed or the queue is full.
 /// Intended for integration tests that verify the source→trace pipeline.
+#[cfg(feature = "analysis")]
 #[doc(hidden)]
 pub fn push_test_alloc(addr: u64, size: u64, ts_ns: u64) -> bool {
     let Some(inner) = ACTIVE.get() else {

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -27,6 +27,9 @@ pub(crate) struct MemoryProfilerInner {
 pub(crate) static ACTIVE: OnceLock<MemoryProfilerInner> = OnceLock::new();
 
 /// Returns `true` if the memory profiler has been installed in this process.
+///
+/// Note: This check is racy. If you need to conditionally install the profiler,
+/// call `install()` directly and handle `InstallError::AlreadyInstalled`.
 pub fn is_installed() -> bool {
     ACTIVE.get().is_some()
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -1,4 +1,4 @@
-//! `MemoryProfiler::install()` — the install-once entry point per design §8.
+//! `MemoryProfiler::install()` — the install-once entry point.
 
 use crate::memory_profiling::config::{MemoryProfilingConfig, TimestampMode};
 use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RingBuffers};
@@ -11,10 +11,11 @@ use std::sync::{Arc, OnceLock};
 /// Process-global state for the active memory profiler.
 ///
 /// Published via `OnceLock` exactly once per process. Never reclaimed
-/// (see design §8: any thread's allocator hook may be reading this).
+/// because any thread's allocator hook may be reading this.
 #[allow(dead_code)]
 pub(crate) struct MemoryProfilerInner {
     pub(crate) unwinder: Unwinder,
+    /// Prevents `SharedState` from being dropped while the profiler is active.
     pub(crate) handle: TelemetryHandle,
     pub(crate) rings: Arc<RingBuffers>,
     pub(crate) sample_rate_bytes: u64,
@@ -93,7 +94,7 @@ impl std::error::Error for InstallError {
 /// Use `MemoryProfiler::from_config(cfg).install(handle)` or
 /// `MemoryProfiler::with_defaults().install(handle)`.
 ///
-/// Install is permanent for the life of the process (design §8).
+/// Install is permanent for the life of the process.
 #[derive(Debug)]
 pub struct MemoryProfiler {
     config: MemoryProfilingConfig,

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -143,7 +143,11 @@ impl MemoryProfiler {
             .map_err(|_| InstallError::AlreadyInstalled)?;
 
         let shared = handle.shared().expect("checked is_enabled above");
-        let source = MemoryProfileSource::new(rings, self.config.track_liveset());
+        let source = MemoryProfileSource::new(
+            rings,
+            self.config.track_liveset(),
+            self.config.sample_rate_bytes(),
+        );
         shared.push_source(Box::new(source));
 
         Ok(MemoryProfilerGuard { _private: () })

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -1,7 +1,9 @@
+#![deny(clippy::arithmetic_side_effects)]
 //! Two lock-free MPMC queues — one for sampled allocations, one for frees.
 
 use crate::primitives::sync::atomic::AtomicU64;
 use crossbeam_queue::ArrayQueue;
+use std::sync::atomic::Ordering;
 
 /// Default maximum frames captured per allocation. 128 × 8 B = 1 KiB stack budget.
 pub(crate) const DEFAULT_MAX_FRAMES: usize = 128;
@@ -15,22 +17,21 @@ pub(crate) const DEFAULT_FREE_QUEUE_CAPACITY: usize = DEFAULT_ALLOC_QUEUE_CAPACI
 
 /// One sampled allocation captured on the producer thread.
 ///
-/// `MAX_FRAMES` controls the size of the inline stack buffer. The default
-/// (128) gives a 1 KiB stack budget for the frames field.
+/// The inline stack buffer holds `DEFAULT_MAX_FRAMES` entries (128),
+/// giving a 1 KiB stack budget for the frames field.
 #[derive(Debug, Clone)]
-pub(crate) struct RawAlloc<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
+pub(crate) struct RawAlloc {
     pub(crate) tid: u32,
     pub(crate) size: u64,
     pub(crate) addr: u64,
     pub(crate) ts_ns: u64,
-    pub(crate) frames: [u64; MAX_FRAMES],
+    pub(crate) frames: [u64; DEFAULT_MAX_FRAMES],
     pub(crate) frame_count: u8,
 }
 
-impl<const MAX_FRAMES: usize> RawAlloc<MAX_FRAMES> {
+impl RawAlloc {
     #[expect(dead_code, reason = "used by allocator hook in a later commit")]
     pub(crate) fn frames(&self) -> &[u64] {
-        const { assert!(MAX_FRAMES <= u8::MAX as usize, "MAX_FRAMES must fit in u8") };
         &self.frames[..self.frame_count as usize]
     }
 }
@@ -51,22 +52,42 @@ pub(crate) struct RawFree {
 /// Process-global pair of lock-free queues for the memory profiler.
 ///
 /// Producers (allocator hook) and the consumer (`MemoryProfileSource`) both
-/// hold `Arc<RingBuffers<N>>` and access the queues via `&self` — no inner
+/// hold `Arc<RingBuffers>` and access the queues via `&self` — no inner
 /// `Arc`s, so the `&Arc<...>` smell is contained to the outer borrow.
-pub(crate) struct RingBuffers<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
-    pub(crate) alloc_queue: ArrayQueue<RawAlloc<MAX_FRAMES>>,
+pub(crate) struct RingBuffers {
+    pub(crate) alloc_queue: ArrayQueue<RawAlloc>,
     pub(crate) free_queue: ArrayQueue<RawFree>,
     pub(crate) dropped_allocs: AtomicU64,
     pub(crate) dropped_frees: AtomicU64,
 }
 
-impl<const MAX_FRAMES: usize> RingBuffers<MAX_FRAMES> {
+impl RingBuffers {
     pub(crate) fn new(alloc_capacity: usize, free_capacity: usize) -> Self {
         Self {
             alloc_queue: ArrayQueue::new(alloc_capacity),
             free_queue: ArrayQueue::new(free_capacity),
             dropped_allocs: AtomicU64::new(0),
             dropped_frees: AtomicU64::new(0),
+        }
+    }
+
+    /// Push a sampled allocation, incrementing the drop counter on overflow.
+    ///
+    /// Allocator-quiet: only `ArrayQueue::push` (lock-free CAS) +
+    /// `AtomicU64::fetch_add`.
+    pub(crate) fn push_alloc(&self, sample: RawAlloc) {
+        if self.alloc_queue.push(sample).is_err() {
+            self.dropped_allocs.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Push a free record, incrementing the drop counter on overflow.
+    ///
+    /// Allocator-quiet: only `ArrayQueue::push` (lock-free CAS) +
+    /// `AtomicU64::fetch_add`.
+    pub(crate) fn push_free(&self, sample: RawFree) {
+        if self.free_queue.push(sample).is_err() {
+            self.dropped_frees.fetch_add(1, Ordering::Relaxed);
         }
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -12,15 +12,19 @@ const _: () = assert!(
     "DEFAULT_MAX_FRAMES must fit in u8 (used as RawAlloc::frame_count)"
 );
 
-/// Default number of `RawAlloc` slots. ~4 MiB total at 128 frames.
-pub(crate) const DEFAULT_ALLOC_QUEUE_CAPACITY: usize = 4096;
-
-/// Default number of `RawFree` slots. 8× the alloc queue.
+/// Default number of `RawFree` slots. 8× the alloc queue
+/// ([`crate::memory_profiling::DEFAULT_RING_CAPACITY`]) — frees are smaller
+/// than allocs (no stack frames), so the budget is asymmetric in their favour
+/// to absorb burst free traffic without dropping. The actual capacity is
+/// derived from `MemoryProfilingConfig::ring_capacity()` in
+/// [`crate::memory_profiling::profiler::MemoryProfiler::install`]; this const
+/// exists to document the 8× relationship in one place.
 #[expect(
     dead_code,
-    reason = "documents the sizing rationale; config uses ring_capacity * 8"
+    reason = "documents the 8x sizing rationale referenced from MemoryProfiler::install"
 )]
-pub(crate) const DEFAULT_FREE_QUEUE_CAPACITY: usize = DEFAULT_ALLOC_QUEUE_CAPACITY * 8;
+pub(crate) const DEFAULT_FREE_QUEUE_CAPACITY: usize =
+    crate::memory_profiling::config::DEFAULT_RING_CAPACITY * 8;
 
 /// One sampled allocation captured on the producer thread.
 ///

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -7,6 +7,10 @@ use std::sync::atomic::Ordering;
 
 /// Default maximum frames captured per allocation. 128 × 8 B = 1 KiB stack budget.
 pub(crate) const DEFAULT_MAX_FRAMES: usize = 128;
+const _: () = assert!(
+    DEFAULT_MAX_FRAMES <= u8::MAX as usize,
+    "DEFAULT_MAX_FRAMES must fit in u8 (used as RawAlloc::frame_count)"
+);
 
 /// Default number of `RawAlloc` slots. ~4 MiB total at 128 frames.
 pub(crate) const DEFAULT_ALLOC_QUEUE_CAPACITY: usize = 4096;

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -8,11 +8,14 @@ use std::sync::atomic::Ordering;
 /// Default maximum frames captured per allocation. 128 × 8 B = 1 KiB stack budget.
 pub(crate) const DEFAULT_MAX_FRAMES: usize = 128;
 
-/// Default number of `RawAlloc` slots. ~4 MiB total at 128 frames (design §5).
+/// Default number of `RawAlloc` slots. ~4 MiB total at 128 frames.
 pub(crate) const DEFAULT_ALLOC_QUEUE_CAPACITY: usize = 4096;
 
-/// Default number of `RawFree` slots. 8× the alloc queue (design §9).
-#[expect(dead_code, reason = "wired up by allocator hook in a later commit")]
+/// Default number of `RawFree` slots. 8× the alloc queue.
+#[expect(
+    dead_code,
+    reason = "documents the sizing rationale; config uses ring_capacity * 8"
+)]
 pub(crate) const DEFAULT_FREE_QUEUE_CAPACITY: usize = DEFAULT_ALLOC_QUEUE_CAPACITY * 8;
 
 /// One sampled allocation captured on the producer thread.
@@ -30,7 +33,7 @@ pub(crate) struct RawAlloc {
 }
 
 impl RawAlloc {
-    #[expect(dead_code, reason = "used by allocator hook in a later commit")]
+    #[expect(dead_code, reason = "available for future consumers of RawAlloc")]
     pub(crate) fn frames(&self) -> &[u64] {
         let count = (self.frame_count as usize).min(DEFAULT_MAX_FRAMES);
         &self.frames[..count]
@@ -69,7 +72,7 @@ impl RingBuffers {
 
     /// Push a sampled allocation, incrementing the drop counter on overflow.
     ///
-    /// Allocator-quiet: only `ArrayQueue::push` (lock-free CAS) +
+    /// Allocation-free: only `ArrayQueue::push` (lock-free CAS) +
     /// `AtomicU64::fetch_add`.
     pub(crate) fn push_alloc(&self, sample: RawAlloc) {
         if self.alloc_queue.push(sample).is_err() {
@@ -79,7 +82,7 @@ impl RingBuffers {
 
     /// Push a free record, incrementing the drop counter on overflow.
     ///
-    /// Allocator-quiet: only `ArrayQueue::push` (lock-free CAS) +
+    /// Allocation-free: only `ArrayQueue::push` (lock-free CAS) +
     /// `AtomicU64::fetch_add`.
     pub(crate) fn push_free(&self, sample: RawFree) {
         if self.free_queue.push(sample).is_err() {

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -32,7 +32,8 @@ pub(crate) struct RawAlloc {
 impl RawAlloc {
     #[expect(dead_code, reason = "used by allocator hook in a later commit")]
     pub(crate) fn frames(&self) -> &[u64] {
-        &self.frames[..self.frame_count as usize]
+        let count = (self.frame_count as usize).min(DEFAULT_MAX_FRAMES);
+        &self.frames[..count]
     }
 }
 

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -42,11 +42,6 @@ impl RawAlloc {
 pub(crate) struct RawFree {
     pub(crate) tid: u32,
     pub(crate) addr: u64,
-    #[expect(
-        dead_code,
-        reason = "consolidator uses size from the liveset entry, not from RawFree; the field is here so the producer doesn't have to do a separate lookup"
-    )]
-    pub(crate) size: u64,
     pub(crate) ts_ns: u64,
 }
 

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -56,16 +56,10 @@ pub(crate) struct RawFree {
 pub(crate) struct RingBuffers<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
     pub(crate) alloc_queue: ArrayQueue<RawAlloc<MAX_FRAMES>>,
     pub(crate) free_queue: ArrayQueue<RawFree>,
-    #[expect(dead_code, reason = "incremented by allocator hook in a later commit")]
     pub(crate) dropped_allocs: AtomicU64,
-    #[expect(dead_code, reason = "incremented by allocator hook in a later commit")]
     pub(crate) dropped_frees: AtomicU64,
 }
 
-// `RingBuffers::new` is only called from tests in this commit. The allocator
-// hook in a later commit will call it from a non-test path; at that point
-// this `allow(dead_code)` becomes inert.
-#[cfg_attr(not(test), allow(dead_code))]
 impl<const MAX_FRAMES: usize> RingBuffers<MAX_FRAMES> {
     pub(crate) fn new(alloc_capacity: usize, free_capacity: usize) -> Self {
         Self {

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -151,10 +151,6 @@ impl Source for MemoryProfileSource {
     fn name(&self) -> &'static str {
         "memory"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 #[cfg(test)]
@@ -459,19 +455,29 @@ mod tests {
         }
 
         // The second allocation must remain live in the liveset.
-        // Access the source directly to check internal state.
-        let sources = shared.sources.lock().unwrap();
-        let source = sources[0]
-            .as_any()
-            .downcast_ref::<MemoryProfileSource>()
-            .expect("source should be MemoryProfileSource");
-        let liveset = source.liveset.as_ref().expect("liveset is on");
-        assert_eq!(liveset.len(), 1, "second alloc should still be live");
-        let entry = liveset
-            .get(&0x5000)
-            .expect("addr 0x5000 should be in liveset");
-        assert_eq!(entry.size, 512);
-        assert_eq!(entry.timestamp_ns, 300);
+        // Prove it by freeing the address in a second flush cycle and checking
+        // the emitted FreeEvent carries the second alloc's size and timestamp.
+        rings.free_queue.push(make_raw_free(0x5000, 400)).ok();
+        let events2 = flush_and_collect(&shared);
+        let frees2: Vec<_> = events2
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(frees2.len(), 1, "second flush should emit one free");
+        match frees2[0] {
+            TelemetryEvent::Free {
+                size,
+                alloc_timestamp_nanos,
+                ..
+            } => {
+                assert_eq!(*size, 512, "free should match second alloc size");
+                assert_eq!(
+                    *alloc_timestamp_nanos, 300,
+                    "free should reference timestamp of second alloc"
+                );
+            }
+            _ => unreachable!(),
+        }
     }
 
     /// Demonstrates that `poll_start_ts_or_now` produces strictly ordered
@@ -516,15 +522,24 @@ mod tests {
         }
 
         // Second alloc remains live.
-        let sources = shared.sources.lock().unwrap();
-        let source = sources[0]
-            .as_any()
-            .downcast_ref::<MemoryProfileSource>()
-            .expect("source should be MemoryProfileSource");
-        let liveset = source.liveset.as_ref().unwrap();
-        assert_eq!(liveset.len(), 1);
-        let entry = liveset.get(&0x6000).unwrap();
-        assert_eq!(entry.size, 512);
-        assert_eq!(entry.timestamp_ns, t3);
+        // Prove it by freeing the address in a second flush cycle.
+        rings.free_queue.push(make_raw_free(0x6000, t3 + 1)).ok();
+        let events2 = flush_and_collect(&shared);
+        let frees2: Vec<_> = events2
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(frees2.len(), 1);
+        match frees2[0] {
+            TelemetryEvent::Free {
+                size,
+                alloc_timestamp_nanos,
+                ..
+            } => {
+                assert_eq!(*size, 512, "free should match second alloc size");
+                assert_eq!(*alloc_timestamp_nanos, t3);
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -1,6 +1,7 @@
+#![deny(clippy::arithmetic_side_effects)]
 //! `Source` impl that drains the alloc and free queues each flush cycle.
 
-use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree, RingBuffers};
+use crate::memory_profiling::ring::{RawAlloc, RawFree, RingBuffers};
 use crate::primitives::sync::Arc;
 use crate::telemetry::buffer::with_encoder;
 use crate::telemetry::format::{AllocEvent, FreeEvent};
@@ -25,25 +26,25 @@ struct LivesetEntry {
 /// correctness when the producer reuses an address within a single flush
 /// cycle (alloc → free → alloc-with-same-addr); naive "drain all allocs,
 /// then all frees" would race and corrupt the liveset.
-pub(crate) struct MemoryProfileSource<const MAX_FRAMES: usize = DEFAULT_MAX_FRAMES> {
-    rings: Arc<RingBuffers<MAX_FRAMES>>,
+pub(crate) struct MemoryProfileSource {
+    rings: Arc<RingBuffers>,
     liveset: Option<HashMap<u64, LivesetEntry>>,
 }
 
-impl<const MAX_FRAMES: usize> MemoryProfileSource<MAX_FRAMES> {
+impl MemoryProfileSource {
     /// Create a new source that drains the supplied ring buffers.
     ///
     /// `track_liveset = true` enables `FreeEvent` emission (matched against
     /// previously-sampled allocations); `false` means frees are silently
     /// dropped on the consumer side.
-    pub(crate) fn new(rings: Arc<RingBuffers<MAX_FRAMES>>, track_liveset: bool) -> Self {
+    pub(crate) fn new(rings: Arc<RingBuffers>, track_liveset: bool) -> Self {
         Self {
             rings,
             liveset: track_liveset.then(HashMap::new),
         }
     }
 
-    fn handle_alloc(&mut self, a: RawAlloc<MAX_FRAMES>, ctx: &FlushContext<'_>) {
+    fn handle_alloc(&mut self, a: RawAlloc, ctx: &FlushContext<'_>) {
         let frame_count = a.frame_count as usize;
         let RawAlloc {
             tid,
@@ -101,7 +102,7 @@ impl<const MAX_FRAMES: usize> MemoryProfileSource<MAX_FRAMES> {
     }
 }
 
-impl<const MAX_FRAMES: usize> Source for MemoryProfileSource<MAX_FRAMES> {
+impl Source for MemoryProfileSource {
     fn flush(&mut self, ctx: &FlushContext<'_>) {
         // Merge-sort drain by timestamp. Hold one peeked element from each
         // queue and emit the older one. `crossbeam_queue::ArrayQueue` has no
@@ -110,7 +111,7 @@ impl<const MAX_FRAMES: usize> Source for MemoryProfileSource<MAX_FRAMES> {
         // pushes during this loop has a timestamp later than anything we've
         // already emitted, and we either pick it up this cycle (if our last
         // pop sees it) or next cycle.
-        let mut next_alloc: Option<RawAlloc<MAX_FRAMES>> = self.rings.alloc_queue.pop();
+        let mut next_alloc: Option<RawAlloc> = self.rings.alloc_queue.pop();
         let mut next_free: Option<RawFree> = self.rings.free_queue.pop();
         loop {
             match (&next_alloc, &next_free) {
@@ -143,6 +144,10 @@ impl<const MAX_FRAMES: usize> Source for MemoryProfileSource<MAX_FRAMES> {
     fn name(&self) -> &'static str {
         "memory"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[cfg(test)]
@@ -150,13 +155,11 @@ mod tests {
     use super::*;
     use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree, RingBuffers};
     use crate::primitives::sync::Arc;
-    use crate::primitives::sync::atomic::AtomicU64;
-    use crate::telemetry::buffer::drain_to_collector;
-    use crate::telemetry::collector::CentralCollector;
-    use crate::telemetry::events::{TelemetryEvent, ThreadRole};
+    use crate::primitives::sync::atomic::Ordering;
+    use crate::telemetry::buffer;
+    use crate::telemetry::events::TelemetryEvent;
     use crate::telemetry::format::decode_events;
-    use crate::telemetry::recorder::source::FlushContext;
-    use std::collections::HashMap;
+    use crate::telemetry::recorder::SharedState;
 
     fn make_raw_alloc(addr: u64, size: u64, ts_ns: u64) -> RawAlloc {
         let mut frames = [0u64; DEFAULT_MAX_FRAMES];
@@ -186,19 +189,17 @@ mod tests {
         Arc::new(RingBuffers::new(alloc_cap, free_cap))
     }
 
-    fn flush_and_collect(source: &mut MemoryProfileSource) -> Vec<TelemetryEvent> {
-        let collector = Arc::new(CentralCollector::new());
-        let drain_epoch = AtomicU64::new(0);
-        let thread_roles: HashMap<u32, ThreadRole> = HashMap::new();
-        let ctx = FlushContext {
-            collector: &collector,
-            drain_epoch: &drain_epoch,
-            thread_roles: &thread_roles,
-        };
-        source.flush(&ctx);
-        drain_to_collector(&collector);
+    fn new_shared() -> SharedState {
+        let shared = SharedState::new(0, None);
+        shared.enabled.store(true, Ordering::Relaxed);
+        shared
+    }
+
+    fn flush_and_collect(shared: &SharedState) -> Vec<TelemetryEvent> {
+        shared.flush_sources();
+        buffer::drain_to_collector(&shared.collector);
         let mut events = Vec::new();
-        while let Some(batch) = collector.next() {
+        while let Some(batch) = shared.collector.next() {
             if let Ok(decoded) = decode_events(&batch.encoded_bytes) {
                 events.extend(decoded);
             }
@@ -214,9 +215,13 @@ mod tests {
             .push(make_raw_alloc(0x1000, 4096, 100))
             .ok();
 
-        let mut source = MemoryProfileSource::new(Arc::clone(&rings), false);
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            false,
+        )));
 
-        let events = flush_and_collect(&mut source);
+        let events = flush_and_collect(&shared);
         let allocs: Vec<_> = events
             .iter()
             .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
@@ -249,9 +254,10 @@ mod tests {
             .ok();
         rings.free_queue.push(make_raw_free(0x2000, 300)).ok();
 
-        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
 
-        let events = flush_and_collect(&mut source);
+        let events = flush_and_collect(&shared);
         let allocs: Vec<_> = events
             .iter()
             .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
@@ -285,9 +291,10 @@ mod tests {
         let rings = rings(16, 16);
         rings.free_queue.push(make_raw_free(0x9999, 400)).ok();
 
-        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
 
-        let events = flush_and_collect(&mut source);
+        let events = flush_and_collect(&shared);
         let frees: Vec<_> = events
             .iter()
             .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
@@ -304,9 +311,13 @@ mod tests {
             .ok();
         rings.free_queue.push(make_raw_free(0x3000, 600)).ok();
 
-        let mut source = MemoryProfileSource::new(Arc::clone(&rings), false);
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            false,
+        )));
 
-        let events = flush_and_collect(&mut source);
+        let events = flush_and_collect(&shared);
         let allocs: Vec<_> = events
             .iter()
             .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
@@ -322,14 +333,16 @@ mod tests {
     #[test]
     fn alloc_then_free_in_separate_flush_cycles() {
         let rings = rings(16, 16);
-        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
 
         // First flush: only the alloc
         rings
             .alloc_queue
             .push(make_raw_alloc(0x4000, 256, 700))
             .ok();
-        let events = flush_and_collect(&mut source);
+        let events = flush_and_collect(&shared);
         assert_eq!(
             events
                 .iter()
@@ -347,7 +360,7 @@ mod tests {
 
         // Second flush: the free arrives
         rings.free_queue.push(make_raw_free(0x4000, 800)).ok();
-        let events = flush_and_collect(&mut source);
+        let events = flush_and_collect(&shared);
         assert_eq!(
             events
                 .iter()
@@ -401,9 +414,10 @@ mod tests {
             .push(make_raw_alloc(0x5000, 512, 300))
             .ok();
 
-        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
 
-        let events = flush_and_collect(&mut source);
+        let events = flush_and_collect(&shared);
         let allocs: Vec<&TelemetryEvent> = events
             .iter()
             .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
@@ -439,6 +453,12 @@ mod tests {
         }
 
         // The second allocation must remain live in the liveset.
+        // Access the source directly to check internal state.
+        let sources = shared.sources.lock().unwrap();
+        let source = sources[0]
+            .as_any()
+            .downcast_ref::<MemoryProfileSource>()
+            .expect("source should be MemoryProfileSource");
         let liveset = source.liveset.as_ref().expect("liveset is on");
         assert_eq!(liveset.len(), 1, "second alloc should still be live");
         let entry = liveset
@@ -468,8 +488,9 @@ mod tests {
         rings.free_queue.push(make_raw_free(0x6000, t2)).ok();
         rings.alloc_queue.push(make_raw_alloc(0x6000, 512, t3)).ok();
 
-        let mut source = MemoryProfileSource::new(Arc::clone(&rings), true);
-        let events = flush_and_collect(&mut source);
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
+        let events = flush_and_collect(&shared);
 
         let frees: Vec<_> = events
             .iter()
@@ -489,6 +510,11 @@ mod tests {
         }
 
         // Second alloc remains live.
+        let sources = shared.sources.lock().unwrap();
+        let source = sources[0]
+            .as_any()
+            .downcast_ref::<MemoryProfileSource>()
+            .expect("source should be MemoryProfileSource");
         let liveset = source.liveset.as_ref().unwrap();
         assert_eq!(liveset.len(), 1);
         let entry = liveset.get(&0x6000).unwrap();

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -29,7 +29,11 @@ struct LivesetEntry {
 pub(crate) struct MemoryProfileSource {
     rings: Arc<RingBuffers>,
     liveset: Option<HashMap<u64, LivesetEntry>>,
-    sample_rate_bytes: u64,
+    /// Precomputed segment metadata, returned (cloned) on every flush
+    /// cycle. Cached in `new()` so the `segment_metadata()` hot path —
+    /// called from the flush loop every ~5 ms — does not allocate fresh
+    /// `String`s per cycle.
+    metadata: Vec<(String, String)>,
 }
 
 impl MemoryProfileSource {
@@ -46,7 +50,10 @@ impl MemoryProfileSource {
         Self {
             rings,
             liveset: track_liveset.then(HashMap::new),
-            sample_rate_bytes,
+            metadata: vec![(
+                "memory.sample_rate_bytes".to_string(),
+                sample_rate_bytes.to_string(),
+            )],
         }
     }
 
@@ -159,10 +166,11 @@ impl Source for MemoryProfileSource {
     }
 
     fn segment_metadata(&self) -> Vec<(String, String)> {
-        vec![(
-            "memory.sample_rate_bytes".to_string(),
-            self.sample_rate_bytes.to_string(),
-        )]
+        // Cached in `new()`. Cloned on every flush cycle (a tiny vec —
+        // typically one entry — so the clone cost is dwarfed by the
+        // surrounding lock acquisitions in the flush loop). Was previously
+        // rebuilding two `String`s per cycle; see PR #442 review.
+        self.metadata.clone()
     }
 }
 
@@ -511,7 +519,7 @@ mod tests {
         }
     }
 
-    /// Demonstrates that `poll_start_ts_or_now` produces strictly ordered
+    /// Demonstrates that `poll_start_ts_monotonic` produces strictly ordered
     /// timestamps even for events that would otherwise share a clock tick —
     /// the scenario that occurs during a realloc (free old + alloc new at
     /// same address).
@@ -520,7 +528,8 @@ mod tests {
         use crate::telemetry::recorder::poll_start_ts_monotonic;
 
         // Simulate a realloc: alloc, free, alloc — all at the "same instant".
-        // poll_start_ts_or_now guarantees each gets a distinct, increasing timestamp.
+        // poll_start_ts_monotonic guarantees each gets a distinct, increasing
+        // timestamp.
         let t1 = poll_start_ts_monotonic();
         let t2 = poll_start_ts_monotonic();
         let t3 = poll_start_ts_monotonic();

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -104,13 +104,20 @@ impl MemoryProfileSource {
 
 impl Source for MemoryProfileSource {
     fn flush(&mut self, ctx: &FlushContext<'_>) {
-        // Merge-sort drain by timestamp. Hold one peeked element from each
-        // queue and emit the older one. `crossbeam_queue::ArrayQueue` has no
-        // peek API, so we pop into local slots and only refill after we
-        // emit. The producer can race in between; that's fine — anything it
-        // pushes during this loop has a timestamp later than anything we've
-        // already emitted, and we either pick it up this cycle (if our last
-        // pop sees it) or next cycle.
+        // Merge-sort drain by timestamp. This produces a best-effort
+        // timestamp-ordered stream. Ordering is not guaranteed to be perfect:
+        // - Multiple producers push concurrently, so queue order may not
+        //   match timestamp order.
+        // - TimestampMode::ReusePollStart can produce stale timestamps.
+        // For profiling purposes, approximate ordering is sufficient.
+        //
+        // Hold one peeked element from each queue and emit the older one.
+        // `crossbeam_queue::ArrayQueue` has no peek API, so we pop into
+        // local slots and only refill after we emit. The producer can race
+        // in between; that's fine — anything it pushes during this loop has
+        // a timestamp later than anything we've already emitted, and we
+        // either pick it up this cycle (if our last pop sees it) or next
+        // cycle.
         let mut next_alloc: Option<RawAlloc> = self.rings.alloc_queue.pop();
         let mut next_free: Option<RawFree> = self.rings.free_queue.pop();
         loop {

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -29,6 +29,7 @@ struct LivesetEntry {
 pub(crate) struct MemoryProfileSource {
     rings: Arc<RingBuffers>,
     liveset: Option<HashMap<u64, LivesetEntry>>,
+    sample_rate_bytes: u64,
 }
 
 impl MemoryProfileSource {
@@ -37,10 +38,15 @@ impl MemoryProfileSource {
     /// `track_liveset = true` enables `FreeEvent` emission (matched against
     /// previously-sampled allocations); `false` means frees are silently
     /// dropped on the consumer side.
-    pub(crate) fn new(rings: Arc<RingBuffers>, track_liveset: bool) -> Self {
+    pub(crate) fn new(
+        rings: Arc<RingBuffers>,
+        track_liveset: bool,
+        sample_rate_bytes: u64,
+    ) -> Self {
         Self {
             rings,
             liveset: track_liveset.then(HashMap::new),
+            sample_rate_bytes,
         }
     }
 
@@ -151,6 +157,13 @@ impl Source for MemoryProfileSource {
     fn name(&self) -> &'static str {
         "memory"
     }
+
+    fn segment_metadata(&self) -> Vec<(String, String)> {
+        vec![(
+            "memory.sample_rate_bytes".to_string(),
+            self.sample_rate_bytes.to_string(),
+        )]
+    }
 }
 
 #[cfg(test)]
@@ -221,6 +234,7 @@ mod tests {
         shared.push_source(Box::new(MemoryProfileSource::new(
             Arc::clone(&rings),
             false,
+            512 * 1024,
         )));
 
         let events = flush_and_collect(&shared);
@@ -257,7 +271,11 @@ mod tests {
         rings.free_queue.push(make_raw_free(0x2000, 300)).ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            true,
+            512 * 1024,
+        )));
 
         let events = flush_and_collect(&shared);
         let allocs: Vec<_> = events
@@ -294,7 +312,11 @@ mod tests {
         rings.free_queue.push(make_raw_free(0x9999, 400)).ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            true,
+            512 * 1024,
+        )));
 
         let events = flush_and_collect(&shared);
         let frees: Vec<_> = events
@@ -317,6 +339,7 @@ mod tests {
         shared.push_source(Box::new(MemoryProfileSource::new(
             Arc::clone(&rings),
             false,
+            512 * 1024,
         )));
 
         let events = flush_and_collect(&shared);
@@ -337,7 +360,11 @@ mod tests {
         let rings = rings(16, 16);
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            true,
+            512 * 1024,
+        )));
 
         // First flush: only the alloc
         rings
@@ -417,7 +444,11 @@ mod tests {
             .ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            true,
+            512 * 1024,
+        )));
 
         let events = flush_and_collect(&shared);
         let allocs: Vec<&TelemetryEvent> = events
@@ -501,7 +532,11 @@ mod tests {
         rings.alloc_queue.push(make_raw_alloc(0x6000, 512, t3)).ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(Arc::clone(&rings), true)));
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            true,
+            512 * 1024,
+        )));
         let events = flush_and_collect(&shared);
 
         let frees: Vec<_> = events
@@ -541,5 +576,20 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn segment_metadata_contains_sample_rate_bytes() {
+        use crate::telemetry::recorder::source::Source;
+        let rings = rings(16, 16);
+        let source = MemoryProfileSource::new(Arc::clone(&rings), false, 1024 * 1024);
+        let meta = source.segment_metadata();
+        assert_eq!(
+            meta,
+            vec![(
+                "memory.sample_rate_bytes".to_string(),
+                "1048576".to_string()
+            )]
+        );
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -36,10 +36,6 @@ impl<const MAX_FRAMES: usize> MemoryProfileSource<MAX_FRAMES> {
     /// `track_liveset = true` enables `FreeEvent` emission (matched against
     /// previously-sampled allocations); `false` means frees are silently
     /// dropped on the consumer side.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired up by allocator hook in a later commit")
-    )]
     pub(crate) fn new(rings: Arc<RingBuffers<MAX_FRAMES>>, track_liveset: bool) -> Self {
         Self {
             rings,

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -187,7 +187,6 @@ mod tests {
         RawFree {
             tid: 2,
             addr,
-            size: 0, // size on the free side is informational; consolidator uses liveset
             ts_ns,
         }
     }

--- a/dial9-tokio-telemetry/src/sampling.rs
+++ b/dial9-tokio-telemetry/src/sampling.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::arithmetic_side_effects)]
 //! Shared geometric/Poisson sampling primitives.
 //!
 //! Used by the task-dump idle sampler (sampling on nanoseconds) and by the

--- a/dial9-tokio-telemetry/src/sampling.rs
+++ b/dial9-tokio-telemetry/src/sampling.rs
@@ -9,7 +9,7 @@
 pub(crate) struct SplitMix64(u64);
 
 impl SplitMix64 {
-    pub(crate) fn new(seed: u64) -> Self {
+    pub(crate) const fn new(seed: u64) -> Self {
         Self(seed)
     }
 

--- a/dial9-tokio-telemetry/src/sampling.rs
+++ b/dial9-tokio-telemetry/src/sampling.rs
@@ -33,6 +33,8 @@ impl SplitMix64 {
         let u = (self.next_u64() >> 11) as f64 / ((1u64 << 53) as f64);
         let u = if u == 0.0 { f64::MIN_POSITIVE } else { u };
         let sample = -u.ln() * (mean as f64);
+        // Cast to u64 (truncates toward zero; NaN becomes 0), then clamp to
+        // at least 1 to avoid immediate re-trigger.
         (sample as u64).max(1)
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
+++ b/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
@@ -213,10 +213,6 @@ impl Source for CpuProfiler {
     fn name(&self) -> &'static str {
         "cpu_profile"
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl Source for SchedProfiler {
@@ -253,9 +249,5 @@ impl Source for SchedProfiler {
 
     fn name(&self) -> &'static str {
         "sched"
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
+++ b/dial9-tokio-telemetry/src/telemetry/cpu_profile.rs
@@ -213,6 +213,10 @@ impl Source for CpuProfiler {
     fn name(&self) -> &'static str {
         "cpu_profile"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl Source for SchedProfiler {
@@ -249,5 +253,9 @@ impl Source for SchedProfiler {
 
     fn name(&self) -> &'static str {
         "sched"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -237,6 +237,22 @@ pub enum TelemetryEvent {
         fields: Vec<(String, FieldValue)>,
     },
     /// A sampled memory allocation event.
+    ///
+    /// **The `size` field is the raw bytes of this single allocation,
+    /// NOT a scaled estimate.** Summing raw `size` values across many
+    /// samples will dramatically undercount allocations dominated by
+    /// small objects. To estimate total bytes allocated through a code
+    /// path, weight each sample by the inverse of its sampling
+    /// probability:
+    ///
+    /// ```text
+    /// total_bytes ≈ Σ s_i / (1 - exp(-s_i / R))
+    /// ```
+    ///
+    /// where `R` is `MemoryProfilingConfig::sample_rate_bytes` at the
+    /// time the trace was recorded. See the `Estimating totals from
+    /// samples` section in `docs/design/memory-profiling.md` for worked
+    /// examples and the aggregation order rules.
     Alloc {
         /// Wall-clock timestamp in nanoseconds (monotonic).
         #[serde(rename = "timestamp_ns")]

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -261,7 +261,10 @@ pub enum TelemetryEvent {
         tid: u32,
         /// Allocation size in bytes.
         size: u64,
-        /// Returned pointer address.
+        /// Returned pointer address. Always populated; only matched against
+        /// `Free.addr` when the producing trace had liveset tracking on.
+        /// See [`crate::telemetry::format::AllocEvent::addr`] for full
+        /// caveats about address reuse without liveset tracking.
         addr: u64,
         /// Raw instruction pointer addresses (leaf first).
         callchain: Vec<u64>,
@@ -712,7 +715,7 @@ mod tests {
     }
 
     #[test]
-    fn poll_start_ts_or_now_is_strictly_increasing() {
+    fn poll_start_ts_monotonic_is_strictly_increasing() {
         use crate::telemetry::recorder::poll_start_ts_monotonic;
         // Rapid-fire calls should never return the same value twice.
         let mut prev = poll_start_ts_monotonic();
@@ -720,7 +723,7 @@ mod tests {
             let next = poll_start_ts_monotonic();
             assert!(
                 next > prev,
-                "poll_start_ts_or_now must be strictly increasing: got {next} after {prev}"
+                "poll_start_ts_monotonic must be strictly increasing: got {next} after {prev}"
             );
             prev = next;
         }

--- a/dial9-tokio-telemetry/src/telemetry/format.rs
+++ b/dial9-tokio-telemetry/src/telemetry/format.rs
@@ -239,8 +239,12 @@ pub struct AllocEvent {
     /// code; the underlying allocator may have rounded up, but that's not
     /// recorded here.
     pub size: u64,
-    /// Returned pointer. Only meaningful when liveset tracking is on; otherwise 0.
-    /// Always present so the schema is stable across track_liveset on/off.
+    /// Returned pointer. Always the actual address returned by the allocator;
+    /// it is only matched against `FreeEvent.addr` when liveset tracking is
+    /// on. Consumers should not assume cross-allocation uniqueness when
+    /// liveset is off — addresses are reused freely once the slot is freed,
+    /// and without paired frees you cannot tell which "generation" of the
+    /// address a given event belongs to.
     pub addr: u64,
     /// Stack at the allocation site. Frame 0 is the most-recent caller.
     pub callchain: InternedStackFrames,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/flush_loop.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/flush_loop.rs
@@ -159,14 +159,22 @@ pub(super) fn run_flush_loop(
             }
         }
 
-        // Merge user-provided metadata with runtime→worker mappings
-        // so the next rotated segment is fully self-describing.
+        // Merge user-provided metadata with runtime→worker mappings and
+        // source metadata so the next rotated segment is fully self-describing.
         let contexts = shared.contexts.lock().unwrap().clone();
         let runtime_entries: Vec<(String, String)> =
             contexts.iter().filter_map(|c| c.metadata_entry()).collect();
-        if !runtime_entries.is_empty() {
+        let source_entries: Vec<(String, String)> = shared
+            .sources
+            .lock()
+            .unwrap()
+            .iter()
+            .flat_map(|s| s.segment_metadata())
+            .collect();
+        if !runtime_entries.is_empty() || !source_entries.is_empty() {
             let mut merged = static_metadata.clone();
             merged.extend(runtime_entries);
+            merged.extend(source_entries);
             writer.update_segment_metadata(merged);
         }
 

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -9,8 +9,6 @@ pub(crate) mod source;
 pub(crate) use runtime_context::RuntimeContext;
 pub use runtime_context::current_worker_id;
 pub(crate) use runtime_context::poll_start_ts_monotonic;
-#[cfg(feature = "memory-profiling")]
-pub(crate) use runtime_context::poll_start_ts_or_now;
 pub(crate) use shared_state::SharedState;
 
 pub use builder::{

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod source;
 pub(crate) use runtime_context::RuntimeContext;
 pub use runtime_context::current_worker_id;
 pub(crate) use runtime_context::poll_start_ts_monotonic;
+#[cfg(feature = "memory-profiling")]
+pub(crate) use runtime_context::poll_start_ts_or_now;
 pub(crate) use shared_state::SharedState;
 
 pub use builder::{

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -41,18 +41,25 @@ thread_local! {
     /// `TaskDumped`, memory profiler) to reuse the timestamp without an extra
     /// clock read.
     static POLL_START_TS: Cell<Option<NonZeroU64>> = const { Cell::new(None) };
-    /// Last timestamp returned by `poll_start_ts_or_now`. Ensures strictly
+    /// Last timestamp returned by `poll_start_ts_monotonic`. Ensures strictly
     /// increasing values within a thread by bumping +1ns on ties.
     static LAST_TS: Cell<u64> = const { Cell::new(0) };
 }
 
 /// Returns a strictly monotonic timestamp for this thread.
 ///
-/// Uses the cached poll-start timestamp if inside a poll, otherwise reads
-/// the clock. Guarantees the returned value is always greater than the
-/// previous call on this thread (bumps by 1ns on ties). This ensures
-/// correct ordering for events that share a clock tick (e.g. a realloc
-/// producing free + alloc at the same address within one poll).
+/// Returns the cached `PollStart` timestamp from this thread's most
+/// recent `on_before_task_poll`, if any; otherwise reads the wall
+/// clock via [`crate::telemetry::events::clock_monotonic_ns`]. The
+/// returned value is always **strictly greater** than the previous
+/// call on this thread (bumps by 1 ns on ties), which keeps event
+/// ordering correct when several samples share a clock tick — e.g.
+/// an in-place realloc producing free + alloc at the same address
+/// within one poll, or repeated allocations inside a tight loop.
+///
+/// Used by:
+/// - the memory profiler hook ([`TimestampMode::ReusePollStart`]).
+/// - the task-dump idle/wake bookkeeping in [`crate::task_dumped`].
 pub(crate) fn poll_start_ts_monotonic() -> u64 {
     let raw = POLL_START_TS.with(|c| c.get()).map_or_else(
         crate::telemetry::events::clock_monotonic_ns,
@@ -63,14 +70,6 @@ pub(crate) fn poll_start_ts_monotonic() -> u64 {
         last.set(next);
         next
     })
-}
-
-/// Returns the poll-start timestamp if inside a task poll, otherwise falls
-/// back to `clock_monotonic_ns()`. The fallback logic lives in
-/// `poll_start_ts_monotonic()`. Used by the memory profiler hook.
-#[cfg(feature = "memory-profiling")]
-pub(crate) fn poll_start_ts_or_now() -> u64 {
-    poll_start_ts_monotonic()
 }
 
 impl RuntimeContext {

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -65,6 +65,12 @@ pub(crate) fn poll_start_ts_monotonic() -> u64 {
     })
 }
 
+/// Alias for `poll_start_ts_monotonic` used by the memory profiler hook.
+#[cfg(feature = "memory-profiling")]
+pub(crate) fn poll_start_ts_or_now() -> u64 {
+    poll_start_ts_monotonic()
+}
+
 impl RuntimeContext {
     pub(crate) fn new(runtime_name: Option<String>) -> Self {
         Self {

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -65,7 +65,9 @@ pub(crate) fn poll_start_ts_monotonic() -> u64 {
     })
 }
 
-/// Alias for `poll_start_ts_monotonic` used by the memory profiler hook.
+/// Returns the poll-start timestamp if inside a task poll, otherwise falls
+/// back to `clock_monotonic_ns()`. The fallback logic lives in
+/// `poll_start_ts_monotonic()`. Used by the memory profiler hook.
 #[cfg(feature = "memory-profiling")]
 pub(crate) fn poll_start_ts_or_now() -> u64 {
     poll_start_ts_monotonic()

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -650,10 +650,6 @@ mod shuttle_tests {
             "mock"
         }
 
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-
         // TODO: exercise on_worker_thread_start/on_thread_stop once shuttle
         // tests include a Tokio runtime.
     }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -59,7 +59,7 @@ pub(crate) struct SharedState {
 }
 
 impl SharedState {
-    pub(super) fn new(start_time_ns: u64, task_dump_rng_seed: Option<u64>) -> Self {
+    pub(crate) fn new(start_time_ns: u64, task_dump_rng_seed: Option<u64>) -> Self {
         Self {
             enabled: AtomicBool::new(false),
             task_dumps_enabled: AtomicBool::new(false),
@@ -648,6 +648,10 @@ mod shuttle_tests {
 
         fn name(&self) -> &'static str {
             "mock"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
 
         // TODO: exercise on_worker_thread_start/on_thread_stop once shuttle

--- a/dial9-tokio-telemetry/src/telemetry/recorder/source.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/source.rs
@@ -34,4 +34,10 @@ pub(crate) trait Source: Send {
     /// Called when a thread stops. Used by per-thread sources like SchedProfiler
     /// to stop tracking the current thread.
     fn on_thread_stop(&mut self) {}
+
+    /// Key-value entries this source contributes to segment metadata.
+    /// Called each flush cycle alongside runtime context entries.
+    fn segment_metadata(&self) -> Vec<(String, String)> {
+        Vec::new()
+    }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/source.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/source.rs
@@ -34,8 +34,4 @@ pub(crate) trait Source: Send {
     /// Called when a thread stops. Used by per-thread sources like SchedProfiler
     /// to stop tracking the current thread.
     fn on_thread_stop(&mut self) {}
-
-    /// Downcast to `&dyn Any` for test assertions on internal state.
-    #[allow(dead_code)]
-    fn as_any(&self) -> &dyn std::any::Any;
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/source.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/source.rs
@@ -34,4 +34,8 @@ pub(crate) trait Source: Send {
     /// Called when a thread stops. Used by per-thread sources like SchedProfiler
     /// to stop tracking the current thread.
     fn on_thread_stop(&mut self) {}
+
+    /// Downcast to `&dyn Any` for test assertions on internal state.
+    #[allow(dead_code)]
+    fn as_any(&self) -> &dyn std::any::Any;
 }

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_captures.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_captures.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "memory-profiling")]
 #![cfg(feature = "analysis")]
+#![cfg(target_os = "linux")]
 //! Test that the allocator hook captures sampled allocations into the trace.
 
 mod common;

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_captures.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_captures.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "memory-profiling")]
+#![cfg(feature = "analysis")]
+//! Test that the allocator hook captures sampled allocations into the trace.
+
+mod common;
+
+use dial9_tokio_telemetry::memory_profiling::{
+    Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
+};
+use dial9_tokio_telemetry::telemetry::{TelemetryEvent, TracedRuntime};
+use std::alloc::{GlobalAlloc, Layout};
+use std::time::Duration;
+
+#[test]
+fn hook_captures_sampled_allocations() {
+    let (writer, events) = common::CapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .build_and_start_with_writer(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    let _mem_guard = MemoryProfiler::from_config(
+        MemoryProfilingConfig::builder()
+            .sample_rate_bytes(1024)
+            .rng_seed(42)
+            .build(),
+    )
+    .install(handle)
+    .expect("install should succeed");
+
+    // Exercise the hook by calling Dial9Allocator methods directly.
+    let allocator = Dial9Allocator::system();
+    runtime.block_on(async {
+        for _ in 0..100 {
+            let layout = Layout::from_size_align(1024, 8).unwrap();
+            // SAFETY: layout is valid.
+            let ptr = unsafe { allocator.alloc(layout) };
+            assert!(!ptr.is_null());
+            std::hint::black_box(ptr);
+            // SAFETY: ptr was allocated with this layout.
+            unsafe { allocator.dealloc(ptr, layout) };
+        }
+        // Give the flush thread time to drain.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let events = events.lock().unwrap();
+    let allocs: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+        .collect();
+
+    assert!(
+        !allocs.is_empty(),
+        "expected at least one AllocEvent from sampled allocations, got 0"
+    );
+
+    // Verify the event has reasonable fields.
+    match &allocs[0] {
+        TelemetryEvent::Alloc {
+            size, callchain, ..
+        } => {
+            assert!(*size > 0, "size should be non-zero");
+            assert!(
+                !callchain.is_empty(),
+                "callchain should have at least one frame"
+            );
+        }
+        _ => unreachable!(),
+    }
+}

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_captures.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_captures.rs
@@ -8,8 +8,10 @@ use dial9_tokio_telemetry::memory_profiling::{
     Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
 };
 use dial9_tokio_telemetry::telemetry::{TelemetryEvent, TracedRuntime};
-use std::alloc::{GlobalAlloc, Layout};
 use std::time::Duration;
+
+#[global_allocator]
+static ALLOC: Dial9Allocator = Dial9Allocator::system();
 
 #[test]
 fn hook_captures_sampled_allocations() {
@@ -31,17 +33,10 @@ fn hook_captures_sampled_allocations() {
     .install(handle)
     .expect("install should succeed");
 
-    // Exercise the hook by calling Dial9Allocator methods directly.
-    let allocator = Dial9Allocator::system();
     runtime.block_on(async {
         for _ in 0..100 {
-            let layout = Layout::from_size_align(1024, 8).unwrap();
-            // SAFETY: layout is valid.
-            let ptr = unsafe { allocator.alloc(layout) };
-            assert!(!ptr.is_null());
-            std::hint::black_box(ptr);
-            // SAFETY: ptr was allocated with this layout.
-            unsafe { allocator.dealloc(ptr, layout) };
+            let v: Vec<u8> = Vec::with_capacity(1024);
+            std::hint::black_box(v);
         }
         // Give the flush thread time to drain.
         tokio::time::sleep(Duration::from_millis(200)).await;

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
@@ -8,8 +8,32 @@ use dial9_tokio_telemetry::memory_profiling::{
     Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
 };
 use dial9_tokio_telemetry::telemetry::{TelemetryEvent, TracedRuntime};
-use std::alloc::{GlobalAlloc, Layout};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAllocator;
+
+impl CountingAllocator {
+    const fn new() -> Self {
+        Self
+    }
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOC: Dial9Allocator<CountingAllocator> = Dial9Allocator::new(CountingAllocator::new());
 
 #[test]
 fn hook_realloc_emits_alloc_and_free_when_liveset_on() {
@@ -24,7 +48,6 @@ fn hook_realloc_emits_alloc_and_free_when_liveset_on() {
     let handle = guard.handle();
     let _mem_guard = MemoryProfiler::from_config(
         MemoryProfilingConfig::builder()
-            // Very low sample rate so nearly every alloc is sampled.
             .sample_rate_bytes(64)
             .track_liveset(true)
             .rng_seed(42)
@@ -33,26 +56,26 @@ fn hook_realloc_emits_alloc_and_free_when_liveset_on() {
     .install(handle)
     .expect("install should succeed");
 
-    // Exercise realloc via the Dial9Allocator directly.
-    let allocator = Dial9Allocator::system();
     runtime.block_on(async {
-        for _ in 0..50 {
-            let layout = Layout::from_size_align(64, 8).unwrap();
-            // SAFETY: layout is valid.
-            let ptr = unsafe { allocator.alloc(layout) };
-            assert!(!ptr.is_null());
-            // SAFETY: ptr was allocated with layout, new_size > 0.
-            let new_ptr = unsafe { allocator.realloc(ptr, layout, 256) };
-            assert!(!new_ptr.is_null());
-            let new_layout = Layout::from_size_align(256, 8).unwrap();
-            // SAFETY: new_ptr was returned by realloc.
-            unsafe { allocator.dealloc(new_ptr, new_layout) };
+        // Push in a loop to force Vec reallocation (capacity growth).
+        let mut v: Vec<u8> = Vec::new();
+        for i in 0..1000u16 {
+            v.push((i & 0xff) as u8);
         }
+        std::hint::black_box(&v);
+        drop(v);
+
         tokio::time::sleep(Duration::from_millis(200)).await;
     });
 
     drop(runtime);
     drop(guard);
+
+    // Verify the inner allocator was actually called.
+    assert!(
+        ALLOC_COUNT.load(Ordering::Relaxed) > 0,
+        "expected CountingAllocator to have been called"
+    );
 
     let events = events.lock().unwrap();
     let allocs: Vec<_> = events
@@ -64,9 +87,6 @@ fn hook_realloc_emits_alloc_and_free_when_liveset_on() {
         .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
         .collect();
 
-    // With sample_rate=64 and 50 iterations of alloc(64)+realloc(64→256)+dealloc(256),
-    // we expect many alloc events and at least some free events (from the realloc
-    // decomposition and the final dealloc).
     assert!(
         !allocs.is_empty(),
         "expected at least one AllocEvent from realloc path"

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "memory-profiling")]
 #![cfg(feature = "analysis")]
+#![cfg(target_os = "linux")]
 //! Test that realloc emits both AllocEvent and FreeEvent when liveset is on.
 
 mod common;

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
@@ -96,4 +96,58 @@ fn hook_realloc_emits_alloc_and_free_when_liveset_on() {
         !frees.is_empty(),
         "expected at least one FreeEvent when liveset tracking is on"
     );
+
+    // Stronger property: every FreeEvent must match a previously-recorded
+    // AllocEvent on (addr, size, alloc_timestamp_ns). Walk the trace in
+    // recording order, maintaining a "live" map keyed by addr; an Alloc
+    // overwrites any prior entry at that addr (an address can be reused
+    // after a free), and a Free must find the current entry and have its
+    // (size, alloc_timestamp_ns) match the recorded Alloc.
+    use std::collections::HashMap;
+    let mut live: HashMap<u64, (u64, u64)> = HashMap::new(); // addr -> (size, ts)
+    let mut matched_frees = 0usize;
+    for ev in events.iter() {
+        match ev {
+            TelemetryEvent::Alloc {
+                addr,
+                size,
+                timestamp_nanos,
+                ..
+            } => {
+                live.insert(*addr, (*size, *timestamp_nanos));
+            }
+            TelemetryEvent::Free {
+                addr,
+                size,
+                alloc_timestamp_nanos,
+                ..
+            } => {
+                let Some((recorded_size, recorded_ts)) = live.remove(addr) else {
+                    panic!(
+                        "FreeEvent at addr {addr:#x} has no matching prior AllocEvent \
+                         (free size={size}, alloc_ts={alloc_timestamp_nanos})"
+                    );
+                };
+                assert_eq!(
+                    recorded_size, *size,
+                    "FreeEvent at addr {addr:#x}: size {size} does not match \
+                     recorded Alloc size {recorded_size}"
+                );
+                assert_eq!(
+                    recorded_ts, *alloc_timestamp_nanos,
+                    "FreeEvent at addr {addr:#x}: alloc_timestamp_ns \
+                     {alloc_timestamp_nanos} does not match recorded \
+                     Alloc timestamp {recorded_ts}"
+                );
+                matched_frees = matched_frees.saturating_add(1);
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(
+        matched_frees,
+        frees.len(),
+        "all {} frees should have matched a prior alloc, only {matched_frees} did",
+        frees.len()
+    );
 }

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
@@ -1,0 +1,78 @@
+#![cfg(feature = "memory-profiling")]
+#![cfg(feature = "analysis")]
+//! Test that realloc emits both AllocEvent and FreeEvent when liveset is on.
+
+mod common;
+
+use dial9_tokio_telemetry::memory_profiling::{
+    Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
+};
+use dial9_tokio_telemetry::telemetry::{TelemetryEvent, TracedRuntime};
+use std::alloc::{GlobalAlloc, Layout};
+use std::time::Duration;
+
+#[test]
+fn hook_realloc_emits_alloc_and_free_when_liveset_on() {
+    let (writer, events) = common::CapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .build_and_start_with_writer(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    let _mem_guard = MemoryProfiler::from_config(
+        MemoryProfilingConfig::builder()
+            // Very low sample rate so nearly every alloc is sampled.
+            .sample_rate_bytes(64)
+            .track_liveset(true)
+            .rng_seed(42)
+            .build(),
+    )
+    .install(handle)
+    .expect("install should succeed");
+
+    // Exercise realloc via the Dial9Allocator directly.
+    let allocator = Dial9Allocator::system();
+    runtime.block_on(async {
+        for _ in 0..50 {
+            let layout = Layout::from_size_align(64, 8).unwrap();
+            // SAFETY: layout is valid.
+            let ptr = unsafe { allocator.alloc(layout) };
+            assert!(!ptr.is_null());
+            // SAFETY: ptr was allocated with layout, new_size > 0.
+            let new_ptr = unsafe { allocator.realloc(ptr, layout, 256) };
+            assert!(!new_ptr.is_null());
+            let new_layout = Layout::from_size_align(256, 8).unwrap();
+            // SAFETY: new_ptr was returned by realloc.
+            unsafe { allocator.dealloc(new_ptr, new_layout) };
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let events = events.lock().unwrap();
+    let allocs: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+        .collect();
+    let frees: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+        .collect();
+
+    // With sample_rate=64 and 50 iterations of alloc(64)+realloc(64→256)+dealloc(256),
+    // we expect many alloc events and at least some free events (from the realloc
+    // decomposition and the final dealloc).
+    assert!(
+        !allocs.is_empty(),
+        "expected at least one AllocEvent from realloc path"
+    );
+    assert!(
+        !frees.is_empty(),
+        "expected at least one FreeEvent when liveset tracking is on"
+    );
+}

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_already_installed.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_already_installed.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "memory-profiling")]
+#![cfg(target_os = "linux")]
 //! Test that a second install() returns AlreadyInstalled.
 
 mod common;

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_already_installed.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_already_installed.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "memory-profiling")]
+//! Test that a second install() returns AlreadyInstalled.
+
+mod common;
+
+use dial9_tokio_telemetry::memory_profiling::{InstallError, MemoryProfiler};
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+
+#[test]
+fn second_install_returns_already_installed() {
+    let (writer, _events) = common::CapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (_runtime, guard) = TracedRuntime::builder()
+        .build_and_start_with_writer(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    let _mem_guard = MemoryProfiler::with_defaults()
+        .install(handle.clone())
+        .expect("first install should succeed");
+
+    let err = MemoryProfiler::with_defaults()
+        .install(handle)
+        .expect_err("second install should fail");
+
+    assert!(
+        matches!(err, InstallError::AlreadyInstalled),
+        "expected AlreadyInstalled, got: {err:?}"
+    );
+}

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_disabled.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_disabled.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "memory-profiling")]
+//! Test that install with a disabled handle is a no-op.
+
+use dial9_tokio_telemetry::memory_profiling::{MemoryProfiler, MemoryProfilingConfig};
+use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+
+#[test]
+fn install_with_disabled_handle_is_noop() {
+    let handle = TelemetryHandle::disabled();
+    let _guard = MemoryProfiler::from_config(MemoryProfilingConfig::default())
+        .install(handle)
+        .expect("install with disabled handle should succeed");
+    // ACTIVE should NOT be set — disabled handle short-circuits.
+}
+
+#[test]
+fn install_with_disabled_handle_does_not_prevent_future_install() {
+    // A disabled-handle install doesn't consume the OnceLock slot,
+    // so a second disabled-handle install also succeeds.
+    let handle = TelemetryHandle::disabled();
+    let _g1 = MemoryProfiler::with_defaults()
+        .install(handle.clone())
+        .expect("first disabled install should succeed");
+    let _g2 = MemoryProfiler::with_defaults()
+        .install(handle)
+        .expect("second disabled install should also succeed");
+}
+
+#[test]
+fn default_config_uses_512_kib_sample_rate() {
+    let config = MemoryProfilingConfig::default();
+    assert_eq!(config.sample_rate_bytes(), 512 * 1024);
+    assert!(!config.track_liveset());
+    assert_eq!(
+        config.timestamp_mode(),
+        dial9_tokio_telemetry::memory_profiling::TimestampMode::ReusePollStart
+    );
+    assert_eq!(config.max_liveset_entries(), None);
+    assert_eq!(config.rng_seed(), None);
+    assert_eq!(config.ring_capacity(), 4096);
+}

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_disabled.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_disabled.rs
@@ -35,7 +35,6 @@ fn default_config_uses_512_kib_sample_rate() {
         config.timestamp_mode(),
         dial9_tokio_telemetry::memory_profiling::TimestampMode::ReusePollStart
     );
-    assert_eq!(config.max_liveset_entries(), None);
     assert_eq!(config.rng_seed(), None);
     assert_eq!(config.ring_capacity(), 4096);
 }

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_publishes.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_publishes.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "memory-profiling")]
+#![cfg(target_os = "linux")]
 //! Test that install() publishes the process-global ACTIVE state.
 
 mod common;

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_publishes.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_publishes.rs
@@ -1,0 +1,34 @@
+#![cfg(feature = "memory-profiling")]
+//! Test that install() publishes the process-global ACTIVE state.
+
+mod common;
+
+use dial9_tokio_telemetry::memory_profiling::{
+    MemoryProfiler, MemoryProfilingConfig, is_installed,
+};
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+
+#[test]
+fn install_publishes_active_inner() {
+    assert!(!is_installed(), "should not be installed before install()");
+
+    let (writer, _events) = common::CapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (_runtime, guard) = TracedRuntime::builder()
+        .build_and_start_with_writer(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    let _mem_guard = MemoryProfiler::from_config(
+        MemoryProfilingConfig::builder()
+            .sample_rate_bytes(256 * 1024)
+            .rng_seed(42)
+            .build(),
+    )
+    .install(handle)
+    .expect("install should succeed");
+
+    assert!(is_installed(), "should be installed after install()");
+}

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_registers_source.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_registers_source.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "memory-profiling")]
 #![cfg(feature = "analysis")]
+#![cfg(target_os = "linux")]
 //! Test that install() registers the MemoryProfileSource with the recorder,
 //! so synthetic allocs pushed into the queue appear in the trace.
 

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_registers_source.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_registers_source.rs
@@ -1,0 +1,66 @@
+#![cfg(feature = "memory-profiling")]
+#![cfg(feature = "analysis")]
+//! Test that install() registers the MemoryProfileSource with the recorder,
+//! so synthetic allocs pushed into the queue appear in the trace.
+
+mod common;
+
+use dial9_tokio_telemetry::memory_profiling::{MemoryProfiler, push_test_alloc};
+use dial9_tokio_telemetry::telemetry::{TelemetryEvent, TracedRuntime};
+use std::time::Duration;
+
+#[test]
+fn install_registers_source_with_recorder() {
+    let (writer, events) = common::CapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .build_and_start_with_writer(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    let _mem_guard = MemoryProfiler::with_defaults()
+        .install(handle)
+        .expect("install should succeed");
+
+    // Push a synthetic alloc into the queue.
+    assert!(
+        push_test_alloc(0xCAFE_0000, 4096, 12345),
+        "push should succeed"
+    );
+
+    // Give the flush thread time to drain.
+    runtime.block_on(async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let events = events.lock().unwrap();
+    let allocs: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, TelemetryEvent::Alloc { .. }))
+        .collect();
+
+    assert!(
+        !allocs.is_empty(),
+        "expected at least one AllocEvent from the synthetic push"
+    );
+
+    // Verify the event has the expected fields.
+    match &allocs[0] {
+        TelemetryEvent::Alloc {
+            addr,
+            size,
+            callchain,
+            ..
+        } => {
+            assert_eq!(*addr, 0xCAFE_0000);
+            assert_eq!(*size, 4096);
+            assert_eq!(callchain, &[0xDEAD, 0xBEEF]);
+        }
+        _ => unreachable!(),
+    }
+}

--- a/dial9-tokio-telemetry/tests/memory_profiling_segment_metadata.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_segment_metadata.rs
@@ -1,0 +1,73 @@
+#![cfg(feature = "memory-profiling")]
+#![cfg(feature = "analysis")]
+#![cfg(target_os = "linux")]
+//! End-to-end test: memory.sample_rate_bytes appears in segment metadata.
+
+use dial9_tokio_telemetry::memory_profiling::{
+    Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
+};
+use dial9_tokio_telemetry::telemetry::{RotatingWriter, TelemetryEvent, TracedRuntime};
+use std::time::Duration;
+
+#[global_allocator]
+static ALLOC: Dial9Allocator = Dial9Allocator::system();
+
+#[test]
+fn memory_sample_rate_appears_in_segment_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let trace_path = dir.path().join("trace.bin");
+
+    let writer = RotatingWriter::single_file(&trace_path).unwrap();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_trace_path(trace_path.to_str().unwrap())
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    let _mem_guard = MemoryProfiler::from_config(
+        MemoryProfilingConfig::builder()
+            .sample_rate_bytes(2048)
+            .rng_seed(42)
+            .build(),
+    )
+    .install(handle)
+    .expect("install should succeed");
+
+    runtime.block_on(async {
+        // Give the flush thread time to merge source metadata.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    drop(runtime);
+    let _ = guard.graceful_shutdown(Duration::from_secs(5));
+
+    // Read all trace files and find SegmentMetadata events.
+    let mut found = false;
+    let files: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "bin"))
+        .collect();
+
+    for file in &files {
+        let data = std::fs::read(file).unwrap();
+        let events =
+            dial9_tokio_telemetry::analysis_unstable::decode_events(&data).unwrap_or_default();
+        for event in &events {
+            if let TelemetryEvent::SegmentMetadata { entries, .. } = event {
+                found |= entries
+                    .iter()
+                    .any(|(k, v)| k == "memory.sample_rate_bytes" && v == "2048");
+            }
+        }
+    }
+
+    assert!(
+        found,
+        "expected memory.sample_rate_bytes=2048 in segment metadata, files: {files:?}"
+    );
+}

--- a/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
@@ -685,6 +685,8 @@ async function parseWorkerMain(traceFile, cachePath) {
   for (const e of trace.events) writeLine({ t: 'e', d: e });
   for (const s of trace.cpuSamples) writeLine({ t: 'c', d: s });
   if (trace.customEvents) for (const x of trace.customEvents) writeLine({ t: 'x', d: x });
+  if (trace.allocEvents) for (const a of trace.allocEvents) writeLine({ t: 'a', d: a });
+  if (trace.freeEvents) for (const f of trace.freeEvents) writeLine({ t: 'f', d: f });
 
   await new Promise((res, rej) => { stream.end(() => { fs.renameSync(tmpPath, cachePath); res(); }); stream.on('error', rej); });
   process.stdout.write('OK\n');
@@ -700,6 +702,7 @@ function loadCacheFile(cachePath) {
   }
   let raw = null;
   const events = [], cpuSamples = [], customEvents = [];
+  const allocEvents = [], freeEvents = [];
   let line;
   while ((line = nextLine()) !== null) {
     if (!line) continue;
@@ -712,9 +715,12 @@ function loadCacheFile(cachePath) {
       case 'e': events.push(rec.d); break;
       case 'c': cpuSamples.push(rec.d); break;
       case 'x': customEvents.push(rec.d); break;
+      case 'a': allocEvents.push(rec.d); break;
+      case 'f': freeEvents.push(rec.d); break;
     }
   }
   raw.events = events; raw.cpuSamples = cpuSamples; raw.customEvents = customEvents;
+  raw.allocEvents = allocEvents; raw.freeEvents = freeEvents;
   return raw;
 }
 

--- a/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
@@ -473,18 +473,24 @@ The same formula handles all size regimes:
 - For `s ≈ R`: each sample contributes ~`1.58 s` bytes.
 - For `s >> R` (huge allocs): each sample contributes ~`s` bytes.
 
-`R` is **not currently embedded in the trace**. Pass it explicitly to
-your analysis (a CLI flag, a constant per service), or inject it into
-segment metadata at install time via
-`with_segment_metadata([("dial9.memory_profiling.sample_rate_bytes",
-rate.to_string())])` and read it from `segmentMetadata` after parsing.
+`R` is recorded in segment metadata as `memory.sample_rate_bytes`.
+Read it from `trace.segmentMetadata` after parsing:
+
+```javascript
+const meta = Object.fromEntries(trace.segmentMetadata || []);
+const SAMPLE_RATE_BYTES = Number(meta['memory.sample_rate_bytes']) || 512 * 1024;
+```
+
+If analysing traces from older versions that lack this field, pass `R`
+explicitly (a CLI flag or a constant per service).
 
 ### Total bytes allocated by call site
 
 ```javascript
 const { parseTrace, symbolizeChain, formatFrame } = require('./trace_parser.js');
 
-const SAMPLE_RATE_BYTES = 512 * 1024;  // pull from your deployment config
+// Read R from segment metadata (falls back to default for old traces)
+let SAMPLE_RATE_BYTES = 512 * 1024;
 
 function inverseProb(size, rate) {
   // 1 / (1 - exp(-size/rate)). For very small size/rate, this approaches

--- a/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
@@ -495,7 +495,10 @@ function inverseProb(size, rate) {
 const byCallSite = new Map();  // leaf symbol -> { bytes, count }
 
 for await (const trace of parseTrace('/path/to/traces/')) {
-  for (const ev of trace.allocEvents) {
+  // `allocEvents` may be absent on traces from older toolkit caches —
+  // memory profiling events were added to the directory cache after
+  // initial release. Defensive `?? []` keeps the recipe portable.
+  for (const ev of (trace.allocEvents ?? [])) {
     const frames = symbolizeChain(ev.callchain, trace.callframeSymbols);
     const leaf = frames[0] ? formatFrame(frames[0]).text : '(unknown)';
     const w = inverseProb(ev.size, SAMPLE_RATE_BYTES);
@@ -543,7 +546,10 @@ for await (const trace of parseTrace('/path/to/traces/')) {
     pollsByTid.set(tid, polls);
   }
 
-  for (const ev of trace.allocEvents) {
+  // `allocEvents` may be absent on traces from older toolkit caches —
+  // memory profiling events were added to the directory cache after
+  // initial release. Defensive `?? []` keeps the recipe portable.
+  for (const ev of (trace.allocEvents ?? [])) {
     const polls = pollsByTid.get(ev.tid);
     if (!polls) continue;
     // Find the poll containing ev.timestamp (linear scan; for big

--- a/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dial9-trace-recipes
-description: Diagnostic recipes for common questions about dial9 Tokio runtime traces. Covers finding long polls, task leaks, worker utilization, blocking calls, wake chains, span analysis, task dumps, and time-window debugging. Use when answering specific diagnostic questions about trace data.
+description: Diagnostic recipes for common questions about dial9 Tokio runtime traces. Covers finding long polls, task leaks, worker utilization, blocking calls, wake chains, span analysis, task dumps, time-window debugging, and estimating allocation totals from sampled `Alloc` events. Use when answering specific diagnostic questions about trace data.
 ---
 
 # Diagnostic Recipes
@@ -448,3 +448,134 @@ for await (const trace of parseTrace('/path/to/traces/')) {
 Note: `block_in_place` is not inherently a problem — it's a legitimate way to
 run blocking code on a worker thread. The gap detection helps you understand
 what happened during the interval, not flag it as an issue.
+
+## Estimating allocation totals from sampled `Alloc` events
+
+> **Critical:** Each `Alloc` event's `size` is the raw bytes of *one*
+> sampled allocation, **not a scaled estimate**. If you sum raw `size`
+> values you will undercount, often by orders of magnitude. Always
+> scale by inverse Poisson sampling probability before aggregating.
+
+Memory profiling samples allocations at a configured rate `R` (mean
+bytes between samples — `MemoryProfilingConfig.sample_rate_bytes`,
+default 512 KiB). The sampling probability for one allocation of size
+`s` is `1 - exp(-s/R)`. The Horvitz–Thompson estimator weights each
+sample by `1 / P(sample)` to produce unbiased totals:
+
+```
+total_bytes ≈ Σ over sampled events  s_i / (1 - exp(-s_i / R))
+total_count ≈ Σ over sampled events       1 / (1 - exp(-s_i / R))
+```
+
+The same formula handles all size regimes:
+
+- For `s << R` (tiny allocs): each sample contributes ~`R` bytes.
+- For `s ≈ R`: each sample contributes ~`1.58 s` bytes.
+- For `s >> R` (huge allocs): each sample contributes ~`s` bytes.
+
+`R` is **not currently embedded in the trace**. Pass it explicitly to
+your analysis (a CLI flag, a constant per service), or inject it into
+segment metadata at install time via
+`with_segment_metadata([("dial9.memory_profiling.sample_rate_bytes",
+rate.to_string())])` and read it from `segmentMetadata` after parsing.
+
+### Total bytes allocated by call site
+
+```javascript
+const { parseTrace, symbolizeChain, formatFrame } = require('./trace_parser.js');
+
+const SAMPLE_RATE_BYTES = 512 * 1024;  // pull from your deployment config
+
+function inverseProb(size, rate) {
+  // 1 / (1 - exp(-size/rate)). For very small size/rate, this approaches
+  // rate/size; for size >> rate, approaches 1.
+  return 1.0 / (1.0 - Math.exp(-size / rate));
+}
+
+const byCallSite = new Map();  // leaf symbol -> { bytes, count }
+
+for await (const trace of parseTrace('/path/to/traces/')) {
+  for (const ev of trace.allocEvents) {
+    const frames = symbolizeChain(ev.callchain, trace.callframeSymbols);
+    const leaf = frames[0] ? formatFrame(frames[0]).text : '(unknown)';
+    const w = inverseProb(ev.size, SAMPLE_RATE_BYTES);
+    const cur = byCallSite.get(leaf) ?? { bytes: 0, count: 0 };
+    // Weight EACH sample individually before summing — sum-then-unbias
+    // under-reports skewed groups.
+    cur.bytes += ev.size * w;
+    cur.count += w;
+    byCallSite.set(leaf, cur);
+  }
+}
+
+const top = [...byCallSite.entries()]
+  .sort((a, b) => b[1].bytes - a[1].bytes)
+  .slice(0, 20);
+for (const [leaf, { bytes, count }] of top) {
+  console.log(`${(bytes / 1024 / 1024).toFixed(1)} MiB  ${count.toFixed(0)} allocs  ${leaf}`);
+}
+```
+
+### Total bytes allocated per task (from poll-correlated allocs)
+
+`Alloc.tid` matches the worker's TID; cross-reference with poll spans
+to attribute allocations to the task running at the time:
+
+```javascript
+const { parseTrace, symbolizeChain, formatFrame } = require('./trace_parser.js');
+const { buildWorkerSpans } = require('./trace_analysis.js');
+
+const SAMPLE_RATE_BYTES = 512 * 1024;
+const inverseProb = (s, r) => 1.0 / (1.0 - Math.exp(-s / r));
+
+const byTask = new Map();  // taskId -> bytes (estimated)
+
+for await (const trace of parseTrace('/path/to/traces/')) {
+  const workerIds = [...new Set(trace.events.filter(e => e.workerId !== undefined).map(e => e.workerId))].sort((a,b)=>a-b);
+  const { workerSpans } = buildWorkerSpans(trace.events, workerIds, trace.maxTs);
+
+  // Index polls by tid for binary search.
+  const pollsByTid = new Map();
+  for (const wid of workerIds) {
+    const polls = workerSpans[wid].polls;
+    if (polls.length === 0) continue;
+    const tid = polls[0].tid;  // worker's OS tid
+    pollsByTid.set(tid, polls);
+  }
+
+  for (const ev of trace.allocEvents) {
+    const polls = pollsByTid.get(ev.tid);
+    if (!polls) continue;
+    // Find the poll containing ev.timestamp (linear scan; for big
+    // traces use binary search).
+    const poll = polls.find(p => p.start <= ev.timestamp && ev.timestamp < p.end);
+    if (!poll) continue;
+    const w = inverseProb(ev.size, SAMPLE_RATE_BYTES);
+    byTask.set(poll.taskId, (byTask.get(poll.taskId) ?? 0) + ev.size * w);
+  }
+}
+
+const top = [...byTask.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20);
+for (const [taskId, bytes] of top) {
+  console.log(`Task ${taskId}: ~${(bytes / 1024 / 1024).toFixed(1)} MiB`);
+}
+```
+
+### Common pitfalls
+
+- **Summing `Alloc.size` directly.** Will report ~2 KiB for a workload
+  that allocated 1 MiB if all allocations were 1 byte each. Always
+  weight by `1 / (1 - exp(-size / R))`.
+- **Sum-then-unbias.** Computing `(Σ s_i) / (1 - exp(-mean(s) / R))`
+  uses the group's mean size as if every allocation were that size;
+  for skewed groups (mix of small and huge) this can be wrong by
+  orders of magnitude. Weight each sample individually.
+- **Hard-coding `R`.** The default may change between releases. Pull
+  the rate from your deployment config or from segment metadata.
+- **Counting `Alloc` events as allocation count.** That's the
+  *sampled* count, not the actual count. Use the
+  `Σ 1 / (1 - exp(-s_i / R))` formula above.
+- **Forgetting `track_liveset`.** Live-set bytes (current allocation
+  footprint) requires pairing `Alloc` with `Free` events and only
+  works when `MemoryProfilingConfig.track_liveset(true)` was set at
+  install time.

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -724,6 +724,8 @@
     const events = [];
     const cpuSamples = [];
     const customEvents = [];
+    const allocEvents = [];
+    const freeEvents = [];
 
     let line;
     while ((line = nextLine()) !== null) {
@@ -744,11 +746,15 @@
         case 'e': events.push(rec.d); break;
         case 'c': cpuSamples.push(rec.d); break;
         case 'x': customEvents.push(rec.d); break;
+        case 'a': allocEvents.push(rec.d); break;
+        case 'f': freeEvents.push(rec.d); break;
       }
     }
     raw.events = events;
     raw.cpuSamples = cpuSamples;
     raw.customEvents = customEvents;
+    raw.allocEvents = allocEvents;
+    raw.freeEvents = freeEvents;
     return raw;
   }
 

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -94,12 +94,14 @@ fn on_alloc(size: usize) {
 }
 
 fn next_gap(rng: &mut SplitMix64, sample_rate_bytes: u64) -> i64 {
-    // `sample_rate_bytes <= 1` is the "sample every allocation" mode:
-    // returning 0 makes the next decision (`counter - size`) go ≤ 0
-    // for any positive `size`, triggering a sample without consulting
-    // the PRNG. Avoids ~63% per-alloc sampling at `size = 1, rate = 1`
-    // due to the exponential's variance around its mean.
-    if sample_rate_bytes <= 1 {
+    // `sample_rate_bytes == 1` is the magic "sample every allocation"
+    // mode: returning 0 makes the next decision (`counter - size`) go
+    // ≤ 0 for any positive `size`, triggering a sample without
+    // consulting the PRNG. Avoids ~63% per-alloc sampling at
+    // `size = 1, rate = 1` due to the exponential's variance around
+    // its mean. `0` is rejected at config build time, so this branch
+    // only ever sees values `>= 1`.
+    if sample_rate_bytes == 1 {
         return 0;
     }
     rng.draw_exponential(sample_rate_bytes) as i64
@@ -110,10 +112,13 @@ Two important details:
 
 - `remaining` must be `i64` (signed). Subtracting `usize` from `usize`
   and comparing to zero invites wraparound bugs.
-- `sample_rate_bytes <= 1` short-circuits to "sample every allocation"
-  mode without consulting the PRNG. Matches user intuition: rate of 1
-  byte between samples means every byte is sampled, which for any
-  allocation larger than 1 byte means every allocation samples.
+- `sample_rate_bytes == 1` is the magic "sample every allocation"
+  short-circuit. The PRNG is bypassed; every call to the allocator is
+  recorded. Matches user intuition: a rate of "1 byte between samples"
+  means every byte is sampled, which for any allocation ≥ 1 byte means
+  every allocation samples. `0` is rejected at config build time
+  because it is ambiguous (sample everything? sample nothing?) — pass
+  `1` for the explicit "sample everything" mode.
 
 ### Why a single fresh draw (no redraw loop)
 
@@ -304,13 +309,15 @@ Always pull `R` from a recorded source rather than a build-time
 constant — the default may change and operators may override it per
 deployment.
 
-#### `sample_rate_bytes <= 1` ("sample every allocation")
+#### `sample_rate_bytes == 1` ("sample every allocation")
 
-In this mode every alloc is in the trace, so the raw `size` field is
-already the truth. The HT formula degenerates to the right answer
+In this magic mode every alloc is in the trace (`0` is rejected at
+config build time, so the only way to get this behaviour is by
+explicitly passing `1`). The raw `size` field is already the truth:
+the HT formula still gives the right answer
 (`exp(-s/1) ≈ 0` for any positive `s`, so the weight is ~1), but you
-can short-circuit: `total_bytes = Σ s_i`, `total_count = number of
-samples`.
+can short-circuit and just sum: `total_bytes = Σ s_i`,
+`total_count = number of samples`.
 
 ---
 

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -84,25 +84,64 @@ fn on_alloc(size: usize) {
         return;               // fast path: one sub, one branch, done
     }
 
-    // Sampled. Draw a new gap — loop in case the draw is smaller than
-    // `-remaining` (rare, but possible for tiny rates / huge allocs).
-    let mut next = remaining;
-    while next <= 0 {
-        next += draw_exponential(sample_rate_bytes);
-    }
-    next_sample_bytes.set(next);
+    // Sampled. Draw a fresh gap to the next sample. We deliberately do
+    // NOT loop to "consume" the deficit when one allocation overshoots
+    // by more than one draw's worth — see "Why a single fresh draw"
+    // below.
+    next_sample_bytes.set(next_gap(rng, sample_rate_bytes));
 
     record_sample(size, capture_stack());
+}
+
+fn next_gap(rng: &mut SplitMix64, sample_rate_bytes: u64) -> i64 {
+    // `sample_rate_bytes <= 1` is the "sample every allocation" mode:
+    // returning 0 makes the next decision (`counter - size`) go ≤ 0
+    // for any positive `size`, triggering a sample without consulting
+    // the PRNG. Avoids ~63% per-alloc sampling at `size = 1, rate = 1`
+    // due to the exponential's variance around its mean.
+    if sample_rate_bytes <= 1 {
+        return 0;
+    }
+    rng.draw_exponential(sample_rate_bytes) as i64
 }
 ```
 
 Two important details:
 
-- The `while` loop handles the case where a single huge allocation (or
-  very low sample rate) pushes `next_sample_bytes` below zero by more
-  than one draw's worth.
 - `remaining` must be `i64` (signed). Subtracting `usize` from `usize`
   and comparing to zero invites wraparound bugs.
+- `sample_rate_bytes <= 1` short-circuits to "sample every allocation"
+  mode without consulting the PRNG. Matches user intuition: rate of 1
+  byte between samples means every byte is sampled, which for any
+  allocation larger than 1 byte means every allocation samples.
+
+### Why a single fresh draw (no redraw loop)
+
+A naive implementation handles the "sampled" branch by looping:
+
+```rust
+let mut next = remaining;       // negative for huge alloc + tiny rate
+while next <= 0 {
+    next += draw_exponential(sample_rate_bytes);
+}
+```
+
+This is the textbook way to keep Poisson-process semantics: each draw is
+a gap to the next event, so when an allocation spans multiple events the
+PRNG must advance by the right number of draws.
+
+But it's a footgun. With `sample_rate_bytes = 1` and a 1 GiB allocation,
+`next ≈ -1e9` and the loop calls `draw_exponential` ~1 billion times —
+~10 seconds inside the allocator hook holding the TLS RefCell.
+
+We don't need it. Each `RawAlloc` carries its own `size` field, so
+downstream rate estimators weight samples by the bytes they represent.
+The number of samples emitted per allocation is capped at one regardless
+of how the counter is replenished. By the strong law of large numbers, a
+single fresh draw on each sample produces the same long-run sampling
+probability per allocation — `1 - exp(-size / mean)` — as the looping
+variant. The `next_gap` helper makes this explicit and preserves the
+single-allocation worst case at O(1) PRNG work.
 
 Default `sample_rate_bytes = 512 KiB`. At that rate, a service doing 1 GB/s
 of allocation generates ~2000 samples/sec — plenty of signal, trivial

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -77,8 +77,8 @@ Per-thread byte counter `next_sample_bytes`. On every allocation of size
 ```rust
 fn on_alloc(size: usize) {
     // i64: must be signed — subtracting a large `size` from a small
-    // remaining counter must go negative, not wrap around.
-    let remaining = next_sample_bytes.get() - size as i64;
+    // remaining counter saturates at i64::MIN rather than wrapping.
+    let remaining = next_sample_bytes.get().saturating_sub(size as i64);
     if remaining > 0 {
         next_sample_bytes.set(remaining);
         return;               // fast path: one sub, one branch, done
@@ -294,18 +294,13 @@ can be off by orders of magnitude.
 #### Where `R` comes from
 
 `sample_rate_bytes` is set at install time on `MemoryProfilingConfig`
-and is **not currently embedded in the trace** itself. Analysis
-tooling needs to know the rate that was active when the trace was
-recorded. Two patterns work:
+and is written into segment metadata as `memory.sample_rate_bytes`.
+Analysis tooling reads it from `TraceReader::segment_metadata` (Rust)
+or `trace.segmentMetadata` (JS). For traces recorded before this
+field was added, fall back to the deployment's configured rate or the
+default (512 KiB).
 
-- **Pass it explicitly to your analysis** (e.g., a flag on the script
-  or a constant per service).
-- **Inject it into segment metadata** at install time using
-  `with_segment_metadata([("dial9.memory_profiling.sample_rate_bytes",
-  rate.to_string())])`. Analysis can then read it from
-  `TraceReader::segment_metadata`.
-
-Always pull `R` from a recorded source rather than a build-time
+Always pull `R` from segment metadata rather than a build-time
 constant — the default may change and operators may override it per
 deployment.
 

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -202,13 +202,115 @@ lifetime. Fixed N-of-every-M biases against large objects that get
 undersampled. Per-byte Bernoulli sampling via the geometric/exponential
 trick gives the lowest variance estimator of the simple strategies.
 
-### Small-object unbiasing
+### Estimating totals from samples
 
-When you sample at rate `R` and see an allocation of size `s < R`, the
-*expected* size represented is `R / (1 - exp(-s/R))`. The analysis toolkit
-applies this to produce unbiased byte totals. Jemalloc uses the same
-formula. Aggregation must happen *after* unbiasing per sample —
-sum-then-unbias underreports small-object stacks.
+> **Read this before consuming `AllocEvent.size`.** The raw `size` field
+> on a sampled event is the bytes of *that one* allocation, not a
+> scaled estimate. Summing raw sizes will undercount allocations
+> dominated by small objects, often dramatically (orders of magnitude
+> for tiny allocations).
+
+Each sampled allocation of size `s` survives Poisson sampling with
+probability:
+
+```
+P(sample | size = s) = 1 - exp(-s / R)
+```
+
+where `R` is `sample_rate_bytes`. The Horvitz–Thompson estimator
+weights each sample by the inverse of its sampling probability. To
+recover the total bytes allocated through a code path:
+
+```
+total_bytes ≈ Σ over sampled events  s_i / (1 - exp(-s_i / R))
+```
+
+To recover the total *count* of allocations:
+
+```
+total_count ≈ Σ over sampled events       1 / (1 - exp(-s_i / R))
+```
+
+#### Two regimes, one formula
+
+The same formula handles both extremes correctly:
+
+| Allocation size | `1 - exp(-s/R)` | Per-sample byte weight |
+|-----------------|-----------------|--------------------------|
+| `s << R` (tiny) | `≈ s / R`       | `s / (s/R) = R`          |
+| `s ≈ R`         | `≈ 0.63`        | `s / 0.63 ≈ 1.58 s`      |
+| `s >> R` (huge) | `≈ 1`           | `s / 1 = s`              |
+
+So a tiny sample contributes one full `R` worth of bytes to the
+estimate; a huge sample contributes its actual size.
+
+#### Worked example
+
+At `sample_rate_bytes = 512` and `total_allocated = 1 MiB` (= 1 048 576 B),
+the same total can be reached via radically different size
+distributions and the unbiased estimator recovers ~1 MiB in every case
+(figures from `unbiased_estimator_recovers_total_bytes_across_strategies`):
+
+| Strategy             | # allocs | # samples | Σ raw sizes | HT estimate | Rel. error |
+|----------------------|----------|-----------|-------------|-------------|------------|
+| 1 B × 1 048 576      | 1 048 576 | 2 040     | 2 040 B     | 1 045 500 B | 0.29% |
+| 64 B × 16 384        | 16 384   | 1 919     | 122 816 B   | 1 045 215 B | 0.32% |
+| 1 024 B × 1 024      | 1 024    | 890       | 911 360 B   | 1 054 004 B | 0.52% |
+| 64 KiB × 16          | 16       | 16        | 1 048 576 B | 1 048 576 B | 0.00% |
+| 1 MiB × 1            | 1        | 1         | 1 048 576 B | 1 048 576 B | 0.00% |
+
+The naive **`Σ raw sizes`** column varies from 2 KiB to 1 MiB across
+strategies — three orders of magnitude — even though every strategy
+allocated the same 1 MiB total. Always apply the inverse-probability
+weight before aggregating.
+
+#### Aggregation order matters
+
+When grouping by call site / task / type, **weight each sample
+individually before summing**:
+
+```
+# CORRECT — unbiased:
+for sample in stack_group:
+    weight = 1.0 / (1.0 - exp(-sample.size / R))
+    total_bytes += sample.size * weight
+
+# WRONG — sum-then-unbias under-reports small-object stacks:
+raw_sum = sum(sample.size for sample in stack_group)
+mean_size = raw_sum / len(stack_group)
+weight = 1.0 / (1.0 - exp(-mean_size / R))
+total_bytes = raw_sum * weight  # ← biased
+```
+
+The right-hand version uses the group's *mean* size as if every
+allocation in the group were that size; for skewed distributions this
+can be off by orders of magnitude.
+
+#### Where `R` comes from
+
+`sample_rate_bytes` is set at install time on `MemoryProfilingConfig`
+and is **not currently embedded in the trace** itself. Analysis
+tooling needs to know the rate that was active when the trace was
+recorded. Two patterns work:
+
+- **Pass it explicitly to your analysis** (e.g., a flag on the script
+  or a constant per service).
+- **Inject it into segment metadata** at install time using
+  `with_segment_metadata([("dial9.memory_profiling.sample_rate_bytes",
+  rate.to_string())])`. Analysis can then read it from
+  `TraceReader::segment_metadata`.
+
+Always pull `R` from a recorded source rather than a build-time
+constant — the default may change and operators may override it per
+deployment.
+
+#### `sample_rate_bytes <= 1` ("sample every allocation")
+
+In this mode every alloc is in the trace, so the raw `size` field is
+already the truth. The HT formula degenerates to the right answer
+(`exp(-s/1) ≈ 0` for any positive `s`, so the weight is ~1), but you
+can short-circuit: `total_bytes = Σ s_i`, `total_count = number of
+samples`.
 
 ---
 


### PR DESCRIPTION
This implements the dial9 core side #287 

Remaining work:
- [ ] README updates
- [x] integration into example app
- [x] update SKILL
- [x] update viewer