### PR TITLE
feat: cpu profiler only mode

### DIFF
--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -91,6 +91,7 @@ Runtime knobs:
 | Name | Default | Meaning |
 | --- | --- | --- |
 | `DIAL9_TASK_TRACKING_ENABLED` | `true` | Track tasks spawned through dial9 handles. |
+| `DIAL9_TOKIO_INSTRUMENTATION_ENABLED` | `true` | Install dial9's Tokio runtime hook instrumentation. |
 | `DIAL9_RUNTIME_NAME` | unset | Human-readable runtime name in trace metadata. |
 
 S3 upload knobs (`worker-s3` feature required):
@@ -213,6 +214,30 @@ Dial9Config::builder()
     })
     // ...
 ```
+
+To use dial9 as a CPU profiler without installing Tokio runtime hooks, keep
+telemetry enabled and disable only Tokio instrumentation:
+
+```rust,ignore
+use dial9_tokio_telemetry::telemetry::cpu_profile::CpuProfilingConfig;
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+
+let (runtime, guard) = TracedRuntime::builder()
+    .with_cpu_profiling(CpuProfilingConfig::default())
+    .with_tokio_instrumentation(false)
+    .build_and_start(tokio::runtime::Builder::new_multi_thread(), writer)?;
+```
+
+Equivalent env config:
+
+```text
+DIAL9_ENABLED=true
+DIAL9_CPU_PROFILE_ENABLED=true
+DIAL9_TOKIO_INSTRUMENTATION_ENABLED=false
+```
+
+In this mode, dial9 does not install Tokio runtime hooks. APIs that depend on
+those hooks will not observe runtime context.
 
 #### System requirements
 - `perf_event_paranoid`: CPU profiling requires <= 2. `sched_events` requires <= 1.

--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -228,6 +228,10 @@ let (runtime, guard) = TracedRuntime::builder()
     .build_and_start(tokio::runtime::Builder::new_multi_thread(), writer)?;
 ```
 
+You can also use `TelemetryCore::builder()` directly when you only need the
+telemetry session and want to decide separately whether to build or attach any
+Tokio runtime.
+
 Equivalent env config:
 
 ```text

--- a/dial9-tokio-telemetry/src/config.rs
+++ b/dial9-tokio-telemetry/src/config.rs
@@ -195,6 +195,7 @@ const ENV_DIAL9_TRACE_DIR: &str = "DIAL9_TRACE_DIR";
 const ENV_DIAL9_ROTATION_SECS: &str = "DIAL9_ROTATION_SECS";
 const ENV_DIAL9_MAX_DISK_USAGE_MB: &str = "DIAL9_MAX_DISK_USAGE_MB";
 const ENV_DIAL9_MAX_FILE_SIZE_MB: &str = "DIAL9_MAX_FILE_SIZE_MB";
+const ENV_DIAL9_TOKIO_INSTRUMENTATION_ENABLED: &str = "DIAL9_TOKIO_INSTRUMENTATION_ENABLED";
 const ENV_DIAL9_TASK_TRACKING_ENABLED: &str = "DIAL9_TASK_TRACKING_ENABLED";
 const ENV_DIAL9_RUNTIME_NAME: &str = "DIAL9_RUNTIME_NAME";
 const ENV_DIAL9_S3_BUCKET: &str = "DIAL9_S3_BUCKET";
@@ -244,6 +245,7 @@ struct ParsedEnvConfig {
     rotation_period: Option<Duration>,
     max_total_size: Option<u64>,
     max_file_size: Option<u64>,
+    tokio_instrumentation_enabled: Option<bool>,
     task_tracking_enabled: Option<bool>,
     runtime_name: Option<String>,
     s3: Option<ParsedS3Config>,
@@ -280,6 +282,7 @@ struct ResolvedEnvConfig {
 
     max_total_size: u64,
     max_file_size: u64,
+    tokio_instrumentation_enabled: Option<bool>,
     task_tracking_enabled: bool,
 
     // Optional config: None means do not set a runtime name.
@@ -301,6 +304,7 @@ struct ResolvedEnvConfig {
 }
 
 struct RuntimeEnvConfig {
+    tokio_instrumentation_enabled: Option<bool>,
     task_tracking_enabled: bool,
     runtime_name: Option<String>,
     cpu_profile_enabled: bool,
@@ -336,6 +340,7 @@ fn parse_env_config(env: &impl EnvSource) -> ParsedEnvConfig {
             .map(Duration::from_secs),
         max_total_size,
         max_file_size,
+        tokio_instrumentation_enabled: env.get_bool(ENV_DIAL9_TOKIO_INSTRUMENTATION_ENABLED),
         task_tracking_enabled: env.get_bool(ENV_DIAL9_TASK_TRACKING_ENABLED),
         runtime_name: env.get_string(ENV_DIAL9_RUNTIME_NAME),
         s3,
@@ -365,6 +370,7 @@ fn resolve_env_config(parsed: ParsedEnvConfig) -> ResolvedEnvConfig {
         rotation_period: parsed.rotation_period,
         max_total_size,
         max_file_size,
+        tokio_instrumentation_enabled: parsed.tokio_instrumentation_enabled,
         task_tracking_enabled: parsed
             .task_tracking_enabled
             .unwrap_or(DEFAULT_TASK_TRACKING_ENABLED),
@@ -519,6 +525,9 @@ fn apply_runtime_env<M>(
     if let Some(name) = config.runtime_name {
         runtime = runtime.with_runtime_name(name);
     }
+    if let Some(enabled) = config.tokio_instrumentation_enabled {
+        runtime = runtime.with_tokio_instrumentation(enabled);
+    }
     runtime = runtime.with_task_tracking(config.task_tracking_enabled);
 
     if config.task_dump_enabled {
@@ -590,6 +599,7 @@ impl Dial9Config {
     /// | Variable | Default | Meaning |
     /// | --- | --- | --- |
     /// | `DIAL9_TASK_TRACKING_ENABLED` | `true` | Track tasks spawned through dial9 handles. |
+    /// | `DIAL9_TOKIO_INSTRUMENTATION_ENABLED` | `true` | Install dial9's Tokio runtime hook instrumentation. |
     /// | `DIAL9_RUNTIME_NAME` | unset | Human-readable runtime name in trace metadata. |
     ///
     /// Supported S3 variables (`worker-s3` feature required):
@@ -632,6 +642,7 @@ impl Dial9Config {
             rotation_period,
             max_total_size,
             max_file_size,
+            tokio_instrumentation_enabled,
             task_tracking_enabled,
             runtime_name,
             s3,
@@ -643,6 +654,7 @@ impl Dial9Config {
         } = resolve_env_config(parse_env_config(env));
 
         let runtime_config = RuntimeEnvConfig {
+            tokio_instrumentation_enabled,
             task_tracking_enabled,
             runtime_name,
             cpu_profile_enabled,
@@ -971,6 +983,7 @@ mod tests {
         assert_eq!(parsed.rotation_period, None);
         assert_eq!(parsed.max_total_size, None);
         assert_eq!(parsed.max_file_size, None);
+        assert_eq!(parsed.tokio_instrumentation_enabled, None);
         assert_eq!(parsed.task_tracking_enabled, None);
         assert_eq!(parsed.runtime_name, None);
         assert!(parsed.s3.is_none());
@@ -1000,6 +1013,7 @@ mod tests {
             resolved.task_tracking_enabled,
             DEFAULT_TASK_TRACKING_ENABLED
         );
+        assert_eq!(resolved.tokio_instrumentation_enabled, None);
         assert_eq!(resolved.cpu_profile_enabled, supported_profiling);
         assert_eq!(resolved.schedule_profile_enabled, supported_profiling);
         assert_eq!(resolved.task_dump_enabled, DEFAULT_TASK_DUMP_ENABLED);
@@ -1048,6 +1062,7 @@ mod tests {
     fn env_parses_runtime_storage_s3_cpu_and_taskdump_values() {
         let parsed = parse_env_config(
             &FakeEnv::default()
+                .with("DIAL9_TOKIO_INSTRUMENTATION_ENABLED", "off")
                 .with("DIAL9_TASK_TRACKING_ENABLED", "off")
                 .with("DIAL9_RUNTIME_NAME", " api-runtime ")
                 .with("DIAL9_MAX_FILE_SIZE_MB", "128")
@@ -1061,6 +1076,7 @@ mod tests {
                 .with("DIAL9_TASK_DUMP_IDLE_THRESHOLD_MS", "25"),
         );
 
+        assert_eq!(parsed.tokio_instrumentation_enabled, Some(false));
         assert_eq!(parsed.task_tracking_enabled, Some(false));
         assert_eq!(parsed.runtime_name.as_deref(), Some("api-runtime"));
         assert_eq!(parsed.max_file_size, Some(128 * 1024 * 1024));
@@ -1126,6 +1142,7 @@ mod tests {
         let parsed = parse_env_config(
             &FakeEnv::default()
                 .with("DIAL9_ENABLED", "maybe")
+                .with("DIAL9_TOKIO_INSTRUMENTATION_ENABLED", "maybe")
                 .with("DIAL9_TRACE_DIR", "   ")
                 .with("DIAL9_ROTATION_SECS", "0")
                 .with("DIAL9_MAX_DISK_USAGE_MB", "wat")
@@ -1137,6 +1154,7 @@ mod tests {
         );
 
         assert_eq!(parsed.enabled, None);
+        assert_eq!(parsed.tokio_instrumentation_enabled, None);
         assert_eq!(parsed.trace_dir, None);
         assert_eq!(parsed.rotation_period, None);
         assert_eq!(parsed.max_total_size, None);
@@ -1206,6 +1224,34 @@ mod tests {
         assert_eq!(
             shared.task_dump_idle_threshold_ns.load(Ordering::Relaxed),
             25_000_000
+        );
+    }
+
+    #[test]
+    fn env_config_can_disable_tokio_instrumentation_without_disabling_telemetry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let trace_dir = dir.path().to_str().expect("utf8 tempdir");
+        let env = FakeEnv::default()
+            .with("DIAL9_ENABLED", "true")
+            .with("DIAL9_TRACE_DIR", trace_dir)
+            .with("DIAL9_TOKIO_INSTRUMENTATION_ENABLED", "false");
+
+        let cfg = Dial9Config::from_env_source(&env);
+        let rt = TracedRuntime::try_new(cfg).expect("runtime should build");
+        assert!(rt.guard().is_enabled(), "telemetry should remain enabled");
+        assert!(
+            rt.guard()
+                .shared()
+                .expect("telemetry should be enabled")
+                .contexts
+                .lock()
+                .unwrap()
+                .is_empty(),
+            "no Tokio runtime contexts should be registered when Tokio instrumentation is disabled"
+        );
+        assert!(
+            !rt.block_on(async { crate::telemetry::TelemetryHandle::current().is_enabled() }),
+            "TelemetryHandle::current() should remain inert without Tokio hooks"
         );
     }
 

--- a/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
@@ -50,6 +50,7 @@ pub(super) enum PipelineConfig {
 /// Builder for configuring a traced Tokio runtime.
 pub struct TracedRuntimeBuilder<P = NoTracePath, M = PipelineUnset> {
     pub(super) enabled: bool,
+    pub(super) tokio_instrumentation_enabled: bool,
     pub(super) task_tracking_enabled: bool,
     pub(super) task_dump_config: Option<crate::telemetry::task_dump_config::TaskDumpConfig>,
     pub(super) trace_path: Option<PathBuf>,
@@ -92,6 +93,15 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
     /// Enable or disable task spawn/terminate tracking.
     pub fn with_task_tracking(mut self, enabled: bool) -> Self {
         self.task_tracking_enabled = enabled;
+        self
+    }
+
+    /// Enable or disable dial9's Tokio runtime instrumentation.
+    ///
+    /// Defaults to `true`. Set this to `false` to build the Tokio runtime
+    /// without dial9's Tokio hook instrumentation.
+    pub fn with_tokio_instrumentation(mut self, enabled: bool) -> Self {
+        self.tokio_instrumentation_enabled = enabled;
         self
     }
 
@@ -192,6 +202,9 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
     /// from the original `TelemetryGuard`. Only the tokio callbacks are
     /// registered on the new builder. The new runtime's workers get a unique
     /// runtime index so their `WorkerId`s don't collide with existing runtimes.
+    ///
+    /// If [`with_tokio_instrumentation(false)`](Self::with_tokio_instrumentation)
+    /// was set, this builds a plain runtime instead.
     pub fn build_and_attach_to_telemetry(
         self,
         mut builder: tokio::runtime::Builder,
@@ -202,6 +215,11 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
             // telemetry hooks so attaching still works gracefully.
             return builder.build();
         };
+
+        if !self.tokio_instrumentation_enabled {
+            return builder.build();
+        }
+
         attach_runtime(
             shared,
             builder,
@@ -215,6 +233,7 @@ impl<P, M> TracedRuntimeBuilder<P, M> {
     pub(super) fn into_state<Q, N>(self) -> TracedRuntimeBuilder<Q, N> {
         TracedRuntimeBuilder {
             enabled: self.enabled,
+            tokio_instrumentation_enabled: self.tokio_instrumentation_enabled,
             task_tracking_enabled: self.task_tracking_enabled,
             task_dump_config: self.task_dump_config,
             trace_path: self.trace_path,
@@ -427,7 +446,7 @@ impl<M> TracedRuntimeBuilder<HasTracePath, M> {
 
     fn build_inner(
         self,
-        builder: tokio::runtime::Builder,
+        mut builder: tokio::runtime::Builder,
         writer: Box<dyn TraceWriter>,
     ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
         if !self.enabled {
@@ -455,6 +474,12 @@ impl<M> TracedRuntimeBuilder<HasTracePath, M> {
             .maybe_sched_events(self.sched_event_config);
 
         let guard = core_builder.build()?;
+
+        if !self.tokio_instrumentation_enabled {
+            let runtime = builder.build()?;
+            return Ok((runtime, guard));
+        }
+
         let control_tx = guard
             .control_tx()
             .expect("TelemetryCore::builder().build() always returns an enabled guard")
@@ -799,6 +824,7 @@ impl TracedRuntime {
     pub fn builder() -> TracedRuntimeBuilder<NoTracePath, PipelineUnset> {
         TracedRuntimeBuilder {
             enabled: true,
+            tokio_instrumentation_enabled: true,
             task_tracking_enabled: false,
             task_dump_config: None,
             trace_path: None,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
@@ -150,6 +150,7 @@ impl TelemetryGuard {
             guard: self,
             name: name.into(),
             task_tracking: false,
+            tokio_instrumentation_enabled: true,
             tokio_hooks: super::TokioHooks::default(),
         }
     }
@@ -258,6 +259,7 @@ pub struct TraceRuntimeCoreBuilder<'a> {
     guard: &'a TelemetryGuard,
     name: String,
     task_tracking: bool,
+    tokio_instrumentation_enabled: bool,
     tokio_hooks: super::TokioHooks,
 }
 
@@ -266,6 +268,13 @@ impl<'a> TraceRuntimeCoreBuilder<'a> {
     /// Defaults to `false`.
     pub fn task_tracking(mut self, enabled: bool) -> Self {
         self.task_tracking = enabled;
+        self
+    }
+
+    /// Enable or disable dial9's Tokio runtime instrumentation for this runtime.
+    /// Defaults to `true`.
+    pub fn with_tokio_instrumentation(mut self, enabled: bool) -> Self {
+        self.tokio_instrumentation_enabled = enabled;
         self
     }
 
@@ -283,7 +292,8 @@ impl<'a> TraceRuntimeCoreBuilder<'a> {
     /// Install telemetry hooks, build the runtime, and reserve worker IDs.
     ///
     /// Returns the runtime and a [`RuntimeTelemetryHandle`] for spawning
-    /// instrumented futures via [`RuntimeTelemetryHandle::spawn`].
+    /// instrumented futures via [`RuntimeTelemetryHandle::spawn`]. If Tokio
+    /// instrumentation is disabled, builds a plain runtime instead.
     pub fn build(
         self,
         mut builder: tokio::runtime::Builder,
@@ -303,6 +313,16 @@ impl<'a> TraceRuntimeCoreBuilder<'a> {
             };
             return Ok((runtime, handle));
         };
+
+        if !self.tokio_instrumentation_enabled {
+            let runtime = builder.build()?;
+            let handle = RuntimeTelemetryHandle {
+                runtime: runtime.handle().clone(),
+                traced: None,
+            };
+            return Ok((runtime, handle));
+        }
+
         let runtime = attach_runtime(
             shared,
             builder,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -319,10 +319,11 @@ mod tests {
     use crate::telemetry::NullWriter;
     use crate::telemetry::buffer;
     use crate::telemetry::collector::CentralCollector;
+    #[cfg(feature = "cpu-profiling")]
     use crate::telemetry::writer::RotatingWriter;
     use std::panic::Location;
     use std::sync::Arc;
-    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::{AtomicU64, AtomicUsize};
 
     /// Drain all pending batches from a `CentralCollector` into a writer.
     /// Call `buffer::drain_to_collector` first to flush the thread-local buffer.
@@ -415,6 +416,82 @@ mod tests {
              but {}/{} were UNKNOWN",
             unknown.len(),
             poll_starts.len()
+        );
+    }
+
+    #[test]
+    fn tokio_instrumentation_can_be_disabled_without_installing_hooks() {
+        let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        let on_thread_start_calls = hook_calls.clone();
+        let on_before_poll_calls = hook_calls.clone();
+
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder.worker_threads(2).enable_all();
+
+        let (runtime, guard) = TracedRuntime::builder()
+            .with_tokio_instrumentation(false)
+            .with_task_tracking(true)
+            .with_tokio_hooks(|hooks| {
+                hooks.on_thread_start(move || {
+                    on_thread_start_calls.fetch_add(1, Ordering::Relaxed);
+                });
+                hooks.on_before_task_poll(move |_meta| {
+                    on_before_poll_calls.fetch_add(1, Ordering::Relaxed);
+                });
+            })
+            .build_and_start_with_writer(builder, CapturingWriter(data.clone()))
+            .unwrap();
+
+        assert!(guard.is_enabled());
+        assert!(guard.shared().unwrap().is_enabled());
+        assert!(
+            guard.shared().unwrap().contexts.lock().unwrap().is_empty(),
+            "disabled Tokio instrumentation should not register runtime contexts"
+        );
+
+        runtime.block_on(async {
+            for _ in 0..8 {
+                tokio::spawn(async {
+                    tokio::task::yield_now().await;
+                })
+                .await
+                .unwrap();
+            }
+        });
+
+        assert!(
+            guard.shared().unwrap().contexts.lock().unwrap().is_empty(),
+            "disabled Tokio instrumentation should not register runtime contexts after running work"
+        );
+        assert_eq!(
+            hook_calls.load(Ordering::Relaxed),
+            0,
+            "user Tokio hooks should not be installed when Tokio instrumentation is disabled"
+        );
+
+        drop(runtime);
+        drop(guard);
+
+        let raw = data.lock().unwrap();
+        let events = if raw.is_empty() {
+            Vec::new()
+        } else {
+            crate::telemetry::format::decode_events(&raw).unwrap()
+        };
+        assert!(
+            events.iter().all(|event| !matches!(
+                event,
+                crate::telemetry::events::TelemetryEvent::PollStart { .. }
+                    | crate::telemetry::events::TelemetryEvent::PollEnd { .. }
+                    | crate::telemetry::events::TelemetryEvent::WorkerPark { .. }
+                    | crate::telemetry::events::TelemetryEvent::WorkerUnpark { .. }
+                    | crate::telemetry::events::TelemetryEvent::QueueSample { .. }
+                    | crate::telemetry::events::TelemetryEvent::TaskSpawn { .. }
+                    | crate::telemetry::events::TelemetryEvent::TaskTerminate { .. }
+                    | crate::telemetry::events::TelemetryEvent::WakeEvent { .. }
+            )),
+            "Tokio runtime events should not be recorded when Tokio instrumentation is disabled: {events:?}"
         );
     }
 

--- a/dial9-viewer/ui/test_trace_analysis.js
+++ b/dial9-viewer/ui/test_trace_analysis.js
@@ -17,6 +17,8 @@ const {
   collectDescendants,
   selectSpanRenderSet,
   computeSpanLayout,
+  getTraceTimeRange,
+  hasCpuProfileSamples,
   analyzeAllocations,
 } = require("./trace_analysis.js");
 
@@ -36,6 +38,39 @@ async function main() {
   function pass(msg) {
     console.log(`✓ ${msg}`);
   }
+
+  function testProfilerOnlyTraceRangeUsesCpuSamples() {
+    const profilerOnlyTrace = {
+      events: [],
+      cpuSamples: [
+        { timestamp: 300, source: 0, callchain: ["0x3"] },
+        { timestamp: 100, source: 0, callchain: ["0x1"] },
+        { timestamp: 200, source: 1, callchain: ["0x2"] },
+      ],
+    };
+
+    if (!hasCpuProfileSamples(profilerOnlyTrace.cpuSamples)) {
+      fail("CPU profile samples should make a trace displayable without runtime events");
+    }
+    const range = getTraceTimeRange(profilerOnlyTrace.events, profilerOnlyTrace.cpuSamples);
+    if (!range || range.minTs !== 100 || range.maxTs !== 300 || range.durationNs !== 200) {
+      fail(`profiler-only range should come from CPU profile samples, got ${JSON.stringify(range)}`);
+    }
+    pass("Profiler-only trace range uses CPU profile samples");
+  }
+
+  function testProfilerOnlyTraceRangeExpandsSingleCpuSample() {
+    const range = getTraceTimeRange([], [
+      { timestamp: 100, source: 0, callchain: ["0x1"] },
+    ]);
+    if (!range || range.minTs !== 100 || range.maxTs !== 101 || range.durationNs !== 1) {
+      fail(`single-sample profiler-only range should be non-zero, got ${JSON.stringify(range)}`);
+    }
+    pass("Single-sample profiler-only trace range is non-zero");
+  }
+
+  testProfilerOnlyTraceRangeUsesCpuSamples();
+  testProfilerOnlyTraceRangeExpandsSingleCpuSample();
 
   const trace = await parseTrace(fs.readFileSync(tracePath));
   const evts = trace.events;

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -18,6 +18,30 @@
   const EVENT_TYPES = parser.EVENT_TYPES;
   const formatFrame = parser.formatFrame;
 
+  function isCpuProfileSample(sample) {
+    return sample.callchain.length > 0 && sample.source !== 1;
+  }
+
+  function hasCpuProfileSamples(cpuSamples) {
+    return cpuSamples.some(isCpuProfileSample);
+  }
+
+  function getTraceTimeRange(events, cpuSamples) {
+    const timestamps = events.length
+      ? events.map((e) => e.timestamp)
+      : cpuSamples.filter(isCpuProfileSample).map((s) => s.timestamp);
+    if (!timestamps.length) return null;
+
+    let minTs = timestamps[0];
+    let maxTs = timestamps[0];
+    for (const timestamp of timestamps) {
+      if (timestamp < minTs) minTs = timestamp;
+      if (timestamp > maxTs) maxTs = timestamp;
+    }
+    if (maxTs === minTs) maxTs = minTs + 1;
+    return { minTs, maxTs, durationNs: maxTs - minTs };
+  }
+
   /**
    * Reconstruct poll/park/active spans from raw events using a state machine.
    * @param {import('./trace_parser.js').TraceEvent[]} events - raw trace events
@@ -999,6 +1023,8 @@
     buildFlamegraphTree,
     flattenFlamegraph,
     buildFgData,
+    getTraceTimeRange,
+    hasCpuProfileSamples,
     buildSpanData,
     collectDescendants,
     selectSpanRenderSet,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -791,7 +791,7 @@
         <script src="panel_layout.js"></script>
         <script>
             const { EVENT_TYPES: ET, parseTrace, formatFrame, symbolizeChain, deduplicateSamples } = TraceParser;
-            const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline, computeSchedulingDelays, filterPointsOfInterest, buildSpanData, collectDescendants, selectSpanRenderSet, computeSpanLayout } = TraceAnalysis;
+            const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline, computeSchedulingDelays, filterPointsOfInterest, buildSpanData, collectDescendants, selectSpanRenderSet, computeSpanLayout, getTraceTimeRange, hasCpuProfileSamples } = TraceAnalysis;
 
             function esc(s) {
                 return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -1204,10 +1204,16 @@
                     trace = await parseTrace(buffer, fullOpts);
                     updateLoadProgress(`Analyzing ${trace.events.length.toLocaleString()} events…`);
                     await new Promise((r) => setTimeout(r, 0));
-                    processTrace();
+                    if (!processTrace()) {
+                        resetDropZone();
+                        return;
+                    }
                     currentTraceBuffer = buffer;
                     currentTraceName = name;
                     showViewer(name);
+                    if (trace.events.length === 0 && hasCpuProfileSamples(trace.cpuSamples)) {
+                        requestAnimationFrame(() => showFlamegraph(minTs, maxTs));
+                    }
                 } catch (err) {
                     if (err.name === "AbortError") return;
                     alert("Error: " + err.message);
@@ -1337,9 +1343,10 @@
 
             function processTrace() {
                 const evts = trace.events;
-                if (!evts.length) {
-                    alert("No events in trace");
-                    return;
+                const timeRange = getTraceTimeRange(evts, trace.cpuSamples);
+                if (!timeRange) {
+                    alert("No runtime events or CPU profile samples in trace");
+                    return false;
                 }
 
                 const wSet = new Set();
@@ -1348,14 +1355,9 @@
                 });
                 workerIds = [...wSet].sort((a, b) => a - b);
 
-                minTs = evts[0].timestamp;
-                maxTs = evts[evts.length - 1].timestamp;
-                // Scan for true min/max in case events aren't sorted
-                for (const e of evts) {
-                    if (e.timestamp < minTs) minTs = e.timestamp;
-                    if (e.timestamp > maxTs) maxTs = e.timestamp;
-                }
-                durationNs = maxTs - minTs || 1;
+                minTs = timeRange.minTs;
+                maxTs = timeRange.maxTs;
+                durationNs = timeRange.durationNs;
                 viewStart = minTs;
                 viewEnd = maxTs;
 
@@ -1486,6 +1488,8 @@
                         cePanel.style.display = "none";
                     }
                 }
+
+                return true;
             }
 
             function showViewer(filename) {


### PR DESCRIPTION
## Changes
- Adds a `.with_tokio_instrumentation(...)` method and a `DIAL9_TOKIO_INSTRUMENTATION_ENABLED` env var, that avoids installing tokio hooks (by not calling `attach_runtime`) when set to `false` (default `true`).
- Modify the web viewer to open the flamegraph if the trace file contains cpu profiling info only. 

## Other
Closes #351 