### PR TITLE
viewer: rename tab title to "dial9 Trace Viewer"

### DIFF
--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Tokio Trace Viewer</title>
+        <title>dial9 Trace Viewer</title>
         <link rel="stylesheet" href="flamegraph.css" />
         <style>
             * {


### PR DESCRIPTION
Since tokio is no longer the only thing dial9 traces (and can be used without tracing tokio)