### PR TITLE
fix(ci): allow security audit job to create issues

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,6 +2,7 @@ name: Security audit
 on:
   push:
     paths:
+      - '.github/workflows/audit.yml'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   schedule:
@@ -10,6 +11,7 @@ on:
 permissions:
   checks: write
   contents: read
+  issues: write
 
 jobs:
   security_audit:


### PR DESCRIPTION
Fix for:
```
Run rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998
cargo-audit is not installed, installing it now
Installing "cargo-audit = latest"
Calling cargo-audit (JSON output)
No vulnerabilities were found
Warning: 2 warnings found!
[@octokit/request] "POST https://api.github.com/repos/dial9-rs/dial9/issues" is deprecated. It is scheduled to be removed on Fri, 10 Mar 2028 00:00:00 GMT. See https://docs.github.com/en/rest/about-the-rest-api/api-versions
Error: Resource not accessible by integration - https://docs.github.com/rest/issues/issues#create-an-issue
```

https://github.com/dial9-rs/dial9/actions/runs/27113451786/job/80015612972