### PR TITLE
fix(test): flakyness around sched events

### DIFF
--- a/dial9-tokio-telemetry/tests/common.rs
+++ b/dial9-tokio-telemetry/tests/common.rs
@@ -65,3 +65,44 @@ pub fn decode_file<T: DeserializeOwned>(path: &Path) -> Vec<T> {
     .expect("decode file");
     events
 }
+
+/// Read a thread's total context-switch count (`voluntary_ctxt_switches` +
+/// `nonvoluntary_ctxt_switches`) from `/proc/self/task/<tid>/status`.
+///
+/// This is the same quantity perf's `SwContextSwitches` event counts, so it
+/// serves as an independent kernel ground truth for sampling-ratio assertions.
+/// Returns `None` if the thread has exited or the fields are absent.
+#[cfg(target_os = "linux")]
+pub fn read_switch_count(tid: u32) -> Option<u64> {
+    let status = std::fs::read_to_string(format!("/proc/self/task/{tid}/status")).ok()?;
+    let mut total = 0u64;
+    let mut found = false;
+    for line in status.lines() {
+        if let Some(rest) = line
+            .strip_prefix("voluntary_ctxt_switches:")
+            .or_else(|| line.strip_prefix("nonvoluntary_ctxt_switches:"))
+        {
+            total += rest.trim().parse::<u64>().ok()?;
+            found = true;
+        }
+    }
+    found.then_some(total)
+}
+
+/// Snapshot the context-switch count of every thread in the current process,
+/// keyed by tid. Threads that disappear mid-enumeration are simply skipped.
+#[cfg(target_os = "linux")]
+pub fn snapshot_task_switches() -> std::collections::HashMap<u32, u64> {
+    let mut map = std::collections::HashMap::new();
+    let Ok(entries) = std::fs::read_dir("/proc/self/task") else {
+        return map;
+    };
+    for entry in entries.flatten() {
+        if let Some(tid) = entry.file_name().to_str().and_then(|s| s.parse::<u32>().ok())
+            && let Some(count) = read_switch_count(tid)
+        {
+            map.insert(tid, count);
+        }
+    }
+    map
+}

--- a/dial9-tokio-telemetry/tests/common.rs
+++ b/dial9-tokio-telemetry/tests/common.rs
@@ -98,7 +98,10 @@ pub fn snapshot_task_switches() -> std::collections::HashMap<u32, u64> {
         return map;
     };
     for entry in entries.flatten() {
-        if let Some(tid) = entry.file_name().to_str().and_then(|s| s.parse::<u32>().ok())
+        if let Some(tid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<u32>().ok())
             && let Some(count) = read_switch_count(tid)
         {
             map.insert(tid, count);

--- a/dial9-tokio-telemetry/tests/sched_events.rs
+++ b/dial9-tokio-telemetry/tests/sched_events.rs
@@ -66,65 +66,91 @@ fn sched_events_capture_context_switches() {
     assert_eq!(cpu_profile_samples, 0, "should have no CpuProfile samples");
 }
 
+/// With `sampling_interval(10)`, perf records ~1/10 of the worker threads'
+/// context switches. Rather than compare two independent runs (whose total
+/// switch counts vary, making the ratio flaky), we run once and compare the
+/// emitted sample count against the kernel's own per-worker context-switch
+/// counter read from `/proc`. Numerator and denominator come from the same
+/// threads in the same run, so the ~10x relationship holds deterministically.
 #[test]
 fn sched_events_sampling_reduces_count() {
     use dial9_tokio_telemetry::telemetry::TracedRuntime;
     use dial9_tokio_telemetry::telemetry::cpu_profile::SchedEventConfig;
+    use std::collections::HashSet;
     use std::time::Duration;
 
-    let count_sched_samples = |interval: Option<u64>| -> usize {
-        let (writer, batches) = BytesCapturingWriter::new();
+    const PERIOD: u64 = 10;
+    let num_workers = 2u64;
 
-        let num_workers = 2;
-        let mut builder = tokio::runtime::Builder::new_multi_thread();
-        builder.worker_threads(num_workers).enable_all();
+    let (writer, batches) = BytesCapturingWriter::new();
 
-        let mut config = SchedEventConfig::default();
-        if let Some(n) = interval {
-            config = config.sampling_interval(n);
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(num_workers as usize).enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_sched_events(SchedEventConfig::default().sampling_interval(PERIOD))
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    // Baseline switch counts for all current threads (workers already spawned).
+    let before = common::snapshot_task_switches();
+
+    runtime.block_on(async {
+        let mut handles = Vec::new();
+        for _ in 0..num_workers * 20 {
+            handles.push(tokio::spawn(async {
+                for _ in 0..5 {
+                    std::thread::sleep(Duration::from_millis(2));
+                    tokio::task::yield_now().await;
+                }
+            }));
         }
+        for h in handles {
+            h.await.unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    });
 
-        let (runtime, guard) = TracedRuntime::builder()
-            .with_sched_events(config)
-            .build_and_start(builder, writer)
-            .unwrap();
+    // Snapshot again while the worker threads are still alive.
+    let after = common::snapshot_task_switches();
 
-        runtime.block_on(async {
-            let mut handles = Vec::new();
-            for _ in 0..num_workers * 20 {
-                handles.push(tokio::spawn(async {
-                    for _ in 0..5 {
-                        std::thread::sleep(Duration::from_millis(2));
-                        tokio::task::yield_now().await;
-                    }
-                }));
+    drop(runtime);
+    drop(guard);
+
+    let b = batches.lock().unwrap();
+    let events: Vec<Dial9Event> = decode_all(&b);
+
+    // Worker sched samples and the set of worker tids that produced them.
+    let mut worker_tids = HashSet::new();
+    let records = events
+        .iter()
+        .filter(|e| {
+            matches!(e, Dial9Event::CpuSampleEvent(s)
+            if s.worker_id < WorkerId(num_workers) && s.source == CpuSampleSource::SchedEvent)
+        })
+        .inspect(|e| {
+            if let Dial9Event::CpuSampleEvent(s) = e {
+                worker_tids.insert(s.tid);
             }
-            for h in handles {
-                h.await.unwrap();
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        });
+        })
+        .count();
 
-        drop(runtime);
-        drop(guard);
+    // Ground-truth context switches on exactly those sampled worker threads.
+    let total: u64 = worker_tids
+        .iter()
+        .map(|tid| after.get(tid).copied().unwrap_or(0) - before.get(tid).copied().unwrap_or(0))
+        .sum();
 
-        let b = batches.lock().unwrap();
-        let events: Vec<Dial9Event> = decode_all(&b);
-        events
-            .iter()
-            .filter(|e| {
-                matches!(e, Dial9Event::CpuSampleEvent(s)
-                if s.source == CpuSampleSource::SchedEvent)
-            })
-            .count()
-    };
-
-    let n_all = count_sched_samples(None);
-    let n_sampled = count_sched_samples(Some(10));
-
-    let ratio = n_all as f64 / n_sampled.max(1) as f64;
     assert!(
-        ratio > 8.0 && ratio < 12.0,
-        "expected ~10x ratio, got {ratio:.1}x (n_all={n_all}, n_sampled={n_sampled})"
+        total > 100,
+        "workload produced too few worker context switches to test ({total})"
+    );
+
+    let expected = total as f64 / PERIOD as f64;
+    let ratio = records as f64 / expected;
+    assert!(
+        (0.8..=1.2).contains(&ratio),
+        "expected sampled records (~total/{PERIOD}); records={records}, \
+         total={total}, expected~{expected:.0}, ratio={ratio:.2}"
     );
 }

--- a/dial9-tokio-telemetry/tests/sched_events.rs
+++ b/dial9-tokio-telemetry/tests/sched_events.rs
@@ -34,11 +34,10 @@ fn sched_events_capture_context_switches() {
         for h in handles {
             h.await.unwrap();
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
     });
 
     drop(runtime);
-    drop(guard);
+    guard.graceful_shutdown(Duration::from_secs(5)).unwrap();
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);
@@ -108,14 +107,13 @@ fn sched_events_sampling_reduces_count() {
         for h in handles {
             h.await.unwrap();
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
     });
 
     // Snapshot again while the worker threads are still alive.
     let after = common::snapshot_task_switches();
 
     drop(runtime);
-    drop(guard);
+    guard.graceful_shutdown(Duration::from_secs(5)).unwrap();
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);

--- a/perf-self-profile/tests/sched_triggers.rs
+++ b/perf-self-profile/tests/sched_triggers.rs
@@ -137,34 +137,73 @@ fn captures_sleep_stack() {
     );
 }
 
+/// Total context switches for the calling thread, from `/proc/thread-self/status`
+/// (`voluntary_ctxt_switches` + `nonvoluntary_ctxt_switches`). This is the same
+/// quantity perf's `SwContextSwitches` event counts, so it is an independent
+/// kernel ground truth for the sampling ratio.
+fn thread_switch_count() -> u64 {
+    let status =
+        std::fs::read_to_string("/proc/thread-self/status").expect("read /proc/thread-self/status");
+    let mut total = 0u64;
+    for line in status.lines() {
+        if let Some(rest) = line
+            .strip_prefix("voluntary_ctxt_switches:")
+            .or_else(|| line.strip_prefix("nonvoluntary_ctxt_switches:"))
+        {
+            total += rest.trim().parse::<u64>().expect("parse switch count");
+        }
+    }
+    total
+}
+
+/// `Period(N)` must record ~1/N of the context switches that actually occur.
+///
+/// A previous version compared two independent runs, but their total switch
+/// counts vary, making the ratio flaky. Instead we run once and compare the
+/// recorded sample count against the kernel's own switch counter for this
+/// thread: both numbers come from the same run, so `records ≈ total / N` holds
+/// with only small boundary error.
 #[test]
 fn sampling_interval_controls_ratio() {
     unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 1) };
 
-    let run = |period: u64| -> usize {
-        let sampler = Arc::new(Mutex::new(
-            PerfSampler::new_per_thread(
-                SamplerConfig::default()
-                    .event_source(EventSource::SwContextSwitches)
-                    .include_kernel(false)
-                    .sampling(SamplingMode::Period(period)),
-            )
-            .expect("failed to create sampler"),
-        ));
-        sampler.lock().unwrap().track_current_thread().unwrap();
+    const PERIOD: u64 = 10;
 
-        for _ in 0..200 {
-            thread::sleep(std::time::Duration::from_millis(1));
-        }
-
-        let mut s = sampler.lock().unwrap();
-        s.drain_samples().len()
+    let mut sampler = match PerfSampler::new_per_thread(
+        SamplerConfig::default()
+            .event_source(EventSource::SwContextSwitches)
+            .include_kernel(false)
+            .sampling(SamplingMode::Period(PERIOD)),
+    ) {
+        Ok(s) => s,
+        // perf_event_open blocked (e.g. restricted CI); nothing to verify.
+        Err(e) if e.kind() == std::io::ErrorKind::Unsupported => return,
+        Err(e) => panic!("failed to create sampler: {e}"),
     };
+    sampler.track_current_thread().unwrap();
 
-    let n_all = run(1);
-    let n_sampled = run(10);
-    let ratio = n_all / n_sampled.max(1);
-    assert_eq!(ratio, 10, "n_all={n_all}, n_sampled={n_sampled}");
+    let before = thread_switch_count();
+    for _ in 0..400 {
+        thread::sleep(std::time::Duration::from_millis(1));
+    }
+    sampler.disable();
+    let after = thread_switch_count();
+
+    let records = sampler.drain_samples().len();
+    let total = after - before;
+
+    assert!(
+        total > 100,
+        "workload produced too few context switches to test ({total})"
+    );
+
+    let expected = total as f64 / PERIOD as f64;
+    let ratio = records as f64 / expected;
+    assert!(
+        (0.8..=1.2).contains(&ratio),
+        "expected records ~ total/{PERIOD}; records={records}, total={total}, \
+         expected~{expected:.0}, ratio={ratio:.2}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
closes #492 
 
## Summary
Measure the ratio within a single run against an independent ground truth instead of across two runs. 
The kernel exposes each thread's context-switch count in `/proc/.../status` (`voluntary_ctxt_switches` + `nonvoluntary_ctxt_switches`), which is the same quantity perf's `SwContextSwitches` event counts.
Because recorded samples and true switches now come from the same threads in the same run, `records ~= total / 10` holds with only the +/- 1-record sampling boundary as error, regardless of how many switches occur. The real ~10x guarantee is kept, the cross-run variance is gone.

I've ran them in a privileged `rust:1.94.1-bookworm` container with `kernel.perf_event_paranoid=1`. Each ratio test looped 130 times with zero failures (30 baseline runs, plus 100 runs under CPU contention, 22 busy loops saturating all cores) to maximize involuntary context switches, the condition most likely to expose any residual boundary error.