### PR TITLE
feat: emit MemoryProfileOverflowEvent on ring buffer overflow

### DIFF
--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -4,9 +4,11 @@
 use crate::memory_profiling::ring::{RawAlloc, RawFree, RingBuffers};
 use crate::primitives::sync::Arc;
 use crate::telemetry::buffer::with_encoder;
-use crate::telemetry::format::{AllocEvent, FreeEvent};
+use crate::telemetry::events::clock_monotonic_ns;
+use crate::telemetry::format::{AllocEvent, FreeEvent, MemoryProfileOverflowEvent};
 use crate::telemetry::recorder::source::{FlushContext, Source};
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 
 /// Liveset entry tracking a live sampled allocation, kept by the consolidator
 /// (flush thread). Only `size` and `timestamp_ns` are needed: both are
@@ -29,6 +31,10 @@ struct LivesetEntry {
 pub(crate) struct MemoryProfileSource {
     rings: Arc<RingBuffers>,
     liveset: Option<HashMap<u64, LivesetEntry>>,
+    /// Previous snapshot of `RingBuffers::dropped_allocs` for delta computation.
+    prev_dropped_allocs: u64,
+    /// Previous snapshot of `RingBuffers::dropped_frees` for delta computation.
+    prev_dropped_frees: u64,
     /// Precomputed segment metadata, returned (cloned) on every flush
     /// cycle. Cached in `new()` so the `segment_metadata()` hot path —
     /// called from the flush loop every ~5 ms — does not allocate fresh
@@ -50,6 +56,8 @@ impl MemoryProfileSource {
         Self {
             rings,
             liveset: track_liveset.then(HashMap::new),
+            prev_dropped_allocs: 0,
+            prev_dropped_frees: 0,
             metadata: vec![(
                 "memory.sample_rate_bytes".to_string(),
                 sample_rate_bytes.to_string(),
@@ -158,6 +166,30 @@ impl Source for MemoryProfileSource {
                     }
                 }
             }
+        }
+
+        // Emit overflow event if any samples were dropped since last flush.
+        // Relaxed ordering is sufficient: the flush thread is the sole reader,
+        // and we only need eventual visibility of producer increments. The two
+        // counters are independent so we don't need ordering between the loads.
+        let current_dropped_allocs = self.rings.dropped_allocs.load(Ordering::Relaxed);
+        let current_dropped_frees = self.rings.dropped_frees.load(Ordering::Relaxed);
+        let delta_allocs = current_dropped_allocs.saturating_sub(self.prev_dropped_allocs);
+        let delta_frees = current_dropped_frees.saturating_sub(self.prev_dropped_frees);
+        if delta_allocs > 0 || delta_frees > 0 {
+            self.prev_dropped_allocs = current_dropped_allocs;
+            self.prev_dropped_frees = current_dropped_frees;
+            with_encoder(
+                |enc| {
+                    enc.encode(&MemoryProfileOverflowEvent {
+                        timestamp_ns: clock_monotonic_ns(),
+                        dropped_allocs: delta_allocs,
+                        dropped_frees: delta_frees,
+                    });
+                },
+                ctx.collector,
+                ctx.drain_epoch,
+            );
         }
     }
 

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -177,8 +177,6 @@ impl Source for MemoryProfileSource {
         let delta_allocs = current_dropped_allocs.saturating_sub(self.prev_dropped_allocs);
         let delta_frees = current_dropped_frees.saturating_sub(self.prev_dropped_frees);
         if delta_allocs > 0 || delta_frees > 0 {
-            self.prev_dropped_allocs = current_dropped_allocs;
-            self.prev_dropped_frees = current_dropped_frees;
             with_encoder(
                 |enc| {
                     enc.encode(&MemoryProfileOverflowEvent {
@@ -190,6 +188,8 @@ impl Source for MemoryProfileSource {
                 ctx.collector,
                 ctx.drain_epoch,
             );
+            self.prev_dropped_allocs = current_dropped_allocs;
+            self.prev_dropped_frees = current_dropped_frees;
         }
     }
 

--- a/dial9-tokio-telemetry/src/telemetry/format.rs
+++ b/dial9-tokio-telemetry/src/telemetry/format.rs
@@ -1,6 +1,7 @@
 use crate::telemetry::events::CpuSampleSource;
 #[cfg(any(feature = "analysis", test))]
 use crate::telemetry::events::TelemetryEvent;
+
 use crate::telemetry::task_metadata::TaskId;
 #[cfg(any(feature = "analysis", test))]
 use dial9_trace_format::decoder::{StackPool, StringPool};
@@ -274,6 +275,23 @@ pub struct FreeEvent {
     /// analysis to bucket frees by generation without needing the
     /// `AllocEvent` in the same (unrotated) trace.
     pub alloc_timestamp_ns: u64,
+}
+
+/// Wire-format event emitted when the memory profiler's ring buffers
+/// overflowed during a flush period. Each field is the delta (new drops
+/// since the previous flush), not a cumulative total. Only emitted when
+/// at least one counter is non-zero.
+///
+/// Dropped frees cause the liveset to retain addresses that were actually
+/// freed, producing false positives in leak analysis.
+#[derive(Debug, TraceEvent)]
+pub(crate) struct MemoryProfileOverflowEvent {
+    #[traceevent(timestamp)]
+    pub timestamp_ns: u64,
+    /// Alloc samples dropped since last flush due to alloc queue overflow.
+    pub dropped_allocs: u64,
+    /// Free samples dropped since last flush due to free queue overflow.
+    pub dropped_frees: u64,
 }
 
 /// Wire-format event for a wake notification.

--- a/dial9-tokio-telemetry/tests/memory_profiling_no_overflow.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_no_overflow.rs
@@ -1,0 +1,79 @@
+#![cfg(feature = "memory-profiling")]
+#![cfg(target_os = "linux")]
+//! Test that no MemoryProfileOverflowEvent is emitted when ring has sufficient capacity.
+
+mod common;
+
+use common::{BytesCapturingWriter, decode_all};
+use dial9_tokio_telemetry::memory_profiling::{
+    Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
+};
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use serde::Deserialize;
+use std::time::Duration;
+
+#[global_allocator]
+static ALLOC: Dial9Allocator = Dial9Allocator::system();
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "event")]
+enum OverflowEvent {
+    MemoryProfileOverflowEvent {
+        #[allow(dead_code)]
+        timestamp_ns: u64,
+        #[allow(dead_code)]
+        dropped_allocs: u64,
+        #[allow(dead_code)]
+        dropped_frees: u64,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[test]
+fn no_overflow_event_when_ring_has_capacity() {
+    let (writer, batches) = BytesCapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .build_and_start_with_writer(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    let _mem_guard = MemoryProfiler::from_config(
+        MemoryProfilingConfig::builder()
+            .sample_rate_bytes(512 * 1024)
+            .ring_capacity(4096)
+            .rng_seed(42)
+            .build(),
+    )
+    .install(handle)
+    .expect("install should succeed");
+
+    runtime.block_on(async {
+        for _ in 0..10 {
+            let v: Vec<u8> = vec![0u8; 64];
+            std::hint::black_box(&v);
+            drop(v);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let batches = batches.lock().unwrap();
+    let events: Vec<OverflowEvent> = decode_all(&batches);
+
+    let overflows: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, OverflowEvent::MemoryProfileOverflowEvent { .. }))
+        .collect();
+
+    assert!(
+        overflows.is_empty(),
+        "expected no MemoryProfileOverflowEvent when ring has capacity, got {}",
+        overflows.len()
+    );
+}

--- a/dial9-tokio-telemetry/tests/memory_profiling_overflow_event.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_overflow_event.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "memory-profiling")]
+#![cfg(target_os = "linux")]
+//! Test that MemoryProfileOverflowEvent is emitted when ring buffers overflow.
+
+mod common;
+
+use common::{BytesCapturingWriter, decode_all};
+use dial9_tokio_telemetry::memory_profiling::{
+    Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
+};
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use serde::Deserialize;
+use std::time::Duration;
+
+#[global_allocator]
+static ALLOC: Dial9Allocator = Dial9Allocator::system();
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "event")]
+enum OverflowEvent {
+    MemoryProfileOverflowEvent {
+        #[allow(dead_code)]
+        timestamp_ns: u64,
+        dropped_allocs: u64,
+        dropped_frees: u64,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[test]
+fn overflow_event_emitted_when_ring_overflows() {
+    let (writer, batches) = BytesCapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .build_and_start_with_writer(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    // Use a tiny ring (capacity 4) so it overflows easily under allocation pressure.
+    let _mem_guard = MemoryProfiler::from_config(
+        MemoryProfilingConfig::builder()
+            .sample_rate_bytes(1) // sample every allocation
+            .ring_capacity(4)
+            .rng_seed(42)
+            .build(),
+    )
+    .install(handle)
+    .expect("install should succeed");
+
+    // Generate enough allocations to overflow the tiny ring.
+    runtime.block_on(async {
+        for _ in 0..1000 {
+            let v: Vec<u8> = vec![0u8; 64];
+            std::hint::black_box(&v);
+            drop(v);
+        }
+        // Wait for at least one flush cycle to pick up the overflow.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    let batches = batches.lock().unwrap();
+    let events: Vec<OverflowEvent> = decode_all(&batches);
+
+    let overflows: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            OverflowEvent::MemoryProfileOverflowEvent {
+                dropped_allocs,
+                dropped_frees,
+                ..
+            } => Some((*dropped_allocs, *dropped_frees)),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !overflows.is_empty(),
+        "expected at least one MemoryProfileOverflowEvent"
+    );
+
+    let total_dropped_allocs: u64 = overflows.iter().map(|(a, _)| a).sum();
+    let total_dropped_frees: u64 = overflows.iter().map(|(_, f)| f).sum();
+
+    // With ring capacity 4 and 1000 allocations at sample_rate=1, we should
+    // have many dropped samples.
+    assert!(
+        total_dropped_allocs > 0 || total_dropped_frees > 0,
+        "expected non-zero drops, got allocs={total_dropped_allocs} frees={total_dropped_frees}"
+    );
+}

--- a/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
@@ -104,6 +104,7 @@ function createAccumulator() {
     schedDelayHist: null, // Histogram
     allocEvents: [],
     freeEvents: [],
+    memoryOverflows: [],
     tidToWorker: new Map(),
     pollEvents: [], // PollStart events for per-task alloc attribution
   };
@@ -218,6 +219,7 @@ function accumulateTrace(acc, trace) {
   // Memory events
   if (trace.allocEvents) for (const e of trace.allocEvents) acc.allocEvents.push(e);
   if (trace.freeEvents) for (const e of trace.freeEvents) acc.freeEvents.push(e);
+  if (trace.memoryOverflows) for (const e of trace.memoryOverflows) acc.memoryOverflows.push(e);
   if (trace.tidToWorker) for (const [k, v] of trace.tidToWorker) acc.tidToWorker.set(k, v);
   for (const e of trace.events) {
     if (e.eventType === 0 && e.taskId) acc.pollEvents.push(e); // PollStart
@@ -267,6 +269,7 @@ function finalizeAccumulator(acc) {
     memory: analyzeAllocations(acc.allocEvents, acc.freeEvents, {
       events: acc.pollEvents,
       tidToWorker: acc.tidToWorker,
+      memoryOverflows: acc.memoryOverflows,
     }),
   };
 }
@@ -497,6 +500,15 @@ function reportAnalysis(a, label) {
     console.log(`  Total allocs: ${m.summary.totalAllocCount} sampled, ~${m.summary.estimatedTotalBytes.toLocaleString()} bytes estimated`);
     console.log(`  Total frees:  ${m.summary.totalFreeCount}`);
     console.log(`  Leaked:       ${m.summary.leakedCount} allocs, ${m.summary.leakedBytes.toLocaleString()} sampled bytes`);
+    if (m.summary.totalDroppedAllocs > 0 || m.summary.totalDroppedFrees > 0) {
+      console.log(`  ⚠️  Ring buffer overflow: ${m.summary.totalDroppedAllocs} alloc samples and ${m.summary.totalDroppedFrees} free samples dropped`);
+      if (m.summary.totalDroppedAllocs > 0) {
+        console.log(`      Dropped allocs cause underreporting of allocation volume — increase ring_capacity`);
+      }
+      if (m.summary.totalDroppedFrees > 0) {
+        console.log(`      Dropped frees cause false positives in leak analysis — increase ring_capacity`);
+      }
+    }
     if (m.topSites.length > 0) {
       console.log(`\n  Top allocation sites:`);
       for (const s of m.topSites.slice(0, 10)) {
@@ -736,6 +748,7 @@ async function parseWorkerMain(traceFile, cachePath) {
   if (trace.customEvents) for (const x of trace.customEvents) writeLine({ t: 'x', d: x });
   if (trace.allocEvents) for (const a of trace.allocEvents) writeLine({ t: 'a', d: a });
   if (trace.freeEvents) for (const f of trace.freeEvents) writeLine({ t: 'f', d: f });
+  if (trace.memoryOverflows) for (const o of trace.memoryOverflows) writeLine({ t: 'o', d: o });
 
   await new Promise((res, rej) => { stream.end(() => { fs.renameSync(tmpPath, cachePath); res(); }); stream.on('error', rej); });
   process.stdout.write('OK\n');

--- a/dial9-viewer/skills/dial9-trace-analysis/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-analysis/SKILL.md
@@ -131,6 +131,8 @@ process.stderr.write('\n');
       leakedBytes: number,                  // sum of leaked allocation sizes
       leakedCount: number,                  // allocations with no matching free
       estimatedTotalBytes: number,          // unbiased estimate of total allocation volume
+      totalDroppedAllocs: number,           // alloc samples lost to ring buffer overflow
+      totalDroppedFrees: number,            // free samples lost to ring buffer overflow (causes false leaks)
     },
   },
 }

--- a/dial9-viewer/skills/dial9-trace-loading/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-loading/SKILL.md
@@ -38,6 +38,7 @@ description: Parse and load dial9 Tokio runtime trace files. Covers the ParsedTr
   taskDumps: Map<number, [{timestamp, callchain}]>, // task ID → async stack captures (sorted by timestamp); see dial9-tokio-telemetry `taskdump` feature
   allocEvents: AllocEvent[],     // Sampled memory allocations (requires dial9-tokio-telemetry memory-profiling feature)
   freeEvents: FreeEvent[],       // Deallocations paired with sampled allocs (requires `track_liveset`)
+  memoryOverflows: [{timestamp, droppedAllocs, droppedFrees}], // Ring buffer overflow events (dropped samples per flush period)
   blockInPlaceGaps: [{workerId, fromTid, toTid, startNs, endNs}], // Detected block_in_place handoff intervals (worker attribution unknowable during gap)
   tidToWorker: Map<number, number>,  // thread ID → worker ID mapping (derived from park/unpark events)
 }

--- a/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
@@ -591,6 +591,14 @@ for (const [taskId, bytes] of top) {
   footprint) requires pairing `Alloc` with `Free` events and only
   works when `MemoryProfilingConfig.track_liveset(true)` was set at
   install time.
+- **Ring buffer overflow causing false leaks.** When the free queue
+  overflows (visible as `MemoryProfileOverflowEvent` in the trace or
+  `totalDroppedFrees > 0` in the analysis summary), dropped frees
+  leave their matching allocations permanently in the liveset. These
+  appear as leaks but are actually freed memory the profiler couldn't
+  record. If you see overflow warnings, increase `ring_capacity` in
+  `MemoryProfilingConfig` and re-record. Until then, treat leak
+  counts as upper bounds.
 
 ### Heap flamegraph: where are allocations happening and how big are they?
 

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -913,6 +913,7 @@
    * @param {Array} [opts.events] - Parsed trace events (PollStart/PollEnd with workerId+taskId)
    * @param {Map<number,number>} [opts.tidToWorker] - tid → workerId mapping from park/unpark events
    * @param {number} [opts.sampleRateBytes] - Mean bytes between samples (default 524288)
+   * @param {Array<{timestamp: number, droppedAllocs: number, droppedFrees: number}>} [opts.memoryOverflows] - Ring buffer overflow events
    * @returns {{ topSites: Array<{callchain: string[], totalBytes: number, count: number, estimatedBytes: number}>,
    *             leaks: Array<{callchain: string[], size: number, timestamp: number, addr: string}>,
    *             perTask: Map<number, {sampledBytes: number, count: number, estimatedBytes: number}>,
@@ -1002,6 +1003,10 @@
       }
     }
 
+    const overflows = (opts && opts.memoryOverflows) || [];
+    const totalDroppedAllocs = overflows.reduce((sum, o) => sum + o.droppedAllocs, 0);
+    const totalDroppedFrees = overflows.reduce((sum, o) => sum + o.droppedFrees, 0);
+
     return {
       topSites,
       leaks,
@@ -1014,6 +1019,8 @@
         leakedBytes,
         leakedCount: leaks.length,
         estimatedTotalBytes: Math.round(estimatedTotalBytes),
+        totalDroppedAllocs,
+        totalDroppedFrees,
       },
     };
   }

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -923,7 +923,7 @@
   function analyzeAllocations(allocEvents, freeEvents, opts) {
     const sampleRateBytes = (opts && opts.sampleRateBytes) || 524288;
     if (!allocEvents || !freeEvents) {
-      return { topSites: [], leaks: [], perTask: new Map(), sampleRateBytes, summary: { totalAllocBytes: 0, totalAllocCount: 0, totalFreeCount: 0, leakedBytes: 0, leakedCount: 0, estimatedTotalBytes: 0 } };
+      return { topSites: [], leaks: [], perTask: new Map(), sampleRateBytes, summary: { totalAllocBytes: 0, totalAllocCount: 0, totalFreeCount: 0, leakedBytes: 0, leakedCount: 0, estimatedTotalBytes: 0, totalDroppedAllocs: 0, totalDroppedFrees: 0 } };
     }
 
     /** Unbiased weight for a sampled allocation of size s with rate R. */

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -327,6 +327,7 @@
     const cpuSamples = [];
     const allocEvents = [];
     const freeEvents = [];
+    const memoryOverflows = [];
     const threadNames = new Map();
     const tidToWorker = new Map(); // tid → workerId (stable mapping from park/unpark events)
     const runtimeWorkers = new Map(); // runtime name → [workerId, ...]
@@ -554,6 +555,14 @@
           });
           break;
         }
+        case "MemoryProfileOverflowEvent": {
+          memoryOverflows.push({
+            timestamp: ts,
+            droppedAllocs: num(v.dropped_allocs),
+            droppedFrees: num(v.dropped_frees),
+          });
+          break;
+        }
         case "ClockSyncEvent": {
           const real = num(v.realtime_ns);
           if (real > 0) {
@@ -688,6 +697,7 @@
       cpuSamples,
       allocEvents,
       freeEvents,
+      memoryOverflows,
       callframeSymbols,
       threadNames,
       tidToWorker,
@@ -730,6 +740,7 @@
     const customEvents = [];
     const allocEvents = [];
     const freeEvents = [];
+    const memoryOverflows = [];
 
     let line;
     while ((line = nextLine()) !== null) {
@@ -752,6 +763,7 @@
         case 'x': customEvents.push(rec.d); break;
         case 'a': allocEvents.push(rec.d); break;
         case 'f': freeEvents.push(rec.d); break;
+        case 'o': memoryOverflows.push(rec.d); break;
       }
     }
     raw.events = events;
@@ -759,6 +771,7 @@
     raw.customEvents = customEvents;
     raw.allocEvents = allocEvents;
     raw.freeEvents = freeEvents;
+    raw.memoryOverflows = memoryOverflows;
     return raw;
   }
 


### PR DESCRIPTION
Emit a trace event when the memory profiler's ring buffers drop samples during flush. JS parser/analysis surfaces overflow counts and warns about false leaks from dropped frees.