### PR TITLE
fix: merge CPU sample groups by full stack, not just leaf frame

### DIFF
--- a/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
@@ -195,14 +195,16 @@ function accumulateTrace(acc, trace) {
   for (const [k, v] of trace.taskTerminateTimes) acc.taskTerminateTimes.set(k, v);
   for (const [k, v] of trace.callframeSymbols) acc.callframeSymbols.set(k, v);
 
-  // Sample groups
+  // Sample groups — key by full stack to avoid merging unrelated stacks with same leaf
   for (const g of deduplicateSamples(onCpu, trace.callframeSymbols)) {
-    const e = acc.cpuGroupMap.get(g.leaf);
-    if (e) e.count += g.count; else acc.cpuGroupMap.set(g.leaf, { ...g });
+    const key = g.frames.map(f => f.symbol).join('\0');
+    const e = acc.cpuGroupMap.get(key);
+    if (e) e.count += g.count; else acc.cpuGroupMap.set(key, { ...g });
   }
   for (const g of deduplicateSamples(offCpu, trace.callframeSymbols)) {
-    const e = acc.schedGroupMap.get(g.leaf);
-    if (e) e.count += g.count; else acc.schedGroupMap.set(g.leaf, { ...g });
+    const key = g.frames.map(f => f.symbol).join('\0');
+    const e = acc.schedGroupMap.get(key);
+    if (e) e.count += g.count; else acc.schedGroupMap.set(key, { ...g });
   }
 
   // Span durations (native HDR histogram for bounded memory, exact percentiles)
@@ -691,14 +693,16 @@ function mergePartial(acc, p) {
   if (p.taskTerminateTimes) for (const [k, v] of p.taskTerminateTimes) acc.taskTerminateTimes.set(k, v);
   if (p.callframeSymbols) for (const [k, v] of p.callframeSymbols) acc.callframeSymbols.set(k, v);
 
-  // Sample groups
+  // Sample groups — key by full stack to avoid merging unrelated stacks with same leaf
   for (const g of (p.cpuGroups || [])) {
-    const e = acc.cpuGroupMap.get(g.leaf);
-    if (e) e.count += g.count; else acc.cpuGroupMap.set(g.leaf, { ...g });
+    const key = g.frames.map(f => f.symbol).join('\0');
+    const e = acc.cpuGroupMap.get(key);
+    if (e) e.count += g.count; else acc.cpuGroupMap.set(key, { ...g });
   }
   for (const g of (p.schedGroups || [])) {
-    const e = acc.schedGroupMap.get(g.leaf);
-    if (e) e.count += g.count; else acc.schedGroupMap.set(g.leaf, { ...g });
+    const key = g.frames.map(f => f.symbol).join('\0');
+    const e = acc.schedGroupMap.get(key);
+    if (e) e.count += g.count; else acc.schedGroupMap.set(key, { ...g });
   }
 
   // Poll durations by location -> histogram


### PR DESCRIPTION
Previously, cpuGroupMap and schedGroupMap merged sample groups by leaf frame text only. This caused unrelated stacks sharing the same leaf (e.g. memcpy from serialization vs memcpy from a background thread) to collapse into one entry, with the "app frame" heuristic reporting whichever caller happened to be stored first.

Now groups are keyed by the full symbolized stack signature, preserving distinct call paths in the aggregate report.