### PR TITLE
feat(tokio-telemetry): add Deserialize to built-in event structs

### DIFF
--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = "1"
 smallvec = "1"
 bytes = "1"
 dial9-perf-self-profile = { workspace = true, optional = true }
-dial9-trace-format = { workspace = true, features = ["serde"] }
+dial9-trace-format = { workspace = true, features = ["serde", "serde-deserialize"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = [
     "registry",

--- a/dial9-tokio-telemetry/src/telemetry/analysis_events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis_events.rs
@@ -1,0 +1,649 @@
+//! Decode-side companion structs for built-in trace events.
+//!
+//! These structs mirror the wire-format event types but use owned, resolved
+//! types (`String` instead of `InternedString`, `Vec<u64>` instead of
+//! `InternedStackFrames`). They derive [`serde::Deserialize`] so they can be
+//! used as decode targets with the serde-based trace iterator.
+//!
+//! # Backwards Compatibility
+//!
+//! All structs and the [`Dial9Event`] enum are `#[non_exhaustive]`, so new
+//! fields and variants can be added without breaking changes. When new fields
+//! are added to the wire format, old traces simply won't have those fields in
+//! their schema — serde will skip them during deserialization.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
+//! use dial9_trace_format::decoder::Decoder;
+//!
+//! # let bytes: &[u8] = &[];
+//! let mut dec = Decoder::new(bytes).unwrap();
+//! dec.for_each_event(|raw| {
+//!     let ev: Dial9Event = raw.deserialize().unwrap();
+//!     // ...
+//! }).unwrap();
+//! ```
+
+use serde::Deserialize;
+
+/// Worker thread identifier (decoded as a plain `u64`).
+pub type WorkerId = u64;
+
+/// Task identifier (decoded as a plain `u64`).
+pub type TaskId = u64;
+
+/// What triggered a CPU sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CpuSampleSource {
+    /// Periodic CPU profiling sample (frequency-based).
+    CpuProfile = 0,
+    /// Context switch captured by per-thread sched event tracking.
+    SchedEvent = 1,
+}
+
+impl<'de> serde::Deserialize<'de> for CpuSampleSource {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let v = u64::deserialize(deserializer)?;
+        match v {
+            0 => Ok(Self::CpuProfile),
+            1 => Ok(Self::SchedEvent),
+            other => Err(serde::de::Error::custom(format!(
+                "unknown CpuSampleSource discriminant: {other}"
+            ))),
+        }
+    }
+}
+
+/// A task poll began on a worker thread.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct PollStartEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Worker thread index.
+    pub worker_id: WorkerId,
+    /// Local queue depth.
+    pub local_queue: u8,
+    /// Task being polled.
+    pub task_id: TaskId,
+    /// Spawn location string.
+    pub spawn_loc: String,
+}
+
+/// A task poll completed on a worker thread.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct PollEndEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Worker thread index.
+    pub worker_id: WorkerId,
+}
+
+/// A worker thread parked (went idle).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct WorkerParkEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Worker thread index.
+    pub worker_id: WorkerId,
+    /// Local queue depth.
+    pub local_queue: u8,
+    /// Thread CPU time in nanoseconds.
+    pub cpu_time_ns: u64,
+    /// OS thread ID.
+    pub tid: u32,
+}
+
+/// A worker thread unparked (resumed).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct WorkerUnparkEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Worker thread index.
+    pub worker_id: WorkerId,
+    /// Local queue depth.
+    pub local_queue: u8,
+    /// Thread CPU time in nanoseconds.
+    pub cpu_time_ns: u64,
+    /// Scheduling wait delta in nanoseconds.
+    pub sched_wait_ns: u64,
+    /// OS thread ID.
+    pub tid: u32,
+}
+
+/// Periodic sample of the global task queue depth.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct QueueSampleEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Global queue depth.
+    pub global_queue: u8,
+}
+
+/// A new task was spawned.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct TaskSpawnEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Spawned task identifier.
+    pub task_id: TaskId,
+    /// Spawn location string.
+    pub spawn_loc: String,
+    /// Whether this spawn was instrumented.
+    pub instrumented: bool,
+}
+
+/// A task terminated.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct TaskTerminateEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Task that terminated.
+    pub task_id: TaskId,
+}
+
+/// A CPU stack trace sample.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct CpuSampleEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Worker thread index.
+    pub worker_id: WorkerId,
+    /// OS thread ID.
+    pub tid: u32,
+    /// What triggered this sample.
+    pub source: CpuSampleSource,
+    /// Thread name, if known.
+    pub thread_name: Option<String>,
+    /// Raw instruction pointer addresses (leaf first).
+    pub callchain: Vec<u64>,
+    /// CPU the sample was taken on.
+    pub cpu: Option<u64>,
+}
+
+/// Async backtrace captured at a yield point.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct TaskDumpEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Task that was idle.
+    pub task_id: TaskId,
+    /// Raw instruction pointer addresses (leaf first).
+    pub callchain: Vec<u64>,
+}
+
+/// One task woke another task.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct WakeEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Task that issued the wake.
+    pub waker_task_id: TaskId,
+    /// Task that was woken.
+    pub woken_task_id: TaskId,
+    /// Worker thread index that issued the wake (255 = unknown).
+    pub target_worker: u8,
+}
+
+/// Key-value metadata written at the start of each segment.
+///
+/// The wire format encodes entries as a list of key-value pairs, but we
+/// deserialize into a `HashMap` for convenient lookup. Keys are unique
+/// within a segment.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct SegmentMetadataEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Key-value metadata pairs.
+    pub entries: std::collections::HashMap<String, String>,
+}
+
+/// Clock-correlation anchor.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct ClockSyncEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// Nanoseconds since the Unix epoch.
+    pub realtime_ns: u64,
+}
+
+/// A sampled memory allocation event.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct AllocEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// OS thread ID.
+    pub tid: u32,
+    /// Allocation size in bytes.
+    pub size: u64,
+    /// Returned pointer address.
+    pub addr: u64,
+    /// Raw instruction pointer addresses (leaf first).
+    pub callchain: Vec<u64>,
+}
+
+/// A deallocation paired with a previously-sampled allocation.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[non_exhaustive]
+pub struct FreeEvent {
+    /// Timestamp in nanoseconds (monotonic).
+    pub timestamp_ns: u64,
+    /// OS thread ID.
+    pub tid: u32,
+    /// Pointer that was freed.
+    pub addr: u64,
+    /// Size of the allocation being freed.
+    pub size: u64,
+    /// Monotonic-ns timestamp of the original allocation.
+    pub alloc_timestamp_ns: u64,
+}
+
+/// Tagged enum of all built-in event types for use as a serde decode target.
+///
+/// Use with `#[serde(tag = "event")]` — the discriminant matches the wire
+/// schema name (e.g. `"PollStartEvent"`).
+///
+/// Unknown event types (custom events, future additions) are captured by the
+/// `Other` variant via `#[serde(other)]`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "event")]
+#[non_exhaustive]
+pub enum Dial9Event {
+    /// A task poll began.
+    PollStartEvent(PollStartEvent),
+    /// A task poll completed.
+    PollEndEvent(PollEndEvent),
+    /// A worker thread parked.
+    WorkerParkEvent(WorkerParkEvent),
+    /// A worker thread unparked.
+    WorkerUnparkEvent(WorkerUnparkEvent),
+    /// Global queue depth sample.
+    QueueSampleEvent(QueueSampleEvent),
+    /// A task was spawned.
+    TaskSpawnEvent(TaskSpawnEvent),
+    /// A task terminated.
+    TaskTerminateEvent(TaskTerminateEvent),
+    /// A CPU stack trace sample.
+    CpuSampleEvent(CpuSampleEvent),
+    /// An async backtrace at a yield point.
+    TaskDumpEvent(TaskDumpEvent),
+    /// One task woke another.
+    ///
+    /// Wire schema name is `"WakeEventEvent"` for historical reasons.
+    #[serde(rename = "WakeEventEvent")]
+    WakeEvent(WakeEvent),
+    /// Segment metadata.
+    SegmentMetadataEvent(SegmentMetadataEvent),
+    /// Clock sync anchor.
+    ClockSyncEvent(ClockSyncEvent),
+    /// A sampled allocation.
+    AllocEvent(AllocEvent),
+    /// A deallocation.
+    FreeEvent(FreeEvent),
+    /// Unknown/custom event type.
+    #[serde(other)]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::telemetry::format;
+    use crate::telemetry::task_metadata::TaskId;
+    use dial9_trace_format::decoder::Decoder;
+    use dial9_trace_format::encoder::Encoder;
+
+    #[test]
+    fn synthetic_trace_round_trip_all_events() {
+        let mut enc = Encoder::new();
+
+        // 1. PollStartEvent
+        let spawn_loc = enc.intern_string("src/main.rs:42").unwrap();
+        enc.write(&format::PollStartEvent {
+            timestamp_ns: 1_000_000,
+            worker_id: format::WorkerId::from(2u8),
+            local_queue: 5,
+            task_id: TaskId::from_u32(100),
+            spawn_loc,
+        })
+        .unwrap();
+
+        // 2. PollEndEvent
+        enc.write(&format::PollEndEvent {
+            timestamp_ns: 1_000_500,
+            worker_id: format::WorkerId::from(2u8),
+        })
+        .unwrap();
+
+        // 3. WorkerParkEvent
+        enc.write(&format::WorkerParkEvent {
+            timestamp_ns: 2_000_000,
+            worker_id: format::WorkerId::from(1u8),
+            local_queue: 0,
+            cpu_time_ns: 500_000,
+            tid: 12345,
+        })
+        .unwrap();
+
+        // 4. WorkerUnparkEvent
+        enc.write(&format::WorkerUnparkEvent {
+            timestamp_ns: 3_000_000,
+            worker_id: format::WorkerId::from(1u8),
+            local_queue: 3,
+            cpu_time_ns: 600_000,
+            sched_wait_ns: 100_000,
+            tid: 12345,
+        })
+        .unwrap();
+
+        // 5. QueueSampleEvent
+        enc.write(&format::QueueSampleEvent {
+            timestamp_ns: 4_000_000,
+            global_queue: 7,
+        })
+        .unwrap();
+
+        // 6. TaskSpawnEvent
+        let spawn_loc2 = enc.intern_string("src/lib.rs:10").unwrap();
+        enc.write(&format::TaskSpawnEvent {
+            timestamp_ns: 5_000_000,
+            task_id: TaskId::from_u32(200),
+            spawn_loc: spawn_loc2,
+            instrumented: true,
+        })
+        .unwrap();
+
+        // 7. TaskTerminateEvent
+        enc.write(&format::TaskTerminateEvent {
+            timestamp_ns: 6_000_000,
+            task_id: TaskId::from_u32(200),
+        })
+        .unwrap();
+
+        // 8. CpuSampleEvent
+        let thread_name = enc.intern_string("tokio-runtime-worker").unwrap();
+        let callchain = enc
+            .intern_stack_frames(&[0xdead_beef, 0xcafe_babe])
+            .unwrap();
+        enc.write(&format::CpuSampleEvent {
+            timestamp_ns: 7_000_000,
+            worker_id: format::WorkerId::from(0u8),
+            tid: 9999,
+            source: crate::telemetry::events::CpuSampleSource::CpuProfile,
+            thread_name: Some(thread_name),
+            callchain,
+            cpu: Some(3),
+        })
+        .unwrap();
+
+        // 9. TaskDumpEvent
+        let dump_chain = enc.intern_stack_frames(&[0x1111, 0x2222, 0x3333]).unwrap();
+        enc.write(&format::TaskDumpEvent {
+            timestamp_ns: 8_000_000,
+            task_id: TaskId::from_u32(100),
+            callchain: dump_chain,
+        })
+        .unwrap();
+
+        // 10. WakeEventEvent
+        enc.write(&format::WakeEventEvent {
+            timestamp_ns: 9_000_000,
+            waker_task_id: TaskId::from_u32(100),
+            woken_task_id: TaskId::from_u32(200),
+            target_worker: 1,
+        })
+        .unwrap();
+
+        // 11. SegmentMetadataEvent
+        enc.write(&format::SegmentMetadataEvent {
+            timestamp_ns: 10_000_000,
+            entries: vec![
+                ("runtime".to_string(), "main".to_string()),
+                ("version".to_string(), "0.3.11".to_string()),
+            ],
+        })
+        .unwrap();
+
+        // 12. ClockSyncEvent
+        enc.write(&format::ClockSyncEvent {
+            timestamp_ns: 11_000_000,
+            realtime_ns: 1_700_000_000_000_000_000,
+        })
+        .unwrap();
+
+        // 13. AllocEvent
+        let alloc_chain = enc.intern_stack_frames(&[0xaaaa, 0xbbbb]).unwrap();
+        enc.write(&format::AllocEvent {
+            timestamp_ns: 12_000_000,
+            tid: 5555,
+            size: 1024,
+            addr: 0x7fff_0000_1000,
+            callchain: alloc_chain,
+        })
+        .unwrap();
+
+        // 14. FreeEvent
+        enc.write(&format::FreeEvent {
+            timestamp_ns: 13_000_000,
+            tid: 5555,
+            addr: 0x7fff_0000_1000,
+            size: 1024,
+            alloc_timestamp_ns: 12_000_000,
+        })
+        .unwrap();
+
+        // ── Decode ──────────────────────────────────────────────────────────
+        let bytes = enc.finish();
+        let mut dec = Decoder::new(&bytes).expect("valid trace header");
+        let mut events: Vec<Dial9Event> = Vec::new();
+        dec.for_each_event(|raw| {
+            events.push(raw.deserialize().expect("deserialize event"));
+        })
+        .expect("decode");
+
+        assert_eq!(events.len(), 14);
+
+        // 1. PollStartEvent
+        let Dial9Event::PollStartEvent(ref e) = events[0] else {
+            panic!("expected PollStartEvent, got {:?}", events[0]);
+        };
+        assert_eq!(e.timestamp_ns, 1_000_000);
+        assert_eq!(e.worker_id, 2);
+        assert_eq!(e.local_queue, 5);
+        assert_eq!(e.task_id, 100);
+        assert_eq!(e.spawn_loc, "src/main.rs:42");
+
+        // 2. PollEndEvent
+        let Dial9Event::PollEndEvent(ref e) = events[1] else {
+            panic!("expected PollEndEvent, got {:?}", events[1]);
+        };
+        assert_eq!(e.timestamp_ns, 1_000_500);
+        assert_eq!(e.worker_id, 2);
+
+        // 3. WorkerParkEvent
+        let Dial9Event::WorkerParkEvent(ref e) = events[2] else {
+            panic!("expected WorkerParkEvent, got {:?}", events[2]);
+        };
+        assert_eq!(e.timestamp_ns, 2_000_000);
+        assert_eq!(e.worker_id, 1);
+        assert_eq!(e.local_queue, 0);
+        assert_eq!(e.cpu_time_ns, 500_000);
+        assert_eq!(e.tid, 12345);
+
+        // 4. WorkerUnparkEvent
+        let Dial9Event::WorkerUnparkEvent(ref e) = events[3] else {
+            panic!("expected WorkerUnparkEvent, got {:?}", events[3]);
+        };
+        assert_eq!(e.timestamp_ns, 3_000_000);
+        assert_eq!(e.worker_id, 1);
+        assert_eq!(e.local_queue, 3);
+        assert_eq!(e.cpu_time_ns, 600_000);
+        assert_eq!(e.sched_wait_ns, 100_000);
+        assert_eq!(e.tid, 12345);
+
+        // 5. QueueSampleEvent
+        let Dial9Event::QueueSampleEvent(ref e) = events[4] else {
+            panic!("expected QueueSampleEvent, got {:?}", events[4]);
+        };
+        assert_eq!(e.timestamp_ns, 4_000_000);
+        assert_eq!(e.global_queue, 7);
+
+        // 6. TaskSpawnEvent
+        let Dial9Event::TaskSpawnEvent(ref e) = events[5] else {
+            panic!("expected TaskSpawnEvent, got {:?}", events[5]);
+        };
+        assert_eq!(e.timestamp_ns, 5_000_000);
+        assert_eq!(e.task_id, 200);
+        assert_eq!(e.spawn_loc, "src/lib.rs:10");
+        assert!(e.instrumented);
+
+        // 7. TaskTerminateEvent
+        let Dial9Event::TaskTerminateEvent(ref e) = events[6] else {
+            panic!("expected TaskTerminateEvent, got {:?}", events[6]);
+        };
+        assert_eq!(e.timestamp_ns, 6_000_000);
+        assert_eq!(e.task_id, 200);
+
+        // 8. CpuSampleEvent
+        let Dial9Event::CpuSampleEvent(ref e) = events[7] else {
+            panic!("expected CpuSampleEvent, got {:?}", events[7]);
+        };
+        assert_eq!(e.timestamp_ns, 7_000_000);
+        assert_eq!(e.worker_id, 0);
+        assert_eq!(e.tid, 9999);
+        assert_eq!(e.source, CpuSampleSource::CpuProfile);
+        assert_eq!(e.thread_name.as_deref(), Some("tokio-runtime-worker"));
+        assert_eq!(e.callchain, vec![0xdead_beef, 0xcafe_babe]);
+        assert_eq!(e.cpu, Some(3));
+
+        // 9. TaskDumpEvent
+        let Dial9Event::TaskDumpEvent(ref e) = events[8] else {
+            panic!("expected TaskDumpEvent, got {:?}", events[8]);
+        };
+        assert_eq!(e.timestamp_ns, 8_000_000);
+        assert_eq!(e.task_id, 100);
+        assert_eq!(e.callchain, vec![0x1111, 0x2222, 0x3333]);
+
+        // 10. WakeEvent
+        let Dial9Event::WakeEvent(ref e) = events[9] else {
+            panic!("expected WakeEvent, got {:?}", events[9]);
+        };
+        assert_eq!(e.timestamp_ns, 9_000_000);
+        assert_eq!(e.waker_task_id, 100);
+        assert_eq!(e.woken_task_id, 200);
+        assert_eq!(e.target_worker, 1);
+
+        // 11. SegmentMetadataEvent
+        let Dial9Event::SegmentMetadataEvent(ref e) = events[10] else {
+            panic!("expected SegmentMetadataEvent, got {:?}", events[10]);
+        };
+        assert_eq!(e.timestamp_ns, 10_000_000);
+        assert_eq!(e.entries.get("runtime").unwrap(), "main");
+        assert_eq!(e.entries.get("version").unwrap(), "0.3.11");
+        assert_eq!(e.entries.len(), 2);
+
+        // 12. ClockSyncEvent
+        let Dial9Event::ClockSyncEvent(ref e) = events[11] else {
+            panic!("expected ClockSyncEvent, got {:?}", events[11]);
+        };
+        assert_eq!(e.timestamp_ns, 11_000_000);
+        assert_eq!(e.realtime_ns, 1_700_000_000_000_000_000);
+
+        // 13. AllocEvent
+        let Dial9Event::AllocEvent(ref e) = events[12] else {
+            panic!("expected AllocEvent, got {:?}", events[12]);
+        };
+        assert_eq!(e.timestamp_ns, 12_000_000);
+        assert_eq!(e.tid, 5555);
+        assert_eq!(e.size, 1024);
+        assert_eq!(e.addr, 0x7fff_0000_1000);
+        assert_eq!(e.callchain, vec![0xaaaa, 0xbbbb]);
+
+        // 14. FreeEvent
+        let Dial9Event::FreeEvent(ref e) = events[13] else {
+            panic!("expected FreeEvent, got {:?}", events[13]);
+        };
+        assert_eq!(e.timestamp_ns, 13_000_000);
+        assert_eq!(e.tid, 5555);
+        assert_eq!(e.addr, 0x7fff_0000_1000);
+        assert_eq!(e.size, 1024);
+        assert_eq!(e.alloc_timestamp_ns, 12_000_000);
+    }
+
+    #[test]
+    fn unknown_event_deserializes_as_other() {
+        use dial9_trace_format::TraceEvent;
+
+        #[derive(TraceEvent)]
+        struct MyCustomEvent {
+            #[traceevent(timestamp)]
+            timestamp_ns: u64,
+            value: u64,
+        }
+
+        let mut enc = Encoder::new();
+        enc.write(&MyCustomEvent {
+            timestamp_ns: 1_000,
+            value: 42,
+        })
+        .unwrap();
+
+        let bytes = enc.finish();
+        let mut dec = Decoder::new(&bytes).expect("valid header");
+        let mut events: Vec<Dial9Event> = Vec::new();
+        dec.for_each_event(|raw| {
+            events.push(raw.deserialize().expect("deserialize"));
+        })
+        .expect("decode");
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], Dial9Event::Other));
+    }
+
+    #[test]
+    fn optional_fields_decode_as_none() {
+        let mut enc = Encoder::new();
+
+        let callchain = enc.intern_stack_frames(&[0x1234]).unwrap();
+        enc.write(&format::CpuSampleEvent {
+            timestamp_ns: 1_000_000,
+            worker_id: format::WorkerId::from(0u8),
+            tid: 1111,
+            source: crate::telemetry::events::CpuSampleSource::CpuProfile,
+            thread_name: None,
+            callchain,
+            cpu: None,
+        })
+        .unwrap();
+
+        let bytes = enc.finish();
+        let mut dec = Decoder::new(&bytes).expect("valid header");
+        let mut events: Vec<Dial9Event> = Vec::new();
+        dec.for_each_event(|raw| {
+            events.push(raw.deserialize().expect("deserialize"));
+        })
+        .expect("decode");
+
+        assert_eq!(events.len(), 1);
+        let Dial9Event::CpuSampleEvent(ref e) = events[0] else {
+            panic!("expected CpuSampleEvent, got {:?}", events[0]);
+        };
+        assert_eq!(e.thread_name, None);
+        assert_eq!(e.cpu, None);
+    }
+}

--- a/dial9-tokio-telemetry/src/telemetry/analysis_events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis_events.rs
@@ -39,9 +39,11 @@ pub type TaskId = u64;
 #[non_exhaustive]
 pub enum CpuSampleSource {
     /// Periodic CPU profiling sample (frequency-based).
-    CpuProfile = 0,
+    CpuProfile,
     /// Context switch captured by per-thread sched event tracking.
-    SchedEvent = 1,
+    SchedEvent,
+    /// Unknown variant from a newer trace format.
+    Unknown(u64),
 }
 
 impl<'de> serde::Deserialize<'de> for CpuSampleSource {
@@ -50,9 +52,7 @@ impl<'de> serde::Deserialize<'de> for CpuSampleSource {
         match v {
             0 => Ok(Self::CpuProfile),
             1 => Ok(Self::SchedEvent),
-            other => Err(serde::de::Error::custom(format!(
-                "unknown CpuSampleSource discriminant: {other}"
-            ))),
+            other => Ok(Self::Unknown(other)),
         }
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -5,6 +5,9 @@
 
 #[cfg(feature = "analysis")]
 pub(crate) mod analysis;
+/// Decode-side companion structs for built-in trace events.
+#[cfg(any(feature = "analysis", test))]
+pub mod analysis_events;
 pub(crate) mod buffer;
 pub(crate) mod collector;
 pub use collector::Batch;

--- a/dial9-tokio-telemetry/tests/builtin_event_serde.rs
+++ b/dial9-tokio-telemetry/tests/builtin_event_serde.rs
@@ -1,0 +1,89 @@
+//! End-to-end test: encode events via TracedRuntime, decode via serde into
+//! the built-in analysis event structs.
+
+mod common;
+
+use common::{BytesCapturingWriter, decode_all};
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
+
+#[test]
+fn decode_builtin_events_via_serde() {
+    let (writer, batches) = BytesCapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .build_and_start_with_writer(builder, writer)
+        .unwrap();
+
+    runtime.block_on(async {
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            handles.push(tokio::spawn(async {
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        // Let workers park
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let batches = batches.lock().unwrap();
+    let events: Vec<Dial9Event> = decode_all(&batches);
+
+    // We should have at least some poll start/end events
+    let poll_starts: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, Dial9Event::PollStartEvent(_)))
+        .collect();
+    assert!(
+        !poll_starts.is_empty(),
+        "expected at least one PollStartEvent"
+    );
+
+    let poll_ends: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, Dial9Event::PollEndEvent(_)))
+        .collect();
+    assert!(!poll_ends.is_empty(), "expected at least one PollEndEvent");
+
+    // Should have park/unpark events
+    let parks: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, Dial9Event::WorkerParkEvent(_)))
+        .collect();
+    assert!(!parks.is_empty(), "expected at least one WorkerParkEvent");
+
+    let unparks: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, Dial9Event::WorkerUnparkEvent(_)))
+        .collect();
+    assert!(
+        !unparks.is_empty(),
+        "expected at least one WorkerUnparkEvent"
+    );
+
+    // Should have task spawn events
+    let spawns: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, Dial9Event::TaskSpawnEvent(_)))
+        .collect();
+    assert!(!spawns.is_empty(), "expected at least one TaskSpawnEvent");
+
+    // Verify a PollStartEvent has sensible data
+    if let Dial9Event::PollStartEvent(ps) = &poll_starts[0] {
+        assert!(ps.timestamp_ns > 0, "timestamp should be non-zero");
+    }
+
+    // Verify a WorkerParkEvent has non-zero tid
+    if let Dial9Event::WorkerParkEvent(wp) = &parks[0] {
+        assert_ne!(wp.tid, 0, "WorkerPark tid must be non-zero");
+    }
+}

--- a/dial9-tokio-telemetry/tests/park_unpark_tid.rs
+++ b/dial9-tokio-telemetry/tests/park_unpark_tid.rs
@@ -4,21 +4,7 @@ mod common;
 
 use common::{BytesCapturingWriter, decode_all};
 use dial9_tokio_telemetry::telemetry::TracedRuntime;
-use serde::Deserialize;
-
-/// Tagged union over the events this test cares about.
-#[derive(Debug, Deserialize)]
-#[serde(tag = "event")]
-enum ParkOrUnpark {
-    WorkerParkEvent {
-        tid: u32,
-    },
-    WorkerUnparkEvent {
-        tid: u32,
-    },
-    #[serde(other)]
-    Other,
-}
+use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
 
 #[test]
 fn worker_park_unpark_events_carry_nonzero_tid() {
@@ -49,12 +35,12 @@ fn worker_park_unpark_events_carry_nonzero_tid() {
     drop(guard);
 
     let batches = batches.lock().unwrap();
-    let events: Vec<ParkOrUnpark> = decode_all(&batches);
+    let events: Vec<Dial9Event> = decode_all(&batches);
 
     let park_tids: Vec<u32> = events
         .iter()
         .filter_map(|e| match e {
-            ParkOrUnpark::WorkerParkEvent { tid, .. } => Some(*tid),
+            Dial9Event::WorkerParkEvent(p) => Some(p.tid),
             _ => None,
         })
         .collect();
@@ -62,7 +48,7 @@ fn worker_park_unpark_events_carry_nonzero_tid() {
     let unpark_tids: Vec<u32> = events
         .iter()
         .filter_map(|e| match e {
-            ParkOrUnpark::WorkerUnparkEvent { tid, .. } => Some(*tid),
+            Dial9Event::WorkerUnparkEvent(u) => Some(u.tid),
             _ => None,
         })
         .collect();


### PR DESCRIPTION
Context: #446 

Adds decode-side companion structs for all built-in trace events in `telemetry::analysis_events`. These structs derive/implement `serde::Deserialize` so they can be used as decode targets with the serde-based trace iterator.

## Tests

- `builtin_event_serde.rs`: end-to-end test with a real TracedRuntime
- `synthetic_trace_serde.rs`: deterministic round-trip encoding all 14 event types with exact field assertions (no runtime needed)