### PR TITLE
Address misc UI usability issues (#450)

### DIFF
--- a/dial9-viewer/ui/test_poll_color.js
+++ b/dial9-viewer/ui/test_poll_color.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+"use strict";
+
+// Unit tests for pollHeatmapColor — a continuous, log-scale heatmap mapping
+// poll duration (in nanoseconds) to a hex color string.
+//
+// Run with: node test_poll_color.js
+// Used by viewer.html for issue #450 (item 1: poll color heatmap).
+
+const { pollHeatmapColor } = require("./trace_analysis.js");
+
+let failures = 0;
+function fail(msg) {
+  console.log(`✗ ${msg}`);
+  failures++;
+}
+function pass(msg) {
+  console.log(`✓ ${msg}`);
+}
+
+function isHex(s) {
+  return typeof s === "string" && /^#[0-9a-f]{6}$/i.test(s);
+}
+
+function hexToRgb(hex) {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ];
+}
+
+// 1. Returns valid hex strings for any input duration
+function testHexFormat() {
+  const inputs = [0, 1, 100, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e12];
+  for (const d of inputs) {
+    const c = pollHeatmapColor(d);
+    if (!isHex(c)) {
+      fail(`pollHeatmapColor(${d}) returned ${JSON.stringify(c)} — not valid hex`);
+      return;
+    }
+  }
+  pass(`pollHeatmapColor returns valid #rrggbb for diverse inputs`);
+}
+
+// 2. Monotonic redness — longer polls should be at least as "red"
+//    (R component never decreases) as shorter polls across the interesting
+//    range. The blue channel doesn't need to be strictly monotonic — the ramp
+//    intentionally passes through cyan (peak blue) on its way from dim navy
+//    to red — but the start and end of the range must clearly differ in the
+//    expected direction.
+function testMonotonicRednessAcrossRange() {
+  const samples = [];
+  // Sample log-spaced from 1µs to 1s
+  for (let lg = 3; lg <= 9; lg += 0.5) {
+    samples.push(Math.pow(10, lg));
+  }
+  const colors = samples.map((d) => hexToRgb(pollHeatmapColor(d)));
+  const reds = colors.map((c) => c[0]);
+  const blues = colors.map((c) => c[2]);
+  // Per-step: red never decreases (allow plateau at 255)
+  for (let i = 1; i < reds.length; i++) {
+    if (reds[i] < reds[i - 1]) {
+      fail(`red decreased between samples ${i - 1}→${i}: ${reds[i - 1]} → ${reds[i]}`);
+      return;
+    }
+  }
+  // Overall trend: end clearly redder and less blue than start
+  if (reds[reds.length - 1] <= reds[0]) {
+    fail(`expected red to grow across range, got ${reds[0]} → ${reds[reds.length - 1]}`);
+    return;
+  }
+  if (blues[blues.length - 1] >= blues[0]) {
+    fail(`expected blue to shrink across range, got ${blues[0]} → ${blues[blues.length - 1]}`);
+    return;
+  }
+  pass(`redness grows monotonically (with plateau at 255) across log-spaced 1µs–1s range`);
+}
+
+// 3. Clamps below the floor: very short polls (≤100ns) all map to the same dim color
+function testClampBelowFloor() {
+  const c0 = pollHeatmapColor(0);
+  const c1 = pollHeatmapColor(50);
+  const c2 = pollHeatmapColor(100);
+  if (c0 !== c1 || c1 !== c2) {
+    fail(`expected all sub-100ns durations to map to the same color, got ${c0}, ${c1}, ${c2}`);
+    return;
+  }
+  pass(`durations ≤100ns clamp to a single floor color (${c0})`);
+}
+
+// 4. Clamps above the ceiling: very long polls all map to the same hot color
+function testClampAboveCeiling() {
+  const c1 = pollHeatmapColor(1e9);    // 1s
+  const c2 = pollHeatmapColor(1e10);   // 10s
+  const c3 = pollHeatmapColor(1e15);   // ridiculous
+  if (c1 !== c2 || c2 !== c3) {
+    fail(`expected very long durations to clamp to a ceiling color, got ${c1}, ${c2}, ${c3}`);
+    return;
+  }
+  pass(`durations ≥1s clamp to a single ceiling color (${c1})`);
+}
+
+// 5. Colors at the canonical anchor points should match the legend swatches
+//    so the legend stays an honest reference point.
+function testAnchorPointsMatchLegend() {
+  // These are the colors the heatmap legend explicitly shows. The function
+  // must produce them at exactly these durations.
+  const ANCHORS = [
+    { ns: 100,    color: "#2a5a7a", label: "≤100ns (floor: dim navy)" },
+    { ns: 10e3,   color: "#4fc3f7", label: "10µs (cyan)" },
+    { ns: 100e3,  color: "#ff8a65", label: "100µs (orange)" },
+    { ns: 1e6,    color: "#ff4444", label: "1ms (bright red)" },
+  ];
+  for (const a of ANCHORS) {
+    const got = pollHeatmapColor(a.ns).toLowerCase();
+    if (got !== a.color.toLowerCase()) {
+      fail(`pollHeatmapColor(${a.ns}) = ${got}, expected ${a.color} for ${a.label}`);
+      return;
+    }
+  }
+  pass(`anchor points (100ns, 10µs, 100µs, 1ms) match legend swatches exactly`);
+}
+
+testHexFormat();
+testMonotonicRednessAcrossRange();
+testClampBelowFloor();
+testClampAboveCeiling();
+testAnchorPointsMatchLegend();
+
+if (failures > 0) {
+  console.log(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log(`\nAll poll color heatmap tests passed`);

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -129,7 +129,6 @@
     const dBin = Math.pow(10, lgBin);
     return pollHeatmapColor(dBin);
   }
-  }
 
   /**
    * Reconstruct poll/park/active spans from raw events using a state machine.

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -42,6 +42,95 @@
     return { minTs, maxTs, durationNs: maxTs - minTs };
   }
 
+  // ── Poll color heatmap ────────────────────────────────────────────────
+  // Maps a poll duration in nanoseconds to a hex color string using a
+  // log-scale ramp.
+  //
+  // Why log scale: poll durations span many orders of magnitude (≤100ns
+  // common, occasional 100ms+ stalls). A linear ramp would either compress
+  // most polls into a single color, or overwhelm the visualization with the
+  // hottest few. Log scale gives roughly equal visual weight to each decade.
+  //
+  // Anchor stops are pinned to the legend swatches in viewer.html so the
+  // legend stays an honest reference. Stops between anchors are interpolated
+  // linearly in RGB. Inputs below the floor (100ns) clamp to dim navy;
+  // inputs above the ceiling (1s) clamp to deep red.
+  //
+  // The previous bucketed scheme (4 colors at fixed thresholds) is replaced
+  // by this continuous version — see issue #450.
+  const POLL_HEATMAP_STOPS = [
+    { logNs: 2, rgb: [0x2a, 0x5a, 0x7a] }, // 100ns: dim navy (floor)
+    { logNs: 4, rgb: [0x4f, 0xc3, 0xf7] }, // 10µs: cyan
+    { logNs: 5, rgb: [0xff, 0x8a, 0x65] }, // 100µs: orange
+    { logNs: 6, rgb: [0xff, 0x44, 0x44] }, // 1ms: bright red
+    { logNs: 9, rgb: [0xff, 0x00, 0x00] }, // 1s+: pure red (ceiling)
+  ];
+
+  function _toHex2(n) {
+    const h = Math.round(n).toString(16);
+    return h.length === 1 ? "0" + h : h;
+  }
+
+  /**
+   * Continuous, log-scale color heatmap for poll durations.
+   * @param {number} durationNs poll duration in nanoseconds (≥ 0)
+   * @returns {string} `#rrggbb` color
+   */
+  function pollHeatmapColor(durationNs) {
+    const stops = POLL_HEATMAP_STOPS;
+    if (!(durationNs > 0)) {
+      const f = stops[0].rgb;
+      return "#" + _toHex2(f[0]) + _toHex2(f[1]) + _toHex2(f[2]);
+    }
+    const lg = Math.log10(durationNs);
+    if (lg <= stops[0].logNs) {
+      const f = stops[0].rgb;
+      return "#" + _toHex2(f[0]) + _toHex2(f[1]) + _toHex2(f[2]);
+    }
+    if (lg >= stops[stops.length - 1].logNs) {
+      const f = stops[stops.length - 1].rgb;
+      return "#" + _toHex2(f[0]) + _toHex2(f[1]) + _toHex2(f[2]);
+    }
+    // Find interpolation segment
+    for (let i = 0; i < stops.length - 1; i++) {
+      const a = stops[i],
+        b = stops[i + 1];
+      if (lg >= a.logNs && lg <= b.logNs) {
+        const t = (lg - a.logNs) / (b.logNs - a.logNs);
+        const r = a.rgb[0] + (b.rgb[0] - a.rgb[0]) * t;
+        const g = a.rgb[1] + (b.rgb[1] - a.rgb[1]) * t;
+        const bl = a.rgb[2] + (b.rgb[2] - a.rgb[2]) * t;
+        return "#" + _toHex2(r) + _toHex2(g) + _toHex2(bl);
+      }
+    }
+    // Unreachable
+    const f = stops[stops.length - 1].rgb;
+    return "#" + _toHex2(f[0]) + _toHex2(f[1]) + _toHex2(f[2]);
+  }
+
+  // Quantize a poll duration to a small fixed set of bucket colors. Used by
+  // the LOD path in viewer.html to merge adjacent polls with identical color
+  // into a single fillRect; with 16 quantization bins per decade-spanning
+  // log scale, runs of "approximately equal" polls still fold into one
+  // rectangle, which keeps zoomed-out rendering fast.
+  function pollHeatmapColorQuantized(durationNs, bins) {
+    const NBINS = bins || 24;
+    const stops = POLL_HEATMAP_STOPS;
+    const minLg = stops[0].logNs;
+    const maxLg = stops[stops.length - 1].logNs;
+    let lg;
+    if (!(durationNs > 0)) lg = minLg;
+    else lg = Math.log10(durationNs);
+    if (lg < minLg) lg = minLg;
+    if (lg > maxLg) lg = maxLg;
+    const t = (lg - minLg) / (maxLg - minLg);
+    const bin = Math.min(NBINS - 1, Math.floor(t * NBINS));
+    const lgBin = minLg + (bin / (NBINS - 1)) * (maxLg - minLg);
+    const dBin = Math.pow(10, lgBin);
+    return pollHeatmapColor(dBin);
+  }
+  }
+
   /**
    * Reconstruct poll/park/active spans from raw events using a state machine.
    * @param {import('./trace_parser.js').TraceEvent[]} events - raw trace events
@@ -1035,6 +1124,8 @@
     selectSpanRenderSet,
     computeSpanLayout,
     analyzeAllocations,
+    pollHeatmapColor,
+    pollHeatmapColorQuantized,
   };
 
   if (typeof module !== "undefined" && module.exports) {

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -107,7 +107,7 @@
             }
 
             #stack-sidebar {
-                width: 400px;
+                width: min(640px, 50vw);
                 min-width: 200px;
                 max-width: 70vw;
                 background: #1a1a2e;
@@ -729,9 +729,12 @@
                     <canvas id="task-detail-canvas"></canvas>
                 </div>
                 <div id="queue-chart" tabindex="0" aria-label="Queue depth chart">
-                    <span class="chart-label"
-                        >Queue Depth (global=blue, local max=orange)</span
-                    >
+                    <span class="chart-label" style="display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+                        <span style="font-weight:600">Queue Depth</span>
+                        <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:8px;background:rgba(79,195,247,0.5);border:1px solid #4fc3f7;display:inline-block"></span>Global</span>
+                        <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:2px;background:#ff8a65;display:inline-block"></span>Max local</span>
+                        <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:2px;background:#81c784;display:inline-block"></span>Active tasks</span>
+                    </span>
                     <div id="info-panel"></div>
                     <canvas id="queue-canvas"></canvas>
                 </div>
@@ -853,13 +856,14 @@
             ];
             const ET_COLORS = { poll: "#4fc3f7", park: "#ff8a65" };
 
-            // Duration-based poll coloring: short=dim, long=hot
+            // Duration-based poll coloring: short=dim, long=hot. The
+            // continuous log-scale heatmap lives in trace_analysis.js
+            // (`pollHeatmapColor`); we call the quantized variant here so
+            // adjacent polls of "approximately equal" duration share a color
+            // string, which lets the LOD path merge them into one fillRect.
+            // See issue #450 (item 1).
             function pollColor(startNs, endNs) {
-                const durUs = (endNs - startNs) / 1e3;
-                if (durUs > 1000) return "#ff4444"; // >1ms: red
-                if (durUs > 100)  return "#ff8a65"; // >100µs: orange
-                if (durUs > 10)   return "#4fc3f7"; // >10µs: bright blue
-                return "#2a5a7a";                    // ≤10µs: dim blue
+                return TraceAnalysis.pollHeatmapColorQuantized(endNs - startNs);
             }
 
             const SPAN_COLORS = [
@@ -929,12 +933,17 @@
 
             let spanPctFilter = 0; // 0 = no filter, 50/90/99 = show only >= that percentile
 
+            // Dimmed variant of `pollColor` used when a task is selected, to
+            // fade the non-selected polls into the background. Compute the
+            // heatmap color and multiply each channel by ~0.4 so the hue is
+            // preserved but the bar visually recedes.
             function pollColorDim(startNs, endNs) {
-                const durUs = (endNs - startNs) / 1e3;
-                if (durUs > 1000) return "#803030"; // >1ms: muted red
-                if (durUs > 100)  return "#805540"; // >100µs: muted orange
-                if (durUs > 10)   return "#2a5a7a"; // >10µs: dim blue
-                return "#1e3040";                    // ≤10µs: very dim
+                const c = TraceAnalysis.pollHeatmapColorQuantized(endNs - startNs);
+                const r = Math.round(parseInt(c.slice(1, 3), 16) * 0.4);
+                const g = Math.round(parseInt(c.slice(3, 5), 16) * 0.4);
+                const b = Math.round(parseInt(c.slice(5, 7), 16) * 0.4);
+                const hex2 = (n) => n.toString(16).padStart(2, "0");
+                return "#" + hex2(r) + hex2(g) + hex2(b);
             }
 
             // ── State ──
@@ -1691,12 +1700,18 @@
                 requestAnimationFrame(renderAll);
             }
 
-            function updatePointsOfInterest() {
+            function updatePointsOfInterest({ autoJump = false } = {}) {
                 const filterType = document.getElementById("poi-filter").value;
                 const sortByWorst = document.getElementById("sort-by-worst").checked;
                 pointsOfInterest = filterPointsOfInterest(filterType, workerSpans, workerIds, schedDelays, { hasSchedWait: trace.hasSchedWait, sortByWorst, taskInstrumented: trace.taskInstrumented });
                 currentPoiIndex = -1;
                 updatePoiCounter();
+                // When the user changes the filter or sort, auto-jump to the
+                // first POI so they immediately see what matches. On initial
+                // trace load we leave the view at the overview (autoJump=false).
+                if (autoJump && pointsOfInterest.length > 0) {
+                    jumpToPoi(0);
+                }
             }
 
             function updatePoiCounter() {
@@ -3448,8 +3463,8 @@
             }
 
             // ──  Pan ──
-            document.getElementById("poi-filter").addEventListener("change", updatePointsOfInterest);
-            document.getElementById("sort-by-worst").addEventListener("change", updatePointsOfInterest);
+            document.getElementById("poi-filter").addEventListener("change", () => updatePointsOfInterest({ autoJump: true }));
+            document.getElementById("sort-by-worst").addEventListener("change", () => updatePointsOfInterest({ autoJump: true }));
             document.getElementById("btn-sched-panel").addEventListener("click", showSchedPanel);
             document.getElementById("btn-heap-flamegraph").addEventListener("click", () => showHeapFlamegraph());
             document.getElementById("btn-uninstrumented-info").addEventListener("click", (e) => {
@@ -4804,17 +4819,24 @@
                 leg.style.cssText =
                     "font-size:0.8em;display:flex;gap:12px;align-items:center;flex-wrap:wrap;";
                 leg.innerHTML = `
-    <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:12px;background:#2a5a7a;display:inline-block;border-radius:2px"></span>Poll ≤10µs</span>
-    <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:12px;background:#4fc3f7;display:inline-block;border-radius:2px"></span>&gt;10µs</span>
-    <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:12px;background:#ff8a65;display:inline-block;border-radius:2px"></span>&gt;100µs</span>
-    <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:12px;background:#ff4444;display:inline-block;border-radius:2px"></span>&gt;1ms</span>
+    <span style="display:flex;align-items:center;gap:4px" title="Poll duration heatmap (log scale)">
+        Poll
+        <span style="display:inline-flex;flex-direction:column;align-items:stretch;gap:1px;position:relative">
+            <span style="width:140px;height:8px;background:linear-gradient(to right, #2a5a7a 0%, #4fc3f7 28.6%, #ff8a65 42.9%, #ff4444 57.1%, #ff0000 100%);display:inline-block;border-radius:1px"></span>
+            <span style="position:relative;width:140px;height:0.95em;font-size:0.85em;color:#888;line-height:1">
+                <span style="position:absolute;left:0;transform:translateX(0)">100ns</span>
+                <span style="position:absolute;left:28.6%;transform:translateX(-50%)">10µs</span>
+                <span style="position:absolute;left:57.1%;transform:translateX(-50%)">1ms</span>
+                <span style="position:absolute;left:100%;transform:translateX(-100%)">1s</span>
+            </span>
+        </span>
+    </span>
     <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:12px;background:#2a1520;border-top:3px solid #cc5533;display:inline-block;border-radius:2px"></span>Parked</span>
     <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:12px;background:#ff0000;display:inline-block;border-radius:2px"></span>Kernel Sched Delay</span>
     <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:4px;background:#ce93d8;display:inline-block"></span>CPU Sampled</span>
     <span style="display:flex;align-items:center;gap:4px"><span style="color:#ff2222;font-size:10px">▲</span>Sched (blocking)</span>
     <span style="display:flex;align-items:center;gap:4px"><span style="color:#66bb6a;font-size:10px">▼</span>Wake</span>
     <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:2px;background:rgba(255,200,50,0.7);display:inline-block"></span>Local Q</span>
-    <span style="display:flex;align-items:center;gap:4px"><span style="width:12px;height:2px;background:#81c784;display:inline-block"></span>Active Tasks</span>
   `;
                 tb.insertBefore(leg, tb.firstChild);
 

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -2382,8 +2382,9 @@
                         lastY = y;
                     }
                     ctx.lineTo(pw, lastY);
-                    const colors = ["rgba(255,200,50,0.8)", "rgba(50,255,200,0.8)", "rgba(255,50,200,0.8)", "rgba(200,50,255,0.8)"];
-                    ctx.strokeStyle = colors[workerId % colors.length];
+                    // Single color for all workers — the legend's "Local Q"
+                    // swatch matches this. Per-worker colors were too noisy.
+                    ctx.strokeStyle = "rgba(255,200,50,0.8)";
                     ctx.lineWidth = 1.5;
                     ctx.stroke();
                 }


### PR DESCRIPTION
Closes #450.

Four small fixes to the viewer's timeline UX, in roughly increasing order of size.

### 3. Auto-jump to first POI on dropdown / sort change
Changing the POI filter (`Kernel Scheduling Delays`, `Long Polls (>1ms)`, …) or the "Worst first" toggle now jumps the view to POI #1 of the new list, so users can immediately see what matched. Initial trace load still leaves the user at the overview.

### 4. Wider flamegraph sidebar by default
`#stack-sidebar` opens at `min(640px, 50vw)` instead of `400px`. The drag-resize handle still works (min 200, max 70vw unchanged).

### 2. Rework the legend
The top toolbar legend was mixing items that visualize on the worker lanes with one item (Active Tasks) that only appears in the queue-chart panel at the bottom. Now:

- The queue-chart panel has its own inline legend covering Global queue, Max local queue, and Active tasks.
- "Active Tasks" is removed from the top toolbar legend.
- "Local Q" stays in the top legend because it is also overlaid on each worker lane (yellow line).

### 1. Log-scale poll color heatmap
Replaced the four hard-coded duration buckets with a continuous, log-scale heatmap. The function lives in `trace_analysis.js` so it can be unit-tested in node:

| duration | color |
|----------|-------|
| ≤100ns   | dim navy `#2a5a7a` (floor) |
| 10µs     | cyan `#4fc3f7` |
| 100µs    | orange `#ff8a65` |
| 1ms      | bright red `#ff4444` |
| ≥1s      | pure red `#ff0000` (ceiling) |

Stops are linearly interpolated in RGB on the log10(duration) axis. The quantized variant (24 bins) is what `pollColor` actually calls, so adjacent polls of "approximately equal" duration still share a color string and the existing LOD merging in the worker-lane renderer keeps zoomed-out drawing fast.

The toolbar legend is now a gradient strip with tick labels at 100ns/10µs/1ms/1s aligned with the actual stops.

### Testing
- New unit tests in `dial9-viewer/ui/test_poll_color.js` (TDD: hex format, monotonic redness, floor/ceiling clamping, anchor points match legend swatches).
- All existing `dial9-viewer/ui/test_*.js` tests pass.
- `cargo build -p dial9-viewer` clean.

JS/HTML-only change — no `.rs` files touched, no trace format changes, so per `AGENTS.md` no `cargo nextest` / stress run required.