### PR TITLE
fix: exclude test-traces/*.bin from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.bin
 # except the demo trace
 !dial9-viewer/ui/demo-trace.bin
+!dial9-viewer/ui/test-traces/*.bin
 target/
 .agents/skills/
 .claude/


### PR DESCRIPTION
The `block_in_place.bin` test trace is tracked by git but matched the top-level `*.bin` ignore pattern, causing release-plz to fail with 'uncommitted changes' in CI.

Fixes https://github.com/dial9-rs/dial9/actions/runs/26293766433/job/77400679375