### PR TITLE
add Deserialize impl for dial9-trace-format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
 name = "dial9-trace-format"
 version = "0.4.0"
 dependencies = [
+ "dial9-trace-format",
  "dial9-trace-format-derive",
  "flate2",
  "iai-callgrind",

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -107,6 +107,9 @@ dial9-tokio-telemetry = { path = ".", features = [
     "unstable-events",
     "worker-s3",
 ] }
+# Tests use the serde-based decoder API. Enabling the feature only here keeps
+# it out of the production build of the library.
+dial9-trace-format = { workspace = true, features = ["serde-deserialize"] }
 assert2 = { workspace = true }
 criterion = "0.5"
 clap = { version = "4", features = ["derive", "env"] }

--- a/dial9-tokio-telemetry/tests/common.rs
+++ b/dial9-tokio-telemetry/tests/common.rs
@@ -1,5 +1,8 @@
+#![allow(dead_code)]
 use dial9_tokio_telemetry::analysis_unstable::decode_events;
 use dial9_tokio_telemetry::telemetry::{Batch, TelemetryEvent, TraceWriter};
+use dial9_trace_format::decoder::Decoder;
+use serde::de::DeserializeOwned;
 use std::sync::{Arc, Mutex};
 
 /// A [`TraceWriter`] that accumulates all events into a shared `Vec`.
@@ -32,4 +35,54 @@ impl TraceWriter for CapturingWriter {
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
+}
+
+/// A [`TraceWriter`] that accumulates the raw encoded bytes of every batch it
+/// receives.
+///
+/// Unlike [`CapturingWriter`], this writer does NOT pre-decode into
+/// `TelemetryEvent` — the test layer is responsible for decoding via the serde
+/// path under test.
+pub struct BytesCapturingWriter {
+    batches: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl BytesCapturingWriter {
+    pub fn new() -> (Self, Arc<Mutex<Vec<Vec<u8>>>>) {
+        let batches = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                batches: batches.clone(),
+            },
+            batches,
+        )
+    }
+}
+
+impl TraceWriter for BytesCapturingWriter {
+    fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()> {
+        self.batches
+            .lock()
+            .unwrap()
+            .push(batch.encoded_bytes().to_vec());
+        Ok(())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Decode every batch in `batches`, deserializing each event as `T`.
+pub fn decode_all<T: DeserializeOwned>(batches: &[Vec<u8>]) -> Vec<T> {
+    let mut events = Vec::new();
+    for bytes in batches {
+        let mut dec = Decoder::new(bytes).expect("valid trace header");
+        dec.for_each_event(|raw| {
+            let ev: T = raw.deserialize().expect("deserialize event");
+            events.push(ev);
+        })
+        .expect("decode batch");
+    }
+    events
 }

--- a/dial9-tokio-telemetry/tests/park_unpark_tid.rs
+++ b/dial9-tokio-telemetry/tests/park_unpark_tid.rs
@@ -2,12 +2,27 @@
 
 mod common;
 
-use dial9_tokio_telemetry::telemetry::{TelemetryEvent, TracedRuntime};
+use common::{BytesCapturingWriter, decode_all};
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use serde::Deserialize;
+
+/// Tagged union over the events this test cares about.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "event")]
+enum ParkOrUnpark {
+    WorkerParkEvent {
+        tid: u32,
+    },
+    WorkerUnparkEvent {
+        tid: u32,
+    },
+    #[serde(other)]
+    Other,
+}
 
 #[test]
-#[cfg(feature = "analysis")]
 fn worker_park_unpark_events_carry_nonzero_tid() {
-    let (writer, events) = common::CapturingWriter::new();
+    let (writer, batches) = BytesCapturingWriter::new();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(2).enable_all();
@@ -15,7 +30,7 @@ fn worker_park_unpark_events_carry_nonzero_tid() {
         .build_and_start_with_writer(builder, writer)
         .unwrap();
 
-    // Generate park/unpark cycles by spawning work that yields
+    // Generate park/unpark cycles by spawning work that yields.
     runtime.block_on(async {
         let mut handles = Vec::new();
         for _ in 0..20 {
@@ -26,19 +41,20 @@ fn worker_park_unpark_events_carry_nonzero_tid() {
         for h in handles {
             h.await.unwrap();
         }
-        // Sleep briefly to ensure workers park
+        // Sleep briefly to ensure workers park.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     });
 
     drop(runtime);
     drop(guard);
 
-    let events = events.lock().unwrap();
+    let batches = batches.lock().unwrap();
+    let events: Vec<ParkOrUnpark> = decode_all(&batches);
 
     let park_tids: Vec<u32> = events
         .iter()
         .filter_map(|e| match e {
-            TelemetryEvent::WorkerPark { tid, .. } => Some(*tid),
+            ParkOrUnpark::WorkerParkEvent { tid, .. } => Some(*tid),
             _ => None,
         })
         .collect();
@@ -46,7 +62,7 @@ fn worker_park_unpark_events_carry_nonzero_tid() {
     let unpark_tids: Vec<u32> = events
         .iter()
         .filter_map(|e| match e {
-            TelemetryEvent::WorkerUnpark { tid, .. } => Some(*tid),
+            ParkOrUnpark::WorkerUnparkEvent { tid, .. } => Some(*tid),
             _ => None,
         })
         .collect();

--- a/dial9-trace-format/Cargo.toml
+++ b/dial9-trace-format/Cargo.toml
@@ -9,12 +9,19 @@ autobenches = false
 
 [features]
 serde = ["dep:serde"]
+# Enables a serde `Deserializer` for trace events. This is gated separately
+# from `serde` because the deserializer is significantly larger than the
+# `Serialize` impls and is only useful for analysis-side consumers.
+serde-deserialize = ["serde"]
 
 [dependencies]
 dial9-trace-format-derive = { workspace = true }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]
+# Tests in this crate exercise the serde Deserializer.
+dial9-trace-format = { path = ".", features = ["serde-deserialize"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 flate2 = "1"

--- a/dial9-trace-format/src/de.rs
+++ b/dial9-trace-format/src/de.rs
@@ -71,7 +71,7 @@ pub struct DeserError(String);
 
 impl DeserError {
     /// Construct a new error with the given message.
-    pub fn new(msg: impl Into<String>) -> Self {
+    pub(crate) fn new(msg: impl Into<String>) -> Self {
         Self(msg.into())
     }
 
@@ -233,17 +233,12 @@ impl<'de, 'a, 'f> MapAccess<'de> for RawEventMapAccess<'a, 'f> {
         }
 
         let synthetic = self.synthetic_offset();
-        let key: &str;
-        let pending: PendingValue<'a, 'f>;
-        match self.index {
-            0 => {
-                key = "event";
-                pending = PendingValue::Name(self.name);
-            }
-            1 if self.timestamp_ns.is_some() => {
-                key = "timestamp_ns";
-                pending = PendingValue::Timestamp(self.timestamp_ns.unwrap());
-            }
+        let (key, pending) = match self.index {
+            0 => ("event", PendingValue::Name(self.name)),
+            1 if self.timestamp_ns.is_some() => (
+                "timestamp_ns",
+                PendingValue::Timestamp(self.timestamp_ns.unwrap()),
+            ),
             i => {
                 let field_idx = i - synthetic;
                 let field_def = self.schema.fields().get(field_idx).ok_or_else(|| {
@@ -258,14 +253,16 @@ impl<'de, 'a, 'f> MapAccess<'de> for RawEventMapAccess<'a, 'f> {
                         self.name
                     ))
                 })?;
-                key = field_def.name();
-                pending = PendingValue::Field {
-                    value,
-                    string_pool: self.string_pool,
-                    stack_pool: self.stack_pool,
-                };
+                (
+                    field_def.name(),
+                    PendingValue::Field {
+                        value,
+                        string_pool: self.string_pool,
+                        stack_pool: self.stack_pool,
+                    },
+                )
             }
-        }
+        };
 
         self.pending_value = Some(pending);
         self.index += 1;
@@ -413,6 +410,13 @@ impl<'de, 'a, 'f> de::Deserializer<'de> for FieldValueDeserializer<'a, 'f> {
             FieldValueRef::Bytes(v) => visitor.visit_seq(U64SeqAccess {
                 iter: v.iter().map(|&b| b as u64),
             }),
+            // A `StringMap` field can also be deserialized as a sequence of
+            // `(key, value)` tuples. This makes `Vec<(String, String)>` work
+            // naturally without `#[serde(deserialize_with = "...")]`, which is
+            // useful for ordered or duplicate-tolerant key-value data.
+            FieldValueRef::StringMap(map) => {
+                visitor.visit_seq(StringMapSeqAccess { iter: map.iter() })
+            }
             _ => self.deserialize_any(visitor),
         }
     }
@@ -527,12 +531,117 @@ impl<'de, 'a> MapAccess<'de> for StringMapAccess<'a> {
         let v = self
             .pending_value
             .take()
-            .expect("next_value without next_key");
+            .ok_or_else(|| DeserError::new("next_value called without preceding next_key"))?;
         seed.deserialize(StrDeserializer(v))
     }
 
     fn size_hint(&self) -> Option<usize> {
         Some(self.iter.len())
+    }
+}
+
+// ── Helpers: SeqAccess for StringMap (for `Vec<(String, String)>` decode) ──
+
+/// `SeqAccess` over a `StringMapIter`, yielding each `(key, value)` pair as
+/// a 2-element tuple deserializer. Together with [`StringMapPairDeserializer`]
+/// this lets `StringMap` fields decode into `Vec<(String, String)>` (or any
+/// shape serde can produce from a sequence of 2-tuples).
+struct StringMapSeqAccess<'a> {
+    iter: StringMapIter<'a>,
+}
+
+impl<'de, 'a> SeqAccess<'de> for StringMapSeqAccess<'a> {
+    type Error = DeserError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error> {
+        match self.iter.next() {
+            Some((k, v)) => seed
+                .deserialize(StringMapPairDeserializer { k, v })
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.iter.len())
+    }
+}
+
+/// Deserializer for one `(key, value)` pair of a `StringMap`, presented as
+/// a 2-element sequence so that `(String, String)` (and other 2-tuple shapes)
+/// decode naturally.
+struct StringMapPairDeserializer<'a> {
+    k: &'a str,
+    v: &'a str,
+}
+
+impl<'de, 'a> de::Deserializer<'de> for StringMapPairDeserializer<'a> {
+    type Error = DeserError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        // Pairs are tuples by default — present as a 2-element sequence.
+        visitor.visit_seq(StringMapPairSeqAccess {
+            entries: [Some(self.k), Some(self.v)],
+            idx: 0,
+        })
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char
+        str string bytes byte_buf option unit unit_struct newtype_struct
+        map struct enum identifier ignored_any
+    }
+}
+
+/// `SeqAccess` walking the two entries `[key, value]` of a `StringMap` pair.
+struct StringMapPairSeqAccess<'a> {
+    entries: [Option<&'a str>; 2],
+    idx: usize,
+}
+
+impl<'de, 'a> SeqAccess<'de> for StringMapPairSeqAccess<'a> {
+    type Error = DeserError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error> {
+        if self.idx >= self.entries.len() {
+            return Ok(None);
+        }
+        let entry = self.entries[self.idx]
+            .take()
+            .ok_or_else(|| DeserError::new("tuple pair entry already consumed"))?;
+        self.idx += 1;
+        seed.deserialize(StrDeserializer(entry)).map(Some)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.entries.len() - self.idx)
     }
 }
 
@@ -578,7 +687,7 @@ where
         let value = self
             .pending_value
             .take()
-            .expect("next_value without next_key");
+            .ok_or_else(|| DeserError::new("next_value called without preceding next_key"))?;
         seed.deserialize(FieldValueDeserializer {
             value,
             string_pool: self.string_pool,

--- a/dial9-trace-format/src/de.rs
+++ b/dial9-trace-format/src/de.rs
@@ -1,0 +1,588 @@
+//! serde [`Deserializer`] for raw trace events.
+//!
+//! This module presents a [`RawEvent`](crate::decoder::RawEvent) (the
+//! callback type yielded by [`Decoder::for_each_event`](crate::decoder::Decoder::for_each_event))
+//! as a flat map compatible with serde's internally-tagged-enum representation.
+//!
+//! # Mapping
+//!
+//! The deserializer presents each event as a map with these entries (in order):
+//!
+//! 1. `"event"` → the schema name (the discriminant for `#[serde(tag = "event")]`).
+//! 2. `"timestamp_ns"` → the absolute frame-header timestamp (only if the
+//!    schema has `has_timestamp = true`).
+//! 3. One entry per schema field, keyed by field name.
+//!
+//! Pool resolution is automatic:
+//!
+//! - [`FieldValueRef::PooledString`](crate::types::FieldValueRef::PooledString)
+//!   resolves through the decoder's
+//!   [`StringPool`](crate::decoder::StringPool) and presents as a string.
+//! - [`FieldValueRef::PooledStackFrames`](crate::types::FieldValueRef::PooledStackFrames)
+//!   resolves through the decoder's
+//!   [`StackPool`](crate::decoder::StackPool) and presents as a sequence of
+//!   `u64`.
+//! - [`FieldValueRef::None`](crate::types::FieldValueRef::None) presents as
+//!   serde `None`, so optional fields work transparently.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use dial9_trace_format::decoder::Decoder;
+//! use serde::Deserialize;
+//!
+//! #[derive(Deserialize)]
+//! #[serde(tag = "event")]
+//! enum MyEvent {
+//!     #[serde(rename = "PollStart")]
+//!     PollStart {
+//!         timestamp_ns: u64,
+//!         worker_id: u64,
+//!     },
+//!     #[serde(other)]
+//!     Other,
+//! }
+//!
+//! # let bytes: &[u8] = &[];
+//! let mut dec = Decoder::new(bytes).unwrap();
+//! dec.for_each_event(|raw| {
+//!     match raw.deserialize::<MyEvent>() {
+//!         Ok(MyEvent::PollStart { timestamp_ns, worker_id }) => {
+//!             println!("poll {worker_id} at {timestamp_ns}");
+//!         }
+//!         Ok(MyEvent::Other) => {}
+//!         Err(e) => eprintln!("decode error: {e}"),
+//!     }
+//! }).unwrap();
+//! ```
+
+use crate::decoder::{RawEvent, StackPool, StringPool};
+use crate::schema::SchemaEntry;
+use crate::types::{FieldValueRef, StringMapIter};
+use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
+use std::fmt;
+
+/// Error returned when deserializing a trace event into a typed value fails.
+///
+/// This wraps a message produced by serde or by the deserializer itself
+/// (e.g. for missing fields or pool lookup failures).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeserError(String);
+
+impl DeserError {
+    /// Construct a new error with the given message.
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+
+    /// The error message.
+    pub fn message(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DeserError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for DeserError {}
+
+impl de::Error for DeserError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self(msg.to_string())
+    }
+}
+
+// ── Deserializer entry point ───────────────────────────────────────────────
+
+/// Deserialize a [`RawEvent`] into `T`.
+///
+/// Most callers should use [`RawEvent::deserialize`] instead, which is a thin
+/// wrapper over this function.
+pub fn from_raw_event<'a, 'f, T: serde::de::DeserializeOwned>(
+    raw: &RawEvent<'a, 'f>,
+) -> Result<T, DeserError> {
+    T::deserialize(RawEventDeserializer {
+        name: raw.name,
+        timestamp_ns: raw.timestamp_ns,
+        fields: raw.fields,
+        schema: raw.schema,
+        string_pool: raw.string_pool,
+        stack_pool: raw.stack_pool,
+    })
+}
+
+// ── RawEventDeserializer: the top-level deserializer for a raw event ───────
+
+/// Deserializer that presents a [`RawEvent`] as an internally-tagged enum
+/// or struct.
+struct RawEventDeserializer<'a, 'f> {
+    name: &'f str,
+    timestamp_ns: Option<u64>,
+    fields: &'f [FieldValueRef<'a>],
+    schema: &'f SchemaEntry,
+    string_pool: &'f StringPool,
+    stack_pool: &'f StackPool,
+}
+
+impl<'de, 'a, 'f> de::Deserializer<'de> for RawEventDeserializer<'a, 'f> {
+    type Error = DeserError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        // For internally-tagged enums and plain structs, present as a map.
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_map(RawEventMapAccess {
+            name: self.name,
+            timestamp_ns: self.timestamp_ns,
+            fields: self.fields,
+            schema: self.schema,
+            string_pool: self.string_pool,
+            stack_pool: self.stack_pool,
+            index: 0,
+            pending_value: None,
+        })
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        // For internally-tagged enums, serde first deserializes the tag from a
+        // map representation, so route through deserialize_map.
+        self.deserialize_map(visitor)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct identifier ignored_any
+    }
+}
+
+// ── MapAccess: walks "event" → "timestamp_ns" → schema fields ──────────────
+
+struct RawEventMapAccess<'a, 'f> {
+    name: &'f str,
+    timestamp_ns: Option<u64>,
+    fields: &'f [FieldValueRef<'a>],
+    schema: &'f SchemaEntry,
+    string_pool: &'f StringPool,
+    stack_pool: &'f StackPool,
+    /// Cursor into the synthetic map:
+    ///   0                                     → "event"
+    ///   1 (if timestamp_ns is Some)           → "timestamp_ns"
+    ///   1 + (timestamp offset) + field_idx    → schema field
+    index: usize,
+    /// Value paired with the most recently yielded key. Cleared after
+    /// `next_value_seed` consumes it.
+    pending_value: Option<PendingValue<'a, 'f>>,
+}
+
+/// A value temporarily held between `next_key_seed` and `next_value_seed`.
+enum PendingValue<'a, 'f> {
+    /// Tag value: the event name, deserialized as a `&str`.
+    Name(&'f str),
+    /// Synthetic timestamp, deserialized as `u64`.
+    Timestamp(u64),
+    /// A schema field. The pools are needed to resolve `PooledString`
+    /// and `PooledStackFrames`.
+    Field {
+        value: &'f FieldValueRef<'a>,
+        string_pool: &'f StringPool,
+        stack_pool: &'f StackPool,
+    },
+}
+
+impl<'a, 'f> RawEventMapAccess<'a, 'f> {
+    /// Total number of map entries (tag + optional timestamp + fields).
+    fn total_entries(&self) -> usize {
+        1 + (self.timestamp_ns.is_some() as usize) + self.fields.len()
+    }
+
+    /// Number of leading "synthetic" entries (1 for tag, +1 if timestamp).
+    fn synthetic_offset(&self) -> usize {
+        1 + (self.timestamp_ns.is_some() as usize)
+    }
+}
+
+impl<'de, 'a, 'f> MapAccess<'de> for RawEventMapAccess<'a, 'f> {
+    type Error = DeserError;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, Self::Error> {
+        if self.index >= self.total_entries() {
+            return Ok(None);
+        }
+
+        let synthetic = self.synthetic_offset();
+        let key: &str;
+        let pending: PendingValue<'a, 'f>;
+        match self.index {
+            0 => {
+                key = "event";
+                pending = PendingValue::Name(self.name);
+            }
+            1 if self.timestamp_ns.is_some() => {
+                key = "timestamp_ns";
+                pending = PendingValue::Timestamp(self.timestamp_ns.unwrap());
+            }
+            i => {
+                let field_idx = i - synthetic;
+                let field_def = self.schema.fields().get(field_idx).ok_or_else(|| {
+                    DeserError::new(format!(
+                        "schema for event '{}' has fewer fields than the wire stream",
+                        self.name
+                    ))
+                })?;
+                let value = self.fields.get(field_idx).ok_or_else(|| {
+                    DeserError::new(format!(
+                        "wire stream for event '{}' has fewer fields than the schema",
+                        self.name
+                    ))
+                })?;
+                key = field_def.name();
+                pending = PendingValue::Field {
+                    value,
+                    string_pool: self.string_pool,
+                    stack_pool: self.stack_pool,
+                };
+            }
+        }
+
+        self.pending_value = Some(pending);
+        self.index += 1;
+        seed.deserialize(key.into_deserializer()).map(Some)
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, Self::Error> {
+        let pending = self
+            .pending_value
+            .take()
+            .ok_or_else(|| DeserError::new("next_value_seed called without next_key_seed"))?;
+        match pending {
+            PendingValue::Name(s) => seed.deserialize(StrDeserializer(s)),
+            PendingValue::Timestamp(t) => seed.deserialize(U64Deserializer(t)),
+            PendingValue::Field {
+                value,
+                string_pool,
+                stack_pool,
+            } => seed.deserialize(FieldValueDeserializer {
+                value,
+                string_pool,
+                stack_pool,
+            }),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.total_entries() - self.index)
+    }
+}
+
+// ── Trivial leaf deserializers for the synthetic entries ───────────────────
+
+/// Deserializer that always yields a borrowed `&str`.
+struct StrDeserializer<'f>(&'f str);
+
+impl<'de, 'f> de::Deserializer<'de> for StrDeserializer<'f> {
+    type Error = DeserError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_str(self.0)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+/// Deserializer that always yields a `u64`.
+struct U64Deserializer(u64);
+
+impl<'de> de::Deserializer<'de> for U64Deserializer {
+    type Error = DeserError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u64(self.0)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+// ── FieldValueDeserializer: deserializer for one schema field's value ──────
+
+/// Deserializer for a single [`FieldValueRef`], with pool context for
+/// transparent resolution of `PooledString` / `PooledStackFrames`.
+struct FieldValueDeserializer<'a, 'f> {
+    value: &'f FieldValueRef<'a>,
+    string_pool: &'f StringPool,
+    stack_pool: &'f StackPool,
+}
+
+impl<'de, 'a, 'f> de::Deserializer<'de> for FieldValueDeserializer<'a, 'f> {
+    type Error = DeserError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value {
+            FieldValueRef::I64(v) => visitor.visit_i64(*v),
+            FieldValueRef::F64(v) => visitor.visit_f64(*v),
+            FieldValueRef::Bool(v) => visitor.visit_bool(*v),
+            FieldValueRef::String(v) => visitor.visit_str(v),
+            FieldValueRef::Bytes(v) => visitor.visit_bytes(v),
+            FieldValueRef::Varint(v) => visitor.visit_u64(*v),
+            FieldValueRef::PooledString(id) => match self.string_pool.get(*id) {
+                Some(s) => visitor.visit_str(s),
+                None => Err(DeserError::new(format!(
+                    "PooledString id {id:?} not found in string pool"
+                ))),
+            },
+            FieldValueRef::PooledStackFrames(id) => match self.stack_pool.get(*id) {
+                Some(frames) => visitor.visit_seq(U64SeqAccess {
+                    iter: frames.iter().copied(),
+                }),
+                None => Err(DeserError::new(format!(
+                    "PooledStackFrames id {id:?} not found in stack pool"
+                ))),
+            },
+            FieldValueRef::StackFrames(frames) => visitor.visit_seq(U64SeqAccess {
+                iter: frames.iter(),
+            }),
+            FieldValueRef::None => visitor.visit_none(),
+            FieldValueRef::List(list) => visitor.visit_seq(FieldValueSeqAccess {
+                iter: list.iter(),
+                string_pool: self.string_pool,
+                stack_pool: self.stack_pool,
+            }),
+            FieldValueRef::StringMap(map) => visitor.visit_map(StringMapAccess {
+                iter: map.iter(),
+                pending_value: None,
+            }),
+            FieldValueRef::Map(map) => visitor.visit_map(DynamicMapAccess {
+                iter: map.iter(),
+                pending_value: None,
+                string_pool: self.string_pool,
+                stack_pool: self.stack_pool,
+            }),
+        }
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value {
+            FieldValueRef::None => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value {
+            FieldValueRef::Bytes(v) => visitor.visit_seq(U64SeqAccess {
+                iter: v.iter().map(|&b| b as u64),
+            }),
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char
+        unit unit_struct newtype_struct tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+// ── Helpers: SeqAccess wrapper for u64 sequences (stack frames) ───────────
+
+/// `SeqAccess` over an iterator of `u64`. Used for both pooled stack frames
+/// (`&[u64]` via `.iter().copied()`) and inline stack frames (`StackFrameIter`).
+struct U64SeqAccess<I: Iterator<Item = u64>> {
+    iter: I,
+}
+
+impl<'de, I: Iterator<Item = u64>> SeqAccess<'de> for U64SeqAccess<I> {
+    type Error = DeserError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error> {
+        match self.iter.next() {
+            Some(v) => seed.deserialize(v.into_deserializer()).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        let (lower, upper) = self.iter.size_hint();
+        if Some(lower) == upper {
+            Some(lower)
+        } else {
+            None
+        }
+    }
+}
+
+// ── Helpers: SeqAccess for DynamicList ─────────────────────────────────────
+
+/// `SeqAccess` over an iterator of `&FieldValueRef`, delegating each element
+/// to `FieldValueDeserializer`.
+struct FieldValueSeqAccess<'f, I> {
+    iter: I,
+    string_pool: &'f StringPool,
+    stack_pool: &'f StackPool,
+}
+
+impl<'de, 'a: 'f, 'f, I> SeqAccess<'de> for FieldValueSeqAccess<'f, I>
+where
+    I: Iterator<Item = &'f FieldValueRef<'a>>,
+{
+    type Error = DeserError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error> {
+        match self.iter.next() {
+            Some(value) => seed
+                .deserialize(FieldValueDeserializer {
+                    value,
+                    string_pool: self.string_pool,
+                    stack_pool: self.stack_pool,
+                })
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+}
+
+// ── Helpers: MapAccess for StringMap ───────────────────────────────────────
+
+/// `MapAccess` over a `StringMapIter`, yielding `(&str, &str)` pairs.
+struct StringMapAccess<'a> {
+    iter: StringMapIter<'a>,
+    pending_value: Option<&'a str>,
+}
+
+impl<'de, 'a> MapAccess<'de> for StringMapAccess<'a> {
+    type Error = DeserError;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, Self::Error> {
+        match self.iter.next() {
+            Some((k, v)) => {
+                self.pending_value = Some(v);
+                seed.deserialize(StrDeserializer(k)).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, Self::Error> {
+        let v = self
+            .pending_value
+            .take()
+            .expect("next_value without next_key");
+        seed.deserialize(StrDeserializer(v))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.iter.len())
+    }
+}
+
+// ── Helpers: MapAccess for DynamicMap ──────────────────────────────────────
+
+/// `MapAccess` over a `DynamicMapRef` iterator, delegating both keys and values
+/// to `FieldValueDeserializer`.
+struct DynamicMapAccess<'a, 'f, I> {
+    iter: I,
+    pending_value: Option<&'f FieldValueRef<'a>>,
+    string_pool: &'f StringPool,
+    stack_pool: &'f StackPool,
+}
+
+impl<'de, 'a: 'f, 'f, I> MapAccess<'de> for DynamicMapAccess<'a, 'f, I>
+where
+    I: Iterator<Item = (&'f FieldValueRef<'a>, &'f FieldValueRef<'a>)>,
+{
+    type Error = DeserError;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, Self::Error> {
+        match self.iter.next() {
+            Some((k, v)) => {
+                self.pending_value = Some(v);
+                seed.deserialize(FieldValueDeserializer {
+                    value: k,
+                    string_pool: self.string_pool,
+                    stack_pool: self.stack_pool,
+                })
+                .map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, Self::Error> {
+        let value = self
+            .pending_value
+            .take()
+            .expect("next_value without next_key");
+        seed.deserialize(FieldValueDeserializer {
+            value,
+            string_pool: self.string_pool,
+            stack_pool: self.stack_pool,
+        })
+    }
+}

--- a/dial9-trace-format/src/decoder.rs
+++ b/dial9-trace-format/src/decoder.rs
@@ -70,6 +70,26 @@ impl<'a, 'f> RawEvent<'a, 'f> {
     pub fn field_names(&self) -> impl Iterator<Item = &'f str> {
         self.schema.fields.iter().map(|f| f.name.as_str())
     }
+
+    /// Deserialize this event into a typed value `E` via serde.
+    ///
+    /// The deserializer presents the event as a flat map containing:
+    ///
+    /// 1. `"event"` → the schema name (the discriminant for
+    ///    `#[serde(tag = "event")]`).
+    /// 2. `"timestamp_ns"` → the absolute frame-header timestamp (only if
+    ///    the schema has `has_timestamp = true`).
+    /// 3. One entry per schema field, keyed by field name.
+    ///
+    /// Pool-resolved values appear as their resolved form: `PooledString`
+    /// presents as a string, `PooledStackFrames` presents as a sequence of
+    /// `u64`. See [`crate::de`] for details.
+    ///
+    /// Available only when the `serde-deserialize` feature is enabled.
+    #[cfg(feature = "serde-deserialize")]
+    pub fn deserialize<E: serde::de::DeserializeOwned>(&self) -> Result<E, crate::de::DeserError> {
+        crate::de::from_raw_event(self)
+    }
 }
 
 /// A map from interned string IDs to their resolved string values.

--- a/dial9-trace-format/src/lib.rs
+++ b/dial9-trace-format/src/lib.rs
@@ -17,12 +17,16 @@
 //!   trait, and the [`EventEncoder`] used by derived code
 
 pub mod codec;
+#[cfg(feature = "serde-deserialize")]
+pub mod de;
 pub mod decoder;
 pub mod encoder;
 pub(crate) mod leb128;
 pub mod schema;
 pub mod types;
 
+#[cfg(feature = "serde-deserialize")]
+pub use de::DeserError;
 pub use dial9_trace_format_derive::TraceEvent;
 pub use types::DynamicListRef;
 pub use types::DynamicMapRef;

--- a/dial9-trace-format/tests/serde_deserialize.rs
+++ b/dial9-trace-format/tests/serde_deserialize.rs
@@ -1,0 +1,847 @@
+//! Tests for the [`dial9_trace_format::de`] module — serde Deserializer for
+//! `RawEvent`.
+//!
+//! These tests cover the full matrix of behaviors described in
+//! `prd-serde-deserializer.md`:
+//!
+//! - Round-trip encode → decode → deserialize for all field types
+//!   (varints, signed/unsigned, bool, floats, strings, pooled strings,
+//!   stack frames, pooled stack frames).
+//! - Optional fields, both present and absent, deserialize correctly.
+//! - `#[serde(other)]` catches unknown event names.
+//! - Required-field schema mismatch produces an error from the deserializer.
+//! - End-to-end test using `#[derive(TraceEvent)]` for the encode side and
+//!   `#[derive(serde::Deserialize)]` for the decode side.
+
+use dial9_trace_format::decoder::Decoder;
+use dial9_trace_format::encoder::Encoder;
+use dial9_trace_format::schema::FieldDef;
+use dial9_trace_format::types::{FieldType, FieldValue};
+use dial9_trace_format::{InternedStackFrames, InternedString, StackFrames, TraceEvent};
+use serde::Deserialize;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Decode the first event in `bytes` and deserialize into `T`.
+///
+/// Panics if no events are present in the trace or if deserialization fails.
+fn decode_first<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
+    let mut dec = Decoder::new(bytes).expect("valid trace header");
+    let mut out: Option<T> = None;
+    dec.for_each_event(|raw| {
+        if out.is_none() {
+            out = Some(raw.deserialize::<T>().expect("deserialize first event"));
+        }
+    })
+    .expect("no decode error");
+    out.expect("at least one event in trace")
+}
+
+/// Decode all events into a Vec<T>.
+fn decode_all<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Vec<T> {
+    let mut dec = Decoder::new(bytes).expect("valid trace header");
+    let mut events = Vec::new();
+    dec.for_each_event(|raw| {
+        events.push(raw.deserialize::<T>().expect("deserialize event"));
+    })
+    .expect("no decode error");
+    events
+}
+
+// ── Test 1: simple varint round-trip ───────────────────────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Simple {
+    timestamp_ns: u64,
+    worker_id: u64,
+    task_id: u64,
+}
+
+#[test]
+fn varint_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "Simple",
+            vec![
+                FieldDef::new("worker_id", FieldType::Varint),
+                FieldDef::new("task_id", FieldType::Varint),
+            ],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(1_000_000_000),
+            FieldValue::Varint(7),
+            FieldValue::Varint(42),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: Simple = decode_first(&bytes);
+    assert_eq!(
+        event,
+        Simple {
+            timestamp_ns: 1_000_000_000,
+            worker_id: 7,
+            task_id: 42,
+        }
+    );
+}
+
+// ── Test 2: pooled string resolves transparently ────────────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithPool {
+    timestamp_ns: u64,
+    label: String,
+}
+
+#[test]
+fn pooled_string_resolves_to_string() {
+    let mut enc = Encoder::new();
+    let interned = enc.intern_string("worker-thread-3").unwrap();
+    let schema = enc
+        .register_schema(
+            "WithPool",
+            vec![FieldDef::new("label", FieldType::PooledString)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(2_000),
+            FieldValue::PooledString(interned),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithPool = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 2_000);
+    assert_eq!(event.label, "worker-thread-3");
+}
+
+// ── Test 3: pooled stack frames resolve to Vec<u64> ─────────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithStack {
+    timestamp_ns: u64,
+    callchain: Vec<u64>,
+}
+
+#[test]
+fn pooled_stack_frames_resolve_to_vec_u64() {
+    let mut enc = Encoder::new();
+    let stack = enc
+        .intern_stack_frames(&[0xdead_beef, 0xcafe_babe, 0x1234_5678])
+        .unwrap();
+    let schema = enc
+        .register_schema(
+            "WithStack",
+            vec![FieldDef::new("callchain", FieldType::PooledStackFrames)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(5_000),
+            FieldValue::PooledStackFrames(stack),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithStack = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 5_000);
+    assert_eq!(event.callchain, vec![0xdead_beef, 0xcafe_babe, 0x1234_5678]);
+}
+
+// ── Test 4: non-pooled StackFrames also deserializes as Vec<u64> ────────────
+
+#[test]
+fn inline_stack_frames_deserialize_as_vec_u64() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithStack",
+            vec![FieldDef::new("callchain", FieldType::StackFrames)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(6_000),
+            FieldValue::StackFrames(StackFrames::from(vec![1u64, 2, 3])),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithStack = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 6_000);
+    assert_eq!(event.callchain, vec![1, 2, 3]);
+}
+
+// ── Test 4b: Bytes field round-trip ─────────────────────────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithBytes {
+    timestamp_ns: u64,
+    payload: Vec<u8>,
+}
+
+#[test]
+fn bytes_field_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithBytes",
+            vec![FieldDef::new("payload", FieldType::Bytes)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(6_500),
+            FieldValue::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithBytes = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 6_500);
+    assert_eq!(event.payload, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+}
+
+// ── Test 5: optional present and absent ─────────────────────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithOption {
+    timestamp_ns: u64,
+    name: Option<String>,
+    count: Option<u64>,
+}
+
+#[test]
+fn optional_fields_present() {
+    let mut enc = Encoder::new();
+    let pooled = enc.intern_string("present").unwrap();
+    let schema = enc
+        .register_schema(
+            "WithOption",
+            vec![
+                FieldDef::new("name", FieldType::OptionalPooledString),
+                FieldDef::new("count", FieldType::OptionalVarint),
+            ],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(7_000),
+            FieldValue::PooledString(pooled),
+            FieldValue::Varint(99),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithOption = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 7_000);
+    assert_eq!(event.name.as_deref(), Some("present"));
+    assert_eq!(event.count, Some(99));
+}
+
+#[test]
+fn optional_fields_absent() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithOption",
+            vec![
+                FieldDef::new("name", FieldType::OptionalPooledString),
+                FieldDef::new("count", FieldType::OptionalVarint),
+            ],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(8_000),
+            FieldValue::None,
+            FieldValue::None,
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithOption = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 8_000);
+    assert_eq!(event.name, None);
+    assert_eq!(event.count, None);
+}
+
+// ── Test 6: full type matrix using #[derive(TraceEvent)] ─────────────────────
+
+#[derive(TraceEvent)]
+#[allow(dead_code)]
+struct KitchenSinkEvent {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    a_u8: u8,
+    b_u16: u16,
+    c_u32: u32,
+    d_u64: u64,
+    e_i64: i64,
+    f_f64: f64,
+    g_bool: bool,
+    h_string: String,
+    i_pooled: InternedString,
+    j_frames: StackFrames,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct KitchenSinkDecoded {
+    timestamp_ns: u64,
+    a_u8: u64, // U8 wire type decodes as u64 / Varint
+    b_u16: u64,
+    c_u32: u64,
+    d_u64: u64,
+    e_i64: i64,
+    f_f64: f64,
+    g_bool: bool,
+    h_string: String,
+    i_pooled: String, // PooledString resolves transparently
+    j_frames: Vec<u64>,
+}
+
+#[test]
+fn full_type_matrix_round_trip() {
+    let mut enc = Encoder::new();
+    let interned = enc.intern_string("kitchen_pool_value").unwrap();
+    let ev = KitchenSinkEvent {
+        timestamp_ns: 9_000,
+        a_u8: 250,
+        b_u16: 60_000,
+        c_u32: 0xDEAD_BEEF,
+        d_u64: u64::MAX,
+        e_i64: i64::MIN,
+        f_f64: std::f64::consts::PI,
+        g_bool: true,
+        h_string: "an inline string".into(),
+        i_pooled: interned,
+        j_frames: StackFrames::from(vec![10, 20, 30]),
+    };
+    enc.write::<KitchenSinkEvent>(&ev).unwrap();
+    let bytes = enc.finish();
+
+    let decoded: KitchenSinkDecoded = decode_first(&bytes);
+    assert_eq!(
+        decoded,
+        KitchenSinkDecoded {
+            timestamp_ns: 9_000,
+            a_u8: 250,
+            b_u16: 60_000,
+            c_u32: 0xDEAD_BEEF,
+            d_u64: u64::MAX,
+            e_i64: i64::MIN,
+            f_f64: std::f64::consts::PI,
+            g_bool: true,
+            h_string: "an inline string".into(),
+            i_pooled: "kitchen_pool_value".into(),
+            j_frames: vec![10, 20, 30],
+        }
+    );
+}
+
+// ── Test 7: #[serde(other)] catches unknown events ─────────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(tag = "event")]
+enum OnlyKnown {
+    Simple(Simple),
+    #[serde(other)]
+    Unknown,
+}
+
+#[test]
+fn serde_other_catches_unknown_events() {
+    let mut enc = Encoder::new();
+    let known = enc
+        .register_schema(
+            "Simple",
+            vec![
+                FieldDef::new("worker_id", FieldType::Varint),
+                FieldDef::new("task_id", FieldType::Varint),
+            ],
+        )
+        .unwrap();
+    let unknown = enc
+        .register_schema(
+            "TotallyUnknownEvent",
+            vec![FieldDef::new("data", FieldType::Varint)],
+        )
+        .unwrap();
+
+    enc.write_event(
+        &known,
+        &[
+            FieldValue::Varint(10_000),
+            FieldValue::Varint(0),
+            FieldValue::Varint(1),
+        ],
+    )
+    .unwrap();
+    enc.write_event(
+        &unknown,
+        &[FieldValue::Varint(11_000), FieldValue::Varint(99)],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let events: Vec<OnlyKnown> = decode_all(&bytes);
+    assert_eq!(
+        events,
+        vec![
+            OnlyKnown::Simple(Simple {
+                timestamp_ns: 10_000,
+                worker_id: 0,
+                task_id: 1,
+            }),
+            OnlyKnown::Unknown,
+        ]
+    );
+}
+
+// ── Test 8: missing required field returns an error ─────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct ExpectsExtra {
+    timestamp_ns: u64,
+    worker_id: u64,
+    /// Schema does NOT contain this field — deserialization must fail.
+    task_id: u64,
+    extra_required_field: u64,
+}
+
+#[test]
+fn missing_required_field_errors() {
+    // Schema has only worker_id + task_id. Struct expects an extra required
+    // field — serde should report a missing-field error.
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "Simple",
+            vec![
+                FieldDef::new("worker_id", FieldType::Varint),
+                FieldDef::new("task_id", FieldType::Varint),
+            ],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(12_000),
+            FieldValue::Varint(0),
+            FieldValue::Varint(1),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let mut dec = Decoder::new(&bytes).expect("valid header");
+    let mut got_err = false;
+    dec.for_each_event(|raw| {
+        let result = raw.deserialize::<ExpectsExtra>();
+        if result.is_err() {
+            got_err = true;
+        }
+    })
+    .expect("no decode error");
+
+    assert!(
+        got_err,
+        "deserializing into a struct with an extra required field should error"
+    );
+}
+
+// ── Test 9: #[derive(TraceEvent)] + #[derive(Deserialize)] enum end-to-end ──
+
+#[derive(TraceEvent)]
+#[allow(dead_code)]
+struct AppEvent {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    user_id: u64,
+    action: InternedString,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(tag = "event")]
+enum AnalysisEvent {
+    AppEvent {
+        timestamp_ns: u64,
+        user_id: u64,
+        action: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[test]
+fn derive_traceevent_to_serde_enum_end_to_end() {
+    let mut enc = Encoder::new();
+    let click = enc.intern_string("click").unwrap();
+    let scroll = enc.intern_string("scroll").unwrap();
+
+    enc.write::<AppEvent>(&AppEvent {
+        timestamp_ns: 100,
+        user_id: 1,
+        action: click,
+    })
+    .unwrap();
+    enc.write::<AppEvent>(&AppEvent {
+        timestamp_ns: 200,
+        user_id: 2,
+        action: scroll,
+    })
+    .unwrap();
+    let bytes = enc.finish();
+
+    let events: Vec<AnalysisEvent> = decode_all(&bytes);
+    assert_eq!(
+        events,
+        vec![
+            AnalysisEvent::AppEvent {
+                timestamp_ns: 100,
+                user_id: 1,
+                action: "click".into(),
+            },
+            AnalysisEvent::AppEvent {
+                timestamp_ns: 200,
+                user_id: 2,
+                action: "scroll".into(),
+            },
+        ]
+    );
+}
+
+// ── Test 10: float and bool round-trip through deserializer ─────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Mixed {
+    timestamp_ns: u64,
+    pi: f64,
+    flag: bool,
+    delta: i64,
+}
+
+#[test]
+fn float_bool_signed_round_trip() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "Mixed",
+            vec![
+                FieldDef::new("pi", FieldType::F64),
+                FieldDef::new("flag", FieldType::Bool),
+                FieldDef::new("delta", FieldType::I64),
+            ],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(13_000),
+            FieldValue::F64(std::f64::consts::PI),
+            FieldValue::Bool(true),
+            FieldValue::I64(-9_999),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: Mixed = decode_first(&bytes);
+    assert_eq!(
+        event,
+        Mixed {
+            timestamp_ns: 13_000,
+            pi: std::f64::consts::PI,
+            flag: true,
+            delta: -9_999,
+        }
+    );
+}
+
+// ── Test 11: Option<T> field entirely absent from wire schema ────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct NewerStruct {
+    timestamp_ns: u64,
+    worker_id: u64,
+    /// This field doesn't exist in the wire schema — should default to None.
+    new_optional_field: Option<String>,
+}
+
+#[test]
+fn option_field_absent_from_schema_defaults_to_none() {
+    // Schema only has "worker_id" — no "new_optional_field". This simulates
+    // reading an old trace with a newer decoder struct that added an Option field.
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "NewerStruct",
+            vec![FieldDef::new("worker_id", FieldType::Varint)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: NewerStruct = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 1_000);
+    assert_eq!(event.worker_id, 42);
+    assert_eq!(event.new_optional_field, None);
+}
+
+// ── Test 11: pool-miss error paths ──────────────────────────────────────────
+
+#[test]
+fn pooled_string_miss_returns_error() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithPool",
+            vec![FieldDef::new("label", FieldType::PooledString)],
+        )
+        .unwrap();
+    // Write an event referencing pool ID 999 which was never interned.
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(1_000),
+            FieldValue::PooledString(InternedString::from_raw(999)),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let mut dec = Decoder::new(&bytes).expect("valid header");
+    let mut got_err = false;
+    dec.for_each_event(|raw| {
+        if let Err(e) = raw.deserialize::<WithPool>() {
+            assert!(
+                e.message().contains("not found in string pool"),
+                "unexpected error: {e}"
+            );
+            got_err = true;
+        }
+    })
+    .expect("no decode error");
+    assert!(got_err, "expected a pool-miss error");
+}
+
+#[test]
+fn pooled_stack_frames_miss_returns_error() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithStack",
+            vec![FieldDef::new("callchain", FieldType::PooledStackFrames)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(2_000),
+            FieldValue::PooledStackFrames(InternedStackFrames::from_raw(999)),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let mut dec = Decoder::new(&bytes).expect("valid header");
+    let mut got_err = false;
+    dec.for_each_event(|raw| {
+        if let Err(e) = raw.deserialize::<WithStack>() {
+            assert!(
+                e.message().contains("not found in stack pool"),
+                "unexpected error: {e}"
+            );
+            got_err = true;
+        }
+    })
+    .expect("no decode error");
+    assert!(got_err, "expected a pool-miss error");
+}
+
+// ── Test 12: DynamicList deserializes into Vec<T> ───────────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithList {
+    timestamp_ns: u64,
+    items: Vec<String>,
+}
+
+#[test]
+fn dynamic_list_deserializes_to_vec() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithList",
+            vec![FieldDef::new("items", FieldType::DynamicList)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(1_000),
+            FieldValue::List(vec![
+                FieldValue::String("hello".into()),
+                FieldValue::String("world".into()),
+            ]),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithList = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 1_000);
+    assert_eq!(event.items, vec!["hello", "world"]);
+}
+
+// ── Test 13: StringMap deserializes into HashMap<String, String> ─────────────
+
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithStringMap {
+    timestamp_ns: u64,
+    headers: HashMap<String, String>,
+}
+
+#[test]
+fn string_map_deserializes_to_hashmap() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithStringMap",
+            vec![FieldDef::new("headers", FieldType::StringMap)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(2_000),
+            FieldValue::StringMap(vec![
+                ("content-type".into(), "application/json".into()),
+                ("x-request-id".into(), "abc123".into()),
+            ]),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithStringMap = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 2_000);
+    let mut expected = HashMap::new();
+    expected.insert("content-type".into(), "application/json".into());
+    expected.insert("x-request-id".into(), "abc123".into());
+    assert_eq!(event.headers, expected);
+}
+
+// ── Test 14: DynamicMap deserializes into HashMap<String, u64> ───────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithDynamicMap {
+    timestamp_ns: u64,
+    counts: HashMap<String, u64>,
+}
+
+#[test]
+fn dynamic_map_deserializes_to_hashmap() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithDynamicMap",
+            vec![FieldDef::new("counts", FieldType::DynamicMap)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(3_000),
+            FieldValue::Map(vec![
+                (FieldValue::String("reads".into()), FieldValue::Varint(100)),
+                (FieldValue::String("writes".into()), FieldValue::Varint(42)),
+            ]),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithDynamicMap = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 3_000);
+    let mut expected = HashMap::new();
+    expected.insert("reads".into(), 100u64);
+    expected.insert("writes".into(), 42u64);
+    assert_eq!(event.counts, expected);
+}
+
+// ── Test 15: DynamicMap deserializes into a typed struct ─────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Metadata {
+    status: u64,
+    path: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithStructMap {
+    timestamp_ns: u64,
+    meta: Metadata,
+}
+
+#[test]
+fn dynamic_map_deserializes_to_struct() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithStructMap",
+            vec![FieldDef::new("meta", FieldType::DynamicMap)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(4_000),
+            FieldValue::Map(vec![
+                (FieldValue::String("status".into()), FieldValue::Varint(200)),
+                (
+                    FieldValue::String("path".into()),
+                    FieldValue::String("/api/users".into()),
+                ),
+            ]),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithStructMap = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 4_000);
+    assert_eq!(
+        event.meta,
+        Metadata {
+            status: 200,
+            path: "/api/users".into(),
+        }
+    );
+}

--- a/dial9-trace-format/tests/serde_deserialize.rs
+++ b/dial9-trace-format/tests/serde_deserialize.rs
@@ -1,8 +1,7 @@
 //! Tests for the [`dial9_trace_format::de`] module — serde Deserializer for
 //! `RawEvent`.
 //!
-//! These tests cover the full matrix of behaviors described in
-//! `prd-serde-deserializer.md`:
+//! These tests cover the full matrix of behaviors:
 //!
 //! - Round-trip encode → decode → deserialize for all field types
 //!   (varints, signed/unsigned, bool, floats, strings, pooled strings,
@@ -10,6 +9,7 @@
 //! - Optional fields, both present and absent, deserialize correctly.
 //! - `#[serde(other)]` catches unknown event names.
 //! - Required-field schema mismatch produces an error from the deserializer.
+//! - Type coercion failures produce an error from the deserializer.
 //! - End-to-end test using `#[derive(TraceEvent)]` for the encode side and
 //!   `#[derive(serde::Deserialize)]` for the decode side.
 
@@ -612,7 +612,7 @@ fn option_field_absent_from_schema_defaults_to_none() {
     assert_eq!(event.new_optional_field, None);
 }
 
-// ── Test 11: pool-miss error paths ──────────────────────────────────────────
+// ── Test 11b: pool-miss error paths ──────────────────────────────────────────
 
 #[test]
 fn pooled_string_miss_returns_error() {
@@ -681,6 +681,43 @@ fn pooled_stack_frames_miss_returns_error() {
     })
     .expect("no decode error");
     assert!(got_err, "expected a pool-miss error");
+}
+
+// ── Test 11c: type coercion failure (bool from varint) ───────────────────────
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct WantsBool {
+    timestamp_ns: u64,
+    flag: bool,
+}
+
+#[test]
+fn type_coercion_bool_from_varint_returns_error() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema("WantsBool", vec![FieldDef::new("flag", FieldType::Varint)])
+        .unwrap();
+    // Wire has a varint where the struct expects a bool.
+    enc.write_event(
+        &schema,
+        &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let mut dec = Decoder::new(&bytes).expect("valid header");
+    let mut got_err = false;
+    dec.for_each_event(|raw| {
+        if let Err(e) = raw.deserialize::<WantsBool>() {
+            assert!(
+                e.message().contains("invalid type"),
+                "unexpected error: {e}"
+            );
+            got_err = true;
+        }
+    })
+    .expect("no decode error");
+    assert!(got_err, "expected a type coercion error");
 }
 
 // ── Test 12: DynamicList deserializes into Vec<T> ───────────────────────────
@@ -843,5 +880,51 @@ fn dynamic_map_deserializes_to_struct() {
             status: 200,
             path: "/api/users".into(),
         }
+    );
+}
+
+// ── Test 16: StringMap deserializes into Vec<(String, String)> ─────────────
+
+/// `Vec<(String, String)>` is the natural Rust shape for the wire-format
+/// `StringMap` when callers want order-preserving entries instead of a
+/// `HashMap`. The deserializer should present a `StringMap` as a sequence of
+/// (key, value) pairs so that this just works without `#[serde(deserialize_with = "...")]`
+/// helpers.
+#[derive(Debug, Deserialize, PartialEq)]
+struct WithStringMapAsVec {
+    timestamp_ns: u64,
+    headers: Vec<(String, String)>,
+}
+
+#[test]
+fn string_map_deserializes_to_vec_of_tuples() {
+    let mut enc = Encoder::new();
+    let schema = enc
+        .register_schema(
+            "WithStringMapAsVec",
+            vec![FieldDef::new("headers", FieldType::StringMap)],
+        )
+        .unwrap();
+    enc.write_event(
+        &schema,
+        &[
+            FieldValue::Varint(5_000),
+            FieldValue::StringMap(vec![
+                ("content-type".into(), "application/json".into()),
+                ("x-request-id".into(), "abc123".into()),
+            ]),
+        ],
+    )
+    .unwrap();
+    let bytes = enc.finish();
+
+    let event: WithStringMapAsVec = decode_first(&bytes);
+    assert_eq!(event.timestamp_ns, 5_000);
+    assert_eq!(
+        event.headers,
+        vec![
+            ("content-type".to_string(), "application/json".to_string()),
+            ("x-request-id".to_string(), "abc123".to_string()),
+        ]
     );
 }


### PR DESCRIPTION
This is the first in a series of changes en route to #446 where we will fully rip out telemetry event and replace it with something much more akin to what we currently do on the JS side.

This makes _deserializing_ actually function as a serde Format. I ported one test to use it. We will port the remaining tests to use it in a future PR.

After that, we will fully delete telemetry event in route to 0.4