### PR TITLE
Add setup diagnostic skill to toolkit

### DIFF
--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -195,6 +195,10 @@ name = "kernel_sched_events"
 required-features = ["cpu-profiling", "analysis"]
 
 [[example]]
+name = "generate_diagnostic_traces"
+required-features = ["cpu-profiling"]
+
+[[example]]
 name = "thread_per_core"
 required-features = ["analysis"]
 

--- a/dial9-tokio-telemetry/examples/generate_diagnostic_traces.rs
+++ b/dial9-tokio-telemetry/examples/generate_diagnostic_traces.rs
@@ -1,0 +1,161 @@
+//! Generate traces with common misconfigurations for testing the diagnostic skill.
+//!
+//! Usage:
+//!   cargo run --release --features cpu-profiling --example generate_diagnostic_traces -- <output-dir>
+//!
+//! Produces:
+//!   <output-dir>/no-wake-events/    — tasks spawned via tokio::spawn (not instrumented)
+//!   <output-dir>/good/              — properly configured trace for comparison
+//!   <output-dir>/no-sched-events/   — no off-CPU scheduling samples
+//!
+//! Note: "missing frame pointers" and "missing debug symbols" require building
+//! with different RUSTFLAGS, so they are handled by the shell script wrapper.
+
+use dial9_tokio_telemetry::telemetry::{
+    RotatingWriter, TelemetryHandle, TracedRuntime,
+    cpu_profile::{CpuProfilingConfig, SchedEventConfig},
+};
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[inline(never)]
+fn burn_cpu(duration: Duration) {
+    let start = std::time::Instant::now();
+    let mut x: u64 = 1;
+    while start.elapsed() < duration {
+        for _ in 0..1000 {
+            x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+        }
+        std::hint::black_box(x);
+    }
+}
+
+async fn cpu_task(_id: usize) {
+    for _ in 0..5 {
+        burn_cpu(Duration::from_millis(20));
+        tokio::task::yield_now().await;
+    }
+}
+
+/// Generate a trace where tasks are NOT instrumented (no wake events).
+/// Uses tokio::spawn instead of TelemetryHandle::spawn.
+fn generate_no_wake_events(dir: &PathBuf) {
+    std::fs::create_dir_all(dir).unwrap();
+    let trace_path = dir.join("trace.bin");
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(4).enable_all();
+
+    let writer = RotatingWriter::new(&trace_path, 4 * 1024, 50 * 1024 * 1024).unwrap();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
+        .with_trace_path(&trace_path)
+        .with_worker_poll_interval(Duration::from_millis(50))
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    runtime.block_on(async {
+        // Deliberately use tokio::spawn — NOT TelemetryHandle::spawn
+        let tasks: Vec<_> = (0..50).map(|i| tokio::spawn(cpu_task(i))).collect();
+        for t in tasks {
+            let _ = t.await;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    drop(runtime);
+    guard
+        .graceful_shutdown(Duration::from_secs(10))
+        .expect("graceful shutdown");
+}
+
+/// Generate a fully-configured "good" trace for comparison.
+fn generate_good_trace(dir: &PathBuf) {
+    std::fs::create_dir_all(dir).unwrap();
+    let trace_path = dir.join("trace.bin");
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(4).enable_all();
+
+    let writer = RotatingWriter::new(&trace_path, 4 * 1024, 50 * 1024 * 1024).unwrap();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
+        .with_sched_events(SchedEventConfig::default())
+        .with_trace_path(&trace_path)
+        .with_worker_poll_interval(Duration::from_millis(50))
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    runtime.block_on(async {
+        let handle = TelemetryHandle::current();
+        let tasks: Vec<_> = (0..50).map(|i| handle.spawn(cpu_task(i))).collect();
+        for t in tasks {
+            let _ = t.await;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    drop(runtime);
+    guard
+        .graceful_shutdown(Duration::from_secs(10))
+        .expect("graceful shutdown");
+}
+
+/// Generate a trace with CPU profiling but NO sched events.
+fn generate_no_sched_events(dir: &PathBuf) {
+    std::fs::create_dir_all(dir).unwrap();
+    let trace_path = dir.join("trace.bin");
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(4).enable_all();
+
+    let writer = RotatingWriter::new(&trace_path, 4 * 1024, 50 * 1024 * 1024).unwrap();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
+        // Deliberately omit .with_sched_events()
+        .with_trace_path(&trace_path)
+        .with_worker_poll_interval(Duration::from_millis(50))
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    runtime.block_on(async {
+        let handle = TelemetryHandle::current();
+        let tasks: Vec<_> = (0..50).map(|i| handle.spawn(cpu_task(i))).collect();
+        for t in tasks {
+            let _ = t.await;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    drop(runtime);
+    guard
+        .graceful_shutdown(Duration::from_secs(10))
+        .expect("graceful shutdown");
+}
+
+fn main() {
+    let output_dir = PathBuf::from(
+        std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| "/tmp/dial9-diagnostic-traces".to_string()),
+    );
+
+    eprintln!(
+        "Generating diagnostic traces in {}...",
+        output_dir.display()
+    );
+
+    eprintln!("  → no-wake-events (tasks not instrumented)");
+    generate_no_wake_events(&output_dir.join("no-wake-events"));
+
+    eprintln!("  → no-sched-events (schedule profiling disabled)");
+    generate_no_sched_events(&output_dir.join("no-sched-events"));
+
+    eprintln!("  → good (fully configured)");
+    generate_good_trace(&output_dir.join("good"));
+
+    eprintln!("Done. Traces at: {}", output_dir.display());
+}

--- a/dial9-viewer/skills/dial9-toolkit/SKILL.md
+++ b/dial9-viewer/skills/dial9-toolkit/SKILL.md
@@ -34,15 +34,33 @@ node scripts/analyze.js trace.bin --force          # ignore cached results
 | File | Purpose |
 |------|---------|
 | `scripts/analyze.js` | CLI entry point and `analyzeTraces()` aggregation function |
+| `scripts/diagnose_setup.js` | Setup diagnostic: detects missing frame pointers, wake events, debug symbols, sched events |
 | `scripts/trace_parser.js` | Binary parser: `parseTrace(path)` yields `ParsedTrace` objects |
 | `scripts/trace_analysis.js` | Analysis functions: `buildWorkerSpans`, `attachCpuSamples`, etc. |
 | `scripts/decode.js` | Low-level binary format decoder |
 
 ## Default workflow
 
-1. Always run `analyzeTraces(path)` first for trace diagnosis.
-2. Base initial findings on the aggregate result: long polls, worker spans, scheduling delays, CPU/off-CPU groups, queue depth, task lifecycle counts, and span summaries.
-3. Then use `parseTrace()` or lower-level helpers only to confirm assumptions, inspect raw events, or follow a specific task/wake/span chronology.
+1. Always run `analyzeTraces(path)` first for trace diagnosis. This automatically runs setup diagnostics first.
+2. If setup diagnostics report issues (missing frame pointers, missing wake events, missing debug symbols), help the user fix those before diving into performance analysis.
+3. Base initial findings on the aggregate result: long polls, worker spans, scheduling delays, CPU/off-CPU groups, queue depth, task lifecycle counts, and span summaries.
+4. Then use `parseTrace()` or lower-level helpers only to confirm assumptions, inspect raw events, or follow a specific task/wake/span chronology.
+
+## Setup diagnostic
+
+The setup diagnostic (`diagnose_setup.js`) runs automatically as part of `analyze.js` and checks for common configuration issues:
+
+| Check | Severity | Symptom |
+|-------|----------|---------|
+| `missing-frame-pointers` | critical | CPU stacks are 1–3 frames deep instead of 10+ |
+| `missing-wake-events` | warning | Tasks spawned but no wake events recorded |
+| `missing-debug-symbols` | warning | Stack addresses unresolved or no source locations |
+| `no-scheduling-events` | info | No off-CPU samples (sched profiling not enabled) |
+
+Run standalone:
+```bash
+node scripts/diagnose_setup.js <trace.bin or directory>
+```
 
 ```javascript
 const { analyzeTraces } = require('./scripts/analyze.js');

--- a/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
@@ -22,6 +22,7 @@ function resolve(name) {
 const { parseTrace, EVENT_TYPES, formatFrame, symbolizeChain, deduplicateSamples } = require(resolve('trace_parser.js'));
 const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline,
         computeSchedulingDelays, filterPointsOfInterest, buildSpanData, analyzeAllocations } = require(resolve('trace_analysis.js'));
+const { diagnoseSetup } = require(resolve('diagnose_setup.js'));
 
 // ── Helpers ──
 
@@ -621,6 +622,7 @@ async function main() {
   if (isDir) process.stderr.write('\n');
 
   const label = isDir ? `${result.files ? result.files.length : ''} files in ${path.basename(TRACE_PATH)}` : path.basename(TRACE_PATH);
+  await diagnoseSetup(TRACE_PATH);
   reportAnalysis(result, label);
 }
 

--- a/dial9-viewer/skills/dial9-toolkit/scripts/diagnose_setup.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/diagnose_setup.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// dial9 setup diagnostic — detects common configuration issues in traces.
+// Usage: node diagnose_setup.js <trace.bin or directory>
+//
+// Checks:
+//   1. Missing frame pointers (shallow stacks)
+//   2. Missing wake events (tasks not instrumented)
+//   3. Missing debug symbols (no source locations)
+//   4. No scheduling events (informational)
+"use strict";
+
+const fs = require('fs');
+const path = require('path');
+
+function resolve(name) {
+  const sibling = path.resolve(__dirname, name);
+  if (fs.existsSync(sibling)) return sibling;
+  const toolkit = path.resolve(__dirname, '..', '..', 'dial9-toolkit', 'scripts', name);
+  if (fs.existsSync(toolkit)) return toolkit;
+  return path.resolve(__dirname, '..', '..', '..', 'ui', name);
+}
+
+const { parseTrace, EVENT_TYPES } = require(resolve('trace_parser.js'));
+
+async function diagnoseSetup(tracePath) {
+  const findings = [];
+  let totalOnCpu = 0, totalOffCpu = 0;
+  let callchainDepths = [];
+  let totalSymbols = 0, symbolsWithLocation = 0;
+  let totalWakeEvents = 0, totalTaskSpawns = 0;
+  let uniqueAddresses = new Set();
+
+  for await (const trace of parseTrace(tracePath)) {
+    // Wake events
+    totalWakeEvents += trace.events.filter(e => e.eventType === EVENT_TYPES.WakeEvent).length;
+    totalTaskSpawns += trace.taskSpawnTimes.size;
+
+    // CPU samples
+    for (const s of trace.cpuSamples) {
+      if (s.source === 0) {
+        totalOnCpu++;
+        callchainDepths.push(s.callchain.length);
+        for (const addr of s.callchain) uniqueAddresses.add(addr);
+      } else {
+        totalOffCpu++;
+      }
+    }
+
+    // Symbols
+    for (const [addr, entry] of trace.callframeSymbols) {
+      totalSymbols++;
+      const e = Array.isArray(entry) ? entry[0] : entry;
+      if (e && e.location) symbolsWithLocation++;
+    }
+  }
+
+  // ── Check 1: Missing frame pointers ──
+  if (totalOnCpu > 10) {
+    const avgDepth = callchainDepths.reduce((a, b) => a + b, 0) / callchainDepths.length;
+    if (avgDepth < 3) {
+      findings.push({
+        severity: 'critical',
+        check: 'missing-frame-pointers',
+        message: `CPU stack traces are only ${avgDepth.toFixed(1)} frames deep on average (expected 10+). Frame pointers are not enabled.`,
+        fix: `Add to .cargo/config.toml:
+
+[build]
+rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
+
+Then rebuild your application. This enables the compiler to emit frame pointer instructions,
+which dial9 uses to walk the call stack during CPU profiling.`,
+      });
+    }
+  }
+
+  // ── Check 2: Missing wake events ──
+  if (totalTaskSpawns > 0 && totalWakeEvents === 0) {
+    findings.push({
+      severity: 'warning',
+      check: 'missing-wake-events',
+      message: `${totalTaskSpawns} tasks were spawned but 0 wake events were recorded. Tasks are not instrumented.`,
+      fix: `Use TelemetryHandle::spawn() instead of tokio::spawn() to instrument tasks:
+
+use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+
+let handle = TelemetryHandle::current();
+handle.spawn(async { /* your task */ });
+
+// Or use the free function:
+dial9_tokio_telemetry::telemetry::spawn(async { /* your task */ });
+
+Wake events let dial9 measure scheduling delays (time between Waker::wake()
+and the task actually being polled). Without them, you cannot diagnose
+whether tasks are waiting too long in the queue.`,
+    });
+  }
+
+  // ── Check 3: Missing debug symbols ──
+  if (totalOnCpu > 10 && uniqueAddresses.size > 0) {
+    const resolutionRate = totalSymbols / uniqueAddresses.size;
+    if (totalSymbols === 0 || (resolutionRate < 0.1 && symbolsWithLocation === 0)) {
+      findings.push({
+        severity: 'warning',
+        check: 'missing-debug-symbols',
+        message: `Only ${totalSymbols} symbols resolved out of ${uniqueAddresses.size} unique addresses (${symbolsWithLocation} with source locations). Debug symbols are missing.`,
+        fix: `Ensure your release profile includes debug info. In Cargo.toml:
+
+[profile.release]
+debug = 1        # line tables only (minimal size overhead)
+# or
+debug = 2        # full debug info (larger binary, best diagnostics)
+strip = false    # do NOT strip symbols
+
+Do NOT pass -C strip=symbols in RUSTFLAGS for builds you want to profile.
+Debug info is needed for dial9 to resolve stack addresses to function names
+and source locations. Without it, CPU profiles show only hex addresses.`,
+      });
+    }
+  }
+
+  // ── Check 4: No scheduling events (informational) ──
+  if (totalOnCpu > 0 && totalOffCpu === 0) {
+    findings.push({
+      severity: 'info',
+      check: 'no-scheduling-events',
+      message: `No off-CPU scheduling samples found. Schedule profiling is not enabled or not available.`,
+      fix: `To enable scheduling event capture:
+
+1. Set perf_event_paranoid <= 1:
+   sudo sysctl kernel.perf_event_paranoid=1
+
+2. Enable sched events in your dial9 config:
+   use dial9_tokio_telemetry::telemetry::cpu_profile::SchedEventConfig;
+
+   Dial9Config::builder()
+       .with_runtime(|r| r.with_sched_events(SchedEventConfig::default()))
+       // ...
+
+Or via environment variable:
+   DIAL9_SCHEDULE_PROFILE_ENABLED=true
+
+Scheduling events show stack traces when the kernel deschedules your worker
+threads. This reveals blocking calls (file I/O, DNS, mutexes) that should
+use spawn_blocking instead of running on the async runtime.`,
+    });
+  }
+
+  // ── Report ──
+  console.log(`\n${'='.repeat(60)}`);
+  console.log('DIAL9 SETUP DIAGNOSTIC');
+  console.log(`${'='.repeat(60)}`);
+  console.log(`CPU samples: ${totalOnCpu} on-CPU, ${totalOffCpu} off-CPU`);
+  console.log(`Tasks spawned: ${totalTaskSpawns}, Wake events: ${totalWakeEvents}`);
+  console.log(`Symbols: ${totalSymbols} resolved (${symbolsWithLocation} with source locations)`);
+  console.log();
+
+  if (findings.length === 0) {
+    console.log('✅ No setup issues detected');
+  } else {
+    const icons = { critical: '🔴', warning: '🟡', info: 'ℹ️' };
+    for (const f of findings) {
+      console.log(`${icons[f.severity]} [${f.check}] ${f.message}`);
+      console.log();
+      console.log('  Fix:');
+      for (const line of f.fix.split('\n')) {
+        console.log('  ' + line);
+      }
+      console.log();
+    }
+    const crit = findings.filter(f => f.severity === 'critical').length;
+    const warn = findings.filter(f => f.severity === 'warning').length;
+    const info = findings.filter(f => f.severity === 'info').length;
+    console.log(`${crit} critical, ${warn} warnings, ${info} info`);
+  }
+
+  return findings;
+}
+
+if (require.main === module) {
+  const tracePath = process.argv[2];
+  if (!tracePath) {
+    console.error('Usage: node diagnose_setup.js <trace.bin or directory>');
+    process.exit(1);
+  }
+  diagnoseSetup(tracePath).catch(err => { console.error(err); process.exit(1); });
+}
+
+module.exports = { diagnoseSetup };

--- a/dial9-viewer/skills/dial9-toolkit/scripts/diagnose_setup.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/diagnose_setup.js
@@ -79,15 +79,11 @@ which dial9 uses to walk the call stack during CPU profiling.`,
       severity: 'warning',
       check: 'missing-wake-events',
       message: `${totalTaskSpawns} tasks were spawned but 0 wake events were recorded. Tasks are not instrumented.`,
-      fix: `Use TelemetryHandle::spawn() instead of tokio::spawn() to instrument tasks:
+      fix: `Use dial9's spawn() instead of tokio::spawn() to instrument tasks:
 
-use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+use dial9_tokio_telemetry::telemetry::spawn;
 
-let handle = TelemetryHandle::current();
-handle.spawn(async { /* your task */ });
-
-// Or use the free function:
-dial9_tokio_telemetry::telemetry::spawn(async { /* your task */ });
+spawn(async { /* your task */ });
 
 Wake events let dial9 measure scheduling delays (time between Waker::wake()
 and the task actually being polled). Without them, you cannot diagnose
@@ -106,10 +102,8 @@ whether tasks are waiting too long in the queue.`,
         fix: `Ensure your release profile includes debug info. In Cargo.toml:
 
 [profile.release]
-debug = 1        # line tables only (minimal size overhead)
-# or
-debug = 2        # full debug info (larger binary, best diagnostics)
-strip = false    # do NOT strip symbols
+debug = "line-tables-only"   # minimal size overhead, enough for dial9
+strip = false                # do NOT strip symbols
 
 Do NOT pass -C strip=symbols in RUSTFLAGS for builds you want to profile.
 Debug info is needed for dial9 to resolve stack addresses to function names
@@ -136,7 +130,7 @@ and source locations. Without it, CPU profiles show only hex addresses.`,
        .with_runtime(|r| r.with_sched_events(SchedEventConfig::default()))
        // ...
 
-Or via environment variable:
+   Or via environment variable:
    DIAL9_SCHEDULE_PROFILE_ENABLED=true
 
 Scheduling events show stack traces when the kernel deschedules your worker

--- a/dial9-viewer/ui/test_diagnose_setup.js
+++ b/dial9-viewer/ui/test_diagnose_setup.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Test for diagnose_setup.js — verifies detection of common dial9 misconfigurations.
+// Usage: node test_diagnose_setup.js [trace-dir]
+//
+// If trace-dir is provided, tests against real traces.
+// Otherwise, tests the detection logic with synthetic data.
+"use strict";
+
+const path = require('path');
+const fs = require('fs');
+
+function resolve(name) {
+  const sibling = path.resolve(__dirname, name);
+  if (fs.existsSync(sibling)) return sibling;
+  const toolkit = path.resolve(__dirname, '..', 'skills', 'dial9-toolkit', 'scripts', name);
+  if (fs.existsSync(toolkit)) return toolkit;
+  return path.resolve(__dirname, name);
+}
+
+const { parseTrace, EVENT_TYPES, symbolizeChain } = require(resolve('trace_parser.js'));
+const { diagnoseSetup } = require(resolve('diagnose_setup.js'));
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { passed++; }
+  else { failed++; console.error(`  FAIL: ${msg}`); }
+}
+
+async function testWithTraces(traceDir) {
+  console.log('Testing with real traces from:', traceDir);
+
+  // Test 1: no-frame-pointers should detect missing frame pointers
+  {
+    const dir = path.join(traceDir, 'no-frame-pointers');
+    if (fs.existsSync(dir)) {
+      console.log('\n  no-frame-pointers:');
+      const findings = await diagnoseSetup(dir);
+      const fp = findings.find(f => f.check === 'missing-frame-pointers');
+      assert(fp != null, 'should detect missing frame pointers');
+      assert(fp && fp.severity === 'critical', 'missing frame pointers should be critical');
+    } else {
+      console.log('  SKIP: no-frame-pointers dir not found');
+    }
+  }
+
+  // Test 2: no-wake-events should detect missing wake events
+  {
+    const dir = path.join(traceDir, 'no-wake-events');
+    if (fs.existsSync(dir)) {
+      console.log('\n  no-wake-events:');
+      const findings = await diagnoseSetup(dir);
+      const we = findings.find(f => f.check === 'missing-wake-events');
+      assert(we != null, 'should detect missing wake events');
+      assert(we && we.severity === 'warning', 'missing wake events should be warning');
+    } else {
+      console.log('  SKIP: no-wake-events dir not found');
+    }
+  }
+
+  // Test 3: no-debug-symbols should detect missing debug symbols
+  {
+    const dir = path.join(traceDir, 'no-debug-symbols');
+    if (fs.existsSync(dir)) {
+      console.log('\n  no-debug-symbols:');
+      const findings = await diagnoseSetup(dir);
+      const ds = findings.find(f => f.check === 'missing-debug-symbols');
+      assert(ds != null, 'should detect missing debug symbols');
+      assert(ds && ds.severity === 'warning', 'missing debug symbols should be warning');
+    } else {
+      console.log('  SKIP: no-debug-symbols dir not found');
+    }
+  }
+
+  // Test 4: no-sched-events should detect no scheduling events
+  {
+    const dir = path.join(traceDir, 'no-sched-events');
+    if (fs.existsSync(dir)) {
+      console.log('\n  no-sched-events:');
+      const findings = await diagnoseSetup(dir);
+      const se = findings.find(f => f.check === 'no-scheduling-events');
+      assert(se != null, 'should detect no scheduling events');
+      assert(se && se.severity === 'info', 'no scheduling events should be info');
+    } else {
+      console.log('  SKIP: no-sched-events dir not found');
+    }
+  }
+
+  // Test 5: good trace should NOT have critical/warning findings (only info)
+  {
+    const dir = path.join(traceDir, 'good');
+    if (fs.existsSync(dir)) {
+      console.log('\n  good (reference):');
+      const findings = await diagnoseSetup(dir);
+      const serious = findings.filter(f => f.severity === 'critical' || f.severity === 'warning');
+      assert(serious.length === 0, `good trace should have no critical/warning findings, got: ${serious.map(f => f.check).join(', ')}`);
+    } else {
+      console.log('  SKIP: good dir not found');
+    }
+  }
+}
+
+async function main() {
+  const traceDir = process.argv[2] || '/tmp/dial9-diagnostic-traces';
+
+  if (fs.existsSync(traceDir)) {
+    // Suppress console.log output from diagnoseSetup during tests
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await testWithTraces(traceDir);
+    } finally {
+      console.log = origLog;
+    }
+  } else {
+    console.log('No trace directory found at', traceDir);
+    console.log('Run scripts/generate_diagnostic_traces.sh first to generate test traces.');
+    process.exit(1);
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/generate_diagnostic_traces.sh
+++ b/scripts/generate_diagnostic_traces.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate diagnostic test traces for the dial9 setup diagnostic skill.
+# Produces traces with common misconfigurations so the JS skill can be tested.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="${1:-/tmp/dial9-diagnostic-traces}"
+
+echo "Generating diagnostic traces in $OUTPUT_DIR..."
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# 1. Good trace + no-wake-events + no-sched-events (normal build with frame pointers)
+echo "=== Building with frame pointers + debug symbols ==="
+RUSTFLAGS="--cfg tokio_unstable -C force-frame-pointers=yes" \
+  cargo build --release --features cpu-profiling \
+  --example generate_diagnostic_traces \
+  --manifest-path "$REPO_ROOT/dial9-tokio-telemetry/Cargo.toml"
+
+RUSTFLAGS="--cfg tokio_unstable -C force-frame-pointers=yes" \
+  cargo run --release --features cpu-profiling \
+  --example generate_diagnostic_traces \
+  --manifest-path "$REPO_ROOT/dial9-tokio-telemetry/Cargo.toml" \
+  -- "$OUTPUT_DIR"
+
+# 2. Missing frame pointers: build WITHOUT -C force-frame-pointers=yes
+echo ""
+echo "=== Building WITHOUT frame pointers ==="
+mkdir -p "$OUTPUT_DIR/no-frame-pointers"
+RUSTFLAGS="--cfg tokio_unstable" \
+  cargo build --release --features cpu-profiling \
+  --example generate_diagnostic_traces \
+  --manifest-path "$REPO_ROOT/dial9-tokio-telemetry/Cargo.toml"
+
+# Run just the "good" config but without frame pointers — stacks will be shallow
+RUSTFLAGS="--cfg tokio_unstable" \
+  cargo run --release --features cpu-profiling \
+  --example generate_diagnostic_traces \
+  --manifest-path "$REPO_ROOT/dial9-tokio-telemetry/Cargo.toml" \
+  -- "$OUTPUT_DIR/no-frame-pointers-tmp"
+
+# Move the "good" trace (which now has bad stacks) to no-frame-pointers
+mv "$OUTPUT_DIR/no-frame-pointers-tmp/good"/* "$OUTPUT_DIR/no-frame-pointers/"
+rm -rf "$OUTPUT_DIR/no-frame-pointers-tmp"
+
+# 3. Missing debug symbols: build with strip=symbols
+echo ""
+echo "=== Building WITHOUT debug symbols (stripped) ==="
+mkdir -p "$OUTPUT_DIR/no-debug-symbols"
+
+# Use a custom profile-like approach: build with strip
+RUSTFLAGS="--cfg tokio_unstable -C force-frame-pointers=yes -C strip=symbols" \
+  cargo build --release --features cpu-profiling \
+  --example generate_diagnostic_traces \
+  --manifest-path "$REPO_ROOT/dial9-tokio-telemetry/Cargo.toml"
+
+RUSTFLAGS="--cfg tokio_unstable -C force-frame-pointers=yes -C strip=symbols" \
+  cargo run --release --features cpu-profiling \
+  --example generate_diagnostic_traces \
+  --manifest-path "$REPO_ROOT/dial9-tokio-telemetry/Cargo.toml" \
+  -- "$OUTPUT_DIR/no-debug-symbols-tmp"
+
+mv "$OUTPUT_DIR/no-debug-symbols-tmp/good"/* "$OUTPUT_DIR/no-debug-symbols/"
+rm -rf "$OUTPUT_DIR/no-debug-symbols-tmp"
+
+echo ""
+echo "=== Done ==="
+echo "Traces generated:"
+echo "  $OUTPUT_DIR/good/              — fully configured (reference)"
+echo "  $OUTPUT_DIR/no-frame-pointers/ — stacks are 1-2 frames deep"
+echo "  $OUTPUT_DIR/no-wake-events/    — tasks not instrumented"
+echo "  $OUTPUT_DIR/no-debug-symbols/  — symbols are hex addresses only"
+echo "  $OUTPUT_DIR/no-sched-events/   — no off-CPU scheduling samples"


### PR DESCRIPTION

Adds `diagnose_setup.js` to the toolkit, run by default before the main analysis. Detects 4 common misconfigurations and offers fixes.

## Output samples

**Missing frame pointers** (critical):
```
🔴 [missing-frame-pointers] CPU stack traces are only 1.4 frames deep on average (expected 10+). Frame pointers are not enabled.

  Fix:
  Add to .cargo/config.toml:

  [build]
  rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
```

**Missing wake events** (warning):
```
🟡 [missing-wake-events] 50 tasks were spawned but 0 wake events were recorded. Tasks are not instrumented.

  Fix:
  Use TelemetryHandle::spawn() instead of tokio::spawn() to instrument tasks:

  let handle = TelemetryHandle::current();
  handle.spawn(async { /* your task */ });
```

**Missing debug symbols** (warning):
```
🟡 [missing-debug-symbols] Only 17 symbols resolved out of 769 unique addresses (0 with source locations). Debug symbols are missing.

  Fix:
  Ensure your release profile includes debug info. In Cargo.toml:

  [profile.release]
  debug = 1        # line tables only (minimal size overhead)
  strip = false    # do NOT strip symbols
```

**No scheduling events** (info):
```
ℹ️ [no-scheduling-events] No off-CPU scheduling samples found. Schedule profiling is not enabled or not available.

  Fix:
  sudo sysctl kernel.perf_event_paranoid=1
  DIAL9_SCHEDULE_PROFILE_ENABLED=true
```

**Healthy trace:**
```
✅ No setup issues detected
```
