### PR TITLE
refactor!: remove TraceWriter trait

### DIFF
--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -446,7 +446,7 @@ You can also register a callback that runs from dial9's flush thread and emits
 custom events. This is useful for draining application-owned queues or taking
 periodic snapshots without passing a [`TelemetryHandle`] through your code:
 
-```rust,no_run
+```rust,ignore
 use dial9_trace_format::TraceEvent;
 use dial9_tokio_telemetry::telemetry::{CustomEventsConfig, TracedRuntime};
 
@@ -463,7 +463,7 @@ let (_runtime, _guard) = TracedRuntime::builder()
             ctx.record_event(event);
         }
     })
-    .build_and_start_with_writer(builder, writer)?;
+    .build_and_start(builder, writer)?;
 ```
 
 `CustomEventsConfig::default()` runs the callback every flush cycle
@@ -476,7 +476,7 @@ the callback.
 dial9 installs callbacks on all 8 Tokio runtime hooks to collect telemetry. If you need to run your own logic alongside dial9's instrumentation, use `with_tokio_hooks`:
 
 ```rust,no_run
-use dial9_tokio_telemetry::telemetry::{TracedRuntime, NullWriter};
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 
 let mut builder = tokio::runtime::Builder::new_multi_thread();
 builder.worker_threads(4).enable_all();
@@ -492,7 +492,7 @@ let (runtime, guard) = TracedRuntime::builder()
         // Also available: on_thread_park, on_thread_unpark,
         // on_task_spawn, on_task_terminate, on_before_task_poll, on_after_task_poll
     })
-    .build_and_start_with_writer(builder, NullWriter)
+    .build_and_start(builder, InMemoryWriter::discard())
     .unwrap();
 ```
 

--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -492,7 +492,7 @@ let (runtime, guard) = TracedRuntime::builder()
         // Also available: on_thread_park, on_thread_unpark,
         // on_task_spawn, on_task_terminate, on_before_task_poll, on_after_task_poll
     })
-    .build_and_start(builder, InMemoryWriter::discard())
+    .build_and_start(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
     .unwrap();
 ```
 

--- a/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
+++ b/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
@@ -95,7 +95,7 @@ fn bench_mixed_sizes(c: &mut Criterion) {
 
 fn install_profiler() {
     use dial9_tokio_telemetry::memory_profiling::{MemoryProfiler, MemoryProfilingConfig};
-    use dial9_tokio_telemetry::telemetry::{NullWriter, TracedRuntime};
+    use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
@@ -103,7 +103,7 @@ fn install_profiler() {
     // We leak the runtime and guard so they live for the process lifetime.
     // This is intentional — the profiler is process-permanent anyway.
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
     let handle = guard.handle();
 

--- a/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
+++ b/dial9-tokio-telemetry/benches/memory_profiling_bench.rs
@@ -103,7 +103,7 @@ fn install_profiler() {
     // We leak the runtime and guard so they live for the process lifetime.
     // This is intentional — the profiler is process-permanent anyway.
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
         .unwrap();
     let handle = guard.handle();
 

--- a/dial9-tokio-telemetry/benches/overhead_bench.rs
+++ b/dial9-tokio-telemetry/benches/overhead_bench.rs
@@ -10,7 +10,7 @@
 //! Modes:
 //!   baseline  – plain tokio runtime, no hooks
 //!   telemetry – hooks installed, writing to a temp file
-//!   noop      – hooks installed, InMemoryWriter::discard() (measures pure hook overhead)
+//!   noop      – hooks installed, InMemoryWriter (no I/O)
 //!
 //! Duration defaults to 30 seconds. A 3-second warmup precedes measurement.
 //! --bmf runs all three modes and outputs Bencher Metric Format JSON.
@@ -121,7 +121,7 @@ fn run_bench(mode: &str, duration_secs: u64) -> BenchResult {
         }
         "noop" => {
             let (rt, g) = TracedRuntime::builder()
-                .build_and_start(builder, InMemoryWriter::discard())
+                .build_and_start(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
                 .unwrap();
             (rt, Some(g))
         }

--- a/dial9-tokio-telemetry/benches/overhead_bench.rs
+++ b/dial9-tokio-telemetry/benches/overhead_bench.rs
@@ -10,7 +10,7 @@
 //! Modes:
 //!   baseline  – plain tokio runtime, no hooks
 //!   telemetry – hooks installed, writing to a temp file
-//!   noop      – hooks installed, NullWriter (measures pure hook overhead)
+//!   noop      – hooks installed, InMemoryWriter::discard() (measures pure hook overhead)
 //!
 //! Duration defaults to 30 seconds. A 3-second warmup precedes measurement.
 //! --bmf runs all three modes and outputs Bencher Metric Format JSON.
@@ -20,7 +20,7 @@ mod bmf;
 #[cfg(target_os = "linux")]
 use dial9_tokio_telemetry::telemetry::cpu_profile::CpuProfilingConfig;
 use dial9_tokio_telemetry::telemetry::{
-    DiskWriter, NullWriter, TelemetryGuard, TelemetryHandle, TracedRuntime,
+    DiskWriter, InMemoryWriter, TelemetryGuard, TelemetryHandle, TracedRuntime,
 };
 use hdrhistogram::Histogram;
 use std::sync::Arc;
@@ -121,7 +121,7 @@ fn run_bench(mode: &str, duration_secs: u64) -> BenchResult {
         }
         "noop" => {
             let (rt, g) = TracedRuntime::builder()
-                .build_and_start(builder, NullWriter)
+                .build_and_start(builder, InMemoryWriter::discard())
                 .unwrap();
             (rt, Some(g))
         }

--- a/dial9-tokio-telemetry/benches/tracing_layer_iai.rs
+++ b/dial9-tokio-telemetry/benches/tracing_layer_iai.rs
@@ -36,7 +36,7 @@ fn setup_tracing_only() -> Harness {
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();
     let (runtime, _telemetry_guard) = TracedRuntime::builder()
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
         .unwrap();
     let _sub_guard = tracing::subscriber::set_default(tracing_subscriber::registry());
     Harness {
@@ -50,7 +50,7 @@ fn setup_with_dial9() -> Harness {
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();
     let (runtime, _telemetry_guard) = TracedRuntime::builder()
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
         .unwrap();
     let _sub_guard = tracing::subscriber::set_default(
         tracing_subscriber::registry().with(Dial9TokioLayer::new()),

--- a/dial9-tokio-telemetry/benches/tracing_layer_iai.rs
+++ b/dial9-tokio-telemetry/benches/tracing_layer_iai.rs
@@ -18,7 +18,7 @@
 #[cfg(not(iai_enabled))]
 fn main() {}
 
-use dial9_tokio_telemetry::telemetry::{NullWriter, TelemetryGuard, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TelemetryGuard, TracedRuntime};
 use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
@@ -36,7 +36,7 @@ fn setup_tracing_only() -> Harness {
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();
     let (runtime, _telemetry_guard) = TracedRuntime::builder()
-        .build_and_start(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
     let _sub_guard = tracing::subscriber::set_default(tracing_subscriber::registry());
     Harness {
@@ -50,7 +50,7 @@ fn setup_with_dial9() -> Harness {
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();
     let (runtime, _telemetry_guard) = TracedRuntime::builder()
-        .build_and_start(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
     let _sub_guard = tracing::subscriber::set_default(
         tracing_subscriber::registry().with(Dial9TokioLayer::new()),

--- a/dial9-tokio-telemetry/benches/writer_write_encoded_iai.rs
+++ b/dial9-tokio-telemetry/benches/writer_write_encoded_iai.rs
@@ -18,8 +18,8 @@
 fn main() {}
 
 use dial9_tokio_telemetry::telemetry::{
-    Batch, DiskWriter, PollEndEvent, PollStartEvent, TaskId, TaskSpawnEvent, TraceWriter,
-    WakeEventEvent, WorkerId, WorkerParkEvent, WorkerUnparkEvent,
+    Batch, DiskWriter, PollEndEvent, PollStartEvent, TaskId, TaskSpawnEvent, WakeEventEvent,
+    WorkerId, WorkerParkEvent, WorkerUnparkEvent,
 };
 use dial9_trace_format::encoder::Encoder;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};

--- a/dial9-tokio-telemetry/src/background_task/fs/disk.rs
+++ b/dial9-tokio-telemetry/src/background_task/fs/disk.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use crate::background_task::sealed::{
     SealedSegment, SegmentArtifact, SegmentRef, find_sealed_segments, parse_segment_artifact,
 };
+use crate::primitives::fs;
 use crate::primitives::sync::Mutex;
 use crate::primitives::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use crate::rate_limit::rate_limited;
@@ -51,7 +52,7 @@ impl DiskFs {
     }
 
     pub(super) fn create_segment(&self, path: &Path) -> io::Result<ActiveHandle> {
-        match std::fs::File::create(path) {
+        match fs::File::create(path) {
             Ok(f) => Ok(ActiveHandle::Disk(f)),
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
                 // Parent directory missing. Recreate it once and retry. If
@@ -59,9 +60,9 @@ impl DiskFs {
                 if let Some(parent) = path.parent()
                     && !parent.as_os_str().is_empty()
                 {
-                    std::fs::create_dir_all(parent)?;
+                    fs::create_dir_all(parent)?;
                 }
-                std::fs::File::create(path).map(ActiveHandle::Disk)
+                fs::File::create(path).map(ActiveHandle::Disk)
             }
             Err(e) => Err(e),
         }
@@ -76,7 +77,7 @@ impl DiskFs {
         // File is flushed+closed when the handle is dropped.
         drop(active_handle);
         let sealed_path = strip_active_suffix(active_path);
-        match std::fs::rename(active_path, &sealed_path) {
+        match fs::rename(active_path, &sealed_path) {
             Ok(()) => Ok(SegmentRef::Disk(SealedSegment {
                 path: sealed_path,
                 index,
@@ -99,7 +100,7 @@ impl DiskFs {
         // Best-effort: a missing active file is expected (already sealed or
         // never created). Log anything else so silent FS failures (e.g.
         // permission) are observable instead of leaking active files.
-        match std::fs::remove_file(path) {
+        match fs::remove_file(path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(e) => {
@@ -176,7 +177,7 @@ impl DiskFs {
             if already_claimed.contains(&seg.index) {
                 continue;
             }
-            let size = match std::fs::metadata(&seg.path) {
+            let size = match fs::metadata(&seg.path) {
                 Ok(m) => m.len(),
                 Err(e) => {
                     rate_limited!(Duration::from_secs(60), {
@@ -233,7 +234,7 @@ impl DiskFs {
         if !self.dir.exists() {
             return Ok(DiscoveredArtifacts::default());
         }
-        for entry in std::fs::read_dir(&self.dir)? {
+        for entry in fs::read_dir(&self.dir)? {
             let entry = entry?;
             let path = entry.path();
             let metadata = match entry.metadata() {
@@ -257,7 +258,7 @@ impl DiskFs {
                         path = %path.display(),
                         "discarding stale active trace segment from a previous writer"
                     );
-                    match std::fs::remove_file(&path) {
+                    match fs::remove_file(&path) {
                         Ok(()) => {}
                         Err(e) if e.kind() == io::ErrorKind::NotFound => {}
                         Err(e) => return Err(e),
@@ -297,7 +298,7 @@ fn remove_segment_family(path: &Path) {
     let Some(parent) = path.parent() else {
         return;
     };
-    let entries = match std::fs::read_dir(parent) {
+    let entries = match fs::read_dir(parent) {
         Ok(e) => e,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return,
         Err(e) => {
@@ -324,7 +325,7 @@ fn remove_segment_family(path: &Path) {
         if !is_family {
             continue;
         }
-        match std::fs::remove_file(entry.path()) {
+        match fs::remove_file(&entry.path()) {
             Ok(()) => {}
             Err(e) if e.kind() == io::ErrorKind::NotFound => {}
             Err(e) => {

--- a/dial9-tokio-telemetry/src/background_task/fs/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/fs/mod.rs
@@ -16,6 +16,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::background_task::payload::Payload;
 use crate::background_task::sealed::{MemorySegment, SealedSegment, SegmentRef};
+use crate::primitives::fs;
 use crate::primitives::sync::Arc;
 use crate::primitives::sync::atomic::{AtomicU64, Ordering};
 
@@ -97,7 +98,7 @@ impl Drop for SegmentAccounting {
 
 /// Active-segment write handle.
 pub(crate) enum ActiveHandle {
-    Disk(std::fs::File),
+    Disk(fs::File),
     Mem(MemActiveWriter),
 }
 
@@ -181,7 +182,7 @@ impl TakenSegment {
                         "TakenSegment with no payload and no disk path",
                     ));
                 };
-                let bytes = std::fs::read(path)?;
+                let bytes = fs::read(path)?;
                 Ok((self.seg_ref, Payload::from_vec(bytes), None))
             }
         }

--- a/dial9-tokio-telemetry/src/background_task/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/mod.rs
@@ -2016,7 +2016,7 @@ mod worker_pipeline_tests {
         };
         std::fs::write(dir.path().join("trace.0.bin"), &gzip_data).unwrap();
 
-        let (capture, output_bytes) = super::testutil::CaptureProcessor::new();
+        let (capture, output_bytes) = super::testutil::CapturingProcessor::new();
         let stop = tokio_util::sync::CancellationToken::new();
         stop.cancel();
 
@@ -2033,7 +2033,10 @@ mod worker_pipeline_tests {
         worker.run().await;
 
         // The captured bytes should be identical to the input (not double-gzipped).
-        check!(output_bytes.lock().unwrap().as_slice() == gzip_data.as_slice());
+        // Single segment in this test, so check the first (only) captured payload.
+        let captured = output_bytes.lock().unwrap();
+        check!(captured.len() == 1);
+        check!(captured[0].as_slice() == gzip_data.as_slice());
     }
 
     /// WriteBackProcessor writes to a new path when `write_back_extension` is

--- a/dial9-tokio-telemetry/src/background_task/sealed.rs
+++ b/dial9-tokio-telemetry/src/background_task/sealed.rs
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn test_parse_segment_timestamp() {
         use crate::telemetry::format::WorkerParkEvent;
-        use crate::telemetry::writer::{DiskWriter, TraceWriter};
+        use crate::telemetry::writer::DiskWriter;
         use dial9_trace_format::encoder::Encoder;
         use tempfile::TempDir;
 
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn test_creation_epoch_secs_uses_parsed_timestamp() {
         use crate::telemetry::format::WorkerParkEvent;
-        use crate::telemetry::writer::{DiskWriter, TraceWriter};
+        use crate::telemetry::writer::DiskWriter;
         use dial9_trace_format::encoder::Encoder;
         use tempfile::TempDir;
 
@@ -417,7 +417,7 @@ mod tests {
     #[test]
     fn test_parse_segment_timestamp_no_metadata() {
         use crate::telemetry::format::WorkerParkEvent;
-        use crate::telemetry::writer::{DiskWriter, TraceWriter};
+        use crate::telemetry::writer::DiskWriter;
         use dial9_trace_format::encoder::Encoder;
 
         let dir = TempDir::new().unwrap();

--- a/dial9-tokio-telemetry/src/background_task/sealed.rs
+++ b/dial9-tokio-telemetry/src/background_task/sealed.rs
@@ -5,6 +5,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::primitives::fs;
+
 /// A sealed trace segment ready for processing (disk-backed).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SealedSegment {
@@ -95,7 +97,7 @@ pub(crate) fn creation_epoch_secs(data: &[u8], path: &Path) -> (u64, bool) {
             });
         }
     }
-    let secs = std::fs::metadata(path)
+    let secs = fs::metadata(path)
         .and_then(|m| m.modified())
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
@@ -206,7 +208,7 @@ impl std::fmt::Display for ParseTimestampError {
 /// that don't match the expected naming pattern.
 pub(crate) fn find_sealed_segments(dir: &Path, stem: &str) -> std::io::Result<Vec<SealedSegment>> {
     let mut segments = Vec::new();
-    for entry in std::fs::read_dir(dir)? {
+    for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.extension().is_none_or(|ext| ext != "bin") {

--- a/dial9-tokio-telemetry/src/background_task/testutil.rs
+++ b/dial9-tokio-telemetry/src/background_task/testutil.rs
@@ -4,17 +4,28 @@ use std::sync::{Arc, Mutex};
 
 use super::{ProcessError, SegmentData, SegmentProcessor};
 
-/// Appends each segment's payload bytes to a shared buffer.
-pub(crate) struct CaptureProcessor(pub Arc<Mutex<Vec<u8>>>);
+/// A [`SegmentProcessor`] that stores each sealed segment's payload bytes,
+/// one `Vec<u8>` per segment.
+///
+/// Per-segment (not concatenated): each entry is a self-contained trace blob
+/// with its own header, so [`decode_captured`] can decode them independently.
+pub(crate) struct CapturingProcessor {
+    segments: Arc<Mutex<Vec<Vec<u8>>>>,
+}
 
-impl CaptureProcessor {
-    pub(crate) fn new() -> (Self, Arc<Mutex<Vec<u8>>>) {
-        let buf = Arc::new(Mutex::new(Vec::new()));
-        (Self(Arc::clone(&buf)), buf)
+impl CapturingProcessor {
+    pub(crate) fn new() -> (Self, Arc<Mutex<Vec<Vec<u8>>>>) {
+        let segments = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                segments: segments.clone(),
+            },
+            segments,
+        )
     }
 }
 
-impl SegmentProcessor for CaptureProcessor {
+impl SegmentProcessor for CapturingProcessor {
     fn name(&self) -> &'static str {
         "Capture"
     }
@@ -23,10 +34,20 @@ impl SegmentProcessor for CaptureProcessor {
         &mut self,
         data: SegmentData,
     ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
-        self.0
+        self.segments
             .lock()
             .unwrap()
-            .extend_from_slice(&data.payload().clone().into_vec());
-        Box::pin(async { Ok(data) })
+            .push(data.payload().clone().into_vec());
+        Box::pin(async move { Ok(data) })
     }
+}
+
+/// Decode every event across the captured per-segment payloads.
+pub(crate) fn decode_captured(
+    segments: &[Vec<u8>],
+) -> Vec<crate::telemetry::analysis_events::Dial9Event> {
+    segments
+        .iter()
+        .flat_map(|seg| crate::telemetry::format::decode_events(seg).expect("decode segment"))
+        .collect()
 }

--- a/dial9-tokio-telemetry/src/config.rs
+++ b/dial9-tokio-telemetry/src/config.rs
@@ -27,38 +27,27 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::telemetry::recorder::{
-    HasTracePath, PipelineUnset, TelemetryGuard, TracedRuntime, TracedRuntimeBuilder,
+    BuildAndStartRuntime, HasTracePath, PipelineUnset, TelemetryGuard, TracedRuntime,
+    TracedRuntimeBuilder,
 };
 use crate::telemetry::writer::{
     Disk, DiskWriter, InMemoryWriter, Memory, SegmentWriter, WriterMode,
 };
 
-/// Type-erased terminal step: a configured [`TracedRuntimeBuilder`] paired
-/// with the writer it will drive. Hides both the pipeline marker `M` and the
-/// writer `Mode` so [`Inner::Enabled`] stays non-generic across disk and
-/// in-memory configs.
-pub(crate) trait BuildTracedRuntime: Send {
-    fn build_and_start(
-        self: Box<Self>,
-        tokio_builder: tokio::runtime::Builder,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>;
-}
-
-/// A configured builder bound to its writer. Their `Mode` must agree, which is
-/// what the typed `build_and_start` enforces at the point they are paired.
-struct ModeRuntime<M, Mode: WriterMode> {
-    builder: TracedRuntimeBuilder<HasTracePath, M, Mode>,
-    writer: SegmentWriter<Mode>,
-}
-
-impl<M: Send + 'static, Mode: WriterMode> BuildTracedRuntime for ModeRuntime<M, Mode> {
-    fn build_and_start(
-        self: Box<Self>,
-        tokio_builder: tokio::runtime::Builder,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
-        self.builder.build_and_start(tokio_builder, self.writer)
-    }
-}
+/// Type-erased terminal step: a closure that builds and starts the runtime,
+/// capturing the configured [`TracedRuntimeBuilder`] and its writer at the
+/// point both the pipeline marker `M` and writer `Mode` are concrete. Keeps
+/// [`Inner::Enabled`] non-generic across disk and in-memory configs.
+///
+/// Built where `M`/`Mode` are known, so `build_and_start` resolves to the
+/// right per-pipeline-state method (the no-pipeline state infers `Mode` from
+/// the writer, the mode-bound states require a matching writer).
+pub(crate) type RuntimeBuilderFn = Box<
+    dyn FnOnce(
+            tokio::runtime::Builder,
+        ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>
+        + Send,
+>;
 
 // ---------------------------------------------------------------------------
 // Dial9ConfigBuilderError — unified error for builder validation and writer I/O
@@ -147,7 +136,7 @@ pub(crate) type TokioConfigurator =
 pub(crate) enum Inner {
     Enabled {
         tokio_configurators: Vec<TokioConfigurator>,
-        runtime_builder: Box<dyn BuildTracedRuntime>,
+        runtime_builder: RuntimeBuilderFn,
     },
     Disabled {
         tokio_configurators: Vec<TokioConfigurator>,
@@ -190,7 +179,7 @@ pub(crate) fn materialize_tokio_builder(
 
 /// Deferred runtime config set by `with_runtime`, applied at `build()`: it
 /// configures the seed builder, pairs it with the writer, and erases both into
-/// a [`BuildTracedRuntime`].
+/// a [`RuntimeBuilderFn`].
 ///
 /// The seed starts in `Disk`, the default for [`TracedRuntime::builder`], so
 /// the closure can call `with_custom_pipeline` / `with_s3_uploader`. The writer
@@ -200,7 +189,7 @@ type RuntimeFinalizer<Mode> = Box<
     dyn FnOnce(
         TracedRuntimeBuilder<HasTracePath, PipelineUnset, Disk>,
         SegmentWriter<Mode>,
-    ) -> Box<dyn BuildTracedRuntime>,
+    ) -> RuntimeBuilderFn,
 >;
 
 fn finalizer<F, N, Mode>(f: F) -> RuntimeFinalizer<Mode>
@@ -211,12 +200,16 @@ where
         ) -> TracedRuntimeBuilder<HasTracePath, N, Mode>
         + 'static,
     N: Send + 'static,
+    TracedRuntimeBuilder<HasTracePath, N, Mode>: BuildAndStartRuntime<Mode>,
 {
+    // Two stages. The outer closure runs at config-build time, when seed and
+    // writer exist but the tokio handle does not. The inner one defers the
+    // actual build until that handle is available.
     Box::new(move |seed, writer| {
-        Box::new(ModeRuntime {
-            builder: f(seed),
-            writer,
-        })
+        // `f(seed)` pins marker `N` concrete, so `build_and_start_runtime`
+        // resolves to the right per-state method, captured into the inner closure.
+        let built = f(seed);
+        Box::new(move |tk| built.build_and_start_runtime(tk, writer))
     })
 }
 
@@ -847,12 +840,9 @@ impl Dial9Config {
             .map_err(Dial9ConfigBuilderError::Io)?;
 
         let seed = TracedRuntime::builder().with_trace_path(base_path);
-        let runtime_builder = match runtime_finalizer {
+        let runtime_builder: RuntimeBuilderFn = match runtime_finalizer {
             Some(finalize) => finalize(seed, writer),
-            None => Box::new(ModeRuntime {
-                builder: seed,
-                writer,
-            }),
+            None => Box::new(move |tk| seed.build_and_start(tk, writer)),
         };
 
         Ok(Dial9Config(Inner::Enabled {
@@ -899,14 +889,12 @@ impl Dial9Config {
 
         // Seed in `Disk` mode (where the pipeline-setting methods live); the
         // memory mode is reached by `with_custom_pipeline`/`with_s3_uploader`
-        // in the closure, or by `into_state` when no pipeline is configured.
+        // in the closure, or inferred from the `InMemoryWriter` at build when no
+        // pipeline is configured (the no-pipeline `build_and_start` infers Mode).
         let seed = TracedRuntime::builder().with_trace_path("mem");
-        let runtime_builder = match runtime_finalizer {
+        let runtime_builder: RuntimeBuilderFn = match runtime_finalizer {
             Some(finalize) => finalize(seed, writer),
-            None => Box::new(ModeRuntime {
-                builder: seed.into_state::<HasTracePath, PipelineUnset, Memory>(),
-                writer,
-            }),
+            None => Box::new(move |tk| seed.build_and_start(tk, writer)),
         };
 
         Ok(Dial9Config(Inner::Enabled {
@@ -955,6 +943,7 @@ impl<S: disk_config_builder::State> DiskConfigBuilder<S> {
             ) -> TracedRuntimeBuilder<HasTracePath, N, Disk>
             + 'static,
         N: Send + 'static,
+        TracedRuntimeBuilder<HasTracePath, N, Disk>: BuildAndStartRuntime<Disk>,
     {
         self.runtime_finalizer = Some(finalizer(f));
         self
@@ -985,6 +974,7 @@ impl<S: memory_config_builder::State> MemoryConfigBuilder<S> {
             ) -> TracedRuntimeBuilder<HasTracePath, N, Memory>
             + 'static,
         N: Send + 'static,
+        TracedRuntimeBuilder<HasTracePath, N, Memory>: BuildAndStartRuntime<Memory>,
     {
         self.runtime_finalizer = Some(finalizer(f));
         self

--- a/dial9-tokio-telemetry/src/legacy_config.rs
+++ b/dial9-tokio-telemetry/src/legacy_config.rs
@@ -16,29 +16,23 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::telemetry::recorder::{
-    HasTracePath, PipelineUnset, TelemetryGuard, TracedRuntime, TracedRuntimeBuilder,
+    BuildAndStartRuntime, HasTracePath, PipelineUnset, TelemetryGuard, TracedRuntime,
+    TracedRuntimeBuilder,
 };
-use crate::telemetry::writer::DiskWriter;
+use crate::telemetry::writer::{Disk, DiskWriter};
 
-/// Type-erased terminal step for a [`TracedRuntimeBuilder`]: hides the
-/// pipeline-mode marker `M` so [`Dial9Config`] can stay non-generic.
-trait BuildTracedRuntime: Send {
-    fn build_and_start(
-        self: Box<Self>,
-        tokio_builder: tokio::runtime::Builder,
-        writer: DiskWriter,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>;
-}
-
-impl<M: Send + 'static> BuildTracedRuntime for TracedRuntimeBuilder<HasTracePath, M> {
-    fn build_and_start(
-        self: Box<Self>,
-        tokio_builder: tokio::runtime::Builder,
-        writer: DiskWriter,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
-        TracedRuntimeBuilder::<HasTracePath, M>::build_and_start(*self, tokio_builder, writer)
-    }
-}
+/// Type-erased terminal step: a closure that builds and starts the runtime,
+/// capturing the configured builder at the point its pipeline-mode marker `M`
+/// is concrete (so `build_and_start_runtime` resolves). Takes the `DiskWriter`
+/// since it's constructed later, in [`Dial9Config::build`]. Keeps
+/// [`Dial9Config`] non-generic.
+type LegacyRuntimeBuilderFn = Box<
+    dyn FnOnce(
+            tokio::runtime::Builder,
+            DiskWriter,
+        ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>
+        + Send,
+>;
 
 // ---------------------------------------------------------------------------
 // Dial9Config — opaque value the macro consumes
@@ -59,7 +53,7 @@ enum Inner {
         max_total_size: u64,
         rotation_period: Option<Duration>,
         tokio_builder: tokio::runtime::Builder,
-        runtime_builder: Box<dyn BuildTracedRuntime>,
+        runtime_builder: LegacyRuntimeBuilderFn,
     },
     Disabled {
         tokio_builder: tokio::runtime::Builder,
@@ -87,7 +81,7 @@ impl Dial9Config {
                     .max_total_size(max_total_size)
                     .maybe_rotation_period(rotation_period)
                     .build()?;
-                let (runtime, guard) = runtime_builder.build_and_start(tokio_builder, writer)?;
+                let (runtime, guard) = runtime_builder(tokio_builder, writer)?;
                 Ok((runtime, Some(guard)))
             }
             Inner::Disabled { mut tokio_builder } => {
@@ -204,14 +198,20 @@ impl<M: Send + 'static> Dial9ConfigBuilder<M> {
     }
 
     /// Finalize into a [`Dial9Config`] ready for the macro.
-    pub fn build(self) -> Dial9Config {
+    pub fn build(self) -> Dial9Config
+    where
+        TracedRuntimeBuilder<HasTracePath, M>: BuildAndStartRuntime<Disk>,
+    {
+        // `M` is concrete here, so capture the typed builder into a closure
+        // whose `build_and_start_runtime` resolves to the right per-state method.
+        let rb = self.runtime_builder;
         Dial9Config(Inner::Enabled {
             base_path: self.base_path,
             max_file_size: self.max_file_size,
             max_total_size: self.max_total_size,
             rotation_period: self.rotation_period,
             tokio_builder: self.tokio_builder,
-            runtime_builder: Box::new(self.runtime_builder),
+            runtime_builder: Box::new(move |tk, writer| rb.build_and_start_runtime(tk, writer)),
         })
     }
 }

--- a/dial9-tokio-telemetry/src/primitives.rs
+++ b/dial9-tokio-telemetry/src/primitives.rs
@@ -128,6 +128,155 @@ macro_rules! define_thread_local {
 #[cfg(shuttle)]
 pub(crate) use define_thread_local as thread_local;
 
+#[cfg(not(shuttle))]
+pub(crate) mod fs {
+    use std::io::{self, Write};
+    use std::path::Path;
+
+    pub(crate) fn create_dir_all(path: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(path)
+    }
+    pub(crate) fn rename(from: &Path, to: &Path) -> io::Result<()> {
+        std::fs::rename(from, to)
+    }
+    pub(crate) fn remove_file(path: &Path) -> io::Result<()> {
+        std::fs::remove_file(path)
+    }
+    pub(crate) fn read_dir(path: &Path) -> io::Result<std::fs::ReadDir> {
+        std::fs::read_dir(path)
+    }
+    pub(crate) fn metadata(path: &Path) -> io::Result<std::fs::Metadata> {
+        std::fs::metadata(path)
+    }
+    pub(crate) fn read(path: &Path) -> io::Result<Vec<u8>> {
+        std::fs::read(path)
+    }
+
+    /// Active-segment file handle.
+    #[derive(Debug)]
+    pub(crate) struct File(std::fs::File);
+
+    impl File {
+        pub(crate) fn create(path: &Path) -> io::Result<File> {
+            std::fs::File::create(path).map(File)
+        }
+    }
+
+    impl Write for File {
+        #[inline]
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.write(buf)
+        }
+        #[inline]
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.flush()
+        }
+    }
+}
+
+#[cfg(shuttle)]
+pub(crate) mod fs {
+    use std::cell::Cell;
+    use std::io::{self, ErrorKind, Write};
+    use std::path::Path;
+
+    use shuttle::rand::Rng;
+
+    /// How to fail filesystem operations during a shuttle run.
+    #[derive(Clone, Copy, Debug)]
+    pub(crate) enum FaultPolicy {
+        /// Delegate to real `std::fs`, nothing fails.
+        None,
+        /// Every fallible op returns `PermissionDenied`.
+        FailAll,
+        /// Each op independently fails with this probability, drawn from
+        /// shuttle's RNG so the scheduler explores the fault schedule.
+        FailProb(f64),
+    }
+
+    std::thread_local! {
+        static FAULT: Cell<FaultPolicy> = const { Cell::new(FaultPolicy::None) };
+    }
+
+    /// Arm `policy`: the returned guard restores the previous one on drop so a
+    /// fault can't leak into the next shuttle iteration.
+    #[must_use]
+    pub(crate) fn set_fault(policy: FaultPolicy) -> FaultGuard {
+        let prev = FAULT.with(|f| f.replace(policy));
+        FaultGuard { prev }
+    }
+
+    pub(crate) struct FaultGuard {
+        prev: FaultPolicy,
+    }
+
+    impl Drop for FaultGuard {
+        fn drop(&mut self) {
+            FAULT.with(|f| f.set(self.prev));
+        }
+    }
+
+    fn check() -> io::Result<()> {
+        let fail = match FAULT.with(|f| f.get()) {
+            FaultPolicy::None => false,
+            FaultPolicy::FailAll => true,
+            FaultPolicy::FailProb(p) => shuttle::rand::thread_rng().gen_bool(p),
+        };
+        if fail {
+            Err(io::Error::from(ErrorKind::PermissionDenied))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn create_dir_all(path: &Path) -> io::Result<()> {
+        check()?;
+        std::fs::create_dir_all(path)
+    }
+    pub(crate) fn rename(from: &Path, to: &Path) -> io::Result<()> {
+        check()?;
+        std::fs::rename(from, to)
+    }
+    pub(crate) fn remove_file(path: &Path) -> io::Result<()> {
+        check()?;
+        std::fs::remove_file(path)
+    }
+    pub(crate) fn read_dir(path: &Path) -> io::Result<std::fs::ReadDir> {
+        check()?;
+        std::fs::read_dir(path)
+    }
+    pub(crate) fn metadata(path: &Path) -> io::Result<std::fs::Metadata> {
+        check()?;
+        std::fs::metadata(path)
+    }
+    pub(crate) fn read(path: &Path) -> io::Result<Vec<u8>> {
+        check()?;
+        std::fs::read(path)
+    }
+
+    /// Active-segment file handle whose `write`/`flush` honor the armed fault
+    /// policy. `create` is never faulted, so a writer can always be built.
+    #[derive(Debug)]
+    pub(crate) struct File(std::fs::File);
+
+    impl File {
+        pub(crate) fn create(path: &Path) -> io::Result<File> {
+            std::fs::File::create(path).map(File)
+        }
+    }
+
+    impl Write for File {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            check()?;
+            self.0.write(buf)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            check()?;
+            self.0.flush()
+        }
+    }
+}
+
 // ── BoundedQueue ────────────────────────────────────────────────────────────
 
 /// A bounded MPMC queue. Production uses `crossbeam_queue::ArrayQueue`;

--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -732,7 +732,7 @@ mod tests {
     fn trace_reader_reads_gzip_trace_files() {
         use crate::telemetry::buffer::ThreadLocalBuffer;
         use crate::telemetry::format::WorkerParkEvent;
-        use crate::telemetry::writer::{DiskWriter, TraceWriter};
+        use crate::telemetry::writer::DiskWriter;
         use flate2::Compression;
         use flate2::write::GzEncoder;
         use std::io::Write;

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -33,16 +33,14 @@ pub use format::{
 };
 pub use process_resource_usage::ProcessResourceUsageConfig;
 pub use recorder::{
-    HasTracePath, NoTracePath, PipelineCustom, PipelineS3, PipelineUnset, RuntimeTelemetryHandle,
-    TelemetryCore, TelemetryCoreBuilder, TelemetryGuard, TelemetryHandle, TelemetryRuntimeError,
-    TokioHooks, TraceRuntimeCoreBuilder, TracedRuntime, TracedRuntimeBuilder, current_worker_id,
-    spawn,
+    BuildAndStartRuntime, HasTracePath, NoTracePath, PipelineCustom, PipelineS3, PipelineUnset,
+    RuntimeTelemetryHandle, TelemetryCore, TelemetryCoreBuilder, TelemetryGuard, TelemetryHandle,
+    TelemetryRuntimeError, TokioHooks, TraceRuntimeCoreBuilder, TracedRuntime,
+    TracedRuntimeBuilder, current_worker_id, spawn,
 };
 pub use task_dump_config::TaskDumpConfig;
 pub use task_metadata::{TaskId, UNKNOWN_TASK_ID};
-pub use writer::{
-    Disk, DiskWriter, InMemoryWriter, Memory, NullWriter, SegmentWriter, TraceWriter, WriterMode,
-};
+pub use writer::{Disk, DiskWriter, InMemoryWriter, Memory, SegmentWriter, WriterMode};
 
 /// Record a custom event into the trace.
 ///

--- a/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
@@ -2,7 +2,7 @@ use crate::primitives::sync::Arc;
 use crate::primitives::sync::atomic::Ordering;
 #[cfg(feature = "cpu-profiling")]
 use crate::rate_limit::rate_limited;
-use crate::telemetry::writer::{Disk, SegmentWriter, TraceWriter, WriterMode};
+use crate::telemetry::writer::{Disk, SegmentWriter, WriterMode};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -360,7 +360,7 @@ impl<P> TracedRuntimeBuilder<P, PipelineUnset> {
     /// tk.enable_all();
     /// let _ = TracedRuntime::builder()
     ///     .with_custom_pipeline(|p| p.write_back())
-    ///     .build_with_writer(tk, writer);
+    ///     .build(tk, writer);
     /// ```
     pub fn with_custom_pipeline<F, Mode>(
         mut self,
@@ -419,58 +419,37 @@ impl<M, Mode: WriterMode> TracedRuntimeBuilder<NoTracePath, M, Mode> {
         self.trace_path = Some(path.into());
         self.into_state()
     }
+}
 
-    /// Build with a custom writer (for tests or `NullWriter`).
-    /// No background worker is spawned.
-    pub fn build_with_writer<W>(
+/// Build methods for the no-pipeline state. The writer drives `Mode`: pass a
+/// [`DiskWriter`] or [`InMemoryWriter`](crate::telemetry::InMemoryWriter) and
+/// the mode is inferred. Generic over the trace-path state `P` and the
+/// builder's current mode `BMode` (a no-pipeline builder never pins a mode, so
+/// the writer's `Mode` re-types it freely). Mode-bound pipeline states have
+/// their own `build`, where the writer mode must match the pinned `Mode`.
+impl<P, BMode: WriterMode> TracedRuntimeBuilder<P, PipelineUnset, BMode> {
+    /// Build the traced runtime. Recording starts disabled. `Mode` is inferred
+    /// from `writer`. The background worker spawns only when a pipeline is set,
+    /// so a plain no-pipeline build never starts one.
+    pub fn build<Mode: WriterMode>(
         self,
         builder: tokio::runtime::Builder,
-        writer: W,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>
-    where
-        W: TraceWriter<Mode> + 'static,
-    {
-        self.into_state::<HasTracePath, M, Mode>()
-            .build_inner(builder, Box::new(writer))
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        self.into_state::<HasTracePath, PipelineUnset, Mode>()
+            .build_inner(builder, writer)
     }
 
-    /// Build with a custom writer and immediately enable recording.
-    pub fn build_and_start_with_writer<W>(
+    /// Build the traced runtime and immediately enable recording. `Mode` is
+    /// inferred from `writer`.
+    pub fn build_and_start<Mode: WriterMode>(
         self,
         builder: tokio::runtime::Builder,
-        writer: W,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>
-    where
-        W: TraceWriter<Mode> + 'static,
-    {
-        let (runtime, guard) = self.build_with_writer(builder, writer)?;
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        let (runtime, guard) = self.build(builder, writer)?;
         guard.enable();
         Ok((runtime, guard))
-    }
-
-    /// Build the traced runtime. No background worker is spawned
-    /// (use `with_trace_path()` first for worker support).
-    pub fn build<W>(
-        self,
-        builder: tokio::runtime::Builder,
-        writer: W,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>
-    where
-        W: TraceWriter<Mode> + 'static,
-    {
-        self.build_with_writer(builder, writer)
-    }
-
-    /// Build and immediately enable recording.
-    pub fn build_and_start<W>(
-        self,
-        builder: tokio::runtime::Builder,
-        writer: W,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>
-    where
-        W: TraceWriter<Mode> + 'static,
-    {
-        self.build_and_start_with_writer(builder, writer)
     }
 }
 
@@ -481,63 +460,10 @@ impl<M, Mode: WriterMode> TracedRuntimeBuilder<HasTracePath, M, Mode> {
         self
     }
 
-    /// Build the traced runtime with a `DiskWriter`.
-    ///
-    /// The background worker is auto-spawned when cpu-profiling or any
-    /// pipeline strategy is configured. Recording starts disabled; call
-    /// [`TelemetryGuard::enable`] to begin, or use
-    /// [`build_and_start`](Self::build_and_start).
-    pub fn build(
-        self,
-        builder: tokio::runtime::Builder,
-        writer: SegmentWriter<Mode>,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
-        self.build_inner(builder, Box::new(writer))
-    }
-
-    /// Build the traced runtime and immediately enable recording.
-    pub fn build_and_start(
-        self,
-        builder: tokio::runtime::Builder,
-        writer: SegmentWriter<Mode>,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
-        let (runtime, guard) = self.build(builder, writer)?;
-        guard.enable();
-        Ok((runtime, guard))
-    }
-
-    /// Build with a custom writer (for tests). The background worker is
-    /// still spawned if cpu-profiling or any pipeline strategy is configured
-    /// and `trace_path` is set.
-    pub fn build_with_writer<W>(
-        self,
-        builder: tokio::runtime::Builder,
-        writer: W,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>
-    where
-        W: TraceWriter<Mode> + 'static,
-    {
-        self.build_inner(builder, Box::new(writer))
-    }
-
-    /// Build with a custom writer and immediately enable recording.
-    pub fn build_and_start_with_writer<W>(
-        self,
-        builder: tokio::runtime::Builder,
-        writer: W,
-    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>
-    where
-        W: TraceWriter<Mode> + 'static,
-    {
-        let (runtime, guard) = self.build_with_writer(builder, writer)?;
-        guard.enable();
-        Ok((runtime, guard))
-    }
-
     fn build_inner(
         self,
         mut builder: tokio::runtime::Builder,
-        writer: Box<dyn TraceWriter<Mode>>,
+        writer: SegmentWriter<Mode>,
     ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
         if !self.enabled {
             return TracedRuntime::build_disabled(builder);
@@ -596,6 +522,114 @@ impl<M, Mode: WriterMode> TracedRuntimeBuilder<HasTracePath, M, Mode> {
             self.tokio_hooks,
         )?;
         Ok((runtime, guard))
+    }
+}
+
+/// Build methods for a custom-pipeline runtime. The pipeline pins `Mode`, so
+/// the writer must match it (a `Disk` pipeline cannot take a `Memory` writer).
+/// Generic over the trace-path state `P` (the worker still only spawns once a
+/// path is set; a no-path build just skips it).
+impl<P, Mode: WriterMode> TracedRuntimeBuilder<P, PipelineCustom, Mode> {
+    /// Build the traced runtime. Recording starts disabled.
+    pub fn build(
+        self,
+        builder: tokio::runtime::Builder,
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        self.into_state::<HasTracePath, PipelineCustom, Mode>()
+            .build_inner(builder, writer)
+    }
+
+    /// Build the traced runtime and immediately enable recording.
+    pub fn build_and_start(
+        self,
+        builder: tokio::runtime::Builder,
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        let (runtime, guard) = self.build(builder, writer)?;
+        guard.enable();
+        Ok((runtime, guard))
+    }
+}
+
+/// Build methods for an S3-pipeline runtime. The pipeline pins `Mode`, so the
+/// writer must match it. Generic over the trace-path state `P`.
+#[cfg(feature = "worker-s3")]
+impl<P, Mode: WriterMode> TracedRuntimeBuilder<P, PipelineS3, Mode> {
+    /// Build the traced runtime. Recording starts disabled.
+    pub fn build(
+        self,
+        builder: tokio::runtime::Builder,
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        self.into_state::<HasTracePath, PipelineS3, Mode>()
+            .build_inner(builder, writer)
+    }
+
+    /// Build the traced runtime and immediately enable recording.
+    pub fn build_and_start(
+        self,
+        builder: tokio::runtime::Builder,
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        let (runtime, guard) = self.build(builder, writer)?;
+        guard.enable();
+        Ok((runtime, guard))
+    }
+}
+
+/// Crate-internal: re-unifies `build_and_start` across the pipeline-marker
+/// states so the `#[main]` macro / [`crate::Dial9Config`] path can stay generic
+/// over the marker `N`. The public build methods are split per state (to infer
+/// `Mode` only on the safe no-pipeline state); this trait lets the erased macro
+/// path call a single method regardless of marker.
+///
+/// Public-but-hidden: it appears in the `where` bounds of the public
+/// `Dial9Config` builder methods (`with_runtime`/`build`), so it must be at
+/// least as visible as them to satisfy `private_interfaces`.
+#[doc(hidden)]
+pub trait BuildAndStartRuntime<Mode: WriterMode> {
+    fn build_and_start_runtime(
+        self,
+        builder: tokio::runtime::Builder,
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)>;
+}
+
+impl<BMode: WriterMode, Mode: WriterMode> BuildAndStartRuntime<Mode>
+    for TracedRuntimeBuilder<HasTracePath, PipelineUnset, BMode>
+{
+    fn build_and_start_runtime(
+        self,
+        builder: tokio::runtime::Builder,
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        self.build_and_start(builder, writer)
+    }
+}
+
+impl<Mode: WriterMode> BuildAndStartRuntime<Mode>
+    for TracedRuntimeBuilder<HasTracePath, PipelineCustom, Mode>
+{
+    fn build_and_start_runtime(
+        self,
+        builder: tokio::runtime::Builder,
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        self.build_and_start(builder, writer)
+    }
+}
+
+#[cfg(feature = "worker-s3")]
+impl<Mode: WriterMode> BuildAndStartRuntime<Mode>
+    for TracedRuntimeBuilder<HasTracePath, PipelineS3, Mode>
+{
+    fn build_and_start_runtime(
+        self,
+        builder: tokio::runtime::Builder,
+        writer: SegmentWriter<Mode>,
+    ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
+        self.build_and_start(builder, writer)
     }
 }
 
@@ -701,8 +735,8 @@ impl TelemetryCore {
         #[cfg(feature = "worker-s3")]
         #[builder(field)]
         s3_client: Option<aws_sdk_s3::Client>,
-        /// The trace writer (e.g. [`DiskWriter`], [`NullWriter`](crate::telemetry::NullWriter)).
-        writer: impl TraceWriter<M> + 'static,
+        /// The trace writer ([`DiskWriter`] or [`InMemoryWriter`](crate::telemetry::InMemoryWriter)).
+        writer: SegmentWriter<M>,
         /// Path for trace output. Enables the background worker when any
         /// segment processors are configured.
         #[builder(into)]
@@ -762,7 +796,7 @@ impl TelemetryCore {
         };
 
         #[allow(unused_mut)]
-        let mut writer: Box<dyn crate::telemetry::writer::TraceWriter<M>> = Box::new(writer);
+        let mut writer = writer;
         let writer_fs = writer.fs_handle();
 
         let processors = assemble_processors(
@@ -892,9 +926,7 @@ impl TelemetryCore {
 }
 
 // Custom methods on the generated builder.
-impl<M: WriterMode, W: TraceWriter<M>, S: telemetry_core_builder::State>
-    TelemetryCoreBuilder<M, W, S>
-{
+impl<M: WriterMode, S: telemetry_core_builder::State> TelemetryCoreBuilder<M, S> {
     /// Configure S3 upload for sealed trace segments.
     #[cfg(feature = "worker-s3")]
     pub fn s3_config(mut self, config: crate::background_task::s3::S3Config) -> Self {
@@ -937,11 +969,11 @@ impl<M: WriterMode, W: TraceWriter<M>, S: telemetry_core_builder::State>
 ///   (panicking, used by the `#[dial9_tokio_telemetry::main]` macro) or
 ///   [`TracedRuntime::try_new`] (fallible).
 /// - **Low-level**: via [`TracedRuntime::builder`] →
-///   [`TracedRuntimeBuilder::build_and_start`] for direct control over the
-///   raw [`tokio::runtime::Builder`] and [`crate::telemetry::TraceWriter`].
-///   This is the path used by example code, benchmarks, and integration
-///   tests that want to wire a [`crate::telemetry::NullWriter`] or other
-///   custom writer.
+///   [`build_and_start`](TracedRuntimeBuilder::build_and_start) for direct
+///   control over the raw [`tokio::runtime::Builder`] and the
+///   [`DiskWriter`](crate::telemetry::DiskWriter) /
+///   [`InMemoryWriter`](crate::telemetry::InMemoryWriter). This is the path
+///   used by example code, benchmarks, and integration tests.
 #[derive(Debug)]
 pub struct TracedRuntime {
     pub(crate) runtime: tokio::runtime::Runtime,
@@ -984,26 +1016,22 @@ impl TracedRuntime {
         Ok((runtime, TelemetryGuard::disabled()))
     }
 
-    /// Build the traced runtime. Recording starts disabled. Writer mode is
-    /// inferred from the writer.
-    pub fn build<Mode: WriterMode, W: TraceWriter<Mode> + 'static>(
+    /// Build the traced runtime. Recording starts disabled. `Mode` is inferred
+    /// from the writer.
+    pub fn build<Mode: WriterMode>(
         builder: tokio::runtime::Builder,
-        writer: W,
+        writer: SegmentWriter<Mode>,
     ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
-        Self::builder()
-            .into_state::<NoTracePath, PipelineUnset, Mode>()
-            .build_with_writer(builder, writer)
+        Self::builder().build(builder, writer)
     }
 
-    /// Build the traced runtime and immediately enable recording. Writer
-    /// mode is inferred from the writer.
-    pub fn build_and_start<Mode: WriterMode, W: TraceWriter<Mode> + 'static>(
+    /// Build the traced runtime and immediately enable recording. `Mode` is
+    /// inferred from the writer.
+    pub fn build_and_start<Mode: WriterMode>(
         builder: tokio::runtime::Builder,
-        writer: W,
+        writer: SegmentWriter<Mode>,
     ) -> std::io::Result<(tokio::runtime::Runtime, TelemetryGuard)> {
-        Self::builder()
-            .into_state::<NoTracePath, PipelineUnset, Mode>()
-            .build_and_start_with_writer(builder, writer)
+        Self::builder().build_and_start(builder, writer)
     }
 }
 
@@ -1062,9 +1090,8 @@ fn try_assemble_dial9_config(
             runtime_builder,
         } => {
             let tokio_builder = materialize_tokio_builder(&tokio_configurators);
-            let (runtime, guard) = runtime_builder
-                .build_and_start(tokio_builder)
-                .map_err(TelemetryRuntimeError::TelemetryCore)?;
+            let (runtime, guard) =
+                runtime_builder(tokio_builder).map_err(TelemetryRuntimeError::TelemetryCore)?;
             Ok((runtime, guard))
         }
         Inner::Disabled {

--- a/dial9-tokio-telemetry/src/telemetry/recorder/flush_loop.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/flush_loop.rs
@@ -1,7 +1,7 @@
 use crate::metrics::{FlushMetrics, Operation, TlDrainMetrics};
 use crate::rate_limit::rate_limited;
 use crate::telemetry::buffer;
-use crate::telemetry::writer::{TraceWriter, WriterMode};
+use crate::telemetry::writer::{SegmentWriter, WriterMode};
 use metrique::timers::Timer;
 use metrique::unit::Microsecond;
 use metrique::unit_of_work::metrics;
@@ -46,7 +46,7 @@ pub(crate) struct FlushStats {
 /// events to disk, and flush the writer. This is the only code path that
 /// touches the writer, and it runs exclusively on the flush thread.
 pub(super) fn flush_once<M: WriterMode>(
-    writer: &mut dyn TraceWriter<M>,
+    writer: &mut SegmentWriter<M>,
     events_written: &mut u64,
     shared: &SharedState,
     drain_self: bool,
@@ -110,7 +110,7 @@ pub(super) fn run_flush_loop<M: WriterMode>(
     control_rx: crate::primitives::sync::mpsc::Receiver<ControlCommand>,
     shared: &SharedState,
     flush_metrics_sink: &metrique_writer::BoxEntrySink,
-    mut writer: Box<dyn TraceWriter<M>>,
+    mut writer: SegmentWriter<M>,
 ) {
     // Drain the flush thread's own TL buffer every ~1s (200 × 5ms)
     // rather than every cycle, so queue samples and CPU events
@@ -225,7 +225,7 @@ pub(super) fn run_flush_loop<M: WriterMode>(
             .append_on_drop(flush_metrics_sink.clone());
         }
         let mut flush_timer = Timer::start_now();
-        let stats = flush_once(&mut *writer, &mut events_written, shared, drain_self);
+        let stats = flush_once(&mut writer, &mut events_written, shared, drain_self);
         flush_timer.stop();
 
         // Notify the writer that TL buffers have been drained and flushed.

--- a/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
@@ -135,7 +135,7 @@ impl TelemetryGuard {
     /// # use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TelemetryCore};
     /// # fn main() -> std::io::Result<()> {
     /// let guard = TelemetryCore::builder()
-    ///     .writer(InMemoryWriter::discard())
+    ///     .writer(InMemoryWriter::new(16 * 1024 * 1024)?)
     ///     .build()?;
     /// guard.enable();
     ///

--- a/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/guard.rs
@@ -132,10 +132,10 @@ impl TelemetryGuard {
     /// runtime with no telemetry hooks installed.
     ///
     /// ```rust,no_run
-    /// # use dial9_tokio_telemetry::telemetry::{NullWriter, TelemetryCore};
+    /// # use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TelemetryCore};
     /// # fn main() -> std::io::Result<()> {
     /// let guard = TelemetryCore::builder()
-    ///     .writer(NullWriter)
+    ///     .writer(InMemoryWriter::discard())
     ///     .build()?;
     /// guard.enable();
     ///

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -12,8 +12,9 @@ pub(crate) use runtime_context::poll_start_ts_monotonic;
 pub(crate) use shared_state::SharedState;
 
 pub use builder::{
-    HasTracePath, NoTracePath, PipelineCustom, PipelineS3, PipelineUnset, TelemetryCore,
-    TelemetryCoreBuilder, TelemetryRuntimeError, TracedRuntime, TracedRuntimeBuilder,
+    BuildAndStartRuntime, HasTracePath, NoTracePath, PipelineCustom, PipelineS3, PipelineUnset,
+    TelemetryCore, TelemetryCoreBuilder, TelemetryRuntimeError, TracedRuntime,
+    TracedRuntimeBuilder,
 };
 pub use guard::{TelemetryGuard, TraceRuntimeCoreBuilder};
 pub use handle::{RuntimeTelemetryHandle, TelemetryHandle, spawn};
@@ -316,43 +317,28 @@ fn attach_runtime(
 #[cfg(all(test, not(shuttle)))]
 mod tests {
     use super::*;
-    use crate::telemetry::NullWriter;
+    use crate::background_task::testutil::{CapturingProcessor, decode_captured};
     use crate::telemetry::buffer;
     use crate::telemetry::collector::CentralCollector;
-    #[cfg(feature = "cpu-profiling")]
-    use crate::telemetry::writer::DiskWriter;
+    use crate::telemetry::writer::InMemoryWriter;
     use std::panic::Location;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, AtomicUsize};
 
+    /// In-memory capture budget for runtime tests.
+    const CAPTURE_SIZE: u64 = 16 * 1024 * 1024;
+
     /// Drain all pending batches from a `CentralCollector` into a writer.
     /// Call `buffer::drain_to_collector` first to flush the thread-local buffer.
+    #[cfg(feature = "analysis")]
     fn drain_collector_to_writer(
         collector: &CentralCollector,
-        writer: &mut dyn crate::telemetry::writer::TraceWriter,
+        writer: &mut crate::telemetry::writer::DiskWriter,
     ) {
         while let Some(batch) = collector.next() {
             if batch.event_count > 0 {
                 writer.write_encoded_batch(&batch).unwrap();
             }
-        }
-    }
-
-    /// Writer that captures encoded bytes for test assertions.
-    struct CapturingWriter(Arc<std::sync::Mutex<Vec<u8>>>);
-    impl crate::telemetry::writer::TraceWriter for CapturingWriter {
-        fn write_encoded_batch(
-            &mut self,
-            batch: &crate::telemetry::collector::Batch,
-        ) -> std::io::Result<()> {
-            self.0
-                .lock()
-                .unwrap()
-                .extend_from_slice(batch.encoded_bytes());
-            Ok(())
-        }
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
         }
     }
 
@@ -374,13 +360,14 @@ mod tests {
 
     #[test]
     fn current_thread_runtime_resolves_worker_ids() {
-        let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let (capture, data) = CapturingProcessor::new();
 
         let mut builder = tokio::runtime::Builder::new_current_thread();
         builder.enable_all();
 
         let (rt, guard) = TracedRuntime::builder()
-            .build_and_start_with_writer(builder, CapturingWriter(data.clone()))
+            .with_custom_pipeline(|p| p.pipe(capture))
+            .build_and_start(builder, InMemoryWriter::new(CAPTURE_SIZE).unwrap())
             .unwrap();
 
         rt.block_on(async {
@@ -392,10 +379,12 @@ mod tests {
         });
 
         drop(rt);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .unwrap();
 
         let raw = data.lock().unwrap();
-        let events = crate::telemetry::format::decode_events(&raw).unwrap();
+        let events = decode_captured(&raw);
         let poll_starts: Vec<_> = events
             .iter()
             .filter_map(|e| match e {
@@ -421,7 +410,7 @@ mod tests {
 
     #[test]
     fn tokio_instrumentation_can_be_disabled_without_installing_hooks() {
-        let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let (capture, data) = CapturingProcessor::new();
         let hook_calls = Arc::new(AtomicUsize::new(0));
         let on_thread_start_calls = hook_calls.clone();
         let on_before_poll_calls = hook_calls.clone();
@@ -440,7 +429,8 @@ mod tests {
                     on_before_poll_calls.fetch_add(1, Ordering::Relaxed);
                 });
             })
-            .build_and_start_with_writer(builder, CapturingWriter(data.clone()))
+            .with_custom_pipeline(|p| p.pipe(capture))
+            .build_and_start(builder, InMemoryWriter::new(CAPTURE_SIZE).unwrap())
             .unwrap();
 
         assert!(guard.is_enabled());
@@ -471,13 +461,15 @@ mod tests {
         );
 
         drop(runtime);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .unwrap();
 
         let raw = data.lock().unwrap();
         let events = if raw.is_empty() {
             Vec::new()
         } else {
-            crate::telemetry::format::decode_events(&raw).unwrap()
+            decode_captured(&raw)
         };
         assert!(
             events.iter().all(|event| !matches!(
@@ -505,7 +497,7 @@ mod tests {
         let builder = tokio::runtime::Builder::new_multi_thread();
         let (runtime, guard) = TracedRuntime::builder()
             .install(false)
-            .build(builder, NullWriter)
+            .build(builder, InMemoryWriter::discard())
             .unwrap();
 
         // Guard methods should be safe no-ops
@@ -554,7 +546,7 @@ mod tests {
             .max_total_size(100_000)
             .build()
             .unwrap();
-        let mut ew: Box<dyn crate::telemetry::writer::TraceWriter> = Box::new(writer);
+        let mut ew = writer;
         let collector = Arc::new(CentralCollector::new());
         let drain_epoch = AtomicU64::new(0);
 
@@ -594,7 +586,7 @@ mod tests {
             // Drain after each iteration to produce separate small batches
             // that trigger file rotation (max_file_size is 100 bytes).
             buffer::drain_to_collector(&collector);
-            drain_collector_to_writer(&collector, &mut *ew);
+            drain_collector_to_writer(&collector, &mut ew);
         }
         ew.flush().unwrap();
         ew.finalize().unwrap();
@@ -637,7 +629,7 @@ mod tests {
     fn build_and_attach_to_telemetry_attaches_second_runtime() {
         let builder_a = tokio::runtime::Builder::new_multi_thread();
         let (runtime_a, guard) = TracedRuntime::builder()
-            .build_and_start_with_writer(builder_a, NullWriter)
+            .build_and_start(builder_a, InMemoryWriter::discard())
             .unwrap();
 
         let builder_b = tokio::runtime::Builder::new_multi_thread();
@@ -660,13 +652,14 @@ mod tests {
     fn build_and_attach_to_telemetry_produces_unique_worker_ids() {
         use std::collections::HashSet;
 
-        let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let (capture, data) = CapturingProcessor::new();
 
         let mut builder_a = tokio::runtime::Builder::new_multi_thread();
         builder_a.worker_threads(2);
         let (runtime_a, guard) = TracedRuntime::builder()
             .with_task_tracking(true)
-            .build_and_start_with_writer(builder_a, CapturingWriter(data.clone()))
+            .with_custom_pipeline(|p| p.pipe(capture))
+            .build_and_start(builder_a, InMemoryWriter::new(CAPTURE_SIZE).unwrap())
             .unwrap();
 
         let mut builder_b = tokio::runtime::Builder::new_multi_thread();
@@ -704,10 +697,12 @@ mod tests {
         // Drop runtimes, then guard to flush
         drop(runtime_a);
         drop(runtime_b);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .unwrap();
 
         let raw = data.lock().unwrap();
-        let captured = crate::telemetry::format::decode_events(&raw).unwrap();
+        let captured = decode_captured(&raw);
         let mut worker_ids: HashSet<u64> = HashSet::new();
         for event in captured.iter() {
             let wid = match event {
@@ -792,7 +787,7 @@ mod tests {
 
         drop(runtime_a);
         drop(runtime_b);
-        let _ = guard.graceful_shutdown(std::time::Duration::from_secs(5));
+        let _ = guard.graceful_shutdown(std::time::Duration::from_secs(1));
 
         // Read all sealed trace files and collect SegmentMetadata entries.
         let mut all_metadata: Vec<std::collections::HashMap<String, String>> = Vec::new();
@@ -840,13 +835,14 @@ mod tests {
     fn wake_events_use_global_worker_id_in_multi_runtime() {
         use crate::telemetry::analysis_events::Dial9Event;
 
-        let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let (capture, data) = CapturingProcessor::new();
 
         let mut builder_a = tokio::runtime::Builder::new_multi_thread();
         builder_a.worker_threads(2);
         let (runtime_a, guard) = TracedRuntime::builder()
             .with_task_tracking(true)
-            .build_and_start_with_writer(builder_a, CapturingWriter(data.clone()))
+            .with_custom_pipeline(|p| p.pipe(capture))
+            .build_and_start(builder_a, InMemoryWriter::new(CAPTURE_SIZE).unwrap())
             .unwrap();
 
         let mut builder_b = tokio::runtime::Builder::new_multi_thread();
@@ -872,10 +868,12 @@ mod tests {
 
         drop(runtime_a);
         drop(runtime_b);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .unwrap();
 
         let raw = data.lock().unwrap();
-        let captured = crate::telemetry::format::decode_events(&raw).unwrap();
+        let captured = decode_captured(&raw);
         let wake_workers: Vec<u8> = captured
             .iter()
             .filter_map(|e| match e {
@@ -910,7 +908,7 @@ mod tests {
 
         /// Encode a single event into a batch and write it through the writer.
         fn write_raw_event(
-            writer: &mut dyn crate::telemetry::writer::TraceWriter,
+            writer: &mut DiskWriter,
             event: &dyn crate::telemetry::buffer::Encodable,
         ) -> std::io::Result<()> {
             let encoded_bytes = ThreadLocalBuffer::encode_single(event);
@@ -979,7 +977,7 @@ mod tests {
 
         fn execute_flush_round(
             round: &FlushRound,
-            ew: &mut Box<dyn crate::telemetry::writer::TraceWriter>,
+            ew: &mut DiskWriter,
             locations: &[&'static Location<'static>],
             timestamp: &mut u64,
             expected_raw: &mut usize,
@@ -1001,7 +999,7 @@ mod tests {
                         cpu: None,
                     };
                     *timestamp += 1;
-                    write_raw_event(&mut **ew, &data).unwrap();
+                    write_raw_event(&mut *ew, &data).unwrap();
                 }
             }
 
@@ -1013,7 +1011,7 @@ mod tests {
                     *timestamp += 1;
 
                     write_raw_event(
-                        &mut **ew,
+                        &mut *ew,
                         &runtime_context::PollStart {
                             timestamp_ns: ts,
                             worker_id: WorkerId::from(0usize),
@@ -1078,7 +1076,7 @@ mod tests {
                     .build()
                     .unwrap();
 
-                let mut ew: Box<dyn crate::telemetry::writer::TraceWriter> = Box::new(writer);
+                let mut ew = writer;
 
                 #[track_caller]
                 fn loc0() -> &'static Location<'static> { Location::caller() }
@@ -1115,14 +1113,20 @@ mod tests {
 
     #[test]
     fn telemetry_core_builds_guard_without_runtime() {
-        let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+        let guard = TelemetryCore::builder()
+            .writer(InMemoryWriter::discard())
+            .build()
+            .unwrap();
         assert!(guard.is_enabled());
         let _ = guard.graceful_shutdown(std::time::Duration::from_secs(1));
     }
 
     #[test]
     fn telemetry_core_trace_runtime_produces_working_runtime() {
-        let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+        let guard = TelemetryCore::builder()
+            .writer(InMemoryWriter::discard())
+            .build()
+            .unwrap();
         guard.enable();
 
         let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -1140,9 +1144,10 @@ mod tests {
 
     #[test]
     fn telemetry_core_task_tracking_produces_task_spawn_events() {
-        let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let (capture, data) = CapturingProcessor::new();
         let guard = TelemetryCore::builder()
-            .writer(CapturingWriter(data.clone()))
+            .writer(InMemoryWriter::new(CAPTURE_SIZE).unwrap())
+            .processors(vec![Box::new(capture)])
             .build()
             .unwrap();
         guard.enable();
@@ -1162,10 +1167,12 @@ mod tests {
         });
 
         drop(runtime);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .unwrap();
 
         let raw = data.lock().unwrap();
-        let events = crate::telemetry::format::decode_events(&raw).unwrap();
+        let events = decode_captured(&raw);
         let spawn_count = events
             .iter()
             .filter(|e| {
@@ -1185,9 +1192,10 @@ mod tests {
     fn telemetry_core_trace_runtime_multiple_runtimes_unique_worker_ids() {
         use std::collections::HashSet;
 
-        let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let (capture, data) = CapturingProcessor::new();
         let guard = TelemetryCore::builder()
-            .writer(CapturingWriter(data.clone()))
+            .writer(InMemoryWriter::new(CAPTURE_SIZE).unwrap())
+            .processors(vec![Box::new(capture)])
             .build()
             .unwrap();
         guard.enable();
@@ -1224,10 +1232,12 @@ mod tests {
 
         drop(runtime_a);
         drop(runtime_b);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .unwrap();
 
         let raw = data.lock().unwrap();
-        let captured = crate::telemetry::format::decode_events(&raw).unwrap();
+        let captured = decode_captured(&raw);
         let mut worker_ids: HashSet<u64> = HashSet::new();
         for event in &captured {
             if let crate::telemetry::analysis_events::Dial9Event::PollStartEvent(e) = event
@@ -1247,9 +1257,10 @@ mod tests {
 
     #[test]
     fn trace_runtime_build_returns_telemetry_handle() {
-        let data = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let (capture, data) = CapturingProcessor::new();
         let guard = TelemetryCore::builder()
-            .writer(CapturingWriter(data.clone()))
+            .writer(InMemoryWriter::new(CAPTURE_SIZE).unwrap())
+            .processors(vec![Box::new(capture)])
             .build()
             .unwrap();
         guard.enable();
@@ -1282,11 +1293,13 @@ mod tests {
         );
 
         drop(runtime);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .unwrap();
 
         // Verify wake events were recorded (handle.spawn wraps with wake tracking)
         let raw = data.lock().unwrap();
-        let events = crate::telemetry::format::decode_events(&raw).unwrap();
+        let events = decode_captured(&raw);
         let wake_count = events
             .iter()
             .filter(|e| {
@@ -1306,7 +1319,10 @@ mod tests {
     /// correct runtime even when called from outside any runtime context.
     #[test]
     fn trace_runtime_handle_spawns_on_correct_runtime_from_outside() {
-        let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+        let guard = TelemetryCore::builder()
+            .writer(InMemoryWriter::discard())
+            .build()
+            .unwrap();
         guard.enable();
 
         let mut builder_a = tokio::runtime::Builder::new_multi_thread();
@@ -1708,7 +1724,7 @@ mod tests {
         let s3 = S3Config::builder().bucket("b").service_name("s").build();
 
         let guard = TelemetryCore::builder()
-            .writer(NullWriter)
+            .writer(InMemoryWriter::discard())
             .trace_path(&trace_path)
             .s3_config(s3)
             .build()
@@ -1725,6 +1741,7 @@ mod tests {
     #[test]
     fn telemetry_core_builder_cpu_profiling_auto_wires_processors() {
         use crate::telemetry::cpu_profile::CpuProfilingConfig;
+        use crate::telemetry::writer::DiskWriter;
 
         let dir = tempfile::tempdir().unwrap();
         let trace_path = dir.path().join("trace.bin");

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -497,7 +497,7 @@ mod tests {
         let builder = tokio::runtime::Builder::new_multi_thread();
         let (runtime, guard) = TracedRuntime::builder()
             .install(false)
-            .build(builder, InMemoryWriter::discard())
+            .build(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
             .unwrap();
 
         // Guard methods should be safe no-ops
@@ -629,7 +629,7 @@ mod tests {
     fn build_and_attach_to_telemetry_attaches_second_runtime() {
         let builder_a = tokio::runtime::Builder::new_multi_thread();
         let (runtime_a, guard) = TracedRuntime::builder()
-            .build_and_start(builder_a, InMemoryWriter::discard())
+            .build_and_start(builder_a, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
             .unwrap();
 
         let builder_b = tokio::runtime::Builder::new_multi_thread();
@@ -1114,7 +1114,7 @@ mod tests {
     #[test]
     fn telemetry_core_builds_guard_without_runtime() {
         let guard = TelemetryCore::builder()
-            .writer(InMemoryWriter::discard())
+            .writer(InMemoryWriter::new(16 * 1024 * 1024).unwrap())
             .build()
             .unwrap();
         assert!(guard.is_enabled());
@@ -1124,7 +1124,7 @@ mod tests {
     #[test]
     fn telemetry_core_trace_runtime_produces_working_runtime() {
         let guard = TelemetryCore::builder()
-            .writer(InMemoryWriter::discard())
+            .writer(InMemoryWriter::new(16 * 1024 * 1024).unwrap())
             .build()
             .unwrap();
         guard.enable();
@@ -1320,7 +1320,7 @@ mod tests {
     #[test]
     fn trace_runtime_handle_spawns_on_correct_runtime_from_outside() {
         let guard = TelemetryCore::builder()
-            .writer(InMemoryWriter::discard())
+            .writer(InMemoryWriter::new(16 * 1024 * 1024).unwrap())
             .build()
             .unwrap();
         guard.enable();
@@ -1724,7 +1724,7 @@ mod tests {
         let s3 = S3Config::builder().bucket("b").service_name("s").build();
 
         let guard = TelemetryCore::builder()
-            .writer(InMemoryWriter::discard())
+            .writer(InMemoryWriter::new(16 * 1024 * 1024).unwrap())
             .trace_path(&trace_path)
             .s3_config(s3)
             .build()

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -487,7 +487,7 @@ mod shuttle_tests {
     use crate::primitives::sync::atomic::{AtomicU64, Ordering};
     use crate::primitives::sync::{Arc, Mutex};
     use crate::telemetry::recorder::TelemetryCore;
-    use crate::telemetry::writer::DiskWriter;
+    use crate::telemetry::writer::{DiskWriter, InMemoryWriter};
     use dial9_trace_format::TraceEvent;
     use shuttle::rand::Rng;
     use std::collections::HashMap;
@@ -614,13 +614,14 @@ mod shuttle_tests {
         let num_threads = 3;
         let next_id = Arc::new(AtomicU64::new(0));
 
-        let dir = tempfile::tempdir().unwrap();
-        let writer = DiskWriter::builder()
-            .base_path(dir.path().join("trace"))
-            .max_file_size(256)
+        // Small segments force frequent rotation: the 100 MiB budget is far above the test's data,
+        // so the ring never evicts before we drain it.
+        let writer = InMemoryWriter::builder()
             .max_total_size(100 * 1024 * 1024)
+            .max_segment_size(256)
             .build()
             .unwrap();
+        let fs = writer.fs_handle().expect("in-memory writer exposes its fs");
 
         // Mock source: worker threads push events here, flush thread drains them.
         let source_pending: Arc<Mutex<Vec<ValidationEvent>>> = Arc::new(Mutex::new(Vec::new()));
@@ -672,17 +673,18 @@ mod shuttle_tests {
         }
         drop(guard);
 
-        // Decode per-segment from the sealed `.bin` files.
-        let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(dir.path())
-            .unwrap()
-            .filter_map(|e| e.ok().map(|e| e.path()))
-            .filter(|p| p.to_string_lossy().contains(".bin"))
-            .collect();
-        files.sort();
-        let all_decoded: Vec<ValidationEvent> = files
-            .iter()
-            .flat_map(|p| decode_validation_events(&std::fs::read(p).unwrap()))
-            .collect();
+        // Drain the in-memory ring (memory pops one sealed segment per call).
+        let mut all_decoded: Vec<ValidationEvent> = Vec::new();
+        loop {
+            let taken = fs.take_files();
+            if taken.segments.is_empty() {
+                break;
+            }
+            for seg in taken.segments {
+                let (_seg_ref, payload, _accounting) = seg.load().unwrap();
+                all_decoded.extend(decode_validation_events(&payload.into_vec()));
+            }
+        }
         let expected = expected.lock().unwrap();
 
         // Run all invariants.

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -485,13 +485,11 @@ mod tests {
 mod shuttle_tests {
     use crate::primitives::sync::atomic::{AtomicU64, Ordering};
     use crate::primitives::sync::{Arc, Mutex};
-    use crate::telemetry::collector::Batch;
     use crate::telemetry::recorder::TelemetryCore;
-    use crate::telemetry::writer::TraceWriter;
+    use crate::telemetry::writer::DiskWriter;
     use dial9_trace_format::TraceEvent;
     use shuttle::rand::Rng;
     use std::collections::HashMap;
-    use std::io;
 
     // ── Event definition ────────────────────────────────────────────────
 
@@ -517,50 +515,6 @@ mod shuttle_tests {
             *prev += rng.gen_range(1u64..=1000);
         }
         *prev
-    }
-
-    // ── Writer ──────────────────────────────────────────────────────────
-
-    /// A TraceWriter that captures encoded bytes into per-segment buffers
-    /// and randomly triggers rotation via `should_drain`/`drained`.
-    struct InvariantCheckingWriter {
-        segments: Arc<Mutex<Vec<Vec<u8>>>>,
-    }
-
-    impl InvariantCheckingWriter {
-        fn new(segments: Arc<Mutex<Vec<Vec<u8>>>>) -> Self {
-            segments.lock().unwrap().push(Vec::new());
-            Self { segments }
-        }
-    }
-
-    impl TraceWriter for InvariantCheckingWriter {
-        fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()> {
-            self.segments
-                .lock()
-                .unwrap()
-                .last_mut()
-                .unwrap()
-                .extend_from_slice(batch.encoded_bytes());
-            Ok(())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-
-        fn should_drain(&self) -> bool {
-            shuttle::rand::thread_rng().gen_range(0u32..10) < 3
-        }
-
-        fn drained(&mut self) -> std::io::Result<bool> {
-            if shuttle::rand::thread_rng().gen_range(0u32..2) == 0 {
-                self.segments.lock().unwrap().push(Vec::new());
-                Ok(true)
-            } else {
-                Ok(false)
-            }
-        }
     }
 
     // ── Decoding ────────────────────────────────────────────────────────
@@ -658,15 +612,19 @@ mod shuttle_tests {
 
         let num_threads = 3;
         let next_id = Arc::new(AtomicU64::new(0));
-        let segments: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let dir = tempfile::tempdir().unwrap();
+        let writer = DiskWriter::builder()
+            .base_path(dir.path().join("trace"))
+            .max_file_size(256)
+            .max_total_size(100 * 1024 * 1024)
+            .build()
+            .unwrap();
 
         // Mock source: worker threads push events here, flush thread drains them.
         let source_pending: Arc<Mutex<Vec<ValidationEvent>>> = Arc::new(Mutex::new(Vec::new()));
 
-        let guard = TelemetryCore::builder()
-            .writer(InvariantCheckingWriter::new(segments.clone()))
-            .build()
-            .unwrap();
+        let guard = TelemetryCore::builder().writer(writer).build().unwrap();
         guard
             .shared()
             .unwrap()
@@ -713,12 +671,17 @@ mod shuttle_tests {
         }
         drop(guard);
 
-        // Decode per-segment.
-        let segs = segments.lock().unwrap();
-        let decoded_segments: Vec<Vec<ValidationEvent>> =
-            segs.iter().map(|s| decode_validation_events(s)).collect();
-        let all_decoded: Vec<ValidationEvent> =
-            decoded_segments.iter().flatten().cloned().collect();
+        // Decode per-segment from the sealed `.bin` files.
+        let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.to_string_lossy().contains(".bin"))
+            .collect();
+        files.sort();
+        let all_decoded: Vec<ValidationEvent> = files
+            .iter()
+            .flat_map(|p| decode_validation_events(&std::fs::read(p).unwrap()))
+            .collect();
         let expected = expected.lock().unwrap();
 
         // Run all invariants.
@@ -736,51 +699,16 @@ mod shuttle_tests {
         shuttle::check_pct(test_telemetry_core_pipeline, 10000, 3);
     }
 
-    // ── Always-erroring writer ──────────────────────────────────────────
+    // ── Error injection ─────────────────────────────────────────────────
     //
-    // The companion to `InvariantCheckingWriter`: every fallible method
-    // returns an `io::Error`. This exercises the error paths in the flush
-    // loop and lets us assert that rate limiting bounds log output even
-    // when every operation fails.
+    // The companion to the round-trip pipeline test: a `DiskWriter` with
+    // `.fail_all_writes()` set makes every fallible method return an
+    // `io::Error` and `should_drain` always fire. This exercises the error
+    // paths in the flush loop and lets us assert that rate limiting bounds log
+    // output even when every operation fails.
 
     use std::sync::Arc as StdArc;
     use std::sync::atomic::{AtomicU64 as StdAtomicU64, Ordering as StdOrdering};
-
-    struct AlwaysErroringWriter;
-
-    impl AlwaysErroringWriter {
-        fn err() -> io::Error {
-            io::Error::from(io::ErrorKind::PermissionDenied)
-        }
-    }
-
-    impl TraceWriter for AlwaysErroringWriter {
-        fn write_encoded_batch(&mut self, _batch: &Batch) -> io::Result<()> {
-            Err(Self::err())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Err(Self::err())
-        }
-
-        fn finalize(&mut self) -> io::Result<()> {
-            Err(Self::err())
-        }
-
-        fn write_current_segment_metadata(&mut self) -> io::Result<()> {
-            Err(Self::err())
-        }
-
-        fn should_drain(&self) -> bool {
-            // Always want to drain so the post-drain error path is exercised
-            // every flush tick.
-            true
-        }
-
-        fn drained(&mut self) -> io::Result<bool> {
-            Err(Self::err())
-        }
-    }
 
     // ── Counting subscriber ─────────────────────────────────────────────
     //
@@ -840,10 +768,11 @@ mod shuttle_tests {
             let num_threads = 3;
             let next_id = Arc::new(AtomicU64::new(0));
 
-            let guard = TelemetryCore::builder()
-                .writer(AlwaysErroringWriter)
-                .build()
-                .unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            let writer = DiskWriter::single_file(dir.path().join("trace.bin"))
+                .unwrap()
+                .fail_all_writes();
+            let guard = TelemetryCore::builder().writer(writer).build().unwrap();
             guard.enable();
             let handle = guard.handle();
 

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -483,6 +483,7 @@ mod tests {
 
 #[cfg(all(test, shuttle))]
 mod shuttle_tests {
+    use crate::primitives::fs;
     use crate::primitives::sync::atomic::{AtomicU64, Ordering};
     use crate::primitives::sync::{Arc, Mutex};
     use crate::telemetry::recorder::TelemetryCore;
@@ -701,11 +702,9 @@ mod shuttle_tests {
 
     // ── Error injection ─────────────────────────────────────────────────
     //
-    // The companion to the round-trip pipeline test: a `DiskWriter` with
-    // `.fail_all_writes()` set makes every fallible method return an
-    // `io::Error` and `should_drain` always fire. This exercises the error
-    // paths in the flush loop and lets us assert that rate limiting bounds log
-    // output even when every operation fails.
+    // Companion to the round-trip pipeline test. `primitives::fs` is armed
+    // with a fault policy so the writer's real I/O points (write/flush/rename/
+    // remove) fail, exercising the flush loop's error paths.
 
     use std::sync::Arc as StdArc;
     use std::sync::atomic::{AtomicU64 as StdAtomicU64, Ordering as StdOrdering};
@@ -753,7 +752,9 @@ mod shuttle_tests {
 
     // ── Erroring-pipeline test body ─────────────────────────────────────
 
-    fn test_telemetry_core_erroring_pipeline() {
+    /// Drive the pipeline with the fs armed to `fault`, returning the
+    /// number of WARN/ERROR events the flush loop emitted.
+    fn run_erroring_pipeline(fault: fs::FaultPolicy) -> u64 {
         let _ts_guard =
             metrique_timesource::set_time_source(metrique_timesource::TimeSource::custom(
                 metrique_timesource::fakes::StaticTimeSource::at_time(std::time::UNIX_EPOCH),
@@ -769,9 +770,8 @@ mod shuttle_tests {
             let next_id = Arc::new(AtomicU64::new(0));
 
             let dir = tempfile::tempdir().unwrap();
-            let writer = DiskWriter::single_file(dir.path().join("trace.bin"))
-                .unwrap()
-                .fail_all_writes();
+            let writer = DiskWriter::single_file(dir.path().join("trace.bin")).unwrap();
+            let _fault = fs::set_fault(fault);
             let guard = TelemetryCore::builder().writer(writer).build().unwrap();
             guard.enable();
             let handle = guard.handle();
@@ -810,12 +810,35 @@ mod shuttle_tests {
             drop(guard);
         });
 
-        // Bound the warn+error count by the number of distinct rate-limited
-        // call sites. There are roughly 6 sites that might fire on every
-        // shuttle run; allow some slack but cap firmly below "one per loop
-        // iteration". If a `rate_limited!` wrapper is removed from the flush
-        // loop, this number explodes.
-        let total = warn_count.load(StdOrdering::Relaxed);
+        warn_count.load(StdOrdering::Relaxed)
+    }
+
+    /// The fault is armed on the test thread but read on the flush thread,
+    /// this proves it crosses that boundary.
+    fn fs_fault_visible_across_threads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fault_probe");
+        std::fs::write(&path, b"x").unwrap();
+
+        let _fault = fs::set_fault(fs::FaultPolicy::FailAll);
+        let observed_fault =
+            crate::primitives::thread::spawn(move || fs::remove_file(&path).is_err())
+                .join()
+                .unwrap();
+
+        assert!(
+            observed_fault,
+            "fault armed on the test thread was not observed on a spawned thread"
+        );
+    }
+
+    #[test]
+    fn determinism_check_fs_fault_visible() {
+        shuttle::check_uncontrolled_nondeterminism(fs_fault_visible_across_threads, 100);
+    }
+
+    fn test_telemetry_core_erroring_pipeline() {
+        let total = run_erroring_pipeline(fs::FaultPolicy::FailAll);
         assert!(
             total <= 10,
             "rate limiting failed under persistent writer errors: \
@@ -832,5 +855,27 @@ mod shuttle_tests {
     #[test]
     fn pct_erroring_pipeline() {
         shuttle::check_pct(test_telemetry_core_erroring_pipeline, 10000, 3);
+    }
+
+    fn test_telemetry_core_probabilistic_fs_faults() {
+        let total = run_erroring_pipeline(fs::FaultPolicy::FailProb(0.5));
+        assert!(
+            total <= 10,
+            "rate limiting failed under probabilistic fs faults: observed {total} \
+             WARN/ERROR events, expected <= 10."
+        );
+    }
+
+    #[test]
+    fn determinism_check_probabilistic_fs_faults() {
+        shuttle::check_uncontrolled_nondeterminism(
+            test_telemetry_core_probabilistic_fs_faults,
+            10000,
+        );
+    }
+
+    #[test]
+    fn pct_probabilistic_fs_faults() {
+        shuttle::check_pct(test_telemetry_core_probabilistic_fs_faults, 10000, 3);
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/tokio_hooks.rs
@@ -62,7 +62,7 @@ impl TokioHook<TaskMetaCb> {
 /// # Example
 ///
 /// ```rust,no_run
-/// use dial9_tokio_telemetry::telemetry::{TokioHooks, TracedRuntime, NullWriter};
+/// use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TokioHooks, TracedRuntime};
 ///
 /// let mut builder = tokio::runtime::Builder::new_multi_thread();
 /// builder.worker_threads(4).enable_all();
@@ -71,7 +71,7 @@ impl TokioHook<TaskMetaCb> {
 ///         h.on_thread_start(|| println!("started"));
 ///         h.on_thread_stop(|| println!("stopping"));
 ///     })
-///     .build_and_start_with_writer(builder, NullWriter)
+///     .build_and_start(builder, InMemoryWriter::discard())
 ///     .unwrap();
 /// ```
 #[derive(Clone, Default)]

--- a/dial9-tokio-telemetry/src/telemetry/recorder/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/tokio_hooks.rs
@@ -71,7 +71,7 @@ impl TokioHook<TaskMetaCb> {
 ///         h.on_thread_start(|| println!("started"));
 ///         h.on_thread_stop(|| println!("stopping"));
 ///     })
-///     .build_and_start(builder, InMemoryWriter::discard())
+///     .build_and_start(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
 ///     .unwrap();
 /// ```
 #[derive(Clone, Default)]

--- a/dial9-tokio-telemetry/src/telemetry/writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/writer.rs
@@ -363,21 +363,6 @@ impl SegmentWriter<Memory> {
         )
     }
 
-    /// An in-memory writer whose output is discarded. Used for benchmarks
-    /// measuring hook overhead and tests that don't read the trace. Fixed
-    /// 4 MiB segments / 16 MiB ring (the sizes satisfy every [`create_in_memory`](Self::create_in_memory)
-    /// precondition).
-    #[doc(hidden)]
-    pub fn discard() -> Self {
-        Self::create_in_memory(
-            16 * 1024 * 1024,
-            4 * 1024 * 1024,
-            DEFAULT_ROTATION_PERIOD,
-            SegmentMetadata::default(),
-        )
-        .expect("discard() sizes satisfy create_in_memory validation")
-    }
-
     /// Builder for in-memory writer configuration.
     #[builder(builder_type = InMemoryWriterBuilder, finish_fn = build)]
     pub fn builder(

--- a/dial9-tokio-telemetry/src/telemetry/writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/writer.rs
@@ -2,6 +2,7 @@ use dial9_trace_format::encoder::{Encoder, RawEncoder};
 
 use crate::background_task::fs::{ActiveHandle, Fs, RemoveReason};
 use crate::background_task::sealed::SegmentRef;
+use crate::primitives::fs;
 use crate::rate_limit::rate_limited;
 use crate::telemetry::collector::Batch;
 use crate::telemetry::events::clock_pair;
@@ -162,11 +163,6 @@ pub struct SegmentWriter<Mode: WriterMode = Disk> {
     active_path: PathBuf,
     state: WriterState,
     next_index: u32,
-    /// Test-only error injection: when set, the fallible methods return
-    /// `PermissionDenied` and `should_drain` always fires. Set via
-    /// [`fail_all_writes`](Self::fail_all_writes).
-    #[cfg(test)]
-    fail_writes: bool,
     /// Metadata written at the start of each segment. Updated by the flush
     /// thread to include runtime names alongside any user-provided entries.
     segment_metadata: SegmentMetadata,
@@ -269,7 +265,7 @@ impl SegmentWriter<Disk> {
         if let Some(parent) = base_path.parent()
             && !parent.as_os_str().is_empty()
         {
-            std::fs::create_dir_all(parent)?;
+            fs::create_dir_all(parent)?;
         }
         let fs = Fs::new_disk(&base_path);
         let discovered = fs.discover_existing()?;
@@ -293,8 +289,6 @@ impl SegmentWriter<Disk> {
             active_path: first_path,
             state,
             next_index,
-            #[cfg(test)]
-            fail_writes: false,
             segment_metadata,
             dropped_events: 0,
             has_real_events: false,
@@ -334,8 +328,6 @@ impl SegmentWriter<Disk> {
             active_path,
             state,
             next_index: 1,
-            #[cfg(test)]
-            fail_writes: false,
             segment_metadata: SegmentMetadata::default(),
             dropped_events: 0,
             has_real_events: false,
@@ -463,8 +455,6 @@ impl SegmentWriter<Memory> {
             active_path,
             state,
             next_index: 1,
-            #[cfg(test)]
-            fail_writes: false,
             segment_metadata,
             dropped_events: 0,
             has_real_events: false,
@@ -681,34 +671,12 @@ impl<M: WriterMode> SegmentWriter<M> {
 }
 
 impl<M: WriterMode> SegmentWriter<M> {
-    /// Test-only: make every fallible write return `PermissionDenied` and
-    /// force `should_drain` to fire. Used by the shuttle error-injection test.
-    #[cfg(test)]
-    #[cfg_attr(not(shuttle), allow(dead_code))]
-    pub(crate) fn fail_all_writes(mut self) -> Self {
-        self.fail_writes = true;
-        self
-    }
-
-    /// Test-only error-injection point. Returns `PermissionDenied` once
-    /// [`fail_all_writes`](Self::fail_all_writes) armed it. Called at the top of
-    /// every fallible write.
-    #[cfg(test)]
-    fn fail_point(&self) -> std::io::Result<()> {
-        if self.fail_writes {
-            return Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
-        }
-        Ok(())
-    }
-
     pub(crate) fn fs_handle(&self) -> Option<Arc<Fs>> {
         Some(Arc::clone(&self.fs))
     }
 
     /// Flush buffered data to the underlying storage.
     pub fn flush(&mut self) -> std::io::Result<()> {
-        #[cfg(test)]
-        self.fail_point()?;
         if let WriterState::Active { writer: raw, .. } = &mut self.state {
             raw.flush()?;
         }
@@ -730,22 +698,14 @@ impl<M: WriterMode> SegmentWriter<M> {
     }
 
     pub(crate) fn write_current_segment_metadata(&mut self) -> std::io::Result<()> {
-        #[cfg(test)]
-        self.fail_point()?;
         self.write_metadata_if_needed()
     }
 
     pub(crate) fn should_drain(&self) -> bool {
-        #[cfg(test)]
-        if self.fail_writes {
-            return true;
-        }
         self.has_real_events && time_source().instant().as_std() >= self.next_drain_time
     }
 
     pub(crate) fn drained(&mut self) -> std::io::Result<bool> {
-        #[cfg(test)]
-        self.fail_point()?;
         if !self.has_real_events {
             return Ok(false);
         }
@@ -765,8 +725,6 @@ impl<M: WriterMode> SegmentWriter<M> {
     /// Finalize the writer: flush, seal the active segment, and prevent further
     /// writes. Terminal — the writer is inert afterward.
     pub fn finalize(&mut self) -> std::io::Result<()> {
-        #[cfg(test)]
-        self.fail_point()?;
         if matches!(self.state, WriterState::Finished) {
             rate_limited!(Duration::from_secs(60), {
                 tracing::warn!("writer is already closed.");
@@ -842,8 +800,6 @@ impl<M: WriterMode> SegmentWriter<M> {
 
     /// Transcode an encoded batch into the active segment.
     pub fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()> {
-        #[cfg(test)]
-        self.fail_point()?;
         self.write_metadata_if_needed()?;
         let WriterState::Active { writer: raw, .. } = &mut self.state else {
             self.dropped_events += batch.event_count as usize;

--- a/dial9-tokio-telemetry/src/telemetry/writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/writer.rs
@@ -49,95 +49,6 @@ pub type DiskWriter = SegmentWriter<Disk>;
 /// Alias for the in-memory writer.
 pub type InMemoryWriter = SegmentWriter<Memory>;
 
-/// Trait for writing encoded telemetry batches to a destination.
-///
-/// `Mode` ties the writer's storage backend (disk vs in-memory) to the
-/// builder's pipeline mode at the type level. Defaults to [`Disk`] so
-/// custom implementors of this trait need no changes for disk targets.
-pub trait TraceWriter<Mode: WriterMode = Disk>: Send {
-    /// Flush buffered data to the underlying storage.
-    fn flush(&mut self) -> std::io::Result<()>;
-    /// Returns true if the writer rotated to a new file since the last call to this method.
-    fn take_rotated(&mut self) -> bool {
-        false
-    }
-    /// Finalize the writer: flush, rename `.active` → `.bin`, and prevent
-    /// further writes. This is a terminal operation — the writer becomes
-    /// inert afterward.
-    fn finalize(&mut self) -> std::io::Result<()> {
-        self.flush()
-    }
-    /// Transcode encoded bytes into this writer.
-    fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()>;
-    /// Return the current segment metadata entries. Default returns empty.
-    fn segment_metadata(&self) -> &[(String, String)] {
-        &[]
-    }
-    /// Merge the segment metadata entries that will be written into the next
-    /// rotated segment (e.g. merged static + runtime names). Default is a no-op.
-    fn update_segment_metadata(&mut self, _entries: Vec<(String, String)>) {}
-    /// Write a `SegmentMetadataEvent` into the current segment. Called before
-    /// finalize so that single-segment traces contain runtime→worker mappings.
-    /// Default is a no-op.
-    fn write_current_segment_metadata(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-    /// Returns `true` when the flush loop should drain all thread-local
-    /// buffers before the next step. For `SegmentWriter` this fires when the
-    /// rotation period has elapsed since the last rotation *or* when a periodic
-    /// drain interval elapses (whichever comes first). Default returns `false`.
-    fn should_drain(&self) -> bool {
-        false
-    }
-    /// Called by the flush loop after thread-local buffers have been drained
-    /// and flushed. The writer may rotate the segment, advance a drain timer,
-    /// or do nothing. Returns `true` if a segment rotation occurred.
-    fn drained(&mut self) -> std::io::Result<bool> {
-        Ok(false)
-    }
-    /// Return the `Arc<Fs>` backing this writer, if any, so the recorder
-    /// builder can share it with the worker. Default `None`.
-    #[doc(hidden)]
-    #[allow(private_interfaces)]
-    fn fs_handle(&self) -> Option<Arc<Fs>> {
-        None
-    }
-}
-
-impl<Mode: WriterMode, W: TraceWriter<Mode> + ?Sized> TraceWriter<Mode> for Box<W> {
-    fn flush(&mut self) -> std::io::Result<()> {
-        (**self).flush()
-    }
-    fn take_rotated(&mut self) -> bool {
-        (**self).take_rotated()
-    }
-    fn finalize(&mut self) -> std::io::Result<()> {
-        (**self).finalize()
-    }
-    fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()> {
-        (**self).write_encoded_batch(batch)
-    }
-    fn segment_metadata(&self) -> &[(String, String)] {
-        (**self).segment_metadata()
-    }
-    fn update_segment_metadata(&mut self, entries: Vec<(String, String)>) {
-        (**self).update_segment_metadata(entries)
-    }
-    fn write_current_segment_metadata(&mut self) -> std::io::Result<()> {
-        (**self).write_current_segment_metadata()
-    }
-    fn should_drain(&self) -> bool {
-        (**self).should_drain()
-    }
-    fn drained(&mut self) -> std::io::Result<bool> {
-        (**self).drained()
-    }
-    #[allow(private_interfaces)]
-    fn fs_handle(&self) -> Option<Arc<Fs>> {
-        (**self).fs_handle()
-    }
-}
-
 /// Segment-metadata key carrying the crates.io version of
 /// `dial9-tokio-telemetry`. Populated by default, any user-supplied entry with
 /// this key take precedence.
@@ -186,20 +97,6 @@ impl SegmentMetadata {
         }
         self.entries = merged;
         true
-    }
-}
-
-/// A writer that discards all events. Useful for benchmarking hook overhead
-/// without I/O costs.
-#[derive(Debug)]
-pub struct NullWriter;
-
-impl TraceWriter for NullWriter {
-    fn write_encoded_batch(&mut self, _batch: &Batch) -> std::io::Result<()> {
-        Ok(())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
     }
 }
 
@@ -265,8 +162,11 @@ pub struct SegmentWriter<Mode: WriterMode = Disk> {
     active_path: PathBuf,
     state: WriterState,
     next_index: u32,
-    /// Set after rotation; cleared by `take_rotated()`.
-    did_rotate: bool,
+    /// Test-only error injection: when set, the fallible methods return
+    /// `PermissionDenied` and `should_drain` always fires. Set via
+    /// [`fail_all_writes`](Self::fail_all_writes).
+    #[cfg(test)]
+    fail_writes: bool,
     /// Metadata written at the start of each segment. Updated by the flush
     /// thread to include runtime names alongside any user-provided entries.
     segment_metadata: SegmentMetadata,
@@ -393,7 +293,8 @@ impl SegmentWriter<Disk> {
             active_path: first_path,
             state,
             next_index,
-            did_rotate: false,
+            #[cfg(test)]
+            fail_writes: false,
             segment_metadata,
             dropped_events: 0,
             has_real_events: false,
@@ -433,7 +334,8 @@ impl SegmentWriter<Disk> {
             active_path,
             state,
             next_index: 1,
-            did_rotate: false,
+            #[cfg(test)]
+            fail_writes: false,
             segment_metadata: SegmentMetadata::default(),
             dropped_events: 0,
             has_real_events: false,
@@ -467,6 +369,21 @@ impl SegmentWriter<Memory> {
             DEFAULT_ROTATION_PERIOD,
             SegmentMetadata::default(),
         )
+    }
+
+    /// An in-memory writer whose output is discarded. Used for benchmarks
+    /// measuring hook overhead and tests that don't read the trace. Fixed
+    /// 4 MiB segments / 16 MiB ring (the sizes satisfy every [`create_in_memory`](Self::create_in_memory)
+    /// precondition).
+    #[doc(hidden)]
+    pub fn discard() -> Self {
+        Self::create_in_memory(
+            16 * 1024 * 1024,
+            4 * 1024 * 1024,
+            DEFAULT_ROTATION_PERIOD,
+            SegmentMetadata::default(),
+        )
+        .expect("discard() sizes satisfy create_in_memory validation")
     }
 
     /// Builder for in-memory writer configuration.
@@ -546,7 +463,8 @@ impl SegmentWriter<Memory> {
             active_path,
             state,
             next_index: 1,
-            did_rotate: false,
+            #[cfg(test)]
+            fail_writes: false,
             segment_metadata,
             dropped_events: 0,
             has_real_events: false,
@@ -708,7 +626,6 @@ impl<M: WriterMode> SegmentWriter<M> {
             }
         };
         self.active_path = new_path;
-        self.did_rotate = true;
         self.has_real_events = false;
 
         tracing::debug!(
@@ -763,28 +680,47 @@ impl<M: WriterMode> SegmentWriter<M> {
     }
 }
 
-impl<M: WriterMode> TraceWriter<M> for SegmentWriter<M> {
-    #[allow(private_interfaces)]
-    fn fs_handle(&self) -> Option<Arc<Fs>> {
+impl<M: WriterMode> SegmentWriter<M> {
+    /// Test-only: make every fallible write return `PermissionDenied` and
+    /// force `should_drain` to fire. Used by the shuttle error-injection test.
+    #[cfg(test)]
+    #[cfg_attr(not(shuttle), allow(dead_code))]
+    pub(crate) fn fail_all_writes(mut self) -> Self {
+        self.fail_writes = true;
+        self
+    }
+
+    /// Test-only error-injection point. Returns `PermissionDenied` once
+    /// [`fail_all_writes`](Self::fail_all_writes) armed it. Called at the top of
+    /// every fallible write.
+    #[cfg(test)]
+    fn fail_point(&self) -> std::io::Result<()> {
+        if self.fail_writes {
+            return Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn fs_handle(&self) -> Option<Arc<Fs>> {
         Some(Arc::clone(&self.fs))
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
+    /// Flush buffered data to the underlying storage.
+    pub fn flush(&mut self) -> std::io::Result<()> {
+        #[cfg(test)]
+        self.fail_point()?;
         if let WriterState::Active { writer: raw, .. } = &mut self.state {
             raw.flush()?;
         }
         Ok(())
     }
 
-    fn take_rotated(&mut self) -> bool {
-        std::mem::take(&mut self.did_rotate)
-    }
-
-    fn segment_metadata(&self) -> &[(String, String)] {
+    pub(crate) fn segment_metadata(&self) -> &[(String, String)] {
         &self.segment_metadata.entries
     }
 
-    fn update_segment_metadata(&mut self, entries: Vec<(String, String)>) {
+    /// Merge the segment metadata entries written into the next rotated segment.
+    pub fn update_segment_metadata(&mut self, entries: Vec<(String, String)>) {
         if self.segment_metadata.merge(entries.into_iter()) {
             match &mut self.state {
                 WriterState::Active { need_metadata, .. } => *need_metadata = true,
@@ -793,15 +729,23 @@ impl<M: WriterMode> TraceWriter<M> for SegmentWriter<M> {
         }
     }
 
-    fn write_current_segment_metadata(&mut self) -> std::io::Result<()> {
+    pub(crate) fn write_current_segment_metadata(&mut self) -> std::io::Result<()> {
+        #[cfg(test)]
+        self.fail_point()?;
         self.write_metadata_if_needed()
     }
 
-    fn should_drain(&self) -> bool {
+    pub(crate) fn should_drain(&self) -> bool {
+        #[cfg(test)]
+        if self.fail_writes {
+            return true;
+        }
         self.has_real_events && time_source().instant().as_std() >= self.next_drain_time
     }
 
-    fn drained(&mut self) -> std::io::Result<bool> {
+    pub(crate) fn drained(&mut self) -> std::io::Result<bool> {
+        #[cfg(test)]
+        self.fail_point()?;
         if !self.has_real_events {
             return Ok(false);
         }
@@ -818,7 +762,11 @@ impl<M: WriterMode> TraceWriter<M> for SegmentWriter<M> {
         Ok(false)
     }
 
-    fn finalize(&mut self) -> std::io::Result<()> {
+    /// Finalize the writer: flush, seal the active segment, and prevent further
+    /// writes. Terminal — the writer is inert afterward.
+    pub fn finalize(&mut self) -> std::io::Result<()> {
+        #[cfg(test)]
+        self.fail_point()?;
         if matches!(self.state, WriterState::Finished) {
             rate_limited!(Duration::from_secs(60), {
                 tracing::warn!("writer is already closed.");
@@ -892,7 +840,10 @@ impl<M: WriterMode> TraceWriter<M> for SegmentWriter<M> {
         Ok(())
     }
 
-    fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()> {
+    /// Transcode an encoded batch into the active segment.
+    pub fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()> {
+        #[cfg(test)]
+        self.fail_point()?;
         self.write_metadata_if_needed()?;
         let WriterState::Active { writer: raw, .. } = &mut self.state else {
             self.dropped_events += batch.event_count as usize;
@@ -2675,28 +2626,22 @@ mod tests {
             .expect("3× segment must be accepted");
     }
 
-    /// End to end: a memory `SegmentWriter` feeds the real worker pipeline.
-    /// Bytes must decode and every written event must arrive. Exercises the
-    /// full seam: in_memory -> write -> Fs::Mem seal -> ring -> finalize
-    /// (mark_writer_done) -> WorkerLoop::run drain-to-empty -> processor.
-    #[tokio::test]
-    async fn mem_writer_e2e_delivers_all_events() {
+    /// Drive a memory writer through the real worker pipeline and return the
+    /// captured per-segment payloads. Exercises the full seam: write ->
+    /// Fs::Mem seal -> ring -> finalize (mark_writer_done) -> WorkerLoop::run
+    /// drain-to-empty -> processor.
+    async fn run_mem_e2e(mut writer: InMemoryWriter, events: usize) -> Vec<Vec<u8>> {
         use crate::background_task::WorkerLoop;
-        use crate::background_task::testutil::CaptureProcessor;
-        use crate::telemetry::{analysis_events::Dial9Event, format};
+        use crate::background_task::testutil::CapturingProcessor;
 
-        const EVENTS: usize = 25;
-
-        let mut writer = InMemoryWriter::new(1 << 20).unwrap();
         let fs = writer.fs_handle().expect("memory writer exposes its Fs");
-
-        for _ in 0..EVENTS {
+        for _ in 0..events {
             writer.write_encoded_batch(&test_batch()).unwrap();
         }
         // Seals the active segment onto the ring and signals writer_done.
         writer.finalize().unwrap();
 
-        let (capture, captured) = CaptureProcessor::new();
+        let (capture, captured) = CapturingProcessor::new();
         // stop is never cancelled: the loop exits via writer_done only.
         let stop = tokio_util::sync::CancellationToken::new();
         let mut worker = WorkerLoop::new(
@@ -2708,10 +2653,16 @@ mod tests {
         );
         worker.run().await;
 
-        let bytes = captured.lock().unwrap().clone();
-        assert!(!bytes.is_empty(), "worker captured no bytes");
-        let events = format::decode_events(&bytes)
-            .unwrap()
+        let segments = captured.lock().unwrap();
+        segments.clone()
+    }
+
+    /// Count decoded payload events across `segments`, dropping the per-segment
+    /// metadata/clock-sync framing the writer emits.
+    fn count_payload_events(segments: &[Vec<u8>]) -> usize {
+        use crate::telemetry::analysis_events::Dial9Event;
+
+        crate::background_task::testutil::decode_captured(segments)
             .into_iter()
             .filter(|e| {
                 !matches!(
@@ -2719,10 +2670,46 @@ mod tests {
                     Dial9Event::SegmentMetadataEvent(..) | Dial9Event::ClockSyncEvent(..)
                 )
             })
-            .count();
+            .count()
+    }
+
+    #[tokio::test]
+    async fn mem_writer_e2e_delivers_all_events() {
+        const EVENTS: usize = 25;
+
+        let segments = run_mem_e2e(InMemoryWriter::new(1 << 20).unwrap(), EVENTS).await;
+
+        assert!(!segments.is_empty(), "worker captured no segments");
         assert_eq!(
-            events, EVENTS,
+            count_payload_events(&segments),
+            EVENTS,
             "every written event must reach the processor"
+        );
+    }
+
+    /// Same as `mem_writer_e2e_delivers_all_events`, but a tiny `max_segment_size` forces several rotations so the
+    /// worker delivers multiple sealed segments.
+    #[tokio::test]
+    async fn mem_writer_e2e_delivers_all_events_across_rotations() {
+        const EVENTS: usize = 60;
+
+        // Huge ring (nothing evicts) + tiny segments (rotate every few batches).
+        let writer = InMemoryWriter::builder()
+            .max_total_size(16 * 1024 * 1024)
+            .max_segment_size(256)
+            .build()
+            .unwrap();
+        let segments = run_mem_e2e(writer, EVENTS).await;
+
+        assert!(
+            segments.len() >= 2,
+            "tiny segments must force rotation, got {} segment(s)",
+            segments.len()
+        );
+        assert_eq!(
+            count_payload_events(&segments),
+            EVENTS,
+            "every event across all rotated segments must reach the processor"
         );
     }
 }

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -236,7 +236,7 @@ mod tests {
     #[test]
     fn traced_future_falls_back_after_missing_task_context() {
         let guard = TelemetryCore::builder()
-            .writer(InMemoryWriter::discard())
+            .writer(InMemoryWriter::new(16 * 1024 * 1024).unwrap())
             .build()
             .unwrap();
         let handle = guard

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -226,7 +226,7 @@ mod tests {
     use crate::telemetry::buffer;
     use crate::telemetry::recorder::{TelemetryCore, TracedRuntime};
     use crate::telemetry::task_metadata::UNKNOWN_TASK_ID;
-    use crate::telemetry::writer::{DiskWriter, NullWriter};
+    use crate::telemetry::writer::{DiskWriter, InMemoryWriter};
     use futures_util::task::noop_waker;
     use std::pin::Pin;
     use std::sync::{Arc, Mutex};
@@ -235,7 +235,10 @@ mod tests {
 
     #[test]
     fn traced_future_falls_back_after_missing_task_context() {
-        let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+        let guard = TelemetryCore::builder()
+            .writer(InMemoryWriter::discard())
+            .build()
+            .unwrap();
         let handle = guard
             .handle()
             .traced_handle()

--- a/dial9-tokio-telemetry/src/tracing_layer.rs
+++ b/dial9-tokio-telemetry/src/tracing_layer.rs
@@ -51,7 +51,7 @@
 //!
 //! Each span enter+exit pair costs roughly **300ns** total (tracing dispatch
 //! plus dial9 encoding), of which **~50-100ns** is the dial9 encoding overhead.
-//! Measured with `NullWriter` on a `current_thread` runtime to isolate
+//! Measured with `InMemoryWriter::discard()` on a `current_thread` runtime to isolate
 //! encoding from I/O. This scales linearly with nesting depth and is
 //! comparable to the cost of a single poll event, so the layer is suitable
 //! for production use with appropriate span filtering.

--- a/dial9-tokio-telemetry/src/tracing_layer.rs
+++ b/dial9-tokio-telemetry/src/tracing_layer.rs
@@ -51,8 +51,8 @@
 //!
 //! Each span enter+exit pair costs roughly **300ns** total (tracing dispatch
 //! plus dial9 encoding), of which **~50-100ns** is the dial9 encoding overhead.
-//! Measured with `InMemoryWriter::discard()` on a `current_thread` runtime to isolate
-//! encoding from I/O. This scales linearly with nesting depth and is
+//! Measured with an in-memory writer on a `current_thread` runtime to
+//! isolate encoding from I/O. This scales linearly with nesting depth and is
 //! comparable to the cost of a single poll event, so the layer is suitable
 //! for production use with appropriate span filtering.
 

--- a/dial9-tokio-telemetry/tests/builtin_event_serde.rs
+++ b/dial9-tokio-telemetry/tests/builtin_event_serde.rs
@@ -3,19 +3,20 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
 use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 
 #[test]
 fn decode_builtin_events_via_serde() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(2).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     runtime.block_on(async {
@@ -33,7 +34,9 @@ fn decode_builtin_events_via_serde() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let batches = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&batches);

--- a/dial9-tokio-telemetry/tests/common.rs
+++ b/dial9-tokio-telemetry/tests/common.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 use dial9_tokio_telemetry::background_task::{ProcessError, SegmentData, SegmentProcessor};
+use dial9_tokio_telemetry::telemetry::InMemoryWriter;
 use dial9_trace_format::decoder::Decoder;
 use serde::de::DeserializeOwned;
 use std::future::Future;
@@ -10,6 +11,16 @@ use std::sync::{Arc, Mutex};
 /// Total in-memory byte budget for capture tests. Large enough that a test's
 /// events fit without the ring dropping the oldest segment.
 pub const CAPTURE_BUFFER_SIZE: u64 = 16 * 1024 * 1024;
+
+/// Fixed-size in-memory writer for tests that run a telemetry runtime but don't
+/// read the trace back.
+pub fn small_mem_writer() -> InMemoryWriter {
+    InMemoryWriter::builder()
+        .max_total_size(16 * 1024 * 1024)
+        .max_segment_size(4 * 1024 * 1024)
+        .build()
+        .expect("fixed sizes are valid")
+}
 
 /// A [`SegmentProcessor`] that stores each sealed segment's payload bytes,
 /// one `Vec<u8>` per segment.

--- a/dial9-tokio-telemetry/tests/common.rs
+++ b/dial9-tokio-telemetry/tests/common.rs
@@ -1,54 +1,74 @@
 #![allow(dead_code)]
-use dial9_tokio_telemetry::telemetry::{Batch, TraceWriter};
+use dial9_tokio_telemetry::background_task::{ProcessError, SegmentData, SegmentProcessor};
 use dial9_trace_format::decoder::Decoder;
 use serde::de::DeserializeOwned;
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
-/// A [`TraceWriter`] that accumulates the raw encoded bytes of every batch it
-/// receives.
+/// Total in-memory byte budget for capture tests. Large enough that a test's
+/// events fit without the ring dropping the oldest segment.
+pub const CAPTURE_BUFFER_SIZE: u64 = 16 * 1024 * 1024;
+
+/// A [`SegmentProcessor`] that stores each sealed segment's payload bytes,
+/// one `Vec<u8>` per segment.
 ///
-/// Tests decode via the serde path using [`decode_all`] or [`decode_file`].
-pub struct BytesCapturingWriter {
-    batches: Arc<Mutex<Vec<Vec<u8>>>>,
+/// Per-segment (not concatenated): each entry is a self-contained trace blob
+/// with its own header, so [`decode_all`] can decode them independently.
+///
+/// Pair with an [`InMemoryWriter`](dial9_tokio_telemetry::telemetry::InMemoryWriter)
+/// via `.with_custom_pipeline(|p| p.pipe(capture))`, then
+/// `guard.graceful_shutdown(..)` to drain the worker before reading the captured segments.
+pub struct CapturingProcessor {
+    segments: Arc<Mutex<Vec<Vec<u8>>>>,
 }
 
-impl BytesCapturingWriter {
+impl CapturingProcessor {
     pub fn new() -> (Self, Arc<Mutex<Vec<Vec<u8>>>>) {
-        let batches = Arc::new(Mutex::new(Vec::new()));
+        let segments = Arc::new(Mutex::new(Vec::new()));
         (
             Self {
-                batches: batches.clone(),
+                segments: segments.clone(),
             },
-            batches,
+            segments,
         )
     }
 }
 
-impl TraceWriter for BytesCapturingWriter {
-    fn write_encoded_batch(&mut self, batch: &Batch) -> std::io::Result<()> {
-        self.batches
-            .lock()
-            .unwrap()
-            .push(batch.encoded_bytes().to_vec());
-        Ok(())
+impl SegmentProcessor for CapturingProcessor {
+    fn name(&self) -> &'static str {
+        "Capture"
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
+    fn process(
+        &mut self,
+        data: SegmentData,
+    ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
+        self.segments
+            .lock()
+            .unwrap()
+            .push(data.payload().clone().into_vec());
+        Box::pin(async move { Ok(data) })
     }
 }
 
-/// Decode every batch in `batches`, deserializing each event as `T`.
-pub fn decode_all<T: DeserializeOwned>(batches: &[Vec<u8>]) -> Vec<T> {
+/// Convenience constructor: returns the processor (move into `.pipe(..)`) and
+/// the shared handle to read the captured per-segment bytes after shutdown.
+pub fn capture_processor() -> (CapturingProcessor, Arc<Mutex<Vec<Vec<u8>>>>) {
+    CapturingProcessor::new()
+}
+
+/// Decode every segment in `segments`, deserializing each event as `T`.
+pub fn decode_all<T: DeserializeOwned>(segments: &[Vec<u8>]) -> Vec<T> {
     let mut events = Vec::new();
-    for bytes in batches {
+    for bytes in segments {
         let mut dec = Decoder::new(bytes).expect("valid trace header");
         dec.for_each_event(|raw| {
             let ev: T = raw.deserialize().expect("deserialize event");
             events.push(ev);
         })
-        .expect("decode batch");
+        .expect("decode segment");
     }
     events
 }

--- a/dial9-tokio-telemetry/tests/cpu_sample_clock_alignment.rs
+++ b/dial9-tokio-telemetry/tests/cpu_sample_clock_alignment.rs
@@ -16,7 +16,8 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
+use dial9_tokio_telemetry::telemetry::InMemoryWriter;
 use dial9_tokio_telemetry::telemetry::analysis_events::{CpuSampleSource, Dial9Event, WorkerId};
 
 #[test]
@@ -28,7 +29,7 @@ fn cpu_sample_timestamps_align_with_wall_clock() {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let num_workers = 2u64;
     let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -36,7 +37,8 @@ fn cpu_sample_timestamps_align_with_wall_clock() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     // All timestamps are now absolute CLOCK_MONOTONIC nanoseconds.
@@ -64,7 +66,9 @@ fn cpu_sample_timestamps_align_with_wall_clock() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);
@@ -250,7 +254,7 @@ fn thread_name_attribution_for_external_and_blocking_threads() {
     use dial9_tokio_telemetry::telemetry::cpu_profile::CpuProfilingConfig;
     use std::time::Duration;
 
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder
@@ -260,7 +264,8 @@ fn thread_name_attribution_for_external_and_blocking_threads() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_cpu_profiling(CpuProfilingConfig::default().frequency_hz(999))
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     // ── std::thread with a known name — exits before flush ───────────────
@@ -290,7 +295,9 @@ fn thread_name_attribution_for_external_and_blocking_threads() {
     });
 
     drop(runtime);
-    guard.graceful_shutdown(Duration::from_secs(1)).unwrap();
+    guard
+        .graceful_shutdown(Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);

--- a/dial9-tokio-telemetry/tests/custom_events.rs
+++ b/dial9-tokio-telemetry/tests/custom_events.rs
@@ -1,7 +1,9 @@
 mod common;
 
-use common::BytesCapturingWriter;
-use dial9_tokio_telemetry::telemetry::{CustomEventsConfig, TelemetryCore, TracedRuntime};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor};
+use dial9_tokio_telemetry::telemetry::{
+    CustomEventsConfig, InMemoryWriter, TelemetryCore, TracedRuntime,
+};
 use dial9_trace_format::TraceEvent;
 use dial9_trace_format::decoder::Decoder;
 
@@ -29,7 +31,7 @@ fn decode_queued_events(batches: &[Vec<u8>]) -> Vec<QueuedEvent> {
 
 #[test]
 fn traced_runtime_records_custom_events_callback_events() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
     let (tx, rx) = std::sync::mpsc::channel();
     tx.send(QueuedEvent {
         timestamp_ns: 1,
@@ -46,11 +48,14 @@ fn traced_runtime_records_custom_events_callback_events() {
                 ctx.record_event(event);
             }
         })
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let batches = batches.lock().unwrap();
     let events = decode_queued_events(&batches);
@@ -62,7 +67,7 @@ fn traced_runtime_records_custom_events_callback_events() {
 
 #[test]
 fn telemetry_core_attach_runtime_records_custom_events_callback_events() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
     let (tx, rx) = std::sync::mpsc::channel();
     tx.send(QueuedEvent {
         timestamp_ns: 2,
@@ -71,7 +76,11 @@ fn telemetry_core_attach_runtime_records_custom_events_callback_events() {
     .unwrap();
     drop(tx);
 
-    let guard = TelemetryCore::builder().writer(writer).build().unwrap();
+    let guard = TelemetryCore::builder()
+        .writer(InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
+        .processors(vec![Box::new(capture)])
+        .build()
+        .unwrap();
     guard.enable();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -87,7 +96,9 @@ fn telemetry_core_attach_runtime_records_custom_events_callback_events() {
         .unwrap();
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let batches = batches.lock().unwrap();
     let events = decode_queued_events(&batches);

--- a/dial9-tokio-telemetry/tests/disable_stops_events.rs
+++ b/dial9-tokio-telemetry/tests/disable_stops_events.rs
@@ -1,15 +1,44 @@
-mod common;
-
-use common::{BytesCapturingWriter, decode_all};
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
 use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
+use dial9_tokio_telemetry::telemetry::{DiskWriter, TracedRuntime};
+use dial9_trace_format::decoder::Decoder;
+use std::path::Path;
 use std::time::Duration;
+
+/// Decode every event from all trace segment files in `dir`, including the
+/// live `.active` segment.
+fn read_events_on_disk(dir: &Path) -> Vec<Dial9Event> {
+    let mut files: Vec<_> = std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.to_string_lossy().contains(".bin"))
+        .collect();
+    files.sort();
+
+    let mut events = Vec::new();
+    for path in files {
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
+        };
+        let Some(mut dec) = Decoder::new(&data) else {
+            continue;
+        };
+        // Ignore a trailing decode error from a partially-written .active tail.
+        let _ = dec.for_each_event(|raw| {
+            if let Ok(ev) = raw.deserialize::<Dial9Event>() {
+                events.push(ev);
+            }
+        });
+    }
+    events
+}
 
 /// After `disable()` is called and in-flight events are drained, no new
 /// events should be produced by subsequent work.
 #[test]
 fn disable_stops_all_event_production() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let dir = tempfile::tempdir().unwrap();
+    let trace_path = dir.path().join("trace.bin");
+    let writer = DiskWriter::single_file(&trace_path).unwrap();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(2).enable_all();
@@ -38,16 +67,14 @@ fn disable_stops_all_event_production() {
     handle.disable();
 
     // Wait for the flush thread to drain any in-flight events produced
-    // before disable.
-    std::thread::sleep(Duration::from_millis(200));
+    // before disable. Generous so a slow flush-to-disk doesn't leave a pre-disable
+    // event to land during phase 2 and read as a false "new event".
+    std::thread::sleep(Duration::from_millis(500));
 
-    let count_after_disable = {
-        let b = batches.lock().unwrap();
-        decode_all::<Dial9Event>(&b)
-            .iter()
-            .filter(|e| !matches!(e, Dial9Event::Other))
-            .count()
-    };
+    let count_after_disable = read_events_on_disk(dir.path())
+        .iter()
+        .filter(|e| !matches!(e, Dial9Event::Other))
+        .count();
 
     // Phase 2: produce more work while disabled
     runtime.block_on(async {
@@ -67,13 +94,10 @@ fn disable_stops_all_event_production() {
     // Give the flush thread plenty of time to pick up any leaked events.
     std::thread::sleep(Duration::from_millis(500));
 
-    let count_after_phase2 = {
-        let b = batches.lock().unwrap();
-        decode_all::<Dial9Event>(&b)
-            .iter()
-            .filter(|e| !matches!(e, Dial9Event::Other))
-            .count()
-    };
+    let count_after_phase2 = read_events_on_disk(dir.path())
+        .iter()
+        .filter(|e| !matches!(e, Dial9Event::Other))
+        .count();
 
     assert_eq!(
         count_after_disable,
@@ -96,7 +120,9 @@ fn disable_stops_all_event_production() {
 fn disable_stops_cpu_sample_production() {
     use dial9_tokio_telemetry::telemetry::cpu_profile::CpuProfilingConfig;
 
-    let (writer, batches) = BytesCapturingWriter::new();
+    let dir = tempfile::tempdir().unwrap();
+    let trace_path = dir.path().join("trace.bin");
+    let writer = DiskWriter::single_file(&trace_path).unwrap();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(2).enable_all();
@@ -104,7 +130,7 @@ fn disable_stops_cpu_sample_production() {
     let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
         .with_cpu_profiling(CpuProfilingConfig::default())
-        .build_and_start_with_writer(builder, writer)
+        .build_and_start(builder, writer)
         .unwrap();
 
     let handle = guard.handle();
@@ -127,13 +153,10 @@ fn disable_stops_cpu_sample_production() {
         tokio::time::sleep(Duration::from_millis(1500)).await;
     });
 
-    let cpu_samples_phase1 = {
-        let b = batches.lock().unwrap();
-        decode_all::<Dial9Event>(&b)
-            .iter()
-            .filter(|e| matches!(e, Dial9Event::CpuSampleEvent(_)))
-            .count()
-    };
+    let cpu_samples_phase1 = read_events_on_disk(dir.path())
+        .iter()
+        .filter(|e| matches!(e, Dial9Event::CpuSampleEvent(_)))
+        .count();
     assert!(
         cpu_samples_phase1 > 0,
         "phase 1 should produce CPU samples (got 0). Is perf_event_paranoid <= 2?"
@@ -145,10 +168,7 @@ fn disable_stops_cpu_sample_production() {
     // Wait for in-flight CPU samples to drain.
     std::thread::sleep(Duration::from_millis(1500));
 
-    let total_after_disable = {
-        let b = batches.lock().unwrap();
-        decode_all::<Dial9Event>(&b).len()
-    };
+    let total_after_disable = read_events_on_disk(dir.path()).len();
 
     // Phase 2: burn CPU while disabled — should NOT produce any events
     runtime.block_on(async {
@@ -167,10 +187,7 @@ fn disable_stops_cpu_sample_production() {
         tokio::time::sleep(Duration::from_millis(500)).await;
     });
 
-    let total_after_phase2 = {
-        let b = batches.lock().unwrap();
-        decode_all::<Dial9Event>(&b).len()
-    };
+    let total_after_phase2 = read_events_on_disk(dir.path()).len();
 
     assert_eq!(
         total_after_disable,
@@ -191,8 +208,6 @@ fn disable_stops_cpu_sample_production() {
 /// files appear.
 #[test]
 fn disable_stops_segment_rotation() {
-    use dial9_tokio_telemetry::telemetry::DiskWriter;
-
     let dir = tempfile::tempdir().unwrap();
     let trace_path = dir.path().join("trace.bin");
 
@@ -271,7 +286,9 @@ fn disable_stops_segment_rotation() {
 /// After `disable()`, re-enabling with `enable()` should resume event production.
 #[test]
 fn enable_after_disable_resumes_events() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let dir = tempfile::tempdir().unwrap();
+    let trace_path = dir.path().join("trace.bin");
+    let writer = DiskWriter::single_file(&trace_path).unwrap();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(2).enable_all();
@@ -304,9 +321,7 @@ fn enable_after_disable_resumes_events() {
     drop(runtime);
     drop(guard);
 
-    let b = batches.lock().unwrap();
-    let events: Vec<Dial9Event> = decode_all(&b);
-    let runtime_event_count = events
+    let runtime_event_count = read_events_on_disk(dir.path())
         .iter()
         .filter(|e| {
             matches!(

--- a/dial9-tokio-telemetry/tests/end_to_end.rs
+++ b/dial9-tokio-telemetry/tests/end_to_end.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use common::{BytesCapturingWriter, decode_all, decode_file};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all, decode_file};
 use dial9_tokio_telemetry::telemetry::analysis_events::{Dial9Event, WorkerId};
-use dial9_tokio_telemetry::telemetry::{DiskWriter, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::{DiskWriter, InMemoryWriter, TracedRuntime};
 use std::time::Duration;
 
 /// Run a known workload under TracedRuntime, read the trace back, and verify
@@ -128,7 +128,7 @@ fn end_to_end_trace_matches_workload_and_metrics() {
 /// must appear in the trace.
 #[test]
 fn task_spawn_events_from_main_thread_are_captured() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     const N: usize = 10;
 
@@ -137,7 +137,8 @@ fn task_spawn_events_from_main_thread_are_captured() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     runtime.block_on(async {
@@ -151,7 +152,9 @@ fn task_spawn_events_from_main_thread_are_captured() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);
@@ -168,7 +171,7 @@ fn task_spawn_events_from_main_thread_are_captured() {
 
 #[test]
 fn task_terminate_events_are_captured() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     const N: usize = 10;
 
@@ -177,7 +180,8 @@ fn task_terminate_events_are_captured() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     runtime.block_on(async {
@@ -191,7 +195,9 @@ fn task_terminate_events_are_captured() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_captures.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_captures.rs
@@ -5,12 +5,12 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
 use dial9_tokio_telemetry::memory_profiling::{
     Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
 };
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
 use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 use std::time::Duration;
 
 #[global_allocator]
@@ -18,12 +18,13 @@ static ALLOC: Dial9Allocator = Dial9Allocator::system();
 
 #[test]
 fn hook_captures_sampled_allocations() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let handle = guard.handle();
@@ -46,7 +47,9 @@ fn hook_captures_sampled_allocations() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);

--- a/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_hook_realloc.rs
@@ -5,12 +5,12 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
 use dial9_tokio_telemetry::memory_profiling::{
     Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
 };
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
 use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -40,12 +40,13 @@ static ALLOC: Dial9Allocator<CountingAllocator> = Dial9Allocator::new(CountingAl
 
 #[test]
 fn hook_realloc_emits_alloc_and_free_when_liveset_on() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let handle = guard.handle();
@@ -71,7 +72,9 @@ fn hook_realloc_emits_alloc_and_free_when_liveset_on() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     assert!(
         ALLOC_COUNT.load(Ordering::Relaxed) > 0,

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_already_installed.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_already_installed.rs
@@ -3,14 +3,16 @@
 //! Test that a second install() returns AlreadyInstalled.
 
 use dial9_tokio_telemetry::memory_profiling::{InstallError, MemoryProfiler};
-use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+
+mod common;
 
 #[test]
 fn second_install_returns_already_installed() {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (_runtime, guard) = TracedRuntime::builder()
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     let handle = guard.handle();

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_already_installed.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_already_installed.rs
@@ -2,19 +2,15 @@
 #![cfg(target_os = "linux")]
 //! Test that a second install() returns AlreadyInstalled.
 
-mod common;
-
 use dial9_tokio_telemetry::memory_profiling::{InstallError, MemoryProfiler};
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 
 #[test]
 fn second_install_returns_already_installed() {
-    let (writer, _batches) = common::BytesCapturingWriter::new();
-
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (_runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     let handle = guard.handle();

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_publishes.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_publishes.rs
@@ -5,7 +5,9 @@
 use dial9_tokio_telemetry::memory_profiling::{
     MemoryProfiler, MemoryProfilingConfig, is_installed,
 };
-use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
+
+mod common;
 
 #[test]
 fn install_publishes_active_inner() {
@@ -14,7 +16,7 @@ fn install_publishes_active_inner() {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (_runtime, guard) = TracedRuntime::builder()
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     let handle = guard.handle();

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_publishes.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_publishes.rs
@@ -2,23 +2,19 @@
 #![cfg(target_os = "linux")]
 //! Test that install() publishes the process-global ACTIVE state.
 
-mod common;
-
 use dial9_tokio_telemetry::memory_profiling::{
     MemoryProfiler, MemoryProfilingConfig, is_installed,
 };
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 
 #[test]
 fn install_publishes_active_inner() {
     assert!(!is_installed(), "should not be installed before install()");
 
-    let (writer, _batches) = common::BytesCapturingWriter::new();
-
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (_runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     let handle = guard.handle();

--- a/dial9-tokio-telemetry/tests/memory_profiling_install_registers_source.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_install_registers_source.rs
@@ -6,20 +6,21 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
 use dial9_tokio_telemetry::memory_profiling::{MemoryProfiler, push_test_alloc};
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
 use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 use std::time::Duration;
 
 #[test]
 fn install_registers_source_with_recorder() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let handle = guard.handle();
@@ -39,7 +40,9 @@ fn install_registers_source_with_recorder() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);

--- a/dial9-tokio-telemetry/tests/memory_profiling_no_overflow.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_no_overflow.rs
@@ -4,11 +4,11 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
 use dial9_tokio_telemetry::memory_profiling::{
     Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
 };
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -32,12 +32,13 @@ enum OverflowEvent {
 
 #[test]
 fn no_overflow_event_when_ring_has_capacity() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let handle = guard.handle();
@@ -61,7 +62,9 @@ fn no_overflow_event_when_ring_has_capacity() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let batches = batches.lock().unwrap();
     let events: Vec<OverflowEvent> = decode_all(&batches);

--- a/dial9-tokio-telemetry/tests/memory_profiling_overflow_event.rs
+++ b/dial9-tokio-telemetry/tests/memory_profiling_overflow_event.rs
@@ -4,11 +4,11 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
 use dial9_tokio_telemetry::memory_profiling::{
     Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
 };
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -30,12 +30,13 @@ enum OverflowEvent {
 
 #[test]
 fn overflow_event_emitted_when_ring_overflows() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let handle = guard.handle();
@@ -62,7 +63,9 @@ fn overflow_event_emitted_when_ring_overflows() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let batches = batches.lock().unwrap();
     let events: Vec<OverflowEvent> = decode_all(&batches);

--- a/dial9-tokio-telemetry/tests/park_unpark_tid.rs
+++ b/dial9-tokio-telemetry/tests/park_unpark_tid.rs
@@ -2,8 +2,8 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 use serde::Deserialize;
 
 /// Tagged union over the events this test cares about.
@@ -22,12 +22,13 @@ enum ParkOrUnpark {
 
 #[test]
 fn worker_park_unpark_events_carry_nonzero_tid() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(2).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     // Generate park/unpark cycles by spawning work that yields.
@@ -46,7 +47,9 @@ fn worker_park_unpark_events_carry_nonzero_tid() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let batches = batches.lock().unwrap();
     let events: Vec<ParkOrUnpark> = decode_all(&batches);

--- a/dial9-tokio-telemetry/tests/process_resource_usage.rs
+++ b/dial9-tokio-telemetry/tests/process_resource_usage.rs
@@ -1,26 +1,29 @@
 mod common;
 
 #[cfg(unix)]
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
 #[cfg(unix)]
 use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
 #[cfg(unix)]
-use dial9_tokio_telemetry::telemetry::{ProcessResourceUsageConfig, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, ProcessResourceUsageConfig, TracedRuntime};
 
 #[cfg(unix)]
 #[test]
 fn traced_runtime_records_process_resource_usage() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
         .with_process_resource_usage(ProcessResourceUsageConfig::default())
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let batches = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&batches);
@@ -43,16 +46,19 @@ fn traced_runtime_records_process_resource_usage() {
 #[cfg(unix)]
 #[test]
 fn traced_runtime_does_not_record_process_resource_usage_by_default() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(1).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
-        .build_and_start_with_writer(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let batches = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&batches);

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -6,7 +6,7 @@ mod fake_s3;
 use aws_config::Region;
 use aws_sdk_s3::Client;
 use dial9_tokio_telemetry::background_task::s3::S3Config;
-use dial9_tokio_telemetry::telemetry::{DiskWriter, TraceWriter, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::{DiskWriter, TracedRuntime};
 use fake_s3::{
     fake_s3_client, fake_s3_client_always_failing, fake_s3_client_flaky, fake_s3_client_hanging,
     fake_s3_client_with_region,
@@ -78,7 +78,7 @@ fn graceful_shutdown_seals_segments() {
         .unwrap();
 
     drop(runtime);
-    let result = guard.graceful_shutdown(std::time::Duration::from_secs(5));
+    let result = guard.graceful_shutdown(std::time::Duration::from_secs(1));
 
     assert!(result.is_ok());
 
@@ -145,7 +145,9 @@ fn end_to_end_trace_to_s3_roundtrip() {
     });
 
     drop(runtime);
-    guard.graceful_shutdown(Duration::from_secs(1)).unwrap();
+    guard
+        .graceful_shutdown(Duration::from_secs(1))
+        .expect("clean shutdown");
 
     // List objects in the bucket — should have at least one uploaded segment
     let list_rt = tokio::runtime::Builder::new_current_thread()
@@ -313,7 +315,9 @@ fn region_auto_detection_corrects_wrong_client_region() {
     });
 
     drop(runtime);
-    guard.graceful_shutdown(Duration::from_secs(1)).unwrap();
+    guard
+        .graceful_shutdown(Duration::from_secs(1))
+        .expect("clean shutdown");
 
     // Verify objects were uploaded despite the wrong initial region.
     let list_rt = tokio::runtime::Builder::new_current_thread()
@@ -802,7 +806,7 @@ fn permanently_broken_s3_produces_failure_metrics() {
 
     drop(runtime);
     guard
-        .graceful_shutdown(std::time::Duration::from_secs(5))
+        .graceful_shutdown(std::time::Duration::from_secs(1))
         .expect("graceful shutdown");
 
     let entries = inspector.entries();

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -796,17 +796,28 @@ fn permanently_broken_s3_produces_failure_metrics() {
         .build_and_start(builder, writer)
         .unwrap();
 
-    // Generate enough events to seal at least one segment, then shut down.
+    let has_pipeline_metric = || {
+        inspector
+            .entries()
+            .iter()
+            .any(|e| e.metrics.contains_key("Failure") || e.metrics.contains_key("Success"))
+    };
+
+    // Generate enough events to seal segments, then poll until the worker has
+    // recorded a pipeline (Failure/Success) metric.
     runtime.block_on(async {
         for _ in 0..50 {
             tokio::spawn(async { tokio::task::yield_now().await });
         }
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        while !has_pipeline_metric() && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
     });
 
     drop(runtime);
     guard
-        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .graceful_shutdown(std::time::Duration::from_secs(2))
         .expect("graceful shutdown");
 
     let entries = inspector.entries();

--- a/dial9-tokio-telemetry/tests/sched_clock_alignment.rs
+++ b/dial9-tokio-telemetry/tests/sched_clock_alignment.rs
@@ -5,7 +5,8 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
+use dial9_tokio_telemetry::telemetry::InMemoryWriter;
 use dial9_tokio_telemetry::telemetry::analysis_events::{CpuSampleSource, Dial9Event, WorkerId};
 
 #[test]
@@ -16,7 +17,7 @@ fn sched_event_timestamps_align_with_wall_clock() {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let num_workers = 2u64;
     let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -24,7 +25,8 @@ fn sched_event_timestamps_align_with_wall_clock() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_sched_events(SchedEventConfig::default())
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let _trace_start = guard.start_time();
@@ -60,7 +62,9 @@ fn sched_event_timestamps_align_with_wall_clock() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);

--- a/dial9-tokio-telemetry/tests/sched_events.rs
+++ b/dial9-tokio-telemetry/tests/sched_events.rs
@@ -4,7 +4,8 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
+use dial9_tokio_telemetry::telemetry::InMemoryWriter;
 use dial9_tokio_telemetry::telemetry::analysis_events::{CpuSampleSource, Dial9Event, WorkerId};
 
 #[test]
@@ -13,7 +14,7 @@ fn sched_events_capture_context_switches() {
     use dial9_tokio_telemetry::telemetry::cpu_profile::SchedEventConfig;
     use std::time::Duration;
 
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let num_workers = 2u64;
     let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -21,7 +22,8 @@ fn sched_events_capture_context_switches() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_sched_events(SchedEventConfig::default())
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     runtime.block_on(async {
@@ -38,7 +40,9 @@ fn sched_events_capture_context_switches() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<Dial9Event> = decode_all(&b);
@@ -73,7 +77,7 @@ fn sched_events_sampling_reduces_count() {
     use std::time::Duration;
 
     let count_sched_samples = |interval: Option<u64>| -> usize {
-        let (writer, batches) = BytesCapturingWriter::new();
+        let (capture, batches) = capture_processor();
 
         let num_workers = 2;
         let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -86,7 +90,8 @@ fn sched_events_sampling_reduces_count() {
 
         let (runtime, guard) = TracedRuntime::builder()
             .with_sched_events(config)
-            .build_and_start(builder, writer)
+            .with_custom_pipeline(|p| p.pipe(capture))
+            .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
             .unwrap();
 
         runtime.block_on(async {
@@ -106,7 +111,9 @@ fn sched_events_sampling_reduces_count() {
         });
 
         drop(runtime);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .expect("clean shutdown");
 
         let b = batches.lock().unwrap();
         let events: Vec<Dial9Event> = decode_all(&b);

--- a/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
+++ b/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
@@ -9,10 +9,8 @@
 
 #![cfg(all(feature = "cpu-profiling", target_os = "linux"))]
 
-mod common;
-
-use dial9_tokio_telemetry::telemetry::TracedRuntime;
 use dial9_tokio_telemetry::telemetry::cpu_profile::SchedEventConfig;
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -41,8 +39,6 @@ fn count_perf_fds() -> usize {
 #[test]
 fn sched_profiler_fds_bounded_with_many_blocking_threads() {
     let _lock = PERF_FD_TEST_LOCK.lock().unwrap();
-    let (writer, _events) = common::BytesCapturingWriter::new();
-
     let num_workers = 2;
     let num_blocking_tasks = 50;
 
@@ -51,7 +47,7 @@ fn sched_profiler_fds_bounded_with_many_blocking_threads() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_sched_events(SchedEventConfig::default())
-        .build_and_start(builder, writer)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     // Let workers start and resolve their identity.
@@ -80,7 +76,9 @@ fn sched_profiler_fds_bounded_with_many_blocking_threads() {
     let perf_fds_after = count_perf_fds();
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     // Only worker threads should have perf fds. Before the fix, we'd see
     // ~50 new perf fds (one per blocking thread). After the fix, the count
@@ -103,15 +101,13 @@ fn sched_profiler_fds_cleaned_up_on_shutdown() {
     assert_eq!(count_perf_fds(), 0, "no perf fds should exist before test");
 
     {
-        let (writer, _events) = common::BytesCapturingWriter::new();
-
         let num_workers = 4;
         let mut builder = tokio::runtime::Builder::new_multi_thread();
         builder.worker_threads(num_workers).enable_all();
 
         let (runtime, guard) = TracedRuntime::builder()
             .with_sched_events(SchedEventConfig::default())
-            .build_and_start(builder, writer)
+            .build_and_start(builder, InMemoryWriter::discard())
             .unwrap();
 
         // Do some work so workers resolve their identity.
@@ -132,7 +128,9 @@ fn sched_profiler_fds_cleaned_up_on_shutdown() {
         );
 
         drop(runtime);
-        drop(guard);
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(1))
+            .expect("clean shutdown");
     }
 
     let perf_fds_after = count_perf_fds();

--- a/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
+++ b/dial9-tokio-telemetry/tests/sched_profiler_fd_leak.rs
@@ -9,8 +9,10 @@
 
 #![cfg(all(feature = "cpu-profiling", target_os = "linux"))]
 
+use dial9_tokio_telemetry::telemetry::TracedRuntime;
 use dial9_tokio_telemetry::telemetry::cpu_profile::SchedEventConfig;
-use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TracedRuntime};
+
+mod common;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -47,7 +49,7 @@ fn sched_profiler_fds_bounded_with_many_blocking_threads() {
 
     let (runtime, guard) = TracedRuntime::builder()
         .with_sched_events(SchedEventConfig::default())
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     // Let workers start and resolve their identity.
@@ -107,7 +109,7 @@ fn sched_profiler_fds_cleaned_up_on_shutdown() {
 
         let (runtime, guard) = TracedRuntime::builder()
             .with_sched_events(SchedEventConfig::default())
-            .build_and_start(builder, InMemoryWriter::discard())
+            .build_and_start(builder, common::small_mem_writer())
             .unwrap();
 
         // Do some work so workers resolve their identity.

--- a/dial9-tokio-telemetry/tests/spawn_with.rs
+++ b/dial9-tokio-telemetry/tests/spawn_with.rs
@@ -4,9 +4,9 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all, decode_file};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all, decode_file};
 use dial9_tokio_telemetry::telemetry::{
-    DiskWriter, TaskId, TelemetryGuard, TraceWriter, TracedRuntime,
+    DiskWriter, InMemoryWriter, TaskId, TelemetryGuard, TracedRuntime,
 };
 use serde::Deserialize;
 use std::sync::{Arc, Mutex};
@@ -32,21 +32,23 @@ enum SpawnEvent {
 }
 
 /// Standard 2-worker multi_thread runtime with task tracking enabled.
-fn build_traced_runtime<W: TraceWriter + 'static>(writer: W) -> (Runtime, TelemetryGuard) {
+fn build_capturing_runtime() -> (Runtime, TelemetryGuard, Arc<Mutex<Vec<Vec<u8>>>>) {
+    let (capture, batches) = capture_processor();
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(2).enable_all();
-    TracedRuntime::builder()
+    let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
-        .build_and_start(builder, writer)
-        .unwrap()
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
+        .unwrap();
+    (runtime, guard, batches)
 }
 
 /// `spawn_with(fut, |f| set.spawn(f))` produces `WakeEvent`s for the
 /// spawned task — the same as `handle.spawn(fut)` would.
 #[test]
 fn spawn_with_joinset_emits_wake_events() {
-    let (writer, batches) = BytesCapturingWriter::new();
-    let (runtime, guard) = build_traced_runtime(writer);
+    let (runtime, guard, batches) = build_capturing_runtime();
 
     let handle = guard.handle();
     let spawned_id: Arc<Mutex<Option<TaskId>>> = Arc::new(Mutex::new(None));
@@ -66,7 +68,9 @@ fn spawn_with_joinset_emits_wake_events() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<SpawnEvent> = decode_all(&b);
@@ -86,7 +90,12 @@ fn spawn_with_marks_taskspawn_and_preserves_caller() {
     let dir = tempfile::tempdir().unwrap();
     let trace_path = dir.path().join("trace.bin");
     let writer = DiskWriter::single_file(&trace_path).unwrap();
-    let (runtime, guard) = build_traced_runtime(writer);
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .build_and_start(builder, writer)
+        .unwrap();
 
     let handle = guard.handle();
 
@@ -139,8 +148,12 @@ fn spawn_with_marks_taskspawn_and_preserves_caller() {
 /// `spawn_with` returns whatever the closure returns.
 #[test]
 fn spawn_with_returns_closure_value() {
-    let (writer, _batches) = BytesCapturingWriter::new();
-    let (runtime, guard) = build_traced_runtime(writer);
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .build_and_start(builder, InMemoryWriter::discard())
+        .unwrap();
 
     let handle = guard.handle();
 
@@ -151,7 +164,9 @@ fn spawn_with_returns_closure_value() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(Duration::from_secs(1))
+        .expect("clean shutdown");
 }
 
 /// `RuntimeTelemetryHandle::spawn_with` composes with `JoinSet::spawn_on`
@@ -160,8 +175,12 @@ fn spawn_with_returns_closure_value() {
 fn runtime_handle_spawn_with_targets_correct_runtime() {
     use dial9_tokio_telemetry::telemetry::TelemetryCore;
 
-    let (writer, batches) = BytesCapturingWriter::new();
-    let guard = TelemetryCore::builder().writer(writer).build().unwrap();
+    let (capture, batches) = capture_processor();
+    let guard = TelemetryCore::builder()
+        .writer(InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
+        .processors(vec![Box::new(capture)])
+        .build()
+        .unwrap();
     guard.enable();
 
     let mut builder_a = tokio::runtime::Builder::new_multi_thread();

--- a/dial9-tokio-telemetry/tests/spawn_with.rs
+++ b/dial9-tokio-telemetry/tests/spawn_with.rs
@@ -152,7 +152,7 @@ fn spawn_with_returns_closure_value() {
     builder.worker_threads(2).enable_all();
     let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     let handle = guard.handle();

--- a/dial9-tokio-telemetry/tests/task_dump.rs
+++ b/dial9-tokio-telemetry/tests/task_dump.rs
@@ -2,8 +2,8 @@
 
 mod common;
 
-use common::{BytesCapturingWriter, decode_all};
-use dial9_tokio_telemetry::telemetry::{TaskDumpConfig, TracedRuntime};
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TaskDumpConfig, TracedRuntime};
 use serde::Deserialize;
 use std::time::Duration;
 use tokio::task::JoinSet;
@@ -32,14 +32,15 @@ enum DumpEvent {
 /// produce at least one `TaskDump` event.
 #[test]
 fn task_dump_emitted_for_long_sleep() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();
     let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
         .with_task_dumps(TaskDumpConfig::builder().rng_seed(42).build())
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let handle = guard.handle();
@@ -52,7 +53,9 @@ fn task_dump_emitted_for_long_sleep() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<DumpEvent> = decode_all(&b);
@@ -72,7 +75,7 @@ fn task_dump_emitted_for_long_sleep() {
 /// A task whose idles are all below threshold should produce zero dumps.
 #[test]
 fn no_task_dump_for_short_sleep() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();
@@ -84,7 +87,8 @@ fn no_task_dump_for_short_sleep() {
                 .rng_seed(42)
                 .build(),
         )
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let handle = guard.handle();
@@ -113,7 +117,7 @@ fn no_task_dump_for_short_sleep() {
 #[test]
 fn task_dump_does_not_produce_extra_events() {
     fn run(enable: bool) -> (usize, usize, usize) {
-        let (writer, batches) = BytesCapturingWriter::new();
+        let (capture, batches) = capture_processor();
 
         let mut builder = tokio::runtime::Builder::new_current_thread();
         builder.enable_all();
@@ -121,7 +125,10 @@ fn task_dump_does_not_produce_extra_events() {
         if enable {
             tb = tb.with_task_dumps(TaskDumpConfig::builder().rng_seed(42).build());
         }
-        let (runtime, guard) = tb.build_and_start(builder, writer).unwrap();
+        let (runtime, guard) = tb
+            .with_custom_pipeline(|p| p.pipe(capture))
+            .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
+            .unwrap();
 
         let handle = guard.handle();
         runtime.block_on(async {
@@ -164,14 +171,15 @@ fn task_dump_does_not_produce_extra_events() {
 /// Custom spawn APIs should get the same task-dump instrumentation.
 #[test]
 fn spawn_with_joinset_emits_task_dump() {
-    let (writer, batches) = BytesCapturingWriter::new();
+    let (capture, batches) = capture_processor();
 
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();
     let (runtime, guard) = TracedRuntime::builder()
         .with_task_tracking(true)
         .with_task_dumps(TaskDumpConfig::builder().rng_seed(42).build())
-        .build_and_start(builder, writer)
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build_and_start(builder, InMemoryWriter::new(CAPTURE_BUFFER_SIZE).unwrap())
         .unwrap();
 
     let handle = guard.handle();
@@ -188,7 +196,9 @@ fn spawn_with_joinset_emits_task_dump() {
     });
 
     drop(runtime);
-    drop(guard);
+    guard
+        .graceful_shutdown(std::time::Duration::from_secs(1))
+        .expect("clean shutdown");
 
     let b = batches.lock().unwrap();
     let events: Vec<DumpEvent> = decode_all(&b);

--- a/dial9-tokio-telemetry/tests/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/tests/tokio_hooks.rs
@@ -1,4 +1,4 @@
-use dial9_tokio_telemetry::telemetry::{NullWriter, TelemetryCore, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TelemetryCore, TracedRuntime};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -22,7 +22,7 @@ fn on_thread_start_and_stop_fire() {
                 stc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -60,7 +60,10 @@ fn each_runtime_gets_own_hooks() {
     let ca = count_a.clone();
     let cb = count_b.clone();
 
-    let guard = TelemetryCore::builder().writer(NullWriter).build().unwrap();
+    let guard = TelemetryCore::builder()
+        .writer(InMemoryWriter::discard())
+        .build()
+        .unwrap();
     guard.enable();
 
     let mut builder_a = tokio::runtime::Builder::new_multi_thread();
@@ -147,7 +150,7 @@ fn on_thread_park_fires() {
                 pc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -178,7 +181,7 @@ fn on_thread_unpark_fires() {
                 uc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -222,7 +225,7 @@ fn task_poll_hooks_fire() {
                 ac.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -271,7 +274,7 @@ fn task_lifecycle_hooks_fire() {
                 tc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -317,7 +320,7 @@ fn task_spawn_hook_fires_when_task_tracking_disabled() {
                 sc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -358,7 +361,7 @@ fn task_terminate_hook_fires_when_task_tracking_disabled() {
                 tc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -405,7 +408,7 @@ fn dial9_hooks_run_before_user_hooks() {
                 hf.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -439,7 +442,7 @@ fn hook_stacking_single_callback_fires() {
                 log_c.lock().unwrap().push("park_a");
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -475,7 +478,7 @@ fn hook_stacking_multiple_callbacks_fire_in_order() {
                 log_b.lock().unwrap().push("park_b");
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -523,7 +526,7 @@ fn hook_stacking_multiple_with_tokio_hooks_calls() {
                 log_b.lock().unwrap().push("call_2");
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {
@@ -568,7 +571,7 @@ fn hook_stacking_task_meta_hooks_fire_in_order() {
                 log_b.lock().unwrap().push("poll_b");
             });
         })
-        .build_and_start_with_writer(builder, NullWriter)
+        .build_and_start(builder, InMemoryWriter::discard())
         .unwrap();
 
     runtime.block_on(async {

--- a/dial9-tokio-telemetry/tests/tokio_hooks.rs
+++ b/dial9-tokio-telemetry/tests/tokio_hooks.rs
@@ -1,4 +1,6 @@
-use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TelemetryCore, TracedRuntime};
+use dial9_tokio_telemetry::telemetry::{TelemetryCore, TracedRuntime};
+
+mod common;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -22,7 +24,7 @@ fn on_thread_start_and_stop_fire() {
                 stc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -61,7 +63,7 @@ fn each_runtime_gets_own_hooks() {
     let cb = count_b.clone();
 
     let guard = TelemetryCore::builder()
-        .writer(InMemoryWriter::discard())
+        .writer(common::small_mem_writer())
         .build()
         .unwrap();
     guard.enable();
@@ -150,7 +152,7 @@ fn on_thread_park_fires() {
                 pc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -181,7 +183,7 @@ fn on_thread_unpark_fires() {
                 uc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -225,7 +227,7 @@ fn task_poll_hooks_fire() {
                 ac.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -274,7 +276,7 @@ fn task_lifecycle_hooks_fire() {
                 tc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -320,7 +322,7 @@ fn task_spawn_hook_fires_when_task_tracking_disabled() {
                 sc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -361,7 +363,7 @@ fn task_terminate_hook_fires_when_task_tracking_disabled() {
                 tc.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -408,7 +410,7 @@ fn dial9_hooks_run_before_user_hooks() {
                 hf.fetch_add(1, Ordering::Relaxed);
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -442,7 +444,7 @@ fn hook_stacking_single_callback_fires() {
                 log_c.lock().unwrap().push("park_a");
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -478,7 +480,7 @@ fn hook_stacking_multiple_callbacks_fire_in_order() {
                 log_b.lock().unwrap().push("park_b");
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -526,7 +528,7 @@ fn hook_stacking_multiple_with_tokio_hooks_calls() {
                 log_b.lock().unwrap().push("call_2");
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {
@@ -571,7 +573,7 @@ fn hook_stacking_task_meta_hooks_fire_in_order() {
                 log_b.lock().unwrap().push("poll_b");
             });
         })
-        .build_and_start(builder, InMemoryWriter::discard())
+        .build_and_start(builder, common::small_mem_writer())
         .unwrap();
 
     runtime.block_on(async {


### PR DESCRIPTION
closes #482

# Overview

Removes the `TraceWriter` trait and its test implementations.

`SegmentWriter<Mode>` (the `DiskWriter` / `InMemoryWriter` aliases) is now the only writer. 

This is a breaking change, `TraceWriter` and `NullWriter` were public.

## Changes

**Writer**
 `SegmentWriter`'s methods are now inherent instead of trait methods (`flush` / `finalize` / `write_encoded_batch` / `update_segment_metadata` are `pub`, the flush-loop-only ones are `pub(crate)`). 
 `NullWriter` is replaced by `InMemoryWriter::discard()`, a fixed-size in-memory writer whose output is never
delivered. The flush loop and `TelemetryCore::new` now take a concrete `SegmentWriter<Mode>`.

**The build API now infers the writer mode** 
Previously the only way to reach in-memory mode on the builder was to call a pipeline method, so code that just
wanted to discard output had to write `.with_custom_pipeline(|p| p)` (or something like `with_s3...` purely to flip the mode marker, this is no longer necessary. 

On the no-pipeline state, `build` / `build_and_start` take the writer and infer `Mode` from it:

```rust
// disk
TracedRuntime::builder().build_and_start(tk, DiskWriter::single_file(path)?)?;
// in-memory, output discarded
TracedRuntime::builder().build_and_start(tk, InMemoryWriter::discard())?;
```

A configured pipeline pins the mode, so the custom and S3 pipeline states keep a `SegmentWriter<Mode>` argument that must match. Pairing a disk pipeline with an in-memory writer stays a compile error.

The `*_with_writer` build methods are removed: call `build` / `build_and_start`.

## Breaking changes

- `TraceWriter` and `NullWriter` are removed. Replace `NullWriter` with `InMemoryWriter::discard()`.
- `build_with_writer` / `build_and_start_with_writer` are removed. Use `build` / `build_and_start` (they now take the writer directly and infer the mode).
- Custom `TraceWriter` implementations are no longer possible. To transform or ship sealed segments, implement `SegmentProcessor` and add it with `with_custom_pipeline`.

## Testing

Tests that used to capture output through a custom `TraceWriter` now run a capturing `SegmentProcessor` over a real `InMemoryWriter` and read back the sealed segments after `graceful_shutdown`. The shuttle tests use a real `DiskWriter` and the `fail_all_writes` test hook.

## Note of reviewers

I intentionally didn't dig too much into improving the config API or removing some of the duplication the new mode inference requires. We'll probably rework that either way after crate structure v2.
