### PR TITLE
memory profiling: Optimize memory profiling by tracking liveset on the allocator side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,6 +1555,7 @@ dependencies = [
  "s3s",
  "s3s-aws",
  "s3s-fs",
+ "scc",
  "serde",
  "serde_json",
  "shuttle",
@@ -3874,6 +3875,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,6 +3913,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = "1"
 smallvec = "1"
 bytes = "1"
 dial9-perf-self-profile = { workspace = true, optional = true }
+scc = { version = "2", optional = true }
 dial9-trace-format = { workspace = true, features = ["serde", "serde-deserialize"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = [
@@ -80,7 +81,7 @@ _shuttle = [
 taskdump = ["tokio/taskdump"]
 tracing-layer = ["dep:tracing-subscriber"]
 ## Sampled memory allocation profiling via ring buffers.
-memory-profiling = ["dep:dial9-perf-self-profile"]
+memory-profiling = ["dep:dial9-perf-self-profile", "dep:scc"]
 worker-s3 = [
     "dep:aws-sdk-s3-transfer-manager",
     "dep:aws-sdk-s3",

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -9,36 +9,6 @@ pub const DEFAULT_SAMPLE_RATE_BYTES: u64 = 512 * 1024;
 /// Default number of slots in the producer-to-consolidator alloc ring.
 pub const DEFAULT_RING_CAPACITY: usize = 4096;
 
-/// How `AllocEvent.timestamp_ns` is populated.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[non_exhaustive]
-pub enum TimestampMode {
-    /// Reuse the timestamp from the most recent `PollStart` on this thread
-    /// (~5 ns TLS load), falling back to `clock_monotonic_ns()` when called
-    /// outside a task poll (e.g., between polls or on non-worker threads).
-    ///
-    /// In either case the returned timestamp is strictly greater than the
-    /// previous one this thread observed (a 1 ns bump on ties), so events
-    /// produced inside a single poll — including a free + alloc pair from
-    /// in-place realloc — always have distinct, ordered timestamps. This
-    /// is the default and the recommended mode when `track_liveset` is on.
-    #[default]
-    ReusePollStart,
-
-    /// Emit events with `timestamp_ns = 0`. Smallest on-disk size.
-    ///
-    /// **Incompatible with `track_liveset(true)`** — the consolidator
-    /// relies on timestamp ordering to disambiguate same-address
-    /// free/alloc pairs (e.g. from in-place realloc). Use
-    /// [`TimestampMode::ReusePollStart`] or [`TimestampMode::Precise`]
-    /// instead when liveset tracking is on. The combination is rejected
-    /// at config build time.
-    None,
-
-    /// Call `clock_monotonic_ns()` per sampled allocation (~25 ns via vDSO).
-    Precise,
-}
-
 /// Configuration for the memory profiler.
 ///
 /// Built via `MemoryProfilingConfig::builder()...build()`.
@@ -92,10 +62,6 @@ pub struct MemoryProfilingConfig {
     #[builder(default = false)]
     track_liveset: bool,
 
-    /// How `AllocEvent.timestamp_ns` is populated. See [`TimestampMode`].
-    #[builder(default)]
-    timestamp_mode: TimestampMode,
-
     /// Optional fixed seed for per-thread sampling PRNGs.
     rng_seed: Option<u64>,
 
@@ -114,29 +80,12 @@ impl<S: memory_profiling_config_builder::IsComplete> MemoryProfilingConfigBuilde
     /// "sample every allocation" mode — `0` would mean "zero bytes
     /// between samples", which is ambiguous (sample everything? sample
     /// nothing?), so we require the explicit `1`.
-    ///
-    /// Panics if `timestamp_mode == TimestampMode::None` is combined
-    /// with `track_liveset(true)`. The liveset matches `Free` events to
-    /// prior `Alloc` events by address, and relies on timestamp
-    /// ordering to disambiguate same-address free/alloc pairs (e.g.
-    /// in-place realloc). With every event at `ts = 0` the merge-sort
-    /// drain in `MemoryProfileSource` cannot order those pairs and
-    /// would corrupt the liveset.
     pub fn build(self) -> MemoryProfilingConfig {
         let config = self.build_inner();
         assert!(
             config.sample_rate_bytes >= 1,
             "MemoryProfilingConfig::sample_rate_bytes must be >= 1; pass 1 for \
              'sample every allocation' mode"
-        );
-        assert!(
-            !(config.track_liveset && matches!(config.timestamp_mode, TimestampMode::None)),
-            "MemoryProfilingConfig: TimestampMode::None is incompatible with \
-             track_liveset(true). With every event at ts=0 the consolidator's \
-             merge-sort drain cannot order same-address free/alloc pairs (e.g. \
-             from in-place realloc) and would corrupt the liveset. Choose \
-             TimestampMode::ReusePollStart (default) or TimestampMode::Precise \
-             when liveset tracking is on."
         );
         config
     }
@@ -156,10 +105,6 @@ impl MemoryProfilingConfig {
     /// Whether liveset tracking is enabled.
     pub fn track_liveset(&self) -> bool {
         self.track_liveset
-    }
-    /// Timestamp mode for alloc events.
-    pub fn timestamp_mode(&self) -> TimestampMode {
-        self.timestamp_mode
     }
     /// Optional fixed RNG seed.
     pub fn rng_seed(&self) -> Option<u64> {
@@ -200,49 +145,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "TimestampMode::None")]
-    fn build_rejects_none_timestamp_with_liveset() {
-        // Liveset tracking matches Free→Alloc by addr AND requires
-        // timestamp ordering to disambiguate same-address free/alloc
-        // pairs (e.g. in-place realloc). With every event at ts=0, the
-        // merge-sort drain in `MemoryProfileSource` cannot tell which
-        // came first — see PR #442 review.
-        let _ = MemoryProfilingConfig::builder()
-            .timestamp_mode(TimestampMode::None)
-            .track_liveset(true)
-            .build();
-    }
-
-    #[test]
-    fn build_accepts_none_timestamp_without_liveset() {
-        // The None+!liveset combo is fine: free events are dropped,
-        // so there's no ordering hazard.
-        let cfg = MemoryProfilingConfig::builder()
-            .timestamp_mode(TimestampMode::None)
-            .track_liveset(false)
-            .build();
-        assert!(matches!(cfg.timestamp_mode(), TimestampMode::None));
-        assert!(!cfg.track_liveset());
-    }
-
-    #[test]
-    fn build_accepts_liveset_with_reuse_poll_start() {
-        // The intended liveset combo: ReusePollStart provides per-poll
-        // timestamps, falling back to clock_monotonic_ns elsewhere.
-        let cfg = MemoryProfilingConfig::builder()
-            .timestamp_mode(TimestampMode::ReusePollStart)
-            .track_liveset(true)
-            .build();
-        assert!(cfg.track_liveset());
-    }
-
-    #[test]
-    fn build_accepts_liveset_with_precise() {
-        // Precise also provides real timestamps.
-        let cfg = MemoryProfilingConfig::builder()
-            .timestamp_mode(TimestampMode::Precise)
-            .track_liveset(true)
-            .build();
+    fn build_accepts_liveset() {
+        let cfg = MemoryProfilingConfig::builder().track_liveset(true).build();
         assert!(cfg.track_liveset());
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/config.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/config.rs
@@ -85,14 +85,10 @@ pub struct MemoryProfilingConfig {
 
     /// Whether to track the liveset for leak detection. Default `false`.
     ///
-    /// When enabled, a `RawFree` is pushed into the free queue on
-    /// **every** deallocation (not just sampled ones). At very high
-    /// dealloc rates the free queue can overflow; overflowed frees are
-    /// silently dropped (counted in `dropped_frees`). A dropped free
-    /// for a previously-sampled allocation means its liveset entry
-    /// persists, inflating the reported live set until the next flush
-    /// cycle or process exit. Size the `ring_capacity` accordingly for
-    /// high-throughput services.
+    /// When enabled, a producer-side `scc::HashIndex` tracks sampled
+    /// allocations. On dealloc, only addresses present in the liveset
+    /// (i.e. previously sampled) produce a `RawFree` — ~99.9% of deallocs
+    /// are filtered on the producer side with no queue contention.
     #[builder(default = false)]
     track_liveset: bool,
 

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -224,18 +224,17 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         // anyone moves the `liveset.insert` call site, `check_shutdown` must
         // be called first on every code path that touches the liveset, or
         // we'll panic in `sdd::Collector::current()` during teardown.
-        #[allow(clippy::collapsible_if)]
-        if let Some(liveset) = &inner.liveset {
-            if !crate::memory_profiling::opt_out::check_shutdown() {
-                let key = ptr as u64;
-                let val = (size as u64, timestamp_ns);
-                if let Err((k, v)) = liveset.insert(key, val) {
-                    use scc::hash_index::Entry;
-                    match liveset.entry(k) {
-                        Entry::Occupied(o) => o.update(v),
-                        Entry::Vacant(ve) => {
-                            let _ = ve.insert_entry(v);
-                        }
+        if let Some(liveset) = &inner.liveset
+            && !crate::memory_profiling::opt_out::check_shutdown()
+        {
+            let key = ptr as u64;
+            let val = (size as u64, timestamp_ns);
+            if let Err((k, v)) = liveset.insert(key, val) {
+                use scc::hash_index::Entry;
+                match liveset.entry(k) {
+                    Entry::Occupied(o) => o.update(v),
+                    Entry::Vacant(ve) => {
+                        let _ = ve.insert_entry(v);
                     }
                 }
             }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -29,11 +29,10 @@
 //!
 //! See design §6 (Reentrancy) for the full argument.
 
-use crate::memory_profiling::config::TimestampMode;
 use crate::memory_profiling::profiler::MemoryProfilerInner;
 use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc, RawFree};
 use crate::sampling::SplitMix64;
-use crate::telemetry::events::current_tid;
+use crate::telemetry::events::{clock_monotonic_ns, current_tid};
 
 /// Per-thread sampling state. Held in TLS so each thread reads/writes
 /// its own counter and PRNG without synchronization (design §1).
@@ -80,7 +79,7 @@ fn ensure_initialized(state: &mut SamplingState, inner: &MemoryProfilerInner) {
             // Mix wall clock with the thread ID and the static address.
             // `nonce` (= current_tid()) guarantees uniqueness across threads
             // even if they initialize at the same nanosecond.
-            let now = crate::telemetry::events::clock_monotonic_ns();
+            let now = clock_monotonic_ns();
             now.wrapping_mul(0x517cc1b727220a95) ^ nonce ^ (inner as *const _ as u64)
         }
     };
@@ -109,15 +108,6 @@ fn next_gap(rng: &mut SplitMix64, sample_rate_bytes: u64) -> i64 {
         return 0;
     }
     i64::try_from(rng.draw_exponential(sample_rate_bytes)).unwrap_or(i64::MAX)
-}
-
-#[inline]
-fn stamp(mode: TimestampMode) -> u64 {
-    match mode {
-        TimestampMode::ReusePollStart => crate::telemetry::recorder::poll_start_ts_monotonic(),
-        TimestampMode::None => 0,
-        TimestampMode::Precise => crate::telemetry::events::clock_monotonic_ns(),
-    }
 }
 
 /// Allocator hook: called from `Dial9Allocator::alloc` after the inner
@@ -168,7 +158,7 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         // `0` is rejected at config build time.
         state.next_sample_bytes = next_gap(&mut state.rng, inner.sample_rate_bytes);
 
-        let timestamp_ns = stamp(inner.timestamp_mode);
+        let timestamp_ns = clock_monotonic_ns();
 
         // Stack capture into a stack-resident buffer. The `RefMut`
         // is intentionally held across `capture` and the queue push:
@@ -259,6 +249,21 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
 /// `MemoryProfileSource::handle_free` for the consumer side, including the
 /// `alloc_ts_ns <= free.ts_ns` race check.
 ///
+/// **Re-entrancy guard.** The non-shutdown branch takes the
+/// `SAMPLE_STATE` `RefCell` borrow as a per-thread re-entrancy guard,
+/// symmetric with `on_alloc`. `liveset.peek_with` and `liveset.remove`
+/// are documented as allocation-free on the hot path, but `scc`'s
+/// epoch-based reclamation (via `sdd`) can free retired buckets when an
+/// epoch guard drops, and `remove` takes a per-bucket write lock — so a
+/// re-entrant `on_dealloc` from inside `scc` internals could in theory
+/// hit the same bucket the outer `remove` already holds locked and
+/// deadlock against itself. The guard makes that impossible by
+/// short-circuiting the inner call. The shutdown branch sits *outside*
+/// the guard because (a) it never touches `scc`/`sdd` (just a
+/// queue-CAS push) and (b) `SAMPLE_STATE`'s `LocalKey` may already be
+/// destroyed late in TLS teardown — `try_with` would return `Err` and
+/// silently drop the dying thread's free, defeating the shutdown drain.
+///
 /// SAFETY: must be allocation-free — see module docs.
 #[inline]
 pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize) {
@@ -271,32 +276,45 @@ pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize
         // RawFree and let the consolidator do the lookup. `size` and
         // `alloc_ts_ns` are placeholders (0); the consolidator fills them
         // in from its own peek_with. This is allocation-free and only
-        // touches the queue.
+        // touches the queue. Intentionally outside the SAMPLE_STATE
+        // borrow guard — see the function doc.
         inner.rings.push_free(RawFree {
             tid: current_tid(),
             addr,
-            ts_ns: stamp(inner.timestamp_mode),
+            ts_ns: clock_monotonic_ns(),
             size: 0,
             alloc_ts_ns: 0,
             shutdown: true,
         });
         return;
     }
-    // peek_with returns Some if the address is in the liveset (was sampled).
-    // On hit, remove it and push a RawFree with the denormalized metadata.
-    let entry = liveset.peek_with(&addr, |_, v| *v);
-    if let Some((size, alloc_ts_ns)) = entry {
-        liveset.remove(&addr);
-        let sample = RawFree {
-            tid: current_tid(),
-            addr,
-            ts_ns: stamp(inner.timestamp_mode),
-            size,
-            alloc_ts_ns,
-            shutdown: false,
+    // Non-shutdown branch: take the SAMPLE_STATE borrow as a re-entrancy
+    // guard. If a prior `on_alloc`/`on_dealloc` frame on this thread is
+    // still on the stack and holds the borrow, skip — otherwise the
+    // re-entrant `liveset.remove` could deadlock against the outer one
+    // on a shared bucket lock, and any allocation triggered inside `scc`
+    // would otherwise be unguarded.
+    let _ = SAMPLE_STATE.try_with(|cell| {
+        let Ok(_state) = cell.try_borrow_mut() else {
+            return;
         };
-        inner.rings.push_free(sample);
-    }
+        // peek_with returns Some if the address is in the liveset (was
+        // sampled). On hit, remove it and push a RawFree with the
+        // denormalized metadata.
+        let entry = liveset.peek_with(&addr, |_, v| *v);
+        if let Some((size, alloc_ts_ns)) = entry {
+            liveset.remove(&addr);
+            let sample = RawFree {
+                tid: current_tid(),
+                addr,
+                ts_ns: clock_monotonic_ns(),
+                size,
+                alloc_ts_ns,
+                shutdown: false,
+            };
+            inner.rings.push_free(sample);
+        }
+    });
 }
 
 /// Allocator hook for realloc. Decomposes into free-of-old +
@@ -324,7 +342,6 @@ pub(crate) fn on_realloc(
 #[cfg(target_os = "linux")]
 mod tests {
     use super::*;
-    use crate::memory_profiling::config::TimestampMode;
     use crate::memory_profiling::profiler::MemoryProfilerInner;
     use crate::memory_profiling::ring::RingBuffers;
     use crate::sampling::SplitMix64;
@@ -382,9 +399,7 @@ mod tests {
             handle: TelemetryHandle::disabled(),
             rings,
             sample_rate_bytes,
-            track_liveset: false,
             liveset: None,
-            timestamp_mode: TimestampMode::None,
             rng_seed: Some(0),
         }
     }
@@ -701,9 +716,7 @@ mod tests {
             handle: TelemetryHandle::disabled(),
             rings,
             sample_rate_bytes,
-            track_liveset: true,
             liveset: Some(liveset),
-            timestamp_mode: TimestampMode::Precise,
             rng_seed: Some(0),
         }
     }
@@ -763,6 +776,64 @@ mod tests {
             frees[0].alloc_ts_ns, allocs[1].ts_ns,
             "free's alloc_ts_ns must match the second alloc, not the stale \
              first one; without the overwrite fix this would be allocs[0].ts_ns"
+        );
+    }
+
+    /// Re-entrancy guard for `on_dealloc`. If a prior frame on this thread is
+    /// already inside `on_alloc`/`on_dealloc` and holds the `SAMPLE_STATE`
+    /// borrow, a re-entrant `on_dealloc` must skip — otherwise the inner
+    /// call's `liveset.remove` could try to take a bucket write lock that
+    /// the outer call already holds (same-thread deadlock if `scc` happens
+    /// to recycle a stale liveset key into the very bucket the outer
+    /// operation is mutating).
+    ///
+    /// This test holds the `SAMPLE_STATE::RefCell` borrow explicitly to
+    /// simulate the "outer call still on the stack" condition, then calls
+    /// `on_dealloc`. Without the guard, `on_dealloc` would peek/remove the
+    /// liveset entry and push a `RawFree`. With the guard, both side
+    /// effects must be suppressed.
+    #[test]
+    fn on_dealloc_skips_when_sample_state_is_already_borrowed() {
+        let inner = Arc::new(make_inner_with_liveset(1, 64));
+        let inner_for_thread = Arc::clone(&inner);
+        let addr_u64 = 0xFEED_FACE_u64;
+
+        std::thread::spawn(move || {
+            seed_thread_sampling_state(0xDEAD_C0DE, 1);
+            let addr = addr_u64 as usize as *mut u8;
+
+            // Seed the liveset with a real entry via on_alloc so we have
+            // something for a re-entrant on_dealloc to find.
+            on_alloc(&inner_for_thread, addr, 64);
+
+            // Simulate being mid-flight in on_alloc / on_dealloc: hold the
+            // SAMPLE_STATE borrow before calling on_dealloc. With the
+            // re-entrancy guard, on_dealloc must observe the borrow and
+            // bail without touching the liveset or queue.
+            SAMPLE_STATE.with(|cell| {
+                let _outer_borrow = cell
+                    .try_borrow_mut()
+                    .expect("test thread holds the only borrow");
+                on_dealloc(&inner_for_thread, addr, 64);
+            });
+        })
+        .join()
+        .expect("scenario thread");
+
+        // The liveset entry must still be present — the inner on_dealloc
+        // must not have removed it.
+        let liveset = inner.liveset.as_ref().expect("liveset configured");
+        assert!(
+            liveset.peek_with(&addr_u64, |_, _| ()).is_some(),
+            "re-entrant on_dealloc must skip the liveset.remove; entry was \
+             unexpectedly removed (the guard is not in place)"
+        );
+
+        // And no RawFree should have been pushed.
+        assert!(
+            inner.rings.free_queue.is_empty(),
+            "re-entrant on_dealloc must skip the RawFree push; the queue is \
+             non-empty (the guard is not in place)"
         );
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -200,10 +200,39 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         // scc::HashIndex::insert is allocation-free on the hot path (it uses
         // epoch-based reclamation internally with no heap allocation per insert
         // on the common path).
+        //
+        // **Stale-entry handling.** `scc::HashIndex::insert` returns `Err` and
+        // does NOT overwrite when the key already exists. The address space is
+        // reused by the OS allocator, so a stale entry can land here in two
+        // cases:
+        //   1. The matching dealloc was skipped during thread-teardown by the
+        //      OPT_OUT sentinel (see `opt_out.rs`).
+        //   2. The matching dealloc's `RawFree` was dropped because the free
+        //      queue was full (`MemoryProfileOverflowEvent` was emitted).
+        // In both cases we'd otherwise emit a `FreeEvent` later carrying the
+        // *old* allocation's `(size, ts_ns)` — wrong data. Detect the failure
+        // and remove-then-reinsert. Brief race: a concurrent reader may
+        // observe a transient absence; that's no worse than any other
+        // producer interleaving and the worst outcome is a missed `FreeEvent`
+        // for the new allocation.
+        //
+        // **OPT_OUT init ordering invariant.** `check_shutdown()` MUST be
+        // called before any `liveset` op on this thread. It eagerly initialises
+        // the `LIFETIME_GUARD` TLS *before* `sdd`'s lazy TLS slot, so the
+        // destructor order at thread exit is `sdd` → `LIFETIME_GUARD`, with
+        // the guard flipping `IS_SHUTTING_DOWN = true` after sdd is gone. If
+        // anyone moves the `liveset.insert` call site, `check_shutdown` must
+        // be called first on every code path that touches the liveset, or
+        // we'll panic in `sdd::Collector::current()` during teardown.
         #[allow(clippy::collapsible_if)]
         if let Some(liveset) = &inner.liveset {
             if !crate::memory_profiling::opt_out::check_shutdown() {
-                let _ = liveset.insert(ptr as u64, (size as u64, timestamp_ns));
+                let key = ptr as u64;
+                let val = (size as u64, timestamp_ns);
+                if liveset.insert(key, val).is_err() {
+                    liveset.remove(&key);
+                    let _ = liveset.insert(key, val);
+                }
             }
         }
     });
@@ -213,16 +242,42 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
 /// a `RawFree` if the address was previously sampled (filtering ~99.9% of
 /// deallocs on the producer side).
 ///
+/// **OPT_OUT init ordering invariant.** `check_shutdown()` MUST be called
+/// before any `liveset` op. See the matching comment on `on_alloc`'s liveset
+/// branch and `opt_out.rs` for the full mechanism.
+///
+/// **Shutdown drain.** During TLS teardown the producer can't safely peek
+/// the liveset (sdd's TLS may be destroyed), so it pushes a
+/// `RawFree { shutdown: true, .. }` carrying only `addr`. The consolidator
+/// (running on a different, healthy thread) does the liveset peek/remove
+/// and emits a `FreeEvent` on hit. This recovers dying-thread frees and
+/// bounds liveset growth across thread churn. See
+/// `MemoryProfileSource::handle_free` for the consumer side, including the
+/// `alloc_ts_ns <= free.ts_ns` race check.
+///
 /// SAFETY: must be allocation-free — see module docs.
 #[inline]
 pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize) {
     let Some(liveset) = &inner.liveset else {
         return;
     };
+    let addr = ptr as u64;
     if crate::memory_profiling::opt_out::check_shutdown() {
+        // Shutdown drain: producer can't touch scc here. Push a flagged
+        // RawFree and let the consolidator do the lookup. `size` and
+        // `alloc_ts_ns` are placeholders (0); the consolidator fills them
+        // in from its own peek_with. This is allocation-free and only
+        // touches the queue.
+        inner.rings.push_free(RawFree {
+            tid: current_tid(),
+            addr,
+            ts_ns: stamp(inner.timestamp_mode),
+            size: 0,
+            alloc_ts_ns: 0,
+            shutdown: true,
+        });
         return;
     }
-    let addr = ptr as u64;
     // peek_with returns Some if the address is in the liveset (was sampled).
     // On hit, remove it and push a RawFree with the denormalized metadata.
     let entry = liveset.peek_with(&addr, |_, v| *v);
@@ -234,6 +289,7 @@ pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize
             ts_ns: stamp(inner.timestamp_mode),
             size,
             alloc_ts_ns,
+            shutdown: false,
         };
         inner.rings.push_free(sample);
     }
@@ -622,5 +678,87 @@ mod tests {
             remaining = remaining.saturating_sub(size);
         }
         sizes
+    }
+
+    /// Build a `MemoryProfilerInner` with the producer-side liveset enabled,
+    /// for tests that exercise the address-reuse / stale-entry path.
+    fn make_inner_with_liveset(
+        sample_rate_bytes: u64,
+        ring_capacity: usize,
+    ) -> MemoryProfilerInner {
+        let unwinder = Unwinder::install().expect("unwinder install");
+        let rings = Arc::new(RingBuffers::new(ring_capacity, ring_capacity));
+        let liveset = Arc::new(scc::HashIndex::with_capacity_and_hasher(
+            0,
+            dial9_trace_format::encoder::FxBuildHasher::default(),
+        ));
+        MemoryProfilerInner {
+            unwinder,
+            handle: TelemetryHandle::disabled(),
+            rings,
+            sample_rate_bytes,
+            track_liveset: true,
+            liveset: Some(liveset),
+            timestamp_mode: TimestampMode::Precise,
+            rng_seed: Some(0),
+        }
+    }
+
+    /// Reproduces the address-reuse hazard fixed by the stale-entry overwrite
+    /// in `on_alloc`. Without overwrite-on-Err, the second `on_alloc` for the
+    /// same address silently drops its `(size, ts)` and a subsequent
+    /// `on_dealloc` reports the *first* allocation's metadata.
+    #[test]
+    fn on_alloc_overwrites_stale_liveset_entry() {
+        let inner = Arc::new(make_inner_with_liveset(1, 64));
+        let inner_for_thread = Arc::clone(&inner);
+        std::thread::spawn(move || {
+            seed_thread_sampling_state(0xBEEF_BEEF, 1);
+            let addr = 0xCAFE_F00D_usize as *mut u8;
+
+            // First sampled allocation: size 100. on_alloc inserts
+            // (100, ts1) into the liveset.
+            on_alloc(&inner_for_thread, addr, 100);
+
+            // Simulate the OPT_OUT skip / queue-overflow path: the matching
+            // dealloc never reaches `on_dealloc`. The (100, ts1) entry is
+            // now stale.
+
+            // Second sampled allocation at the same address: size 200. With
+            // the fix, on_alloc detects the duplicate-key Err from
+            // `scc::HashIndex::insert` and overwrites the entry with
+            // (200, ts2).
+            on_alloc(&inner_for_thread, addr, 200);
+
+            // Now dealloc: must observe size = 200, NOT the stale 100.
+            on_dealloc(&inner_for_thread, addr, 200);
+        })
+        .join()
+        .expect("scenario thread");
+
+        // Drain the queues. We expect 2 allocs and 1 free.
+        let mut allocs = Vec::new();
+        while let Some(a) = inner.rings.alloc_queue.pop() {
+            allocs.push(a);
+        }
+        let mut frees = Vec::new();
+        while let Some(f) = inner.rings.free_queue.pop() {
+            frees.push(f);
+        }
+        assert_eq!(allocs.len(), 2, "both allocs should have been recorded");
+        assert_eq!(allocs[0].size, 100);
+        assert_eq!(allocs[1].size, 200);
+
+        assert_eq!(frees.len(), 1, "the dealloc should have produced a free");
+        assert_eq!(
+            frees[0].size, 200,
+            "free must report the second alloc's size, not the stale first \
+             alloc's; without the overwrite fix this would be 100"
+        );
+        assert_eq!(
+            frees[0].alloc_ts_ns, allocs[1].ts_ns,
+            "free's alloc_ts_ns must match the second alloc, not the stale \
+             first one; without the overwrite fix this would be allocs[0].ts_ns"
+        );
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -194,24 +194,49 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         };
 
         inner.rings.push_alloc(sample);
+
+        // Insert into the producer-side liveset OUTSIDE the RefCell borrow.
+        // The borrow is still held (we're inside the try_with closure), but
+        // scc::HashIndex::insert is allocation-free on the hot path (it uses
+        // epoch-based reclamation internally with no heap allocation per insert
+        // on the common path).
+        #[allow(clippy::collapsible_if)]
+        if let Some(liveset) = &inner.liveset {
+            if !crate::memory_profiling::opt_out::check_shutdown() {
+                let _ = liveset.insert(ptr as u64, (size as u64, timestamp_ns));
+            }
+        }
     });
 }
 
-/// Allocator hook for dealloc. No-op when liveset tracking is off.
+/// Allocator hook for dealloc. With the producer-side liveset, only pushes
+/// a `RawFree` if the address was previously sampled (filtering ~99.9% of
+/// deallocs on the producer side).
 ///
 /// SAFETY: must be allocation-free — see module docs.
 #[inline]
 pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize) {
-    if !inner.track_liveset {
+    let Some(liveset) = &inner.liveset else {
+        return;
+    };
+    if crate::memory_profiling::opt_out::check_shutdown() {
         return;
     }
-    let timestamp_ns = stamp(inner.timestamp_mode);
-    let sample = RawFree {
-        tid: current_tid(),
-        addr: ptr as u64,
-        ts_ns: timestamp_ns,
-    };
-    inner.rings.push_free(sample);
+    let addr = ptr as u64;
+    // peek_with returns Some if the address is in the liveset (was sampled).
+    // On hit, remove it and push a RawFree with the denormalized metadata.
+    let entry = liveset.peek_with(&addr, |_, v| *v);
+    if let Some((size, alloc_ts_ns)) = entry {
+        liveset.remove(&addr);
+        let sample = RawFree {
+            tid: current_tid(),
+            addr,
+            ts_ns: stamp(inner.timestamp_mode),
+            size,
+            alloc_ts_ns,
+        };
+        inner.rings.push_free(sample);
+    }
 }
 
 /// Allocator hook for realloc. Decomposes into free-of-old +
@@ -298,6 +323,7 @@ mod tests {
             rings,
             sample_rate_bytes,
             track_liveset: false,
+            liveset: None,
             timestamp_mode: TimestampMode::None,
             rng_seed: Some(0),
         }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -211,10 +211,10 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
         //      queue was full (`MemoryProfileOverflowEvent` was emitted).
         // In both cases we'd otherwise emit a `FreeEvent` later carrying the
         // *old* allocation's `(size, ts_ns)` — wrong data. Detect the failure
-        // and remove-then-reinsert. Brief race: a concurrent reader may
-        // observe a transient absence; that's no worse than any other
-        // producer interleaving and the worst outcome is a missed `FreeEvent`
-        // for the new allocation.
+        // and fall through to the `entry()` API to atomically overwrite (or
+        // insert, if a concurrent dealloc cleared the entry between our
+        // `insert` and `entry`). The hot path stays on the cheap lock-free
+        // `insert`; only the rare stale case pays the bucket-lock cost.
         //
         // **OPT_OUT init ordering invariant.** `check_shutdown()` MUST be
         // called before any `liveset` op on this thread. It eagerly initialises
@@ -229,9 +229,14 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
             if !crate::memory_profiling::opt_out::check_shutdown() {
                 let key = ptr as u64;
                 let val = (size as u64, timestamp_ns);
-                if liveset.insert(key, val).is_err() {
-                    liveset.remove(&key);
-                    let _ = liveset.insert(key, val);
+                if let Err((k, v)) = liveset.insert(key, val) {
+                    use scc::hash_index::Entry;
+                    match liveset.entry(k) {
+                        Entry::Occupied(o) => o.update(v),
+                        Entry::Vacant(ve) => {
+                            let _ = ve.insert_entry(v);
+                        }
+                    }
                 }
             }
         }

--- a/dial9-tokio-telemetry/src/memory_profiling/hook.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/hook.rs
@@ -224,6 +224,8 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
                 match liveset.entry(k) {
                     Entry::Occupied(o) => o.update(v),
                     Entry::Vacant(ve) => {
+                        // Concurrent dealloc removed the stale entry between our
+                        // `insert` and `entry` — treat as fresh insert.
                         let _ = ve.insert_entry(v);
                     }
                 }
@@ -247,22 +249,21 @@ pub(crate) fn on_alloc(inner: &MemoryProfilerInner, ptr: *mut u8, size: usize) {
 /// and emits a `FreeEvent` on hit. This recovers dying-thread frees and
 /// bounds liveset growth across thread churn. See
 /// `MemoryProfileSource::handle_free` for the consumer side, including the
-/// `alloc_ts_ns <= free.ts_ns` race check.
+/// `alloc_ts_ns >= free.ts_ns` race-detection check.
 ///
 /// **Re-entrancy guard.** The non-shutdown branch takes the
 /// `SAMPLE_STATE` `RefCell` borrow as a per-thread re-entrancy guard,
-/// symmetric with `on_alloc`. `liveset.peek_with` and `liveset.remove`
-/// are documented as allocation-free on the hot path, but `scc`'s
-/// epoch-based reclamation (via `sdd`) can free retired buckets when an
-/// epoch guard drops, and `remove` takes a per-bucket write lock — so a
-/// re-entrant `on_dealloc` from inside `scc` internals could in theory
-/// hit the same bucket the outer `remove` already holds locked and
-/// deadlock against itself. The guard makes that impossible by
-/// short-circuiting the inner call. The shutdown branch sits *outside*
-/// the guard because (a) it never touches `scc`/`sdd` (just a
-/// queue-CAS push) and (b) `SAMPLE_STATE`'s `LocalKey` may already be
-/// destroyed late in TLS teardown — `try_with` would return `Err` and
-/// silently drop the dying thread's free, defeating the shutdown drain.
+/// symmetric with `on_alloc`. `liveset.entry` acquires a per-bucket
+/// write lock, and `scc`'s epoch-based reclamation (via `sdd`) can free
+/// retired buckets when an epoch guard drops — so a re-entrant
+/// `on_dealloc` from inside `scc` internals could in theory hit the
+/// same bucket the outer `entry` already holds locked and deadlock
+/// against itself. The guard makes that impossible by short-circuiting
+/// the inner call. The shutdown branch sits *outside* the guard because
+/// (a) it never touches `scc`/`sdd` (just a queue-CAS push) and (b)
+/// `SAMPLE_STATE`'s `LocalKey` may already be destroyed late in TLS
+/// teardown — `try_with` would return `Err` and silently drop the
+/// dying thread's free, defeating the shutdown drain.
 ///
 /// SAFETY: must be allocation-free — see module docs.
 #[inline]
@@ -291,19 +292,21 @@ pub(crate) fn on_dealloc(inner: &MemoryProfilerInner, ptr: *mut u8, _size: usize
     // Non-shutdown branch: take the SAMPLE_STATE borrow as a re-entrancy
     // guard. If a prior `on_alloc`/`on_dealloc` frame on this thread is
     // still on the stack and holds the borrow, skip — otherwise the
-    // re-entrant `liveset.remove` could deadlock against the outer one
-    // on a shared bucket lock, and any allocation triggered inside `scc`
+    // re-entrant `liveset.entry` could deadlock against the outer one on
+    // a shared bucket lock, and any allocation triggered inside `scc`
     // would otherwise be unguarded.
     let _ = SAMPLE_STATE.try_with(|cell| {
         let Ok(_state) = cell.try_borrow_mut() else {
             return;
         };
-        // peek_with returns Some if the address is in the liveset (was
-        // sampled). On hit, remove it and push a RawFree with the
-        // denormalized metadata.
-        let entry = liveset.peek_with(&addr, |_, v| *v);
-        if let Some((size, alloc_ts_ns)) = entry {
-            liveset.remove(&addr);
+        // Use the entry() API for atomic peek + remove. The bucket lock
+        // is held for the duration of the Entry, so a concurrent on_alloc
+        // overwriting the same address cannot interleave between our read
+        // and remove — preventing stale metadata on the emitted RawFree.
+        use scc::hash_index::Entry;
+        if let Entry::Occupied(o) = liveset.entry(addr) {
+            let (size, alloc_ts_ns) = *o.get();
+            o.remove_entry();
             let sample = RawFree {
                 tid: current_tid(),
                 addr,

--- a/dial9-tokio-telemetry/src/memory_profiling/mod.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/mod.rs
@@ -34,9 +34,7 @@ mod ring;
 mod source;
 
 pub use allocator::Dial9Allocator;
-pub use config::{
-    DEFAULT_RING_CAPACITY, DEFAULT_SAMPLE_RATE_BYTES, MemoryProfilingConfig, TimestampMode,
-};
+pub use config::{DEFAULT_RING_CAPACITY, DEFAULT_SAMPLE_RATE_BYTES, MemoryProfilingConfig};
 #[cfg(feature = "analysis")]
 pub use profiler::push_test_alloc;
 pub use profiler::{InstallError, MemoryProfiler, MemoryProfilerGuard, is_installed};

--- a/dial9-tokio-telemetry/src/memory_profiling/mod.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/mod.rs
@@ -28,6 +28,7 @@
 mod allocator;
 mod config;
 mod hook;
+mod opt_out;
 mod profiler;
 mod ring;
 mod source;

--- a/dial9-tokio-telemetry/src/memory_profiling/opt_out.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/opt_out.rs
@@ -1,0 +1,65 @@
+#![deny(clippy::arithmetic_side_effects)]
+//! OPT_OUT TLS sentinel — prevents TLS-teardown panics from `scc`/`sdd`.
+//!
+//! When a thread is being torn down, `sdd`'s TLS slots may already be
+//! destroyed. Accessing the `scc::HashIndex` after that point would panic
+//! inside `sdd::Collector::current()`. This module provides a lightweight
+//! guard that detects shutdown and short-circuits the hook.
+//!
+//! # Mechanism
+//!
+//! Two TLS slots:
+//! - `IS_SHUTTING_DOWN`: a `Cell<bool>` with **no destructor** — reading it
+//!   can never panic, even during teardown.
+//! - `LIFETIME_GUARD`: a `Lifetime` struct whose `Drop` impl flips
+//!   `IS_SHUTTING_DOWN = true`.
+//!
+//! On first hook entry, both slots are initialized. Because `LIFETIME_GUARD`
+//! is initialized *before* `sdd`'s internal TLS (which is lazily initialized
+//! on the first `scc` operation), TLS destructors run in reverse order:
+//! `sdd` drops first, then our `LIFETIME_GUARD`. After our guard drops,
+//! subsequent hook entries see `IS_SHUTTING_DOWN = true` and bail out.
+//!
+//! Cost: ~1 ns (one TLS `Cell::get` + one branch).
+
+use std::cell::Cell;
+
+struct Lifetime;
+
+impl Drop for Lifetime {
+    fn drop(&mut self) {
+        let _ = IS_SHUTTING_DOWN.try_with(|c| c.set(true));
+    }
+}
+
+thread_local! {
+    /// Always-safe flag. `Cell<bool>` has no destructor, so `.try_with()`
+    /// never returns `Err` under normal circumstances.
+    static IS_SHUTTING_DOWN: Cell<bool> = const { Cell::new(false) };
+
+    /// Has `Drop`. Destructor flips `IS_SHUTTING_DOWN = true`.
+    static LIFETIME_GUARD: Lifetime = const { Lifetime };
+}
+
+/// Returns `true` if the current thread is shutting down and `scc` operations
+/// are unsafe. The hook must bail out without touching the liveset.
+///
+/// # Allocation-free guarantee
+///
+/// This function performs only TLS reads — no allocations, no locks.
+#[inline]
+pub(crate) fn check_shutdown() -> bool {
+    let is_shutting_down = IS_SHUTTING_DOWN.try_with(|c| c.get()).unwrap_or(true);
+    if is_shutting_down {
+        return true;
+    }
+
+    // Ensure LIFETIME_GUARD is initialized on this thread. If it can't
+    // be initialized (already in teardown), treat as shutdown.
+    if LIFETIME_GUARD.try_with(|_| ()).is_err() {
+        let _ = IS_SHUTTING_DOWN.try_with(|c| c.set(true));
+        return true;
+    }
+
+    false
+}

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -194,12 +194,8 @@ impl MemoryProfiler {
             .map_err(|_| InstallError::AlreadyInstalled)?;
 
         let shared = handle.shared().expect("checked is_enabled above");
-        let source = MemoryProfileSource::new(
-            rings,
-            self.config.track_liveset(),
-            source_liveset,
-            self.config.sample_rate_bytes(),
-        );
+        let source =
+            MemoryProfileSource::new(rings, source_liveset, self.config.sample_rate_bytes());
         shared.push_source(Box::new(source));
 
         Ok(MemoryProfilerGuard { _private: () })

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -22,6 +22,17 @@ pub(crate) struct MemoryProfilerInner {
     pub(crate) rings: Arc<RingBuffers>,
     pub(crate) sample_rate_bytes: u64,
     pub(crate) track_liveset: bool,
+    /// Producer-side liveset: maps allocation address → (size, timestamp_ns).
+    /// `None` when `track_liveset` is false, avoiding any overhead.
+    ///
+    /// **Known limitation:** the map is currently unbounded. A service that
+    /// leaks sampled allocations indefinitely will grow this map without
+    /// limit. The size is bounded in practice by the live sampled allocation
+    /// count: at the default 512 KiB sample rate and a 10 GiB live heap,
+    /// expect ~20K entries (≈1.3 MiB including scc overhead). Adding a
+    /// `max_liveset_entries` cap is tracked as a follow-up; see
+    /// `docs/design/memory-profiling.md` §7.
+    pub(crate) liveset: Option<Arc<scc::HashIndex<u64, (u64, u64)>>>,
     pub(crate) timestamp_mode: TimestampMode,
     pub(crate) rng_seed: Option<u64>,
 }
@@ -132,12 +143,19 @@ impl MemoryProfiler {
             self.config.ring_capacity() * 8,
         ));
 
+        let liveset = if self.config.track_liveset() {
+            Some(Arc::new(scc::HashIndex::new()))
+        } else {
+            None
+        };
+
         let inner = MemoryProfilerInner {
             unwinder,
             handle: handle.clone(),
             rings: Arc::clone(&rings),
             sample_rate_bytes: self.config.sample_rate_bytes(),
             track_liveset: self.config.track_liveset(),
+            liveset,
             timestamp_mode: self.config.timestamp_mode(),
             rng_seed: self.config.rng_seed(),
         };

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -10,6 +10,13 @@ use crate::telemetry::recorder::TelemetryHandle;
 use dial9_perf_self_profile::unwinder::Unwinder;
 use std::sync::{Arc, OnceLock};
 
+/// Producer-side liveset: maps allocation address → `(size, timestamp_ns)`.
+///
+/// See [`MemoryProfilerInner::liveset`] for the rationale on `Arc<...>` and
+/// `FxBuildHasher`.
+pub(crate) type Liveset =
+    scc::HashIndex<u64, (u64, u64), dial9_trace_format::encoder::FxBuildHasher>;
+
 /// Process-global state for the active memory profiler.
 ///
 /// Published via `OnceLock` exactly once per process. Never reclaimed
@@ -25,6 +32,21 @@ pub(crate) struct MemoryProfilerInner {
     /// Producer-side liveset: maps allocation address → (size, timestamp_ns).
     /// `None` when `track_liveset` is false, avoiding any overhead.
     ///
+    /// **Why `Arc<HashIndex>`?** `scc::HashIndex` *is* `Clone`, but the impl
+    /// is a *deep clone*: it iterates every entry and reinserts into a brand
+    /// new index with independent state (see `scc-2.x` `impl Clone for
+    /// HashIndex`). To share one map across all producer threads we need
+    /// reference-counted shared ownership, hence the `Arc`. This is unlike
+    /// e.g. `dashmap::DashMap` whose `Clone` is a shallow `Arc::clone`.
+    ///
+    /// **Why `FxBuildHasher`?** `scc` calls the `BuildHasher` per operation
+    /// (no internal hash caching — see `scc::hash_table::HashTable::hash`).
+    /// For a `u64` pointer key the default `RandomState`/SipHash-1-3 is
+    /// ~10–25 ns; `FxHash`'s multiply-shift is ~1–2 ns, and that cost
+    /// applies to **every** dealloc when liveset is on (`peek_with` always
+    /// hashes regardless of hit/miss). Pointer alignment-bit skew is not a
+    /// concern at scc's bucket granularity for the hit rates we see here.
+    ///
     /// **Known limitation:** the map is currently unbounded. A service that
     /// leaks sampled allocations indefinitely will grow this map without
     /// limit. The size is bounded in practice by the live sampled allocation
@@ -32,7 +54,7 @@ pub(crate) struct MemoryProfilerInner {
     /// expect ~20K entries (≈1.3 MiB including scc overhead). Adding a
     /// `max_liveset_entries` cap is tracked as a follow-up; see
     /// `docs/design/memory-profiling.md` §7.
-    pub(crate) liveset: Option<Arc<scc::HashIndex<u64, (u64, u64)>>>,
+    pub(crate) liveset: Option<Arc<Liveset>>,
     pub(crate) timestamp_mode: TimestampMode,
     pub(crate) rng_seed: Option<u64>,
 }
@@ -144,10 +166,17 @@ impl MemoryProfiler {
         ));
 
         let liveset = if self.config.track_liveset() {
-            Some(Arc::new(scc::HashIndex::new()))
+            Some(Arc::new(scc::HashIndex::with_capacity_and_hasher(
+                0,
+                dial9_trace_format::encoder::FxBuildHasher::default(),
+            )))
         } else {
             None
         };
+        // Clone the Arc for the consolidator (`MemoryProfileSource`) so it
+        // can service shutdown-flagged frees by doing the liveset peek/remove
+        // on its own healthy thread. See `source.rs::handle_free`.
+        let source_liveset = liveset.as_ref().map(Arc::clone);
 
         let inner = MemoryProfilerInner {
             unwinder,
@@ -168,6 +197,7 @@ impl MemoryProfiler {
         let source = MemoryProfileSource::new(
             rings,
             self.config.track_liveset(),
+            source_liveset,
             self.config.sample_rate_bytes(),
         );
         shared.push_source(Box::new(source));

--- a/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/profiler.rs
@@ -1,6 +1,6 @@
 //! `MemoryProfiler::install()` — the install-once entry point.
 
-use crate::memory_profiling::config::{MemoryProfilingConfig, TimestampMode};
+use crate::memory_profiling::config::MemoryProfilingConfig;
 use crate::memory_profiling::ring::RingBuffers;
 #[cfg(feature = "analysis")]
 use crate::memory_profiling::ring::{DEFAULT_MAX_FRAMES, RawAlloc};
@@ -21,16 +21,22 @@ pub(crate) type Liveset =
 ///
 /// Published via `OnceLock` exactly once per process. Never reclaimed
 /// because any thread's allocator hook may be reading this.
-#[allow(dead_code)]
 pub(crate) struct MemoryProfilerInner {
     pub(crate) unwinder: Unwinder,
-    /// Prevents `SharedState` from being dropped while the profiler is active.
+    /// Held to prevent `SharedState` from being dropped while the
+    /// profiler is active. Never read after construction; the value
+    /// matters, not its accesses.
+    #[expect(
+        dead_code,
+        reason = "lifetime hold for SharedState; the field's existence is the contract"
+    )]
     pub(crate) handle: TelemetryHandle,
     pub(crate) rings: Arc<RingBuffers>,
     pub(crate) sample_rate_bytes: u64,
-    pub(crate) track_liveset: bool,
     /// Producer-side liveset: maps allocation address → (size, timestamp_ns).
-    /// `None` when `track_liveset` is false, avoiding any overhead.
+    /// `None` when liveset tracking is disabled, avoiding any overhead.
+    /// Whether liveset tracking is on is determined by `liveset.is_some()`
+    /// — there is no separate boolean flag.
     ///
     /// **Why `Arc<HashIndex>`?** `scc::HashIndex` *is* `Clone`, but the impl
     /// is a *deep clone*: it iterates every entry and reinserts into a brand
@@ -55,7 +61,6 @@ pub(crate) struct MemoryProfilerInner {
     /// `max_liveset_entries` cap is tracked as a follow-up; see
     /// `docs/design/memory-profiling.md` §7.
     pub(crate) liveset: Option<Arc<Liveset>>,
-    pub(crate) timestamp_mode: TimestampMode,
     pub(crate) rng_seed: Option<u64>,
 }
 
@@ -183,9 +188,7 @@ impl MemoryProfiler {
             handle: handle.clone(),
             rings: Arc::clone(&rings),
             sample_rate_bytes: self.config.sample_rate_bytes(),
-            track_liveset: self.config.track_liveset(),
             liveset,
-            timestamp_mode: self.config.timestamp_mode(),
             rng_seed: self.config.rng_seed(),
         };
 

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -49,11 +49,19 @@ impl RawAlloc {
 }
 
 /// One free captured on the producer thread when liveset tracking is on.
+///
+/// With the producer-side liveset, `size` and `alloc_ts_ns` are denormalized
+/// from the liveset entry so the consolidator can emit `FreeEvent` directly
+/// without a second lookup.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RawFree {
     pub(crate) tid: u32,
     pub(crate) addr: u64,
     pub(crate) ts_ns: u64,
+    /// Size of the original sampled allocation (denormalized from liveset).
+    pub(crate) size: u64,
+    /// Timestamp of the original sampled allocation (denormalized from liveset).
+    pub(crate) alloc_ts_ns: u64,
 }
 
 /// Process-global pair of lock-free queues for the memory profiler.

--- a/dial9-tokio-telemetry/src/memory_profiling/ring.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/ring.rs
@@ -53,15 +53,32 @@ impl RawAlloc {
 /// With the producer-side liveset, `size` and `alloc_ts_ns` are denormalized
 /// from the liveset entry so the consolidator can emit `FreeEvent` directly
 /// without a second lookup.
+///
+/// **Shutdown drain.** When `on_dealloc` fires on a thread that is in TLS
+/// teardown, the OPT_OUT sentinel forbids the producer from touching the
+/// `scc::HashIndex` (`sdd`'s TLS may be destroyed). In that case the
+/// producer pushes a `RawFree { shutdown: true, .. }` carrying only `addr`
+/// (size and alloc_ts_ns are zero — placeholders). The consolidator does
+/// the liveset peek/remove on its own healthy thread; see
+/// `MemoryProfileSource::handle_free`. This recovers the dying thread's
+/// `FreeEvent`s and bounds liveset growth, at the cost of a small
+/// race window when an address is reused before the consolidator drains.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RawFree {
     pub(crate) tid: u32,
     pub(crate) addr: u64,
     pub(crate) ts_ns: u64,
     /// Size of the original sampled allocation (denormalized from liveset).
+    /// `0` when `shutdown == true` (the producer couldn't peek the liveset
+    /// safely; the consolidator fills this in from the lookup it does).
     pub(crate) size: u64,
-    /// Timestamp of the original sampled allocation (denormalized from liveset).
+    /// Timestamp of the original sampled allocation (denormalized from
+    /// liveset). `0` when `shutdown == true`, same reason as `size`.
     pub(crate) alloc_ts_ns: u64,
+    /// `true` if pushed from a thread in TLS teardown; the consolidator
+    /// must do the liveset peek/remove because the producer couldn't.
+    /// See struct-level docs for the protocol.
+    pub(crate) shutdown: bool,
 }
 
 /// Process-global pair of lock-free queues for the memory profiler.

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -140,10 +140,9 @@ impl Source for MemoryProfileSource {
     fn flush(&mut self, ctx: &FlushContext<'_>) {
         // Merge-sort drain by timestamp. This produces a best-effort
         // timestamp-ordered stream. Ordering is not guaranteed to be perfect:
-        // - Multiple producers push concurrently, so queue order may not
-        //   match timestamp order.
-        // - TimestampMode::ReusePollStart can produce stale timestamps.
-        // For profiling purposes, approximate ordering is sufficient.
+        // multiple producers push concurrently, so queue order may not match
+        // timestamp order. For profiling purposes, approximate ordering is
+        // sufficient.
         //
         // Hold one peeked element from each queue and emit the older one.
         // `crossbeam_queue::ArrayQueue` has no peek API, so we pop into

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -104,15 +104,16 @@ impl MemoryProfileSource {
         // - **Shutdown-flagged frees** were pushed by a thread in TLS
         //   teardown that couldn't safely touch `scc`. Do the peek/remove
         //   here, with a race check: if the entry's `alloc_ts_ns` is
-        //   greater than `f.ts_ns`, an address-reuse race means the entry
-        //   now belongs to a *later* allocation. Leave it; the new alloc's
-        //   eventual non-shutdown free will emit the correct event.
+        //   greater than or equal to `f.ts_ns`, an address-reuse race (or
+        //   timestamp tie on nearby cores) means the entry now belongs to a
+        //   *later* allocation. Leave it; the new alloc's eventual
+        //   non-shutdown free will emit the correct event.
         let (size, alloc_ts_ns) = if f.shutdown {
             let Some((size, alloc_ts_ns)) = liveset.peek_with(&f.addr, |_, v| *v) else {
                 return; // already cleaned, or never sampled
             };
-            if alloc_ts_ns > f.ts_ns {
-                return; // address-reuse race — see comment above
+            if alloc_ts_ns >= f.ts_ns {
+                return; // address-reuse race or timestamp tie — see comment above
             }
             liveset.remove(&f.addr);
             (size, alloc_ts_ns)
@@ -776,5 +777,49 @@ mod tests {
             .filter(|e| matches!(e, Dial9Event::FreeEvent(..)))
             .collect();
         assert_eq!(frees.len(), 0);
+    }
+
+    /// Timestamp tie: the shutdown-flagged free has the SAME timestamp as the
+    /// liveset entry's `alloc_ts_ns`. This can happen when `clock_monotonic_ns()`
+    /// returns the same value on nearby cores. The consolidator must treat ties
+    /// conservatively: skip the drain rather than risk removing a live entry that
+    /// belongs to a concurrent new allocation with the same timestamp.
+    #[test]
+    fn shutdown_drain_skips_on_timestamp_tie() {
+        let rings = rings(16, 16);
+        let liveset = fresh_liveset();
+        // Liveset entry has alloc_ts_ns = 100.
+        liveset.insert(0xBBCC, (2048, 100)).expect("liveset insert");
+
+        // Shutdown free also has ts_ns = 100 (tie).
+        rings
+            .free_queue
+            .push(make_shutdown_free(0xBBCC, 100, 3))
+            .ok();
+
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            Some(Arc::clone(&liveset)),
+            512 * 1024,
+        )));
+
+        let events = flush_and_collect(&shared);
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Dial9Event::FreeEvent(..)))
+            .collect();
+        assert_eq!(
+            frees.len(),
+            0,
+            "timestamp tie must be treated as a race — no FreeEvent emitted"
+        );
+
+        // Entry must remain intact.
+        assert_eq!(
+            liveset.peek_with(&0xBBCC, |_, v| *v),
+            Some((2048, 100)),
+            "liveset entry must survive when timestamps tie"
+        );
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -7,30 +7,17 @@ use crate::telemetry::buffer::with_encoder;
 use crate::telemetry::events::clock_monotonic_ns;
 use crate::telemetry::format::{AllocEvent, FreeEvent, MemoryProfileOverflowEvent};
 use crate::telemetry::recorder::source::{FlushContext, Source};
-use std::collections::HashMap;
 use std::sync::atomic::Ordering;
-
-/// Liveset entry tracking a live sampled allocation, kept by the consolidator
-/// (flush thread). Only `size` and `timestamp_ns` are needed: both are
-/// denormalized onto `FreeEvent` so leak analysis stays useful when the
-/// matching `AllocEvent` has been evicted by trace rotation. Storing the stack
-/// here would bloat the liveset (see design §8).
-#[derive(Debug, Clone, Copy)]
-struct LivesetEntry {
-    size: u64,
-    timestamp_ns: u64,
-}
 
 /// Drains the alloc and free queues into the trace each flush cycle.
 ///
-/// The drain is timestamp-ordered: at each step we look at the head of each
-/// queue and process the older one first. This matters for liveset
-/// correctness when the producer reuses an address within a single flush
-/// cycle (alloc → free → alloc-with-same-addr); naive "drain all allocs,
-/// then all frees" would race and corrupt the liveset.
+/// With the producer-side liveset, every `RawFree` that arrives in the queue
+/// is guaranteed to correspond to a previously-sampled allocation. The
+/// consolidator emits `FreeEvent` directly using the denormalized `size` and
+/// `alloc_ts_ns` fields on `RawFree` — no lookup required.
 pub(crate) struct MemoryProfileSource {
     rings: Arc<RingBuffers>,
-    liveset: Option<HashMap<u64, LivesetEntry>>,
+    track_liveset: bool,
     /// Previous snapshot of `RingBuffers::dropped_allocs` for delta computation.
     prev_dropped_allocs: u64,
     /// Previous snapshot of `RingBuffers::dropped_frees` for delta computation.
@@ -45,9 +32,8 @@ pub(crate) struct MemoryProfileSource {
 impl MemoryProfileSource {
     /// Create a new source that drains the supplied ring buffers.
     ///
-    /// `track_liveset = true` enables `FreeEvent` emission (matched against
-    /// previously-sampled allocations); `false` means frees are silently
-    /// dropped on the consumer side.
+    /// `track_liveset = true` enables `FreeEvent` emission; `false` means
+    /// frees are filtered on the producer side and never reach the queue.
     pub(crate) fn new(
         rings: Arc<RingBuffers>,
         track_liveset: bool,
@@ -55,7 +41,7 @@ impl MemoryProfileSource {
     ) -> Self {
         Self {
             rings,
-            liveset: track_liveset.then(HashMap::new),
+            track_liveset,
             prev_dropped_allocs: 0,
             prev_dropped_frees: 0,
             metadata: vec![(
@@ -89,32 +75,22 @@ impl MemoryProfileSource {
             ctx.collector,
             ctx.drain_epoch,
         );
-        if let Some(liveset) = self.liveset.as_mut() {
-            liveset.insert(
-                addr,
-                LivesetEntry {
-                    size,
-                    timestamp_ns: ts_ns,
-                },
-            );
-        }
     }
 
     fn handle_free(&mut self, f: RawFree, ctx: &FlushContext<'_>) {
-        let Some(liveset) = self.liveset.as_mut() else {
+        if !self.track_liveset {
             return;
-        };
-        let Some(entry) = liveset.remove(&f.addr) else {
-            return;
-        };
+        }
+        // With the producer-side liveset, every RawFree is pre-filtered:
+        // it only arrives if the address was in the liveset. Emit directly.
         with_encoder(
             |enc| {
                 enc.encode(&FreeEvent {
                     timestamp_ns: f.ts_ns,
                     tid: f.tid,
                     addr: f.addr,
-                    size: entry.size,
-                    alloc_timestamp_ns: entry.timestamp_ns,
+                    size: f.size,
+                    alloc_timestamp_ns: f.alloc_ts_ns,
                 });
             },
             ctx.collector,
@@ -232,11 +208,13 @@ mod tests {
         }
     }
 
-    fn make_raw_free(addr: u64, ts_ns: u64) -> RawFree {
+    fn make_raw_free(addr: u64, ts_ns: u64, size: u64, alloc_ts_ns: u64) -> RawFree {
         RawFree {
             tid: 2,
             addr,
             ts_ns,
+            size,
+            alloc_ts_ns,
         }
     }
 
@@ -302,7 +280,11 @@ mod tests {
             .alloc_queue
             .push(make_raw_alloc(0x2000, 512, 200))
             .ok();
-        rings.free_queue.push(make_raw_free(0x2000, 300)).ok();
+        // Producer-side liveset denormalizes size and alloc_ts onto RawFree.
+        rings
+            .free_queue
+            .push(make_raw_free(0x2000, 300, 512, 200))
+            .ok();
 
         let shared = new_shared();
         shared.push_source(Box::new(MemoryProfileSource::new(
@@ -334,10 +316,17 @@ mod tests {
         }
     }
 
+    /// With the producer-side liveset, a RawFree only reaches the queue if the
+    /// address was in the liveset. The consolidator emits every RawFree it sees.
+    /// This test verifies that behavior: a RawFree in the queue produces a FreeEvent.
     #[test]
-    fn free_without_alloc_is_silently_dropped() {
+    fn free_in_queue_is_always_emitted() {
         let rings = rings(16, 16);
-        rings.free_queue.push(make_raw_free(0x9999, 400)).ok();
+        // Simulate a RawFree that passed producer-side filtering.
+        rings
+            .free_queue
+            .push(make_raw_free(0x9999, 400, 128, 100))
+            .ok();
 
         let shared = new_shared();
         shared.push_source(Box::new(MemoryProfileSource::new(
@@ -351,7 +340,20 @@ mod tests {
             .iter()
             .filter(|e| matches!(e, Dial9Event::FreeEvent(..)))
             .collect();
-        assert_eq!(frees.len(), 0);
+        assert_eq!(frees.len(), 1);
+        match &frees[0] {
+            TelemetryEvent::Free {
+                addr,
+                size,
+                alloc_timestamp_nanos,
+                ..
+            } => {
+                assert_eq!(*addr, 0x9999);
+                assert_eq!(*size, 128);
+                assert_eq!(*alloc_timestamp_nanos, 100);
+            }
+            _ => unreachable!(),
+        }
     }
 
     #[test]
@@ -361,7 +363,10 @@ mod tests {
             .alloc_queue
             .push(make_raw_alloc(0x3000, 128, 500))
             .ok();
-        rings.free_queue.push(make_raw_free(0x3000, 600)).ok();
+        rings
+            .free_queue
+            .push(make_raw_free(0x3000, 600, 128, 500))
+            .ok();
 
         let shared = new_shared();
         shared.push_source(Box::new(MemoryProfileSource::new(
@@ -415,8 +420,11 @@ mod tests {
             0
         );
 
-        // Second flush: the free arrives
-        rings.free_queue.push(make_raw_free(0x4000, 800)).ok();
+        // Second flush: the free arrives (denormalized from producer-side liveset)
+        rings
+            .free_queue
+            .push(make_raw_free(0x4000, 800, 256, 700))
+            .ok();
         let events = flush_and_collect(&shared);
         assert_eq!(
             events
@@ -439,29 +447,23 @@ mod tests {
         }
     }
 
-    /// Regression test for the address-reuse race during a single flush cycle.
-    ///
-    /// Sequence at the producer (timestamps strictly increasing):
-    ///   t=100  alloc 0x5000 (size 256)   → alloc_queue
-    ///   t=200  free  0x5000              → free_queue
-    ///   t=300  alloc 0x5000 (size 512)   → alloc_queue
-    ///
-    /// Naïve "drain all allocs, then all frees" emits:
-    ///   alloc(t=100, size=256), alloc(t=300, size=512), free(t=200)
-    /// and the free incorrectly evicts the *second* alloc (size=512, t=300)
-    /// from the liveset — the second allocation looks freed even though it's
-    /// still live.
-    ///
-    /// Timestamp-ordered drain emits alloc, free, alloc and the second
-    /// allocation correctly remains in the liveset.
+    /// With the producer-side liveset, address reuse is handled atomically
+    /// by the scc::HashIndex (insert/remove are serialized per-key). The
+    /// consolidator simply emits every RawFree it receives. This test verifies
+    /// that two allocs and one free at the same address produce the expected
+    /// events when processed by the source.
     #[test]
-    fn address_reuse_within_flush_cycle_preserves_liveset() {
+    fn address_reuse_within_flush_cycle_emits_correct_events() {
         let rings = rings(16, 16);
         rings
             .alloc_queue
             .push(make_raw_alloc(0x5000, 256, 100))
             .ok();
-        rings.free_queue.push(make_raw_free(0x5000, 200)).ok();
+        // Free carries denormalized data from the first alloc.
+        rings
+            .free_queue
+            .push(make_raw_free(0x5000, 200, 256, 100))
+            .ok();
         rings
             .alloc_queue
             .push(make_raw_alloc(0x5000, 512, 300))
@@ -490,8 +492,7 @@ mod tests {
             "the matching free should be emitted exactly once"
         );
 
-        // The single free must match the *first* allocation (size=256, t=100).
-        // If drain order is wrong, the free would match alloc2 (size=512).
+        // The free carries denormalized data from the first alloc.
         match frees[0] {
             Dial9Event::FreeEvent(e) => {
                 assert_eq!(e.addr, 0x5000);
@@ -504,10 +505,11 @@ mod tests {
             _ => unreachable!(),
         }
 
-        // The second allocation must remain live in the liveset.
-        // Prove it by freeing the address in a second flush cycle and checking
-        // the emitted FreeEvent carries the second alloc's size and timestamp.
-        rings.free_queue.push(make_raw_free(0x5000, 400)).ok();
+        // Verify a second free for the second alloc also works.
+        rings
+            .free_queue
+            .push(make_raw_free(0x5000, 400, 512, 300))
+            .ok();
         let events2 = flush_and_collect(&shared);
         let frees2: Vec<_> = events2
             .iter()
@@ -529,7 +531,9 @@ mod tests {
     /// Demonstrates that `poll_start_ts_monotonic` produces strictly ordered
     /// timestamps even for events that would otherwise share a clock tick —
     /// the scenario that occurs during a realloc (free old + alloc new at
-    /// same address).
+    /// same address). The producer-side liveset resolves address reuse
+    /// atomically, but timestamp ordering is still useful for event ordering
+    /// in the trace viewer.
     #[test]
     fn monotonic_ts_solves_realloc_ordering() {
         use crate::telemetry::recorder::poll_start_ts_monotonic;
@@ -544,7 +548,11 @@ mod tests {
 
         let rings = rings(16, 16);
         rings.alloc_queue.push(make_raw_alloc(0x6000, 256, t1)).ok();
-        rings.free_queue.push(make_raw_free(0x6000, t2)).ok();
+        // Free carries denormalized data from first alloc.
+        rings
+            .free_queue
+            .push(make_raw_free(0x6000, t2, 256, t1))
+            .ok();
         rings.alloc_queue.push(make_raw_alloc(0x6000, 512, t3)).ok();
 
         let shared = new_shared();
@@ -568,9 +576,12 @@ mod tests {
             _ => unreachable!(),
         }
 
-        // Second alloc remains live.
-        // Prove it by freeing the address in a second flush cycle.
-        rings.free_queue.push(make_raw_free(0x6000, t3 + 1)).ok();
+        // Second alloc still exists — push a free for it.
+        let t4 = poll_start_ts_monotonic();
+        rings
+            .free_queue
+            .push(make_raw_free(0x6000, t4, 512, t3))
+            .ok();
         let events2 = flush_and_collect(&shared);
         let frees2: Vec<_> = events2
             .iter()

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 //! `Source` impl that drains the alloc and free queues each flush cycle.
 
+use crate::memory_profiling::profiler::Liveset;
 use crate::memory_profiling::ring::{RawAlloc, RawFree, RingBuffers};
 use crate::primitives::sync::Arc;
 use crate::telemetry::buffer::with_encoder;
@@ -11,13 +12,25 @@ use std::sync::atomic::Ordering;
 
 /// Drains the alloc and free queues into the trace each flush cycle.
 ///
-/// With the producer-side liveset, every `RawFree` that arrives in the queue
-/// is guaranteed to correspond to a previously-sampled allocation. The
-/// consolidator emits `FreeEvent` directly using the denormalized `size` and
-/// `alloc_ts_ns` fields on `RawFree` — no lookup required.
+/// With the producer-side liveset, every non-shutdown `RawFree` that arrives
+/// in the queue is guaranteed to correspond to a previously-sampled
+/// allocation: the producer already did the peek/remove and denormalized
+/// `size` and `alloc_ts_ns` onto the record. The consolidator emits
+/// `FreeEvent` directly with no lookup.
+///
+/// **Shutdown-flagged frees** (`RawFree::shutdown == true`) are different:
+/// the producer was in TLS teardown and couldn't safely peek the liveset,
+/// so it pushed an addr-only record. The consolidator does the peek/remove
+/// here against the shared `liveset` Arc. See `handle_free` for the race
+/// check that prevents emitting wrong events when an address is reused
+/// before the consolidator drains.
 pub(crate) struct MemoryProfileSource {
     rings: Arc<RingBuffers>,
     track_liveset: bool,
+    /// The producer-side liveset, shared with the allocator hook. `None`
+    /// when liveset tracking is off. Held here so the consolidator can
+    /// handle shutdown-flagged `RawFree`s — see `handle_free`.
+    liveset: Option<Arc<Liveset>>,
     /// Previous snapshot of `RingBuffers::dropped_allocs` for delta computation.
     prev_dropped_allocs: u64,
     /// Previous snapshot of `RingBuffers::dropped_frees` for delta computation.
@@ -34,14 +47,23 @@ impl MemoryProfileSource {
     ///
     /// `track_liveset = true` enables `FreeEvent` emission; `false` means
     /// frees are filtered on the producer side and never reach the queue.
+    /// `liveset` must be `Some` whenever `track_liveset` is `true` so the
+    /// consolidator can service shutdown-flagged frees.
     pub(crate) fn new(
         rings: Arc<RingBuffers>,
         track_liveset: bool,
+        liveset: Option<Arc<Liveset>>,
         sample_rate_bytes: u64,
     ) -> Self {
+        debug_assert_eq!(
+            track_liveset,
+            liveset.is_some(),
+            "track_liveset and liveset.is_some() must agree"
+        );
         Self {
             rings,
             track_liveset,
+            liveset,
             prev_dropped_allocs: 0,
             prev_dropped_frees: 0,
             metadata: vec![(
@@ -81,8 +103,56 @@ impl MemoryProfileSource {
         if !self.track_liveset {
             return;
         }
-        // With the producer-side liveset, every RawFree is pre-filtered:
-        // it only arrives if the address was in the liveset. Emit directly.
+        if f.shutdown {
+            // Shutdown drain: the producer couldn't peek the liveset (sdd's
+            // TLS was already destroyed). Do the peek/remove here on the
+            // consolidator's healthy thread.
+            //
+            // **Race check.** Between the producer push (at `f.ts_ns`) and
+            // now, an address can be reused: a live thread may have freed
+            // some other sampled alloc, then `on_alloc` may have re-keyed
+            // the entry to a brand-new allocation. If the entry's
+            // `alloc_ts_ns` is greater than `f.ts_ns`, that's exactly what
+            // happened — the entry now belongs to a *later* allocation and
+            // we must not remove it (and especially must not emit a
+            // `FreeEvent` carrying its data, since the corresponding alloc
+            // is still live).
+            //
+            // This relies on `TimestampMode::ReusePollStart` /
+            // `TimestampMode::Precise` producing strictly-monotonic
+            // timestamps. `TimestampMode::None` is rejected at config build
+            // time when `track_liveset` is on (every event would be 0,
+            // breaking this invariant), so we only reach this code path in
+            // a mode where the comparison is meaningful.
+            let Some(liveset) = &self.liveset else {
+                return;
+            };
+            let Some((size, alloc_ts_ns)) = liveset.peek_with(&f.addr, |_, v| *v) else {
+                return; // already removed (e.g. by a normal dealloc) or never sampled
+            };
+            if alloc_ts_ns > f.ts_ns {
+                // Race: entry belongs to a newer alloc that landed after
+                // our shutdown push. Leave it; its eventual free will emit
+                // the correct event.
+                return;
+            }
+            liveset.remove(&f.addr);
+            with_encoder(
+                |enc| {
+                    enc.encode(&FreeEvent {
+                        timestamp_ns: f.ts_ns,
+                        tid: f.tid,
+                        addr: f.addr,
+                        size,
+                        alloc_timestamp_ns: alloc_ts_ns,
+                    });
+                },
+                ctx.collector,
+                ctx.drain_epoch,
+            );
+            return;
+        }
+        // Normal path: producer-filtered free with denormalized data.
         with_encoder(
             |enc| {
                 enc.encode(&FreeEvent {
@@ -215,11 +285,51 @@ mod tests {
             ts_ns,
             size,
             alloc_ts_ns,
+            shutdown: false,
+        }
+    }
+
+    /// Build a shutdown-flagged `RawFree`. The producer pushes these during
+    /// TLS teardown when it can't safely peek the liveset; the consolidator
+    /// fills in size / alloc_ts_ns from its own peek.
+    fn make_shutdown_free(addr: u64, ts_ns: u64, tid: u32) -> RawFree {
+        RawFree {
+            tid,
+            addr,
+            ts_ns,
+            size: 0,
+            alloc_ts_ns: 0,
+            shutdown: true,
         }
     }
 
     fn rings(alloc_cap: usize, free_cap: usize) -> Arc<RingBuffers> {
         Arc::new(RingBuffers::new(alloc_cap, free_cap))
+    }
+
+    /// Build a fresh empty liveset with the same hasher we use in production.
+    fn fresh_liveset() -> Arc<Liveset> {
+        Arc::new(scc::HashIndex::with_capacity_and_hasher(
+            0,
+            dial9_trace_format::encoder::FxBuildHasher::default(),
+        ))
+    }
+
+    /// Convenience: build a `MemoryProfileSource` for tests where we don't
+    /// need to retain a separate handle on the liveset. Mirrors the
+    /// production `MemoryProfileSource::new` invariant
+    /// (`track_liveset == liveset.is_some()`).
+    fn make_source(
+        rings: Arc<RingBuffers>,
+        track_liveset: bool,
+        sample_rate_bytes: u64,
+    ) -> MemoryProfileSource {
+        let liveset = if track_liveset {
+            Some(fresh_liveset())
+        } else {
+            None
+        };
+        MemoryProfileSource::new(rings, track_liveset, liveset, sample_rate_bytes)
     }
 
     fn new_shared() -> SharedState {
@@ -249,11 +359,7 @@ mod tests {
             .ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(
-            Arc::clone(&rings),
-            false,
-            512 * 1024,
-        )));
+        shared.push_source(Box::new(make_source(Arc::clone(&rings), false, 512 * 1024)));
 
         let events = flush_and_collect(&shared);
         let allocs: Vec<_> = events
@@ -287,11 +393,7 @@ mod tests {
             .ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(
-            Arc::clone(&rings),
-            true,
-            512 * 1024,
-        )));
+        shared.push_source(Box::new(make_source(Arc::clone(&rings), true, 512 * 1024)));
 
         let events = flush_and_collect(&shared);
         let allocs: Vec<_> = events
@@ -329,11 +431,7 @@ mod tests {
             .ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(
-            Arc::clone(&rings),
-            true,
-            512 * 1024,
-        )));
+        shared.push_source(Box::new(make_source(Arc::clone(&rings), true, 512 * 1024)));
 
         let events = flush_and_collect(&shared);
         let frees: Vec<_> = events
@@ -369,11 +467,7 @@ mod tests {
             .ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(
-            Arc::clone(&rings),
-            false,
-            512 * 1024,
-        )));
+        shared.push_source(Box::new(make_source(Arc::clone(&rings), false, 512 * 1024)));
 
         let events = flush_and_collect(&shared);
         let allocs: Vec<_> = events
@@ -393,11 +487,7 @@ mod tests {
         let rings = rings(16, 16);
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(
-            Arc::clone(&rings),
-            true,
-            512 * 1024,
-        )));
+        shared.push_source(Box::new(make_source(Arc::clone(&rings), true, 512 * 1024)));
 
         // First flush: only the alloc
         rings
@@ -470,11 +560,7 @@ mod tests {
             .ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(
-            Arc::clone(&rings),
-            true,
-            512 * 1024,
-        )));
+        shared.push_source(Box::new(make_source(Arc::clone(&rings), true, 512 * 1024)));
 
         let events = flush_and_collect(&shared);
         let allocs: Vec<&Dial9Event> = events
@@ -556,11 +642,7 @@ mod tests {
         rings.alloc_queue.push(make_raw_alloc(0x6000, 512, t3)).ok();
 
         let shared = new_shared();
-        shared.push_source(Box::new(MemoryProfileSource::new(
-            Arc::clone(&rings),
-            true,
-            512 * 1024,
-        )));
+        shared.push_source(Box::new(make_source(Arc::clone(&rings), true, 512 * 1024)));
         let events = flush_and_collect(&shared);
 
         let frees: Vec<_> = events
@@ -601,7 +683,7 @@ mod tests {
     fn segment_metadata_contains_sample_rate_bytes() {
         use crate::telemetry::recorder::source::Source;
         let rings = rings(16, 16);
-        let source = MemoryProfileSource::new(Arc::clone(&rings), false, 1024 * 1024);
+        let source = make_source(Arc::clone(&rings), false, 1024 * 1024);
         let meta = source.segment_metadata();
         assert_eq!(
             meta,
@@ -610,5 +692,137 @@ mod tests {
                 "1048576".to_string()
             )]
         );
+    }
+
+    /// Happy-path shutdown drain: the producer pushed an addr-only flagged
+    /// `RawFree` because it was in TLS teardown. The liveset still has the
+    /// original entry; the consolidator peeks it, emits a correct
+    /// `FreeEvent`, and removes the entry.
+    #[test]
+    fn shutdown_drain_emits_free_event_and_cleans_liveset() {
+        let rings = rings(16, 16);
+        let liveset = fresh_liveset();
+        // Producer-side state: the dying thread sampled this allocation
+        // earlier with timestamp 100 and size 4096.
+        liveset.insert(0xAABB, (4096, 100)).expect("liveset insert");
+
+        // Producer pushed a shutdown-flagged free at ts=200.
+        rings
+            .free_queue
+            .push(make_shutdown_free(0xAABB, 200, 7))
+            .ok();
+
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            true,
+            Some(Arc::clone(&liveset)),
+            512 * 1024,
+        )));
+
+        let events = flush_and_collect(&shared);
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(frees.len(), 1, "shutdown drain must emit one FreeEvent");
+        match frees[0] {
+            TelemetryEvent::Free {
+                timestamp_nanos,
+                tid,
+                addr,
+                size,
+                alloc_timestamp_nanos,
+            } => {
+                assert_eq!(*timestamp_nanos, 200, "uses producer-push ts");
+                assert_eq!(*tid, 7, "uses producer-push tid");
+                assert_eq!(*addr, 0xAABB);
+                assert_eq!(*size, 4096, "from consolidator-side liveset peek");
+                assert_eq!(*alloc_timestamp_nanos, 100, "from liveset peek");
+            }
+            _ => unreachable!(),
+        }
+
+        assert!(
+            liveset.peek_with(&0xAABB, |_, _| ()).is_none(),
+            "consolidator must have removed the entry"
+        );
+    }
+
+    /// Race detection: between the producer's shutdown push (ts=100) and
+    /// the consolidator drain, the address was reused for a NEW sampled
+    /// allocation (ts=300, after the shutdown push). The consolidator must
+    /// detect this via `alloc_ts_ns > free.ts_ns` and *not* remove the
+    /// entry — otherwise it would emit a wrong `FreeEvent` and lose the
+    /// new alloc's eventual free.
+    #[test]
+    fn shutdown_drain_detects_address_reuse_race() {
+        let rings = rings(16, 16);
+        let liveset = fresh_liveset();
+        // Liveset contains the NEW allocation's data — the dying thread's
+        // entry was already overwritten by `on_alloc` (via the
+        // remove-then-reinsert path) before the consolidator ran.
+        liveset.insert(0xAABB, (8192, 300)).expect("liveset insert");
+
+        // Producer's shutdown push has ts=100 (older than the new alloc).
+        rings
+            .free_queue
+            .push(make_shutdown_free(0xAABB, 100, 9))
+            .ok();
+
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            true,
+            Some(Arc::clone(&liveset)),
+            512 * 1024,
+        )));
+
+        let events = flush_and_collect(&shared);
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(
+            frees.len(),
+            0,
+            "race must be detected and no FreeEvent emitted"
+        );
+
+        // The new alloc's entry must remain so its eventual free still
+        // emits a correct FreeEvent.
+        assert_eq!(
+            liveset.peek_with(&0xAABB, |_, v| *v),
+            Some((8192, 300)),
+            "new alloc's entry must survive the race-aware drain"
+        );
+    }
+
+    /// If a shutdown-flagged free arrives for an address that's not in the
+    /// liveset (already cleaned by a prior dealloc, or never sampled), the
+    /// consolidator must silently drop it — no `FreeEvent`, no panic.
+    #[test]
+    fn shutdown_drain_ignores_misses() {
+        let rings = rings(16, 16);
+        let liveset = fresh_liveset();
+        rings
+            .free_queue
+            .push(make_shutdown_free(0xDEAD, 100, 1))
+            .ok();
+
+        let shared = new_shared();
+        shared.push_source(Box::new(MemoryProfileSource::new(
+            Arc::clone(&rings),
+            true,
+            Some(Arc::clone(&liveset)),
+            512 * 1024,
+        )));
+
+        let events = flush_and_collect(&shared);
+        let frees: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .collect();
+        assert_eq!(frees.len(), 0);
     }
 }

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -407,15 +407,10 @@ mod tests {
             .collect();
         assert_eq!(frees.len(), 1);
         match &frees[0] {
-            TelemetryEvent::Free {
-                addr,
-                size,
-                alloc_timestamp_nanos,
-                ..
-            } => {
-                assert_eq!(*addr, 0x9999);
-                assert_eq!(*size, 128);
-                assert_eq!(*alloc_timestamp_nanos, 100);
+            Dial9Event::FreeEvent(e) => {
+                assert_eq!(e.addr, 0x9999);
+                assert_eq!(e.size, 128);
+                assert_eq!(e.alloc_timestamp_ns, 100);
             }
             _ => unreachable!(),
         }
@@ -689,22 +684,16 @@ mod tests {
         let events = flush_and_collect(&shared);
         let frees: Vec<_> = events
             .iter()
-            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .filter(|e| matches!(e, Dial9Event::FreeEvent(..)))
             .collect();
         assert_eq!(frees.len(), 1, "shutdown drain must emit one FreeEvent");
         match frees[0] {
-            TelemetryEvent::Free {
-                timestamp_nanos,
-                tid,
-                addr,
-                size,
-                alloc_timestamp_nanos,
-            } => {
-                assert_eq!(*timestamp_nanos, 200, "uses producer-push ts");
-                assert_eq!(*tid, 7, "uses producer-push tid");
-                assert_eq!(*addr, 0xAABB);
-                assert_eq!(*size, 4096, "from consolidator-side liveset peek");
-                assert_eq!(*alloc_timestamp_nanos, 100, "from liveset peek");
+            Dial9Event::FreeEvent(e) => {
+                assert_eq!(e.timestamp_ns, 200, "uses producer-push ts");
+                assert_eq!(e.tid, 7, "uses producer-push tid");
+                assert_eq!(e.addr, 0xAABB);
+                assert_eq!(e.size, 4096, "from consolidator-side liveset peek");
+                assert_eq!(e.alloc_timestamp_ns, 100, "from liveset peek");
             }
             _ => unreachable!(),
         }
@@ -746,7 +735,7 @@ mod tests {
         let events = flush_and_collect(&shared);
         let frees: Vec<_> = events
             .iter()
-            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .filter(|e| matches!(e, Dial9Event::FreeEvent(..)))
             .collect();
         assert_eq!(
             frees.len(),
@@ -785,7 +774,7 @@ mod tests {
         let events = flush_and_collect(&shared);
         let frees: Vec<_> = events
             .iter()
-            .filter(|e| matches!(e, TelemetryEvent::Free { .. }))
+            .filter(|e| matches!(e, Dial9Event::FreeEvent(..)))
             .collect();
         assert_eq!(frees.len(), 0);
     }

--- a/dial9-tokio-telemetry/src/memory_profiling/source.rs
+++ b/dial9-tokio-telemetry/src/memory_profiling/source.rs
@@ -26,10 +26,10 @@ use std::sync::atomic::Ordering;
 /// before the consolidator drains.
 pub(crate) struct MemoryProfileSource {
     rings: Arc<RingBuffers>,
-    track_liveset: bool,
     /// The producer-side liveset, shared with the allocator hook. `None`
-    /// when liveset tracking is off. Held here so the consolidator can
-    /// handle shutdown-flagged `RawFree`s — see `handle_free`.
+    /// when liveset tracking is off — in that mode the producer filters
+    /// frees and `handle_free` has nothing to emit. Held here so the
+    /// consolidator can also service shutdown-flagged `RawFree`s.
     liveset: Option<Arc<Liveset>>,
     /// Previous snapshot of `RingBuffers::dropped_allocs` for delta computation.
     prev_dropped_allocs: u64,
@@ -45,24 +45,17 @@ pub(crate) struct MemoryProfileSource {
 impl MemoryProfileSource {
     /// Create a new source that drains the supplied ring buffers.
     ///
-    /// `track_liveset = true` enables `FreeEvent` emission; `false` means
-    /// frees are filtered on the producer side and never reach the queue.
-    /// `liveset` must be `Some` whenever `track_liveset` is `true` so the
-    /// consolidator can service shutdown-flagged frees.
+    /// Pass `liveset = Some(_)` when liveset tracking is on; `None`
+    /// disables `FreeEvent` emission entirely. The Arc is shared with the
+    /// allocator hook so the consolidator can service shutdown-flagged
+    /// frees.
     pub(crate) fn new(
         rings: Arc<RingBuffers>,
-        track_liveset: bool,
         liveset: Option<Arc<Liveset>>,
         sample_rate_bytes: u64,
     ) -> Self {
-        debug_assert_eq!(
-            track_liveset,
-            liveset.is_some(),
-            "track_liveset and liveset.is_some() must agree"
-        );
         Self {
             rings,
-            track_liveset,
             liveset,
             prev_dropped_allocs: 0,
             prev_dropped_frees: 0,
@@ -100,67 +93,41 @@ impl MemoryProfileSource {
     }
 
     fn handle_free(&mut self, f: RawFree, ctx: &FlushContext<'_>) {
-        if !self.track_liveset {
+        // No liveset means the producer drops every free; nothing to emit.
+        let Some(liveset) = &self.liveset else {
             return;
-        }
-        if f.shutdown {
-            // Shutdown drain: the producer couldn't peek the liveset (sdd's
-            // TLS was already destroyed). Do the peek/remove here on the
-            // consolidator's healthy thread.
-            //
-            // **Race check.** Between the producer push (at `f.ts_ns`) and
-            // now, an address can be reused: a live thread may have freed
-            // some other sampled alloc, then `on_alloc` may have re-keyed
-            // the entry to a brand-new allocation. If the entry's
-            // `alloc_ts_ns` is greater than `f.ts_ns`, that's exactly what
-            // happened — the entry now belongs to a *later* allocation and
-            // we must not remove it (and especially must not emit a
-            // `FreeEvent` carrying its data, since the corresponding alloc
-            // is still live).
-            //
-            // This relies on `TimestampMode::ReusePollStart` /
-            // `TimestampMode::Precise` producing strictly-monotonic
-            // timestamps. `TimestampMode::None` is rejected at config build
-            // time when `track_liveset` is on (every event would be 0,
-            // breaking this invariant), so we only reach this code path in
-            // a mode where the comparison is meaningful.
-            let Some(liveset) = &self.liveset else {
-                return;
-            };
+        };
+
+        // Resolve `(size, alloc_ts_ns)`:
+        // - **Normal frees** carry denormalized data from the producer's
+        //   peek/remove (see `hook::on_dealloc`); use it directly.
+        // - **Shutdown-flagged frees** were pushed by a thread in TLS
+        //   teardown that couldn't safely touch `scc`. Do the peek/remove
+        //   here, with a race check: if the entry's `alloc_ts_ns` is
+        //   greater than `f.ts_ns`, an address-reuse race means the entry
+        //   now belongs to a *later* allocation. Leave it; the new alloc's
+        //   eventual non-shutdown free will emit the correct event.
+        let (size, alloc_ts_ns) = if f.shutdown {
             let Some((size, alloc_ts_ns)) = liveset.peek_with(&f.addr, |_, v| *v) else {
-                return; // already removed (e.g. by a normal dealloc) or never sampled
+                return; // already cleaned, or never sampled
             };
             if alloc_ts_ns > f.ts_ns {
-                // Race: entry belongs to a newer alloc that landed after
-                // our shutdown push. Leave it; its eventual free will emit
-                // the correct event.
-                return;
+                return; // address-reuse race — see comment above
             }
             liveset.remove(&f.addr);
-            with_encoder(
-                |enc| {
-                    enc.encode(&FreeEvent {
-                        timestamp_ns: f.ts_ns,
-                        tid: f.tid,
-                        addr: f.addr,
-                        size,
-                        alloc_timestamp_ns: alloc_ts_ns,
-                    });
-                },
-                ctx.collector,
-                ctx.drain_epoch,
-            );
-            return;
-        }
-        // Normal path: producer-filtered free with denormalized data.
+            (size, alloc_ts_ns)
+        } else {
+            (f.size, f.alloc_ts_ns)
+        };
+
         with_encoder(
             |enc| {
                 enc.encode(&FreeEvent {
                     timestamp_ns: f.ts_ns,
                     tid: f.tid,
                     addr: f.addr,
-                    size: f.size,
-                    alloc_timestamp_ns: f.alloc_ts_ns,
+                    size,
+                    alloc_timestamp_ns: alloc_ts_ns,
                 });
             },
             ctx.collector,
@@ -316,9 +283,9 @@ mod tests {
     }
 
     /// Convenience: build a `MemoryProfileSource` for tests where we don't
-    /// need to retain a separate handle on the liveset. Mirrors the
-    /// production `MemoryProfileSource::new` invariant
-    /// (`track_liveset == liveset.is_some()`).
+    /// need to retain a separate handle on the liveset. Pass
+    /// `track_liveset = true` to enable `FreeEvent` emission (the helper
+    /// builds a fresh liveset internally); `false` disables it.
     fn make_source(
         rings: Arc<RingBuffers>,
         track_liveset: bool,
@@ -329,7 +296,7 @@ mod tests {
         } else {
             None
         };
-        MemoryProfileSource::new(rings, track_liveset, liveset, sample_rate_bytes)
+        MemoryProfileSource::new(rings, liveset, sample_rate_bytes)
     }
 
     fn new_shared() -> SharedState {
@@ -715,7 +682,6 @@ mod tests {
         let shared = new_shared();
         shared.push_source(Box::new(MemoryProfileSource::new(
             Arc::clone(&rings),
-            true,
             Some(Arc::clone(&liveset)),
             512 * 1024,
         )));
@@ -773,7 +739,6 @@ mod tests {
         let shared = new_shared();
         shared.push_source(Box::new(MemoryProfileSource::new(
             Arc::clone(&rings),
-            true,
             Some(Arc::clone(&liveset)),
             512 * 1024,
         )));
@@ -813,7 +778,6 @@ mod tests {
         let shared = new_shared();
         shared.push_source(Box::new(MemoryProfileSource::new(
             Arc::clone(&rings),
-            true,
             Some(Arc::clone(&liveset)),
             512 * 1024,
         )));

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -58,7 +58,6 @@ thread_local! {
 /// within one poll, or repeated allocations inside a tight loop.
 ///
 /// Used by:
-/// - the memory profiler hook ([`TimestampMode::ReusePollStart`]).
 /// - the task-dump idle/wake bookkeeping in [`crate::task_dumped`].
 pub(crate) fn poll_start_ts_monotonic() -> u64 {
     let raw = POLL_START_TS.with(|c| c.get()).map_or_else(

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_disabled.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_disabled.rs
@@ -31,10 +31,6 @@ fn default_config_uses_512_kib_sample_rate() {
     let config = MemoryProfilingConfig::default();
     assert_eq!(config.sample_rate_bytes(), 512 * 1024);
     assert!(!config.track_liveset());
-    assert_eq!(
-        config.timestamp_mode(),
-        dial9_tokio_telemetry::memory_profiling::TimestampMode::ReusePollStart
-    );
     assert_eq!(config.rng_seed(), None);
     assert_eq!(config.ring_capacity(), 4096);
 }

--- a/dial9-tokio-telemetry/tests/memory_profiling_opt_out_no_panic.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_opt_out_no_panic.rs
@@ -10,7 +10,7 @@
 use dial9_tokio_telemetry::memory_profiling::{
     Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
 };
-use dial9_tokio_telemetry::telemetry::{NullWriter, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -61,7 +61,7 @@ fn opt_out_prevents_tls_teardown_panic() {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
         .unwrap();
 
     let handle = guard.handle();

--- a/dial9-tokio-telemetry/tests/memory_profiling_opt_out_no_panic.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_opt_out_no_panic.rs
@@ -1,0 +1,124 @@
+#![cfg(feature = "memory-profiling")]
+#![cfg(target_os = "linux")]
+//! Verifies the OPT_OUT TLS sentinel prevents panics during thread teardown.
+//!
+//! Forces TLS destruction order such that a `LateGuard::drop` (registered
+//! BEFORE scc/sdd's TLS) runs AFTER sdd's destructor has already cleared
+//! its slot. Without the OPT_OUT pattern, `scc` operations in `LateGuard::drop`
+//! would panic. With OPT_OUT, they bail out cleanly.
+
+use dial9_tokio_telemetry::memory_profiling::{
+    Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
+};
+use dial9_tokio_telemetry::telemetry::{NullWriter, TracedRuntime};
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+#[global_allocator]
+static ALLOC: Dial9Allocator = Dial9Allocator::system();
+
+static PANICS: AtomicU64 = AtomicU64::new(0);
+
+/// A TLS guard that performs allocations/deallocations in its destructor,
+/// simulating real-world code that frees memory during thread teardown.
+struct LateGuard;
+
+impl Drop for LateGuard {
+    fn drop(&mut self) {
+        // Perform allocations and deallocations that will hit the memory
+        // profiler hook. If the OPT_OUT sentinel is working, these will
+        // bail out without panicking even though sdd's TLS may be destroyed.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // Allocate and free some memory — this exercises the hook path.
+            let v: Vec<u8> = Vec::with_capacity(1024);
+            std::hint::black_box(&v);
+            drop(v);
+            let v2: Vec<u8> = Vec::with_capacity(2048);
+            std::hint::black_box(&v2);
+            drop(v2);
+        }));
+        if result.is_err() {
+            PANICS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+thread_local! {
+    /// Initialized BEFORE the profiler's scc TLS, so it drops AFTER.
+    static LATE: RefCell<Option<LateGuard>> = const { RefCell::new(None) };
+}
+
+#[test]
+fn opt_out_prevents_tls_teardown_panic() {
+    // Install a custom panic hook that suppresses output (if the test were
+    // to fail, we don't want 32 threads worth of panic backtraces).
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+
+    PANICS.store(0, Ordering::Relaxed);
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(1).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .build_and_start_with_writer(builder, NullWriter)
+        .unwrap();
+
+    let handle = guard.handle();
+    let _mem_guard = MemoryProfiler::from_config(
+        MemoryProfilingConfig::builder()
+            .sample_rate_bytes(64) // sample aggressively
+            .track_liveset(true)
+            .rng_seed(42)
+            .build(),
+    )
+    .install(handle)
+    .expect("install should succeed");
+
+    const N_THREADS: usize = 16;
+
+    runtime.block_on(async {
+        // Give time for the profiler to fully initialize.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut handles = Vec::new();
+        for _ in 0..N_THREADS {
+            handles.push(tokio::task::spawn_blocking(|| {
+                // Step 1: Initialize our LATE guard TLS first.
+                LATE.with(|cell| {
+                    *cell.borrow_mut() = Some(LateGuard);
+                });
+
+                // Step 2: Do some allocations that hit the profiler hook,
+                // which initializes scc/sdd's TLS.
+                for _ in 0..50 {
+                    let v: Vec<u8> = Vec::with_capacity(256);
+                    std::hint::black_box(&v);
+                    drop(v);
+                }
+
+                // Thread exits → TLS destructors run in reverse-init order:
+                // sdd drops first → our LateGuard drops second → exercises
+                // the hook path after sdd is gone.
+            }));
+        }
+
+        for h in handles {
+            h.await.expect("spawn_blocking panicked");
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    drop(runtime);
+    drop(guard);
+
+    // Restore the original panic hook.
+    std::panic::set_hook(prev_hook);
+
+    let panics = PANICS.load(Ordering::Relaxed);
+    assert_eq!(
+        panics, 0,
+        "expected 0 panics with OPT_OUT sentinel, got {panics}"
+    );
+}

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -762,21 +762,50 @@ guard.graceful_shutdown(Duration::from_secs(5))?;
 
 ## 7. Liveset tracking
 
-When `track_liveset = true`, the **consolidator thread** maintains:
+When `track_liveset = true`, the **producer-side liveset** maintains a
+concurrent `scc::HashIndex<u64, (u64, u64)>` mapping each sampled
+allocation address to its `(size, timestamp_ns)`:
 
 ```rust
-struct LivesetEntry {
-    size: u64,
-    timestamp_ns: u64,
-}
-
-// Single-threaded — only the consolidator reads or writes it.
-liveset: HashMap<usize, LivesetEntry>,
+// Shared across all producer threads via Arc. Only present when
+// track_liveset is true; None otherwise (zero overhead).
+liveset: Option<Arc<scc::HashIndex<u64, (u64, u64)>>>
 ```
 
-The liveset is a plain `HashMap` because only the consolidator touches
-it. Producers push `RawFree` records into the free queue and never
-access the liveset directly — no synchronization needed.
+### Producer-side filtering
+
+On every `alloc` that fires the sampler, the hook inserts the address into
+the liveset. On every `dealloc`, the hook checks whether the address is in
+the liveset:
+
+- **Hit:** remove the entry, push a `RawFree` with denormalized `size` and
+  `alloc_ts_ns` into the free queue. The consolidator emits `FreeEvent`
+  directly — no second lookup needed.
+- **Miss (~99.9% of deallocs):** the address was never sampled. No queue
+  push, no contention. This is the key performance win: the old design
+  pushed every dealloc into the free queue and filtered on the consolidator,
+  causing ~84% CPU in the profiler under contention.
+
+### OPT_OUT TLS sentinel
+
+`scc` (via `sdd`) uses TLS internally. If the allocator hook is called
+during thread teardown after `sdd`'s TLS slot has been destroyed, the `scc`
+operation would panic. The **OPT_OUT sentinel** eliminates this without
+`catch_unwind`:
+
+```rust
+thread_local! {
+    static IS_SHUTTING_DOWN: Cell<bool> = const { Cell::new(false) };
+    static LIFETIME_GUARD: Lifetime = const { Lifetime };
+}
+// Lifetime::drop sets IS_SHUTTING_DOWN = true.
+// check_shutdown() reads IS_SHUTTING_DOWN; if true, bails out.
+```
+
+Because `LIFETIME_GUARD` is initialized before `sdd`'s TLS (on the first
+hook entry), it drops *after* `sdd`'s destructor runs. Any subsequent hook
+entry sees the flag and returns without touching `scc`. Cost: ~1 ns
+(one TLS Cell read + branch).
 
 ### Bounded liveset
 
@@ -789,31 +818,23 @@ Default: `None` (unbounded). Users opt in to a cap.
 
 ### Memory cost
 
-~32 bytes per live sampled allocation (16 B entry + 16 B HashMap
-overhead). At default 512 KiB sample rate and 1 GiB live heap: ~2K
-entries → ~64 KiB. At 10 GiB live heap: ~20K entries → ~640 KiB.
+~64 bytes per entry in `scc::HashIndex`. At default 512 KiB sample rate
+and 1 GiB live heap: ~2K entries → ~128 KiB. At 10 GiB live heap: ~20K
+entries → ~1.3 MiB.
 
-### Dealloc overhead
+### Performance
 
-Pushing `RawFree` records costs ~9.3 ns uncontended per dealloc. The
-MPMC queue saturates at ~2.7 M pushes/sec aggregate under heavy
-contention. For services with 10M+ deallocs/sec, a producer-side
-optimization is needed:
+| Metric | Old (consolidator-side) | New (producer-side scc) |
+|--------|------------------------|------------------------|
+| 8-thread ops/s | 1.79 M | 13.9 M |
+| Profiler CPU share | 84.2% | 10.6% |
+| Unsampled dealloc cost | ~9.3 ns (queue push) | ~20 ns (HashIndex miss) |
+| Sampled dealloc cost | ~9.3 ns + consolidator lookup | ~25 ns (peek + remove + push) |
 
-- **Per-thread free buffer:** batch frees in a TLS `[RawFree; 64]`
-  array; flush to the free queue every 64 frees. Converts 64 contended
-  pushes into 1.
-- **Producer-side bloom filter:** test whether the address was sampled
-  (~5 ns hash + bit-check) before pushing; 99.9% of deallocs skip the
-  push entirely.
-
-Pick at implementation time based on whether production workloads show
-actual contention. Consolidator-side `HashMap` miss for unsampled
-addresses is ~10–20 ns — not worth optimizing until profiling shows
-otherwise.
-
-Liveset is off by default because even 9.3 ns per dealloc adds up on
-dealloc-heavy workloads.
+The throughput improvement comes from eliminating 99.9% of queue pushes.
+Single-threaded per-op cost is higher (due to epoch-based reclamation
+bookkeeping), but under contention the reduction in CAS retries at the
+queue tail dominates.
 
 ---
 

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -600,15 +600,15 @@ k²N/8000² second-order self-samples. The geometric series converges fast;
 steady-state self-pollution is ~0.01% of trace events.
 
 **Same-thread reentrancy from `scc`.** When the liveset is on, the
-allocator hook calls into `scc::HashIndex` (`insert`/`peek_with`/`remove`)
-which can in turn allocate (bucket resizes) or free (epoch-reclamation of
-retired buckets). Those re-enter the same hook on the same thread. Both
+allocator hook calls into `scc::HashIndex` (`insert`/`entry`) which can
+in turn allocate (bucket resizes) or free (epoch-reclamation of retired
+buckets). Those re-enter the same hook on the same thread. Both
 `on_alloc` and `on_dealloc` defend against this with a per-thread
 `SAMPLE_STATE` `RefCell` borrow taken across the whole liveset
 operation: a re-entrant call sees the borrow already held, gets `Err`
 from `try_borrow_mut`, and silently skips. This makes a same-thread
-deadlock between an outer `remove`'s bucket write lock and a re-entrant
-`remove` on the same bucket impossible. The shutdown-drain branch of
+deadlock between an outer `entry`'s bucket write lock and a re-entrant
+`entry` on the same bucket impossible. The shutdown-drain branch of
 `on_dealloc` deliberately sits *outside* this guard — it never touches
 `scc`/`sdd` and `SAMPLE_STATE`'s `LocalKey` may already be destroyed
 late in TLS teardown, so a guarded `try_with` would silently drop the
@@ -890,8 +890,8 @@ Protocol:
    let Some((size, alloc_ts_ns)) = liveset.peek_with(&f.addr, |_, v| *v) else {
        return; // already cleaned, or never sampled
    };
-   if alloc_ts_ns > f.ts_ns {
-       return; // race: address reused; leave entry for the new alloc
+   if alloc_ts_ns >= f.ts_ns {
+       return; // race or timestamp tie: leave entry for the new alloc
    }
    liveset.remove(&f.addr);
    enc.encode(&FreeEvent { ts_ns: f.ts_ns, addr: f.addr, size, alloc_ts_ns, .. });
@@ -901,12 +901,15 @@ Protocol:
    consolidator's drain (~5 ms later), a *live* thread may have freed
    some unrelated sampled alloc at the same address and `on_alloc` may
    have re-keyed the entry to a new allocation. The
-   `alloc_ts_ns > f.ts_ns` check identifies this exact case: the new
-   alloc's `alloc_ts_ns` is strictly greater than the older shutdown
+   `alloc_ts_ns >= f.ts_ns` check identifies this case: the new
+   alloc's `alloc_ts_ns` is greater than or equal to the older shutdown
    push's `ts_ns` because **all memory profile timestamps are
-   `clock_monotonic_ns()`** — globally monotonic across threads. On
-   race, we leave the entry in place; the new alloc's eventual
-   non-shutdown free will emit the correct event.
+   `clock_monotonic_ns()`** — globally monotonic across threads. The
+   `>=` (rather than strict `>`) handles ties: `clock_monotonic_ns()`
+   can return the same value on nearby cores, and treating a tie as a
+   race conservatively avoids removing a live entry. On race, we leave
+   the entry in place; the new alloc's eventual non-shutdown free will
+   emit the correct event.
 
    In the race case we lose the *original* (dying-thread) alloc's
    `FreeEvent` — same outcome as the pre-shutdown-drain design — but we

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -906,12 +906,19 @@ the existing flush thread does the work as part of its 5-ms cycle.
 
 ### Bounded liveset
 
-`max_liveset_entries` caps the total count. When full:
+**Not yet implemented.** The liveset is currently unbounded. A service
+that leaks sampled allocations indefinitely will grow the map without
+limit. Size is bounded in practice by the live sampled allocation count:
+at default 512 KiB sample rate and 10 GiB live heap, expect ~20K entries
+(~1.3 MiB).
+
+A planned `max_liveset_entries` config would cap the total count. When
+full:
 - New `RawAlloc`: still emit `AllocEvent`, skip liveset insert. Emit a
   rate-limited warning event (once per 60s).
 - `RawFree`: still lookup (miss on overflow entries). No-op on miss.
 
-Default: `None` (unbounded). Users opt in to a cap.
+Tracked as a follow-up.
 
 ### Memory cost
 

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -807,6 +807,103 @@ hook entry), it drops *after* `sdd`'s destructor runs. Any subsequent hook
 entry sees the flag and returns without touching `scc`. Cost: ~1 ns
 (one TLS Cell read + branch).
 
+**Init-order invariant.** Every code path that touches the liveset must
+call `check_shutdown()` first on every entry — that's what eagerly
+initialises `LIFETIME_GUARD` before the first lazy `sdd` TLS init. If a
+new code path skips this and triggers an `scc` op before
+`check_shutdown()`, the destructor order at thread exit can flip and the
+guard becomes useless.
+
+### Stale-entry handling on `on_alloc`
+
+`scc::HashIndex::insert` returns `Err` and does **not** overwrite when the
+key already exists. Address space is recycled by the OS allocator, so a
+stale entry can land on `on_alloc`'s insert in two cases:
+
+1. **Shutdown skip** (see "Shutdown drain" below): the matching dealloc
+   pushed a flagged `RawFree` and the consolidator hasn't drained yet, OR
+   the race-check on the consolidator detected an overlap and left the
+   entry in place.
+2. **Queue overflow:** the matching dealloc's `RawFree` was dropped because
+   the free queue was full (`MemoryProfileOverflowEvent` was emitted).
+
+Without explicit handling, the new allocation's `(size, ts_ns)` would be
+silently dropped and a future `FreeEvent` would carry the *old*
+allocation's data — a hard-to-detect correctness bug. `on_alloc` therefore
+detects the failure and remove-then-reinserts:
+
+```rust
+let key = ptr as u64;
+let val = (size as u64, timestamp_ns);
+if liveset.insert(key, val).is_err() {
+    liveset.remove(&key);
+    let _ = liveset.insert(key, val);
+}
+```
+
+Brief race window: a concurrent reader may observe a transient absence
+between the `remove` and the second `insert`. That's no worse than any
+other producer interleaving, and the worst outcome is a missed `FreeEvent`
+for the new allocation.
+
+### Shutdown drain (consolidator-side cleanup)
+
+The OPT_OUT sentinel forbids the *producer* from touching the liveset
+during teardown, but the *consolidator* runs on a different thread with
+its own healthy `sdd` TLS. We exploit this asymmetry to recover the dying
+thread's `FreeEvent`s and bound liveset growth across thread churn.
+
+Protocol:
+
+1. **Producer (dying thread, `on_dealloc`):** when `check_shutdown()`
+   returns `true`, push a flagged record and bail:
+   ```rust
+   inner.rings.push_free(RawFree {
+       tid, addr, ts_ns: stamp(...),
+       size: 0, alloc_ts_ns: 0,   // placeholders
+       shutdown: true,
+   });
+   ```
+   The push is allocation-free and only touches the queue's CAS
+   tail-slot — no `scc`, no `sdd`.
+
+2. **Consolidator (`MemoryProfileSource::handle_free`):** for shutdown-
+   flagged frees, do the lookup here:
+   ```rust
+   let Some((size, alloc_ts_ns)) = liveset.peek_with(&f.addr, |_, v| *v) else {
+       return; // already cleaned, or never sampled
+   };
+   if alloc_ts_ns > f.ts_ns {
+       return; // race: address reused; leave entry for the new alloc
+   }
+   liveset.remove(&f.addr);
+   enc.encode(&FreeEvent { ts_ns: f.ts_ns, addr: f.addr, size, alloc_ts_ns, .. });
+   ```
+
+3. **Race window.** Between the producer's push (at `f.ts_ns`) and the
+   consolidator's drain (~5 ms later), a *live* thread may have freed
+   some unrelated sampled alloc at the same address and `on_alloc` may
+   have re-keyed the entry to a new allocation. The
+   `alloc_ts_ns > f.ts_ns` check identifies this exact case (the new
+   alloc's `alloc_ts_ns` is strictly greater than the older shutdown
+   push's `ts_ns`, given monotonic timestamps from
+   `TimestampMode::ReusePollStart` or `Precise`). On race, we leave the
+   entry in place; the new alloc's eventual non-shutdown free will emit
+   the correct event.
+
+   In the race case we lose the *original* (dying-thread) alloc's
+   `FreeEvent` — same outcome as the pre-shutdown-drain design — but we
+   avoid emitting a *wrong* `FreeEvent` and avoid removing the new
+   alloc's entry.
+
+4. **`TimestampMode::None` is rejected** at config build time when
+   `track_liveset(true)`; with every event at `ts = 0` the race check
+   would degenerate to "always remove" and the whole protocol breaks.
+
+This protocol does NOT require `catch_unwind`, does NOT add cost to the
+non-shutdown hot path, and does NOT need a separate background thread —
+the existing flush thread does the work as part of its 5-ms cycle.
+
 ### Bounded liveset
 
 `max_liveset_entries` caps the total count. When full:

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -599,6 +599,21 @@ encoding them does ~kN allocations, ~kN/8000 trip the sampler, producing
 k²N/8000² second-order self-samples. The geometric series converges fast;
 steady-state self-pollution is ~0.01% of trace events.
 
+**Same-thread reentrancy from `scc`.** When the liveset is on, the
+allocator hook calls into `scc::HashIndex` (`insert`/`peek_with`/`remove`)
+which can in turn allocate (bucket resizes) or free (epoch-reclamation of
+retired buckets). Those re-enter the same hook on the same thread. Both
+`on_alloc` and `on_dealloc` defend against this with a per-thread
+`SAMPLE_STATE` `RefCell` borrow taken across the whole liveset
+operation: a re-entrant call sees the borrow already held, gets `Err`
+from `try_borrow_mut`, and silently skips. This makes a same-thread
+deadlock between an outer `remove`'s bucket write lock and a re-entrant
+`remove` on the same bucket impossible. The shutdown-drain branch of
+`on_dealloc` deliberately sits *outside* this guard — it never touches
+`scc`/`sdd` and `SAMPLE_STATE`'s `LocalKey` may already be destroyed
+late in TLS teardown, so a guarded `try_with` would silently drop the
+dying thread's flagged free.
+
 **Allocation during stack capture.** `Unwinder::capture()` never allocates —
 it uses only the on-stack `[u64; 128]` buffer and the allocation-free
 frame-pointer unwinder.
@@ -619,7 +634,7 @@ at install time.
 
 ```rust
 use dial9_tokio_telemetry::memory_profiling::{
-    Dial9Allocator, MemoryProfiler, TimestampMode,
+    Dial9Allocator, MemoryProfiler,
 };
 
 #[global_allocator]
@@ -632,10 +647,13 @@ fn main() {
         .build()?;
     guard.enable();
 
+    // Memory profile timestamps always come from `clock_monotonic_ns()`
+    // (~25 ns vDSO call per sampled allocation). Globally monotonic, so
+    // cross-thread comparisons in the liveset's shutdown-drain race
+    // detector (§7) are sound.
     let _mem = MemoryProfiler::builder()
         .sample_rate_bytes(512 * 1024)
         .track_liveset(true)
-        .timestamp_mode(TimestampMode::ReusePollStart)
         .install(guard.handle())?;
 
     let (rt, _) = guard.trace_runtime("main").build(rt_builder)?;
@@ -717,34 +735,22 @@ fn alloc(&self, layout: Layout) -> *mut u8 {
 ```rust
 #[derive(Debug, Clone)]
 pub struct MemoryProfilingConfig {
-    sample_rate_bytes: u64,             // default 512 KiB
-    track_liveset: bool,                // default false
-    timestamp_mode: TimestampMode,      // default ReusePollStart
-    max_liveset_entries: Option<usize>, // default None (unbounded)
-    rng_seed: Option<u64>,              // test-only deterministic seeding
-    ring_capacity: usize,              // default 4096 slots
-}
-
-/// How `AllocEvent.timestamp_ns` is populated.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum TimestampMode {
-    /// Reuse the timestamp from the most recent `PollStart` on this
-    /// thread when available (~2 ns TLS load). Falls back to
-    /// `clock_monotonic_ns()` on threads with no recorded `PollStart`.
-    /// Default.
-    ReusePollStart,
-
-    /// Emit events with `timestamp_ns = 0`. Smallest on-disk size.
-    /// Analysis can still group by stack and size; loses time-range
-    /// filtering.
-    None,
-
-    /// Call `clock_monotonic_ns()` per sampled allocation (~25 ns via
-    /// vDSO). Use for tight allocation loop investigations.
-    Precise,
+    sample_rate_bytes: u64,                 // default 512 KiB
+    track_liveset: bool,                    // default false
+    max_liveset_entries: Option<usize>,     // default None (unbounded)
+    rng_seed: Option<u64>,                  // test-only deterministic seeding
+    ring_capacity: usize,                   // default 4096 slots
 }
 ```
+
+Memory profile events always carry `clock_monotonic_ns()` timestamps —
+~25 ns vDSO call, globally monotonic across threads. There is no
+opt-out: the `timestamp_mode` knob and `TimestampMode` enum that earlier
+revisions exposed have been removed. The cost (~25 ns × ~2K
+samples/sec = ~50 µs/sec at default rate) is dominated by the stack
+capture in the same critical section, and per-thread monotonic
+alternatives leak into a soundness hole in the liveset's shutdown-drain
+race detector (§7).
 
 Built via `#[bon::builder]` as with other dial9 configs.
 
@@ -829,22 +835,33 @@ stale entry can land on `on_alloc`'s insert in two cases:
 
 Without explicit handling, the new allocation's `(size, ts_ns)` would be
 silently dropped and a future `FreeEvent` would carry the *old*
-allocation's data — a hard-to-detect correctness bug. `on_alloc` therefore
-detects the failure and remove-then-reinserts:
+allocation's data — a hard-to-detect correctness bug.
+
+The hot path stays on the cheap lock-free `insert`. On the rare `Err`
+(stale entry), we fall through to `scc::HashIndex::entry` and overwrite
+atomically inside the bucket lock:
 
 ```rust
 let key = ptr as u64;
 let val = (size as u64, timestamp_ns);
-if liveset.insert(key, val).is_err() {
-    liveset.remove(&key);
-    let _ = liveset.insert(key, val);
+if let Err((k, v)) = liveset.insert(key, val) {
+    use scc::hash_index::Entry;
+    match liveset.entry(k) {
+        Entry::Occupied(o) => o.update(v),
+        Entry::Vacant(ve) => {
+            // A concurrent dealloc removed the stale entry between our
+            // `insert` and `entry` — fine, treat as a fresh insert.
+            let _ = ve.insert_entry(v);
+        }
+    }
 }
 ```
 
-Brief race window: a concurrent reader may observe a transient absence
-between the `remove` and the second `insert`. That's no worse than any
-other producer interleaving, and the worst outcome is a missed `FreeEvent`
-for the new allocation.
+The `entry()` API was chosen over the simpler "remove + re-insert" pair
+because it eliminates the brief transient-absence window that the
+remove/insert pattern had between the two calls. Concurrent readers
+either see the old `(size, ts_ns)` or the new one — never `None` — so a
+concurrent `peek_with` from `on_dealloc` can't miss the entry mid-update.
 
 ### Shutdown drain (consolidator-side cleanup)
 
@@ -884,21 +901,28 @@ Protocol:
    consolidator's drain (~5 ms later), a *live* thread may have freed
    some unrelated sampled alloc at the same address and `on_alloc` may
    have re-keyed the entry to a new allocation. The
-   `alloc_ts_ns > f.ts_ns` check identifies this exact case (the new
+   `alloc_ts_ns > f.ts_ns` check identifies this exact case: the new
    alloc's `alloc_ts_ns` is strictly greater than the older shutdown
-   push's `ts_ns`, given monotonic timestamps from
-   `TimestampMode::ReusePollStart` or `Precise`). On race, we leave the
-   entry in place; the new alloc's eventual non-shutdown free will emit
-   the correct event.
+   push's `ts_ns` because **all memory profile timestamps are
+   `clock_monotonic_ns()`** — globally monotonic across threads. On
+   race, we leave the entry in place; the new alloc's eventual
+   non-shutdown free will emit the correct event.
 
    In the race case we lose the *original* (dying-thread) alloc's
    `FreeEvent` — same outcome as the pre-shutdown-drain design — but we
    avoid emitting a *wrong* `FreeEvent` and avoid removing the new
    alloc's entry.
 
-4. **`TimestampMode::None` is rejected** at config build time when
-   `track_liveset(true)`; with every event at `ts = 0` the race check
-   would degenerate to "always remove" and the whole protocol breaks.
+4. **Why a globally monotonic clock is required.** Earlier revisions
+   exposed a `TimestampMode` knob (`ReusePollStart` / `None` /
+   `Precise`) so callers could trade timestamp resolution for ~20 ns of
+   per-sample overhead. That knob was removed because the cheap modes
+   were *unsound* with the liveset on: the shutdown free's `f.ts_ns` is
+   sampled on the dying thread while the reusing alloc's `alloc_ts_ns`
+   is sampled on a *different* live worker, so per-thread monotonicity
+   tells us nothing about the ordering between them, and `ts = 0`
+   collapses the race check entirely. With `clock_monotonic_ns()` the
+   comparison is sound by construction.
 
 This protocol does NOT require `catch_unwind`, does NOT add cost to the
 non-shutdown hot path, and does NOT need a separate background thread —
@@ -960,7 +984,7 @@ For a service doing 1M allocs/sec: ~1 ms/sec of CPU per core (0.1%).
 - Stack capture: ~110 ns (20 frames warm-cache; ~200–400 ns cold)
 - Build `RawAlloc` on stack: ~30 ns
 - `ArrayQueue::push`: ~50–100 ns uncontended
-- Optional timestamp: ~25 ns (`TimestampMode::Precise`)
+- `clock_monotonic_ns()` timestamp: ~25 ns via vDSO
 - Total: **~1226 ns** (dominated by stack capture)
 
 At 2K samples/sec: ~2.5 ms/sec of CPU per core (0.25%).


### PR DESCRIPTION
The current design that pushes every free into an array queue suffered from bad performance for a couple of reasons. This updates the design to use `scc` on the allocator side to track the liveset.

This is _generally_ good, but runs into some trickiness, especially around teardown. There is a race condition where the thread locals inside of SCC race with another thread local that is being freed.

I solved this with an OPT_OUT_TLS sentinel that seems to handle the problem. I also removed the optimization where we use a cached timestamp as it presented some cross-thread ordering issues with the liveset. I think we may _eventually_ move to a hybrid approach where, in general, we have a timer that uses clock monotonic as a base time, but within a short window, e.g. 1s we use a quanta-based approach