### PR TITLE
dial9-viewer: allow empty prefix when searching buckets

### DIFF
--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -248,8 +248,8 @@
     let serverHasPrefix = false;
 
     function updateSearchReady() {
-        const hasPrefix = serverHasPrefix || prefixInput.value.trim() !== '';
-        document.getElementById('search-btn').disabled = !hasPrefix;
+        const waitingForPrefix = serverHasPrefix && prefixInput.value.trim() === '';
+        document.getElementById('search-btn').disabled = waitingForPrefix;
     }
     prefixInput.addEventListener('input', updateSearchReady);
 


### PR DESCRIPTION
Before this change, I wasn't able to search for traces in my bucket which does not have a prefix (i.e. traces are uploaded directly to e.g. `/2026-05-27/...`) as the search button was always disabled. Selecting a date from the list resulted in it appearing in the prefix box as well as the date picker, enabling the Search button but causing it to look for traces under `/2026-05-27/2026-05-27/` and find none.

I believe the condition here is reversed: if the server doesn't return any prefix, we shouldn't require one to enable the search button. With this change, the date picker works as intended, I can click Search and the viewer actually finds traces.