### PR TITLE
feat(viewer): add heap flamegraph visualization

### DIFF
--- a/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
@@ -591,3 +591,94 @@ for (const [taskId, bytes] of top) {
   footprint) requires pairing `Alloc` with `Free` events and only
   works when `MemoryProfilingConfig.track_liveset(true)` was set at
   install time.
+
+### Heap flamegraph: where are allocations happening and how big are they?
+
+Build a weighted flamegraph tree where each node accumulates estimated
+bytes and estimated allocation count. The ratio `bytes / allocs` gives
+the average allocation size for that call path — useful for finding
+code that makes many small allocations vs. few large ones.
+
+```javascript
+const { parseTrace, symbolizeChain, formatFrame } = require('./trace_parser.js');
+const { buildFlamegraphTree } = require('./trace_analysis.js');
+
+const R = 512 * 1024; // sample rate bytes
+
+for await (const trace of parseTrace('/path/to/traces/')) {
+  if (!trace.allocEvents || trace.allocEvents.length === 0) continue;
+
+  // Strip dial9 allocator hook frames (always the top 2 frames)
+  const HOOK_PATTERNS = [
+    'memory_profiling::hook::on_alloc',
+    'memory_profiling::allocator::Dial9Allocator',
+    '__rustc::__rust_alloc',
+    '__rustc::__rust_realloc',
+  ];
+  function stripHook(chain) {
+    let i = 0;
+    while (i < chain.length) {
+      const entry = trace.callframeSymbols.get(chain[i]);
+      const frames = Array.isArray(entry) ? entry : [entry];
+      const name = frames.map(f => f && f.symbol || '').join(' ');
+      if (HOOK_PATTERNS.some(p => name.includes(p))) { i++; continue; }
+      break;
+    }
+    return i > 0 ? chain.slice(i) : chain;
+  }
+
+  // Build weighted samples: weight = estimated bytes, allocWeight = estimated count
+  const samples = trace.allocEvents
+    .map(a => ({ ...a, callchain: stripHook(a.callchain) }))
+    .filter(a => a.callchain.length > 0)
+    .map(a => {
+      const s = a.size;
+      const invP = s <= 0 ? 1 : 1 / (1 - Math.exp(-s / R));
+      return { callchain: a.callchain, weight: s * invP, allocWeight: invP };
+    });
+
+  // buildFlamegraphTree accumulates weight into node.count and allocWeight into node.allocCount
+  const tree = buildFlamegraphTree(samples, trace.callframeSymbols);
+
+  // Walk the tree to find interesting nodes
+  function walk(node, depth) {
+    if (depth > 0 && node.allocCount > 0) {
+      const avgSize = node.count / node.allocCount;
+      const pct = (node.count / tree.count * 100).toFixed(1);
+      console.log(`${'  '.repeat(depth)}${node.name}: ~${(node.count/1024/1024).toFixed(1)} MiB (${pct}%), ~${Math.round(node.allocCount)} allocs, avg ${Math.round(avgSize)} B`);
+    }
+    for (const child of [...node.children.values()].sort((a, b) => b.count - a.count)) {
+      if (child.count / tree.count > 0.05) walk(child, depth + 1); // only >5%
+    }
+  }
+  walk(tree, 0);
+}
+```
+
+**Answering "how big are allocations in X?"**: Find the node for X in
+the tree and compute `node.count / node.allocCount`. This is the
+average allocation size for all code paths through that frame.
+
+**Answering "what's making lots of small allocations?"**: Sort nodes by
+`node.allocCount` descending and look for nodes where
+`node.count / node.allocCount` is small (e.g., < 1 KB). These are
+high-frequency small-allocation sites.
+
+```javascript
+// Find top allocation-count nodes with small avg size
+const nodes = [];
+function collect(node) {
+  if (node.allocCount > 0) nodes.push(node);
+  for (const child of node.children.values()) collect(child);
+}
+collect(tree);
+
+const smallAllocHotspots = nodes
+  .filter(n => n.allocCount > 10 && n.count / n.allocCount < 1024)
+  .sort((a, b) => b.allocCount - a.allocCount)
+  .slice(0, 10);
+
+for (const n of smallAllocHotspots) {
+  console.log(`${n.name}: ~${Math.round(n.allocCount)} allocs, avg ${Math.round(n.count / n.allocCount)} B`);
+}
+```

--- a/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
@@ -666,6 +666,7 @@ high-frequency small-allocation sites.
 
 ```javascript
 // Find top allocation-count nodes with small avg size
+// (assumes `tree` from the snippet above { ... } )
 const nodes = [];
 function collect(node) {
   if (node.allocCount > 0) nodes.push(node);

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -481,7 +481,7 @@
           h += '<br><span style="color:#888">' + locShort + '</span>';
         }
       }
-      h += '<br>' + (formatCount ? formatCount(node.count, total, node.self) : node.count + ' samples (' + pct + '%) \u00b7 ' + node.self + ' self (' + selfPct + '%)');
+      h += '<br>' + (formatCount ? formatCount(node.count, total, node.self, tn) : node.count + ' samples (' + pct + '%) \u00b7 ' + node.self + ' self (' + selfPct + '%)');
       if (pinned && tn.docsUrl) {
         h += '<br><a href="' + tn.docsUrl + '" target="_blank" rel="noopener" style="color:#6c63ff;text-decoration:underline">docs.rs \u2197</a>';
       } else if (tn.docsUrl) {

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -481,7 +481,7 @@
           h += '<br><span style="color:#888">' + locShort + '</span>';
         }
       }
-      h += '<br>' + node.count + ' samples (' + pct + '%) \u00b7 ' + node.self + ' self (' + selfPct + '%)';
+      h += '<br>' + (formatCount ? formatCount(node.count, total, node.self) : node.count + ' samples (' + pct + '%) \u00b7 ' + node.self + ' self (' + selfPct + '%)');
       if (pinned && tn.docsUrl) {
         h += '<br><a href="' + tn.docsUrl + '" target="_blank" rel="noopener" style="color:#6c63ff;text-decoration:underline">docs.rs \u2197</a>';
       } else if (tn.docsUrl) {
@@ -682,18 +682,25 @@
       offworkerZoomStack = [];
 
       workerLabel.textContent =
-        `Worker threads \u2014 ${workerSamples.length} samples`;
+        `${workerLabelPrefix} \u2014 ${workerSamples.length} samples`;
       offworkerLabel.textContent =
-        `Off-worker (sampler thread) \u2014 ${offworkerSamples.length} samples`;
+        `${offworkerLabelPrefix} \u2014 ${offworkerSamples.length} samples`;
 
       renderAll();
     }
 
     spawnFilter.addEventListener("change", applySpawnFilter);
 
-    function setData(samples, callframeSymbols) {
+    let workerLabelPrefix = "Worker threads";
+    let offworkerLabelPrefix = "Off-worker (sampler thread)";
+    let formatCount = null;
+
+    function setData(samples, callframeSymbols, opts) {
       allSamples = samples;
       currentSymbols = callframeSymbols;
+      formatCount = (opts && opts.formatCount) || null;
+      workerLabelPrefix = (opts && opts.workerLabel) || "Worker threads";
+      offworkerLabelPrefix = (opts && opts.offworkerLabel) || "Off-worker (sampler thread)";
 
       // Build spawn location dropdown
       const locCounts = new Map();

--- a/dial9-viewer/ui/test_all_skills_snippets.js
+++ b/dial9-viewer/ui/test_all_skills_snippets.js
@@ -82,7 +82,7 @@ async function main() {
   const { parseTrace, EVENT_TYPES, formatFrame, symbolizeChain, deduplicateSamples } = require("./trace_parser.js");
   const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline,
           computeSchedulingDelays, filterPointsOfInterest, buildFgData,
-          buildSpanData } = require("./trace_analysis.js");
+          buildSpanData, buildFlamegraphTree } = require("./trace_analysis.js");
 
   // Create a temp directory for directory-mode testing
   const os = require("os");
@@ -128,7 +128,7 @@ async function main() {
       trace, workerIds, minTs, maxTs, spans, schedDelays, taskTimeline,
       EVENT_TYPES, formatFrame, symbolizeChain, deduplicateSamples,
       buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline,
-      computeSchedulingDelays, filterPointsOfInterest, buildFgData, buildSpanData,
+      computeSchedulingDelays, filterPointsOfInterest, buildFgData, buildSpanData, buildFlamegraphTree,
       require, console, parseTrace, fs, path,
       event: trace.events[0],
       sample: trace.cpuSamples[0] || {},

--- a/dial9-viewer/ui/test_trace_analysis.js
+++ b/dial9-viewer/ui/test_trace_analysis.js
@@ -429,6 +429,56 @@ async function main() {
     pass("Unresolved addresses still produce a single tree level");
   }
 
+  function testFlamegraphWeightedSamples() {
+    const callframeSymbols = new Map([
+      ["0xA", [{ symbol: "alloc_fn", location: "alloc.rs:1" }]],
+      ["0xB", [{ symbol: "caller_fn", location: "caller.rs:1" }]],
+    ]);
+    // callchain is leaf-first: [leaf, ..., root]. Reversed internally to root→leaf.
+    const samples = [
+      { callchain: ["0xA", "0xB"], weight: 1000, allocWeight: 2 },
+      { callchain: ["0xA", "0xB"], weight: 500, allocWeight: 1.5 },
+      { callchain: ["0xA"], weight: 200, allocWeight: 1 },
+    ];
+    const tree = buildFlamegraphTree(samples, callframeSymbols);
+    if (tree.count !== 1700) fail(`root.count = ${tree.count}, expected 1700`);
+    if (tree.allocCount !== 4.5) fail(`root.allocCount = ${tree.allocCount}, expected 4.5`);
+    // First two samples: caller_fn -> alloc_fn. Third: alloc_fn only.
+    const caller = tree.children.get("caller_fn");
+    if (!caller) fail("expected caller_fn as child of root");
+    if (caller.count !== 1500) fail(`caller.count = ${caller.count}, expected 1500`);
+    if (caller.self !== 0) fail(`caller.self = ${caller.self}, expected 0`);
+    const alloc = caller.children.get("alloc_fn");
+    if (!alloc) fail("expected alloc_fn as child of caller_fn");
+    if (alloc.count !== 1500) fail(`alloc.count = ${alloc.count}, expected 1500`);
+    if (alloc.self !== 1500) fail(`alloc.self = ${alloc.self}, expected 1500`);
+    if (alloc.selfAllocCount !== 3.5) fail(`alloc.selfAllocCount = ${alloc.selfAllocCount}, expected 3.5`);
+    // Third sample: alloc_fn is root-level child
+    const allocDirect = tree.children.get("alloc_fn");
+    if (!allocDirect) fail("expected alloc_fn as direct child of root for single-frame sample");
+    if (allocDirect.count !== 200) fail(`allocDirect.count = ${allocDirect.count}, expected 200`);
+    if (allocDirect.self !== 200) fail(`allocDirect.self = ${allocDirect.self}, expected 200`);
+    if (allocDirect.selfAllocCount !== 1) fail(`allocDirect.selfAllocCount = ${allocDirect.selfAllocCount}, expected 1`);
+    pass("Weighted samples accumulate count, self, allocCount, selfAllocCount correctly");
+  }
+
+  function testFlamegraphDefaultWeightBackcompat() {
+    const callframeSymbols = new Map([
+      ["0xC", [{ symbol: "cpu_fn", location: "cpu.rs:1" }]],
+    ]);
+    const samples = [
+      { callchain: ["0xC"] },
+      { callchain: ["0xC"] },
+    ];
+    const tree = buildFlamegraphTree(samples, callframeSymbols);
+    if (tree.count !== 2) fail(`root.count = ${tree.count}, expected 2`);
+    const node = tree.children.get("cpu_fn");
+    if (node.count !== 2) fail(`node.count = ${node.count}, expected 2`);
+    if (node.self !== 2) fail(`node.self = ${node.self}, expected 2`);
+    if (node.allocCount != null) fail(`node.allocCount should be undefined for unweighted samples`);
+    pass("Unweighted samples default to weight=1, no allocCount fields");
+  }
+
   // ── TaskDumpEvent parsing (verified against the demo trace) ──
 
   function testTaskDumpsParsed() {
@@ -964,6 +1014,8 @@ async function main() {
   testFlamegraphInlineOrder();
   testFlamegraphInlineTolerantOfNullSlots();
   testFlamegraphUnknownAddress();
+  testFlamegraphWeightedSamples();
+  testFlamegraphDefaultWeightBackcompat();
 
   console.log("\ntaskDumps:");
   testTaskDumpsParsed();

--- a/dial9-viewer/ui/test_trace_analysis.js
+++ b/dial9-viewer/ui/test_trace_analysis.js
@@ -1114,6 +1114,52 @@ async function main() {
     pass("address reuse: only the matching alloc is considered freed");
   }
 
+  console.log("\nheap flamegraph from alloc events:");
+  testHeapFlamegraphFromAllocEvents();
+  testHeapFlamegraphEmptyCallchains();
+
+  function testHeapFlamegraphFromAllocEvents() {
+    // Simulate the viewer's heap flamegraph: convert alloc events to samples
+    // and build a flamegraph tree from them.
+    const allocEvents = [
+      { timestamp: 100, tid: 10, size: 1024, addr: "0x1", callchain: ["0xaaa", "0xbbb", "0xccc"] },
+      { timestamp: 200, tid: 10, size: 2048, addr: "0x2", callchain: ["0xaaa", "0xbbb", "0xddd"] },
+      { timestamp: 300, tid: 10, size: 512, addr: "0x3", callchain: ["0xaaa", "0xeee"] },
+    ];
+    const samples = allocEvents
+      .filter(a => a.callchain.length > 0)
+      .map(a => ({ callchain: a.callchain, workerId: 0 }));
+    const symbols = new Map(); // no symbols — raw addresses used as names
+    const tree = buildFlamegraphTree(samples, symbols);
+    if (tree.count !== 3) fail(`heapFg: root count should be 3, got ${tree.count}`);
+    // All samples share "0xaaa" as the bottom frame (reversed: it becomes the first child)
+    // buildFlamegraphTree reverses callchains, so 0xccc/0xddd/0xeee are at the bottom
+    // and 0xaaa is at the top of the tree
+    if (!tree.children.has("0xccc") && !tree.children.has("0xaaa")) {
+      // The tree reverses callchains, so the deepest frame becomes the root child
+      fail("heapFg: expected reversed callchain structure in tree");
+    }
+    const flat = flattenFlamegraph(tree, tree.count);
+    if (flat.nodes.length === 0) fail("heapFg: flattenFlamegraph produced no nodes");
+    if (flat.maxDepth < 1) fail("heapFg: expected depth > 0");
+    pass("alloc events produce valid flamegraph tree");
+  }
+
+  function testHeapFlamegraphEmptyCallchains() {
+    // Alloc events with empty callchains should be filtered out
+    const allocEvents = [
+      { timestamp: 100, tid: 10, size: 1024, addr: "0x1", callchain: [] },
+      { timestamp: 200, tid: 10, size: 2048, addr: "0x2", callchain: ["0xaaa"] },
+    ];
+    const samples = allocEvents
+      .filter(a => a.callchain.length > 0)
+      .map(a => ({ callchain: a.callchain, workerId: 0 }));
+    if (samples.length !== 1) fail(`heapFgEmpty: expected 1 sample after filter, got ${samples.length}`);
+    const tree = buildFlamegraphTree(samples, new Map());
+    if (tree.count !== 1) fail(`heapFgEmpty: root count should be 1, got ${tree.count}`);
+    pass("empty callchains filtered out correctly");
+  }
+
   console.log("\n✓ All analysis checks passed!");
 }
 

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -487,9 +487,12 @@
   function buildFlamegraphTree(samples, callframeSymbols) {
     const root = { name: "(all)", children: new Map(), count: 0, self: 0 };
     for (const s of samples) {
+      const w = s.weight != null ? s.weight : 1;
+      const aw = s.allocWeight;
       const chain = s.callchain.slice().reverse();
       let node = root;
-      node.count++;
+      node.count += w;
+      if (aw != null) node.allocCount = (node.allocCount || 0) + aw;
       for (const addr of chain) {
         const entry = callframeSymbols.get(addr);
         // Expand inlined frames. Per blazesym, an array entry is ordered
@@ -517,10 +520,12 @@
             });
           }
           node = node.children.get(key);
-          node.count++;
+          node.count += w;
+          if (aw != null) node.allocCount = (node.allocCount || 0) + aw;
         }
       }
-      node.self++;
+      node.self += w;
+      if (aw != null) node.selfAllocCount = (node.selfAllocCount || 0) + aw;
     }
     return root;
   }

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -4950,7 +4950,28 @@
                 let allocs = trace.allocEvents;
                 if (startNs != null) allocs = allocs.filter(a => a.timestamp >= startNs);
                 if (endNs != null) allocs = allocs.filter(a => a.timestamp <= endNs);
-                const filtered = allocs.filter(a => a.callchain.length > 0);
+
+                // Strip allocator hook frames from the top of each callchain
+                const HOOK_PATTERNS = [
+                    "memory_profiling::hook::on_alloc",
+                    "memory_profiling::allocator::Dial9Allocator",
+                    "__rustc::__rust_alloc",
+                    "__rustc::__rust_realloc",
+                ];
+                function stripHookFrames(chain) {
+                    let start = 0;
+                    while (start < chain.length) {
+                        const entry = trace.callframeSymbols.get(chain[start]);
+                        const frames = Array.isArray(entry) ? entry : [entry];
+                        const name = frames.map(f => f && f.symbol || "").join(" ");
+                        if (HOOK_PATTERNS.some(p => name.includes(p))) { start++; continue; }
+                        break;
+                    }
+                    return start > 0 ? chain.slice(start) : chain;
+                }
+
+                const filtered = allocs.map(a => ({ ...a, callchain: stripHookFrames(a.callchain) }))
+                    .filter(a => a.callchain.length > 0);
                 // Attribute allocs to tasks via tid → workerId → poll lookup for spawn filter
                 const samples = filtered.map(a => {
                     const wId = trace.tidToWorker && trace.tidToWorker.get(a.tid);

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -3447,7 +3447,7 @@
             document.getElementById("poi-filter").addEventListener("change", updatePointsOfInterest);
             document.getElementById("sort-by-worst").addEventListener("change", updatePointsOfInterest);
             document.getElementById("btn-sched-panel").addEventListener("click", showSchedPanel);
-            document.getElementById("btn-heap-flamegraph").addEventListener("click", showHeapFlamegraph);
+            document.getElementById("btn-heap-flamegraph").addEventListener("click", () => showHeapFlamegraph());
             document.getElementById("btn-uninstrumented-info").addEventListener("click", (e) => {
                 showUninstrumentedPopup(e.target);
             });
@@ -5027,12 +5027,13 @@
                         offworkerLabel: "Non-worker thread allocations",
                         formatCount(count, total, self, treeNode) {
                             const pct = ((count / total) * 100).toFixed(1);
-                            const selfPct = ((self / total) * 100).toFixed(1);
                             const est = fmtB(count);
-                            const selfEst = fmtB(self);
                             const allocs = treeNode && treeNode.allocCount != null ? Math.round(treeNode.allocCount) : null;
-                            let s = `~${est} (${pct}%) \u00b7 ~${selfEst} self (${selfPct}%)`;
-                            if (allocs != null) s += ` \u00b7 ~${allocs.toLocaleString()} allocs`;
+                            let s = `~${est} (${pct}%)`;
+                            if (allocs != null) {
+                                s += ` · ~${allocs.toLocaleString()} allocs`;
+                                s += ` · ${fmtB(count / treeNode.allocCount)} avg`;
+                            }
                             return s;
                         }
                     },

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -5027,7 +5027,6 @@
                                 if (allocs != null) s += ` · ~${allocs.toLocaleString()} allocs · ${fmtB(count / treeNode.allocCount)} avg`;
                                 return s;
                             } else {
-                                const bytes = treeNode && treeNode.allocCount != null ? treeNode.allocCount : count;
                                 // In count mode, count IS the alloc count, allocCount holds bytes
                                 let s = `~${Math.round(count).toLocaleString()} allocs (${pct}%)`;
                                 if (treeNode && treeNode.allocCount != null) s += ` · ~${fmtB(treeNode.allocCount)} · ${fmtB(treeNode.allocCount / count)} avg`;

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -658,6 +658,7 @@
                     <span id="poi-counter" style="font-size:0.85em;color:#888"></span>
                     <span style="width:1px;height:20px;background:#444;margin:0 8px"></span>
                     <button id="btn-sched-panel" style="background:#3a1a1a;border-color:#ff4444;color:#ff8a65">⚠ Blocking Calls</button>
+                    <button id="btn-heap-flamegraph" style="display:none;background:#1a2a1a;border-color:#4caf50;color:#81c784;white-space:nowrap" title="Show heap allocation flamegraph">🔥 Heap</button>
                     <button id="btn-uninstrumented-info" style="display:none;background:#1e2050;border-color:#6c63ff;color:#d0ccff;white-space:nowrap" title="Some tasks lack wake tracking — click for details">ⓘ Blind spawns</button>
                     <button id="btn-set-range" title="Set time range filter (reloads with only events in range)">Set Range</button>
                     <button id="btn-clear-range" title="Clear time range filter" style="display:none">Clear Range</button>
@@ -749,6 +750,7 @@
                     <span class="tab" id="tab-poll-detail" data-tab="poll-detail" style="display:none">Poll Detail</span>
                     <span class="tab" id="tab-flamegraph" data-tab="flamegraph">Flamegraph</span>
                     <span class="tab" id="tab-blocking" data-tab="blocking">Blocking Calls</span>
+                    <span class="tab" id="tab-heap" data-tab="heap" style="display:none">Heap</span>
                 </div>
                 <div class="sidebar-body" id="stack-sidebar-body"></div>
             </div>
@@ -1671,6 +1673,15 @@
                 if (uninstrumentedCount > 0) {
                     btnUninst.textContent = `ⓘ Uninstrumented (${uninstrumentedCount})`;
                 }
+
+                // Show heap flamegraph button if alloc events exist
+                const hasAllocEvents = trace.allocEvents && trace.allocEvents.length > 0;
+                const btnHeap = document.getElementById("btn-heap-flamegraph");
+                btnHeap.style.display = hasAllocEvents ? "" : "none";
+                if (hasAllocEvents) {
+                    btnHeap.textContent = `🔥 Heap (${trace.allocEvents.length})`;
+                }
+
                 showToast("shift-drag-hint", "⇧ Shift+drag to select a region", "info", 0, true);
                 showToast("option-drag-hint", "⌥ Option+drag to zoom", "info", 0, true);
                 requestAnimationFrame(renderAll);
@@ -3436,6 +3447,7 @@
             document.getElementById("poi-filter").addEventListener("change", updatePointsOfInterest);
             document.getElementById("sort-by-worst").addEventListener("change", updatePointsOfInterest);
             document.getElementById("btn-sched-panel").addEventListener("click", showSchedPanel);
+            document.getElementById("btn-heap-flamegraph").addEventListener("click", showHeapFlamegraph);
             document.getElementById("btn-uninstrumented-info").addEventListener("click", (e) => {
                 showUninstrumentedPopup(e.target);
             });
@@ -3654,8 +3666,15 @@
                     const hasCpu = trace.cpuSamples.some(s =>
                         s.timestamp >= selStart && s.timestamp <= selEnd && s.callchain.length > 0 && s.source !== 1
                     );
-                    if (hasSched && !hasCpu) {
+                    const hasHeap = trace.allocEvents && trace.allocEvents.some(a =>
+                        a.callchain.length > 0 && a.timestamp >= selStart && a.timestamp <= selEnd
+                    );
+                    if (hasSched && !hasCpu && !hasHeap) {
                         showSchedPanel(selStart, selEnd);
+                    } else if (!hasCpu && hasHeap) {
+                        sidebarSelStart = selStart;
+                        sidebarSelEnd = selEnd;
+                        showHeapFlamegraph(selStart, selEnd);
                     } else {
                         showFlamegraph(selStart, selEnd);
                     }
@@ -3717,8 +3736,15 @@
                             const hasCpu = trace.cpuSamples.some(s =>
                                 s.timestamp >= selStart && s.timestamp <= selEnd && s.callchain.length > 0 && s.source !== 1
                             );
-                            if (hasSched && !hasCpu) {
+                            const hasHeap = trace.allocEvents && trace.allocEvents.some(a =>
+                                a.callchain.length > 0 && a.timestamp >= selStart && a.timestamp <= selEnd
+                            );
+                            if (hasSched && !hasCpu && !hasHeap) {
                                 showSchedPanel(selStart, selEnd);
+                            } else if (!hasCpu && hasHeap) {
+                                sidebarSelStart = selStart;
+                                sidebarSelEnd = selEnd;
+                                showHeapFlamegraph(selStart, selEnd);
                             } else {
                                 showFlamegraph(selStart, selEnd);
                             }
@@ -4028,20 +4054,30 @@
                 const pollDetail = tabs.querySelector("#tab-poll-detail");
                 const flamegraph = tabs.querySelector("#tab-flamegraph");
                 const blocking = tabs.querySelector("#tab-blocking");
+                const heap = tabs.querySelector("#tab-heap");
 
                 if (activeTab === "poll-detail") {
                     pollDetail.style.display = "";
                     flamegraph.style.display = "none";
                     blocking.style.display = "none";
+                    heap.style.display = "none";
                 } else {
                     pollDetail.style.display = "none";
                     flamegraph.style.display = "";
                     blocking.style.display = "";
+                    // Show heap tab if alloc events exist in the selection range
+                    const hasHeap = trace && trace.allocEvents && trace.allocEvents.some(a =>
+                        a.callchain.length > 0 &&
+                        (sidebarSelStart == null || a.timestamp >= sidebarSelStart) &&
+                        (sidebarSelEnd == null || a.timestamp <= sidebarSelEnd)
+                    );
+                    heap.style.display = hasHeap ? "" : "none";
                 }
 
                 pollDetail.classList.toggle("active", activeTab === "poll-detail");
                 flamegraph.classList.toggle("active", activeTab === "flamegraph");
                 blocking.classList.toggle("active", activeTab === "blocking");
+                heap.classList.toggle("active", activeTab === "heap");
             }
 
             document.getElementById("tab-flamegraph").addEventListener("click", () => {
@@ -4058,6 +4094,16 @@
                     document.getElementById("flamegraph-panel").appendChild(fgContainer);
                 }
                 showSchedPanel(sidebarSelStart, sidebarSelEnd);
+            });
+            document.getElementById("tab-heap").addEventListener("click", () => {
+                // Clean up flamegraph before switching
+                if (fgActive) {
+                    fgActive = false;
+                    document.getElementById("flamegraph-panel").appendChild(fgContainer);
+                }
+                schedActive = false;
+                showSidebarTabs("heap");
+                showHeapFlamegraph(sidebarSelStart, sidebarSelEnd);
             });
 
             // ── Sidebar resize drag ──
@@ -4802,7 +4848,7 @@
             // Used by `showTaskDumpStack`, `showIdleTimeFlamegraph`, and any
             // other caller that just wants "here's a pile of callchains, render
             // them as a flamegraph in the sidebar".
-            function renderFlamegraphInSidebar({ title, subtitle, samples }) {
+            function renderFlamegraphInSidebar({ title, subtitle, samples, fgOpts }) {
                 fgActive = true;
                 schedActive = false;
                 const sidebar = document.getElementById("stack-sidebar");
@@ -4824,7 +4870,7 @@
                 sidebar.style.display = "flex";
                 if (wasHidden && trace) requestAnimationFrame(renderAll);
                 requestAnimationFrame(() => {
-                    fgInstance.setData(samples, trace.callframeSymbols);
+                    fgInstance.setData(samples, trace.callframeSymbols, fgOpts);
                     fgInstance.resize();
                 });
             }
@@ -4899,6 +4945,76 @@
                 });
             }
 
+            function showHeapFlamegraph(startNs, endNs) {
+                if (!trace || !trace.allocEvents || trace.allocEvents.length === 0) return;
+                let allocs = trace.allocEvents;
+                if (startNs != null) allocs = allocs.filter(a => a.timestamp >= startNs);
+                if (endNs != null) allocs = allocs.filter(a => a.timestamp <= endNs);
+                const filtered = allocs.filter(a => a.callchain.length > 0);
+                // Attribute allocs to tasks via tid → workerId → poll lookup for spawn filter
+                const samples = filtered.map(a => {
+                    const wId = trace.tidToWorker && trace.tidToWorker.get(a.tid);
+                    const sample = { callchain: a.callchain, workerId: wId != null ? 0 : 255, spawnLoc: null };
+                    if (wId != null && workerSpans[wId]) {
+                        const polls = workerSpans[wId].polls;
+                        let lo = 0, hi = polls.length - 1;
+                        while (lo <= hi) {
+                            const mid = (lo + hi) >> 1;
+                            if (polls[mid].start <= a.timestamp) lo = mid + 1;
+                            else hi = mid - 1;
+                        }
+                        if (hi >= 0 && a.timestamp <= polls[hi].end) {
+                            sample.spawnLoc = polls[hi].spawnLoc;
+                        }
+                    }
+                    return sample;
+                });
+                if (samples.length === 0) {
+                    showToast("no-heap-samples", "No heap samples in selected region", "error", 4000);
+                    return;
+                }
+                // Estimate total bytes using unbiased weight: weight(s) = s / (1 - exp(-s/R))
+                const R = 524288; // default sample rate bytes (512 KiB)
+                let estimatedBytes = 0;
+                for (const a of filtered) {
+                    const s = a.size;
+                    if (s <= 0) continue;
+                    const ratio = s / R;
+                    estimatedBytes += ratio > 50 ? s : s / (1 - Math.exp(-ratio));
+                }
+                const fmtBytes = estimatedBytes >= 1e9 ? (estimatedBytes / 1e9).toFixed(1) + " GB"
+                    : estimatedBytes >= 1e6 ? (estimatedBytes / 1e6).toFixed(1) + " MB"
+                    : estimatedBytes >= 1e3 ? (estimatedBytes / 1e3).toFixed(1) + " KB"
+                    : Math.round(estimatedBytes) + " B";
+                const rangeNote = (startNs != null || endNs != null) ? " in selected range" : " (full trace)";
+                const durStr = (startNs != null && endNs != null)
+                    ? ` · ${((endNs - startNs) / 1e6).toFixed(1)}ms`
+                    : "";
+                function fmtB(bytes) {
+                    return bytes >= 1e9 ? (bytes / 1e9).toFixed(1) + " GB"
+                        : bytes >= 1e6 ? (bytes / 1e6).toFixed(1) + " MB"
+                        : bytes >= 1e3 ? (bytes / 1e3).toFixed(1) + " KB"
+                        : Math.round(bytes) + " B";
+                }
+                const bytesPerSample = estimatedBytes / filtered.length;
+                renderFlamegraphInSidebar({
+                    title: `Heap flamegraph — ~${fmtBytes}${durStr}`,
+                    subtitle: `${filtered.length} samples · ~${fmtBytes} estimated total allocations${rangeNote}`,
+                    samples,
+                    fgOpts: {
+                        workerLabel: "Worker thread allocations",
+                        offworkerLabel: "Non-worker thread allocations",
+                        formatCount(count, total, self) {
+                            const pct = ((count / total) * 100).toFixed(1);
+                            const selfPct = ((self / total) * 100).toFixed(1);
+                            const est = fmtB(count * bytesPerSample);
+                            const selfEst = fmtB(self * bytesPerSample);
+                            return `~${est} (${pct}%) \u00b7 ~${selfEst} self (${selfPct}%)`;
+                        }
+                    },
+                });
+            }
+
             function showFlamegraph(selStart, selEnd) {
                 const samples = FlamegraphRenderer.filterCpuSamples(trace.cpuSamples, selStart, selEnd);
                 if (!samples.length) {
@@ -4919,9 +5035,12 @@
                 const body = document.getElementById("stack-sidebar-body");
                 title.textContent = `${durMs}ms selected`;
 
-                // Show tabs if both data types exist
+                // Show tabs if multiple data types exist
                 const hasSched = collectSchedSamples({ start: selStart, end: selEnd }).length > 0;
-                if (hasSched) {
+                const hasHeapInRange = trace.allocEvents && trace.allocEvents.some(a =>
+                    a.callchain.length > 0 && a.timestamp >= selStart && a.timestamp <= selEnd
+                );
+                if (hasSched || hasHeapInRange) {
                     showSidebarTabs("flamegraph");
                 } else {
                     document.getElementById("sidebar-tabs").style.display = "none";

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -4978,9 +4978,10 @@
                     const wId = trace.tidToWorker && trace.tidToWorker.get(a.tid);
                     const s = a.size;
                     const ratio = s / R;
+                    // Horvitz-Thompson unbiased estimator: invP = 1/P(sample) where P = 1-exp(-size/R)
                     const invP = (s <= 0 || ratio > 50) ? 1 : 1 / (1 - Math.exp(-ratio));
                     const sample = { callchain: a.callchain, workerId: wId != null ? 0 : 255, spawnLoc: null, byteWeight: s * invP, countWeight: invP };
-                    if (wId != null && workerSpans[wId]) {
+                    if (wId != null && workerSpans[wId] && workerSpans[wId].polls) {
                         const polls = workerSpans[wId].polls;
                         let lo = 0, hi = polls.length - 1;
                         while (lo <= hi) {

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -4972,15 +4972,14 @@
 
                 const filtered = allocs.map(a => ({ ...a, callchain: stripHookFrames(a.callchain) }))
                     .filter(a => a.callchain.length > 0);
-                // Estimate total bytes using unbiased weight: weight(s) = s / (1 - exp(-s/R))
-                const R = 524288; // default sample rate bytes (512 KiB)
-                // Attribute allocs to tasks via tid → workerId → poll lookup for spawn filter
-                const samples = filtered.map(a => {
+                const R = 524288;
+                // Build base samples with both weight types
+                const baseSamples = filtered.map(a => {
                     const wId = trace.tidToWorker && trace.tidToWorker.get(a.tid);
                     const s = a.size;
                     const ratio = s / R;
                     const invP = (s <= 0 || ratio > 50) ? 1 : 1 / (1 - Math.exp(-ratio));
-                    const sample = { callchain: a.callchain, workerId: wId != null ? 0 : 255, spawnLoc: null, weight: s * invP, allocWeight: invP };
+                    const sample = { callchain: a.callchain, workerId: wId != null ? 0 : 255, spawnLoc: null, byteWeight: s * invP, countWeight: invP };
                     if (wId != null && workerSpans[wId]) {
                         const polls = workerSpans[wId].polls;
                         let lo = 0, hi = polls.length - 1;
@@ -4995,48 +4994,111 @@
                     }
                     return sample;
                 });
-                if (samples.length === 0) {
+                if (baseSamples.length === 0) {
                     showToast("no-heap-samples", "No heap samples in selected region", "error", 4000);
                     return;
                 }
-                // Estimate total bytes (for header display)
-                let estimatedBytes = 0;
-                for (const s of samples) {
-                    estimatedBytes += s.weight;
-                }
-                const fmtBytes = estimatedBytes >= 1e9 ? (estimatedBytes / 1e9).toFixed(1) + " GB"
-                    : estimatedBytes >= 1e6 ? (estimatedBytes / 1e6).toFixed(1) + " MB"
-                    : estimatedBytes >= 1e3 ? (estimatedBytes / 1e3).toFixed(1) + " KB"
-                    : Math.round(estimatedBytes) + " B";
-                const rangeNote = (startNs != null || endNs != null) ? " in selected range" : " (full trace)";
-                const durStr = (startNs != null && endNs != null)
-                    ? ` · ${((endNs - startNs) / 1e6).toFixed(1)}ms`
-                    : "";
+
+                let estimatedBytes = 0, estimatedAllocs = 0;
+                for (const s of baseSamples) { estimatedBytes += s.byteWeight; estimatedAllocs += s.countWeight; }
                 function fmtB(bytes) {
                     return bytes >= 1e9 ? (bytes / 1e9).toFixed(1) + " GB"
                         : bytes >= 1e6 ? (bytes / 1e6).toFixed(1) + " MB"
                         : bytes >= 1e3 ? (bytes / 1e3).toFixed(1) + " KB"
                         : Math.round(bytes) + " B";
                 }
-                renderFlamegraphInSidebar({
-                    title: `Heap flamegraph — ~${fmtBytes}${durStr}`,
-                    subtitle: `${filtered.length} samples · ~${fmtBytes} estimated total allocations${rangeNote}`,
-                    samples,
-                    fgOpts: {
-                        workerLabel: "Worker thread allocations",
-                        offworkerLabel: "Non-worker thread allocations",
+                const fmtBytes = fmtB(estimatedBytes);
+                const rangeNote = (startNs != null || endNs != null) ? " in selected range" : " (full trace)";
+                const durStr = (startNs != null && endNs != null)
+                    ? ` · ${((endNs - startNs) / 1e6).toFixed(1)}ms`
+                    : "";
+
+                let heapMode = "bytes"; // "bytes" or "count"
+
+                function heapFgOpts(mode) {
+                    return {
+                        workerLabel: mode === "bytes" ? "Worker thread allocations (by bytes)" : "Worker thread allocations (by count)",
+                        offworkerLabel: mode === "bytes" ? "Non-worker thread allocations (by bytes)" : "Non-worker thread allocations (by count)",
                         formatCount(count, total, self, treeNode) {
                             const pct = ((count / total) * 100).toFixed(1);
-                            const est = fmtB(count);
-                            const allocs = treeNode && treeNode.allocCount != null ? Math.round(treeNode.allocCount) : null;
-                            let s = `~${est} (${pct}%)`;
-                            if (allocs != null) {
-                                s += ` · ~${allocs.toLocaleString()} allocs`;
-                                s += ` · ${fmtB(count / treeNode.allocCount)} avg`;
+                            if (mode === "bytes") {
+                                const allocs = treeNode && treeNode.allocCount != null ? Math.round(treeNode.allocCount) : null;
+                                let s = `~${fmtB(count)} (${pct}%)`;
+                                if (allocs != null) s += ` · ~${allocs.toLocaleString()} allocs · ${fmtB(count / treeNode.allocCount)} avg`;
+                                return s;
+                            } else {
+                                const bytes = treeNode && treeNode.allocCount != null ? treeNode.allocCount : count;
+                                // In count mode, count IS the alloc count, allocCount holds bytes
+                                let s = `~${Math.round(count).toLocaleString()} allocs (${pct}%)`;
+                                if (treeNode && treeNode.allocCount != null) s += ` · ~${fmtB(treeNode.allocCount)} · ${fmtB(treeNode.allocCount / count)} avg`;
+                                return s;
                             }
-                            return s;
                         }
-                    },
+                    };
+                }
+
+                function samplesForMode(mode) {
+                    return baseSamples.map(s => {
+                        if (mode === "bytes") {
+                            return { ...s, weight: s.byteWeight, allocWeight: s.countWeight };
+                        } else {
+                            // count mode: weight by alloc count, store bytes in allocWeight
+                            return { ...s, weight: s.countWeight, allocWeight: s.byteWeight };
+                        }
+                    });
+                }
+
+                // Render with initial mode
+                fgActive = true;
+                schedActive = false;
+                const sidebar = document.getElementById("stack-sidebar");
+                const titleEl = document.getElementById("stack-sidebar-title");
+                const body = document.getElementById("stack-sidebar-body");
+                document.getElementById("sidebar-tabs").style.display = "none";
+                titleEl.textContent = `Heap flamegraph — ~${fmtBytes}${durStr}`;
+                body.innerHTML = "";
+                body.style.display = "flex";
+                body.style.flexDirection = "column";
+
+                const actions = document.createElement("div");
+                actions.style.cssText = "display:flex;gap:8px;margin-bottom:6px;flex-shrink:0;align-items:center";
+                actions.innerHTML = `<span style="color:#888;font-size:0.85em">${filtered.length} samples · ~${fmtBytes} · ~${Math.round(estimatedAllocs).toLocaleString()} allocs${rangeNote}</span>`;
+
+                const toggle = document.createElement("span");
+                toggle.style.cssText = "display:inline-flex;border:1px solid #444;border-radius:4px;overflow:hidden;font-size:0.8em;cursor:pointer";
+                const btnBytes = document.createElement("span");
+                btnBytes.textContent = "Bytes";
+                btnBytes.style.cssText = "padding:2px 8px;background:#4caf50;color:#fff";
+                const btnCount = document.createElement("span");
+                btnCount.textContent = "Count";
+                btnCount.style.cssText = "padding:2px 8px;background:transparent;color:#888";
+                toggle.appendChild(btnBytes);
+                toggle.appendChild(btnCount);
+                function setToggle(mode) {
+                    heapMode = mode;
+                    btnBytes.style.background = mode === "bytes" ? "#4caf50" : "transparent";
+                    btnBytes.style.color = mode === "bytes" ? "#fff" : "#888";
+                    btnCount.style.background = mode === "count" ? "#4caf50" : "transparent";
+                    btnCount.style.color = mode === "count" ? "#fff" : "#888";
+                    requestAnimationFrame(() => {
+                        fgInstance.setData(samplesForMode(heapMode), trace.callframeSymbols, heapFgOpts(heapMode));
+                        fgInstance.resize();
+                    });
+                }
+                btnBytes.addEventListener("click", () => setToggle("bytes"));
+                btnCount.addEventListener("click", () => setToggle("count"));
+                actions.appendChild(toggle);
+                body.appendChild(actions);
+
+                fgContainer.style.flex = "1";
+                fgContainer.style.minHeight = "0";
+                body.appendChild(fgContainer);
+                const wasHidden = sidebar.style.display !== "flex";
+                sidebar.style.display = "flex";
+                if (wasHidden && trace) requestAnimationFrame(renderAll);
+                requestAnimationFrame(() => {
+                    fgInstance.setData(samplesForMode(heapMode), trace.callframeSymbols, heapFgOpts(heapMode));
+                    fgInstance.resize();
                 });
             }
 

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -4972,10 +4972,15 @@
 
                 const filtered = allocs.map(a => ({ ...a, callchain: stripHookFrames(a.callchain) }))
                     .filter(a => a.callchain.length > 0);
+                // Estimate total bytes using unbiased weight: weight(s) = s / (1 - exp(-s/R))
+                const R = 524288; // default sample rate bytes (512 KiB)
                 // Attribute allocs to tasks via tid → workerId → poll lookup for spawn filter
                 const samples = filtered.map(a => {
                     const wId = trace.tidToWorker && trace.tidToWorker.get(a.tid);
-                    const sample = { callchain: a.callchain, workerId: wId != null ? 0 : 255, spawnLoc: null };
+                    const s = a.size;
+                    const ratio = s / R;
+                    const invP = (s <= 0 || ratio > 50) ? 1 : 1 / (1 - Math.exp(-ratio));
+                    const sample = { callchain: a.callchain, workerId: wId != null ? 0 : 255, spawnLoc: null, weight: s * invP, allocWeight: invP };
                     if (wId != null && workerSpans[wId]) {
                         const polls = workerSpans[wId].polls;
                         let lo = 0, hi = polls.length - 1;
@@ -4994,14 +4999,10 @@
                     showToast("no-heap-samples", "No heap samples in selected region", "error", 4000);
                     return;
                 }
-                // Estimate total bytes using unbiased weight: weight(s) = s / (1 - exp(-s/R))
-                const R = 524288; // default sample rate bytes (512 KiB)
+                // Estimate total bytes (for header display)
                 let estimatedBytes = 0;
-                for (const a of filtered) {
-                    const s = a.size;
-                    if (s <= 0) continue;
-                    const ratio = s / R;
-                    estimatedBytes += ratio > 50 ? s : s / (1 - Math.exp(-ratio));
+                for (const s of samples) {
+                    estimatedBytes += s.weight;
                 }
                 const fmtBytes = estimatedBytes >= 1e9 ? (estimatedBytes / 1e9).toFixed(1) + " GB"
                     : estimatedBytes >= 1e6 ? (estimatedBytes / 1e6).toFixed(1) + " MB"
@@ -5017,7 +5018,6 @@
                         : bytes >= 1e3 ? (bytes / 1e3).toFixed(1) + " KB"
                         : Math.round(bytes) + " B";
                 }
-                const bytesPerSample = estimatedBytes / filtered.length;
                 renderFlamegraphInSidebar({
                     title: `Heap flamegraph — ~${fmtBytes}${durStr}`,
                     subtitle: `${filtered.length} samples · ~${fmtBytes} estimated total allocations${rangeNote}`,
@@ -5025,12 +5025,15 @@
                     fgOpts: {
                         workerLabel: "Worker thread allocations",
                         offworkerLabel: "Non-worker thread allocations",
-                        formatCount(count, total, self) {
+                        formatCount(count, total, self, treeNode) {
                             const pct = ((count / total) * 100).toFixed(1);
                             const selfPct = ((self / total) * 100).toFixed(1);
-                            const est = fmtB(count * bytesPerSample);
-                            const selfEst = fmtB(self * bytesPerSample);
-                            return `~${est} (${pct}%) \u00b7 ~${selfEst} self (${selfPct}%)`;
+                            const est = fmtB(count);
+                            const selfEst = fmtB(self);
+                            const allocs = treeNode && treeNode.allocCount != null ? Math.round(treeNode.allocCount) : null;
+                            let s = `~${est} (${pct}%) \u00b7 ~${selfEst} self (${selfPct}%)`;
+                            if (allocs != null) s += ` \u00b7 ~${allocs.toLocaleString()} allocs`;
+                            return s;
                         }
                     },
                 });


### PR DESCRIPTION
Show allocation callstacks as a flamegraph in the trace viewer.

## Changes

- **Toolbar button**: "🔥 Heap (N)" appears when alloc events exist in the trace
- **Shift+drag**: Shows heap flamegraph for selected time range (when no CPU samples available)
- **Sidebar tab**: "Heap" tab appears alongside Flamegraph/Blocking when both data types exist
- **Byte estimates**: Tooltip shows estimated allocation bytes using unbiased weight formula
- **Task picker**: Spawn location filter works via tid→workerId→poll attribution
- **Worker split**: Separates worker thread vs non-worker thread allocations
- **Time filtering**: All entry points support time-range filtering

shows that most of the allocations in the flush task are actually due to perf! interesting and worth optimizing.

<img width="1519" height="710" alt="Screenshot 2026-05-26 at 5 13 16 PM" src="https://github.com/user-attachments/assets/d4f3b316-5b08-430a-8c5c-b34362cd4c37" />



## How it works

Alloc events already have `callchain` arrays from the memory profiler. This PR converts them into flamegraph samples and renders them using the existing `createFlamegraph` component. No Rust changes needed.

## Testing

- Added JS tests verifying alloc events produce valid flamegraph trees
- All existing JS tests pass
- `cargo build -p dial9-viewer` succeeds