### PR TITLE
fix(analysis): O(P²) sched-delay scan + idle-vs-blocking off-CPU split

### DIFF
--- a/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
@@ -582,7 +582,7 @@ function reportAnalysis(a, label) {
     // bucket captures synchronous blocking but not .await-style async lock waits.
     console.log(`\n  Caveat: an async lock wait (lock().await) ends the poll, so its off-CPU time`);
     console.log(`          is counted as idle-park, not in-poll. The IN-POLL bucket captures`);
-    console.log(`          synchronous blocking but not .await-style async lock waits.`);
+    console.log(`          synchronous blocking but not .await-style async lock waits. To see async lock wait, consider enabling task dumps`);
   }
 
   // ── CPU hotspots ──

--- a/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
@@ -70,6 +70,54 @@ function diagnoseStack(frames) {
   return { syscall, blocker, trigger, classified };
 }
 
+/**
+ * Group off-CPU (scheduling) samples, splitting real blocking from idle parking.
+ *
+ * An off-CPU sample taken *inside a poll* means a task voluntarily blocked
+ * mid-poll — that is real blocking. An off-CPU sample taken *between polls*
+ * means a worker parked because it had no work — that is idle, even though the
+ * park is itself a futex/condvar wait at the kernel level. Reporting both as
+ * "blocking calls" makes a mostly-idle runtime look 100% blocked on a futex.
+ *
+ * attachCpuSamples sets sample.inPoll (true when the sample landed within a
+ * poll). We split on that flag, deduplicate the in-poll stacks for the blocking
+ * report, and attribute them per spawn location.
+ *
+ * Caveat: an async lock wait (lock().await returning Pending) ends the poll, so
+ * its subsequent off-CPU time is tagged between-polls (idle), not in-poll. The
+ * in-poll bucket captures synchronous blocking but not .await-style async lock
+ * waits, so the "idle" bucket should not itself be over-trusted.
+ *
+ * Shared by both analysis paths (accumulateTrace and analyzeWorkerMain) so they
+ * cannot drift apart.
+ *
+ * @param {Array} offCpu - off-CPU samples (source === 1), each with .inPoll/.spawnLoc set
+ * @param {Map} callframeSymbols
+ * @returns {{ inPollGroups: Array, inPollCount: number, idleCount: number, inPollByLoc: Array<{loc: string, count: number}> }}
+ */
+function groupOffCpuSamples(offCpu, callframeSymbols) {
+  const inPoll = [];
+  let idleCount = 0;
+  const byLoc = new Map();
+  for (const s of offCpu) {
+    if (s.inPoll) {
+      inPoll.push(s);
+      const loc = s.spawnLoc || '(unknown spawn location)';
+      byLoc.set(loc, (byLoc.get(loc) || 0) + 1);
+    } else {
+      idleCount++;
+    }
+  }
+  return {
+    inPollGroups: deduplicateSamples(inPoll, callframeSymbols),
+    inPollCount: inPoll.length,
+    idleCount,
+    inPollByLoc: [...byLoc.entries()]
+      .map(([loc, count]) => ({ loc, count }))
+      .sort((a, b) => b.count - a.count),
+  };
+}
+
 function fmtDur(ns) {
   if (ns >= 1e9) return (ns / 1e9).toFixed(2) + 's';
   if (ns >= 1e6) return (ns / 1e6).toFixed(2) + 'ms';
@@ -101,6 +149,11 @@ function createAccumulator() {
     callframeSymbols: new Map(),
     cpuGroupMap: new Map(),
     schedGroupMap: new Map(),
+    // Off-CPU split: in-poll = real blocking, idle = worker parked with no work.
+    inPollGroupMap: new Map(),     // stack key -> in-poll blocking sample group
+    offCpuInPollCount: 0,          // off-CPU samples taken inside a poll (real blocking)
+    offCpuIdleCount: 0,            // off-CPU samples taken between polls (idle parking)
+    inPollByLocMap: new Map(),     // spawnLoc -> in-poll blocking sample count
     spanStats: new Map(), // spanName -> Histogram
     pollDurationByLoc: new Map(), // spawnLoc -> Histogram
     schedDelayHist: null, // Histogram
@@ -208,6 +261,18 @@ function accumulateTrace(acc, trace, sourceFile) {
     const e = acc.schedGroupMap.get(key);
     if (e) e.count += g.count; else acc.schedGroupMap.set(key, { ...g });
   }
+  // Off-CPU split: real blocking (in-poll) vs idle parking (between polls).
+  const offCpuSplit = groupOffCpuSamples(offCpu, trace.callframeSymbols);
+  acc.offCpuInPollCount += offCpuSplit.inPollCount;
+  acc.offCpuIdleCount += offCpuSplit.idleCount;
+  for (const g of offCpuSplit.inPollGroups) {
+    const key = g.frames.map(f => f.symbol).join('\0');
+    const e = acc.inPollGroupMap.get(key);
+    if (e) e.count += g.count; else acc.inPollGroupMap.set(key, { ...g });
+  }
+  for (const { loc, count } of offCpuSplit.inPollByLoc) {
+    acc.inPollByLocMap.set(loc, (acc.inPollByLocMap.get(loc) || 0) + count);
+  }
 
   // Span durations (native HDR histogram for bounded memory, exact percentiles)
   if (trace.customEvents && trace.customEvents.length > 0) {
@@ -267,6 +332,13 @@ function finalizeAccumulator(acc) {
     taskTerminateTimes: acc.taskTerminateTimes, callframeSymbols: acc.callframeSymbols,
     cpuGroups: [...acc.cpuGroupMap.values()].sort((a, b) => b.count - a.count),
     schedGroups: [...acc.schedGroupMap.values()].sort((a, b) => b.count - a.count),
+    // Off-CPU split: in-poll groups are real blocking; idle is parked-with-no-work.
+    inPollGroups: [...acc.inPollGroupMap.values()].sort((a, b) => b.count - a.count),
+    offCpuInPollCount: acc.offCpuInPollCount,
+    offCpuIdleCount: acc.offCpuIdleCount,
+    inPollByLoc: [...acc.inPollByLocMap.entries()]
+      .map(([loc, count]) => ({ loc, count }))
+      .sort((a, b) => b.count - a.count),
     spanStats: acc.spanStats,
     pollDurationByLoc: acc.pollDurationByLoc,
     schedDelayHist: acc.schedDelayHist,
@@ -479,15 +551,38 @@ function reportAnalysis(a, label) {
       }
     }
   } else {
-    console.log(`  ${a.offCpuSampleCount} off-CPU sample(s)\n`);
-    for (const g of a.schedGroups.slice(0, 10)) {
-      const pct = (g.count / a.offCpuSampleCount * 100).toFixed(1);
-      const { syscall, blocker, trigger } = diagnoseStack(g.frames);
-      console.log(`  ${String(g.count).padStart(5)} samples (${pct}%) — leaf: ${g.leaf}`);
-      if (blocker) console.log(`         blocked by: ${blocker.symbol} (kernel)`);
-      if (syscall) console.log(`         syscall:    ${syscall.display}`);
-      if (trigger) console.log(`         called from: ${trigger.display}`);
+    const inPoll = a.offCpuInPollCount || 0;
+    const idle = a.offCpuIdleCount || 0;
+    console.log(`  ${a.offCpuSampleCount} off-CPU sample(s): ${inPoll} IN-POLL (real blocking), ${idle} idle-park`);
+    console.log(`  NOTE: idle-park = a worker with no work parked between polls (itself a futex/condvar`);
+    console.log(`        wait); it is NOT blocking. Only IN-POLL samples are a task blocked mid-poll.\n`);
+
+    if (inPoll === 0) {
+      console.log('  No in-poll blocking detected — all off-CPU samples are idle worker parking. ✅');
+    } else {
+      // Per-spawn-location attribution of the real (in-poll) blocking.
+      console.log(`  IN-POLL blocking by task spawn location:`);
+      for (const { loc, count } of (a.inPollByLoc || []).slice(0, 10)) {
+        const pct = (count / inPoll * 100).toFixed(1);
+        console.log(`    ${String(count).padStart(5)} (${pct}%) — ${loc}`);
+      }
+      // Blocking call stacks for the in-poll samples (the actionable part).
+      console.log(`\n  IN-POLL blocking call stacks:`);
+      for (const g of (a.inPollGroups || []).slice(0, 10)) {
+        const pct = (g.count / inPoll * 100).toFixed(1);
+        const { syscall, blocker, trigger } = diagnoseStack(g.frames);
+        console.log(`  ${String(g.count).padStart(5)} samples (${pct}%) — leaf: ${g.leaf}`);
+        if (blocker) console.log(`         blocked by: ${blocker.symbol} (kernel)`);
+        if (syscall) console.log(`         syscall:    ${syscall.display}`);
+        if (trigger) console.log(`         called from: ${trigger.display}`);
+      }
     }
+    // Caveat: an async lock wait (lock().await returning Pending) ends the poll,
+    // so its subsequent off-CPU time is tagged idle, not in-poll. The in-poll
+    // bucket captures synchronous blocking but not .await-style async lock waits.
+    console.log(`\n  Caveat: an async lock wait (lock().await) ends the poll, so its off-CPU time`);
+    console.log(`          is counted as idle-park, not in-poll. The IN-POLL bucket captures`);
+    console.log(`          synchronous blocking but not .await-style async lock waits.`);
   }
 
   // ── CPU hotspots ──
@@ -784,6 +879,17 @@ function mergePartial(acc, p) {
     const e = acc.schedGroupMap.get(key);
     if (e) e.count += g.count; else acc.schedGroupMap.set(key, { ...g });
   }
+  // Off-CPU split: in-poll blocking groups + in-poll/idle counts + per-loc attribution.
+  acc.offCpuInPollCount += p.offCpuInPollCount || 0;
+  acc.offCpuIdleCount += p.offCpuIdleCount || 0;
+  for (const g of (p.inPollGroups || [])) {
+    const key = g.frames.map(f => f.symbol).join('\0');
+    const e = acc.inPollGroupMap.get(key);
+    if (e) e.count += g.count; else acc.inPollGroupMap.set(key, { ...g });
+  }
+  for (const { loc, count } of (p.inPollByLoc || [])) {
+    acc.inPollByLocMap.set(loc, (acc.inPollByLocMap.get(loc) || 0) + count);
+  }
 
   // Poll durations by location -> histogram
   for (const [loc, durations] of Object.entries(p.pollDurationsByLoc || {})) {
@@ -882,6 +988,7 @@ function analyzeWorkerMain(cachePath) {
   const schedDelays = computeSchedulingDelays(spans.workerSpans, wids, spans.wakesByTask);
   const onCpu = trace.cpuSamples.filter(s => s.source === 0);
   const offCpu = trace.cpuSamples.filter(s => s.source === 1);
+  const offCpuSplit = groupOffCpuSamples(offCpu, trace.callframeSymbols);
 
   const partial = {
     workerIds: wids, minTs, maxTs,
@@ -901,6 +1008,11 @@ function analyzeWorkerMain(cachePath) {
     callframeSymbols: mapToEntries(trace.callframeSymbols),
     cpuGroups: deduplicateSamples(onCpu, trace.callframeSymbols),
     schedGroups: deduplicateSamples(offCpu, trace.callframeSymbols),
+    // Off-CPU split: in-poll = real blocking, idle = parked with no work.
+    inPollGroups: offCpuSplit.inPollGroups,
+    offCpuInPollCount: offCpuSplit.inPollCount,
+    offCpuIdleCount: offCpuSplit.idleCount,
+    inPollByLoc: offCpuSplit.inPollByLoc,
     pollDurationsByLoc: {}, spanDurations: {},
     blockInPlaceGaps: trace.blockInPlaceGaps || [],
   };

--- a/dial9-viewer/skills/dial9-trace-analysis/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-analysis/SKILL.md
@@ -113,7 +113,16 @@ process.stderr.write('\n');
   // ── CPU profiling ──
   callframeSymbols: Map<address, {symbol, location}|[{symbol, location}]>, // address → resolved symbol (array for inlined frames)
   cpuGroups: [{count, leaf, leafRaw, frames}],       // on-CPU sample groups, sorted by count descending
-  schedGroups: [{count, leaf, leafRaw, frames}],     // off-CPU sample groups, sorted by count descending
+  schedGroups: [{count, leaf, leafRaw, frames}],     // off-CPU sample groups (all), sorted by count descending
+
+  // ── Off-CPU split: real blocking vs idle parking ──
+  // An off-CPU sample inside a poll = a task blocked mid-poll (real blocking);
+  // between polls = a worker parked with no work (idle, though itself a futex/condvar wait).
+  // Caveat: an async lock wait (lock().await) ends the poll, so it counts as idle, not in-poll.
+  inPollGroups: [{count, leaf, leafRaw, frames}],    // in-poll (real blocking) sample groups, sorted by count descending
+  offCpuInPollCount: number,        // off-CPU samples taken inside a poll (real blocking)
+  offCpuIdleCount: number,          // off-CPU samples taken between polls (idle parking)
+  inPollByLoc: [{loc, count}],      // in-poll blocking sample count by task spawn location, sorted by count descending
 
   // ── Histograms ──
   spanStats: Map<spanName, Histogram>,      // tracing span duration histograms (ns)

--- a/dial9-viewer/ui/test_trace_analysis.js
+++ b/dial9-viewer/ui/test_trace_analysis.js
@@ -184,6 +184,89 @@ async function main() {
     );
   }
 
+  function testInPollFlagMatchesAttachment() {
+    // attachCpuSamples must set sample.inPoll === true iff the sample was
+    // attached to a poll (the in-poll = real-blocking signal). Cross-check the
+    // flag against ground truth: the set of samples actually attached to polls.
+    const attached = new Set();
+    for (const w of workerIds) {
+      for (const p of workerSpans[w].polls) {
+        for (const s of p.cpuSamples || []) attached.add(s);
+        for (const s of p.schedSamples || []) attached.add(s);
+      }
+    }
+    let mismatches = 0;
+    for (const s of trace.cpuSamples) {
+      if (!!s.inPoll !== attached.has(s)) mismatches++;
+    }
+    if (mismatches > 0)
+      fail(`${mismatches} sample(s) have inPoll inconsistent with poll attachment`);
+    pass(`inPoll flag matches poll attachment for all ${trace.cpuSamples.length} samples`);
+  }
+
+  function testOffCpuSplitIsExhaustive() {
+    // Splitting off-CPU samples by inPoll must partition them exactly: every
+    // off-CPU sample is either in-poll (real blocking) or idle-park, never both
+    // or neither. This is the invariant the BLOCKING CALLS report relies on.
+    const offCpu = trace.cpuSamples.filter((s) => s.source === 1);
+    const inPoll = offCpu.filter((s) => s.inPoll);
+    const idle = offCpu.filter((s) => !s.inPoll);
+    if (inPoll.length + idle.length !== offCpu.length)
+      fail(
+        `off-CPU split not exhaustive: ${inPoll.length} + ${idle.length} != ${offCpu.length}`
+      );
+    pass(
+      `off-CPU split exhaustive: ${offCpu.length} = ${inPoll.length} in-poll + ${idle.length} idle-park`
+    );
+  }
+
+  function testSchedDelayMidPollWakeAdjustment() {
+    // Bug-1 regression guard: the mid-poll wake adjustment. If a wake lands
+    // inside an earlier poll of the same task, the delay must be measured from
+    // that poll's end, not the wake itself. The demo trace may not exercise
+    // this branch, so drive it with a synthetic two-poll task.
+    const ws = {
+      0: {
+        polls: [
+          { taskId: 1, start: 100, end: 200 },
+          { taskId: 1, start: 500, end: 600 },
+        ],
+      },
+    };
+    // Wake at t=150 lands inside the first poll [100,200].
+    const wakes = { 1: [{ timestamp: 150, wakerTaskId: 9 }] };
+    const r = computeSchedulingDelays(ws, [0], wakes);
+    // For poll #2 (start=500), effectiveWake should snap to poll #1.end = 200,
+    // giving delay = 500 - 200 = 300 (not 500 - 150 = 350).
+    if (r.length !== 1) fail(`expected 1 sched delay, got ${r.length}`);
+    if (r[0].wakeTime !== 200 || r[0].delay !== 300)
+      fail(
+        `mid-poll wake not adjusted: wakeTime=${r[0].wakeTime} delay=${r[0].delay} (expected 200/300)`
+      );
+    pass("mid-poll wake adjusted to containing poll's end (binary search)");
+  }
+
+  function testSchedDelayWakeInGapUnadjusted() {
+    // Counterpart: a wake that falls in the gap between polls (inside no poll)
+    // must NOT be adjusted — delay is measured straight from the wake.
+    const ws = {
+      0: {
+        polls: [
+          { taskId: 1, start: 100, end: 200 },
+          { taskId: 1, start: 500, end: 600 },
+        ],
+      },
+    };
+    const wakes = { 1: [{ timestamp: 300, wakerTaskId: 9 }] }; // in gap (200,500)
+    const r = computeSchedulingDelays(ws, [0], wakes);
+    if (r.length !== 1) fail(`expected 1 sched delay, got ${r.length}`);
+    if (r[0].wakeTime !== 300 || r[0].delay !== 200)
+      fail(
+        `gap wake wrongly adjusted: wakeTime=${r[0].wakeTime} delay=${r[0].delay} (expected 300/200)`
+      );
+    pass("wake in inter-poll gap left unadjusted");
+  }
+
   // ── extractLocalQueueSamples (via buildWorkerSpans) ──
 
   function testLocalQueueNonNegative() {
@@ -1015,6 +1098,8 @@ async function main() {
   console.log("\nattachCpuSamples:");
   testAttachedSamplesWithinPollBounds();
   testCpuResultCounts();
+  testInPollFlagMatchesAttachment();
+  testOffCpuSplitIsExhaustive();
 
   console.log("\nextractLocalQueueSamples:");
   testLocalQueueNonNegative();
@@ -1034,6 +1119,8 @@ async function main() {
   testDelaysBounded();
   testWakeBeforePoll();
   testDelaysSorted();
+  testSchedDelayMidPollWakeAdjustment();
+  testSchedDelayWakeInGapUnadjusted();
 
   console.log("\nfilterPointsOfInterest:");
   testLongPollFilter();

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -338,7 +338,7 @@
   /**
    * Attach CPU samples to the poll spans they fall within using binary search.
    * Mutates workerSpans poll objects (adds .cpuSamples[], .schedSamples[])
-   * and sample objects (sets .spawnLoc).
+   * and sample objects (sets .spawnLoc and .inPoll).
    * @param {import('./trace_parser.js').CpuSample[]} cpuSamples
    * @param {Object} workerSpans - as returned by buildWorkerSpans
    * @returns {{ pollsWithCpuSamples: number, pollsWithSchedSamples: number }}
@@ -375,6 +375,12 @@
         found = true;
       }
       if (!found) sample.spawnLoc = null;
+      // inPoll records whether the sample landed inside a poll, independent of
+      // whether that poll's spawn location is known. For off-CPU samples this
+      // is the blocking-vs-idle signal: in-poll = a task voluntarily blocked
+      // mid-poll (real blocking); not-in-poll = a worker parked with no work
+      // (idle, even though the park is itself a futex/condvar wait).
+      sample.inPoll = found;
     }
 
     let pollsWithCpuSamples = 0;
@@ -456,12 +462,31 @@
           let effectiveWake = wake.timestamp;
           const taskPolls = pollsByTask[s.taskId];
           if (taskPolls) {
-            for (const p of taskPolls) {
-              if (p.start >= s.start) break;
-              if (wake.timestamp >= p.start && wake.timestamp <= p.end) {
+            // If the wake landed mid-poll (the task was already being polled
+            // when it was woken), measure the delay from the end of that poll
+            // rather than the wake itself. taskPolls is sorted by start and a
+            // single task's polls never overlap, so at most one poll's
+            // [start, end] can contain wake.timestamp. Binary search for the
+            // rightmost poll with start <= wake.timestamp instead of linearly
+            // scanning every poll of the task (which is O(P^2) for a
+            // long-lived task with millions of polls).
+            let plo = 0,
+              phi = taskPolls.length - 1,
+              pbest = -1;
+            while (plo <= phi) {
+              const pmid = (plo + phi) >> 1;
+              if (taskPolls[pmid].start <= wake.timestamp) {
+                pbest = pmid;
+                plo = pmid + 1;
+              } else phi = pmid - 1;
+            }
+            if (pbest >= 0) {
+              const p = taskPolls[pbest];
+              // Preserve original semantics: only an earlier poll counts, and
+              // the wake must fall within it (start <= wake is guaranteed by
+              // the search above).
+              if (p.start < s.start && wake.timestamp <= p.end)
                 effectiveWake = p.end;
-                break;
-              }
             }
           }
           const delay = s.start - effectiveWake;


### PR DESCRIPTION
Two bugs in the dial9 analysis toolkit (`analyze.js` / `trace_analysis.js`), both surfaced while analyzing large applier traces from a storage server (a long-lived task with ~2.3M polls in one 60s / ~50 MB segment, CPU-profiling + sched-events enabled). Validated against the current source and fixed; line numbers in the original report were approximate.

## Bug 1 — `computeSchedulingDelays` is O(polls_per_task²); hangs on large segments

`trace_analysis.js`, `computeSchedulingDelays`. For each poll, the mid-poll-wake adjustment linearly rescanned **every** poll of the same task to find the one whose `[start,end]` interval contains the wake timestamp. For a task with P polls this is O(P²). Most tasks are small, but a single long-lived worker/event-loop task can have millions of polls in one segment → ~10¹¹–10¹² iterations. Symptom: `analyze` on a ~50 MB / ~9M-event segment ran >14 min and never completed, one core pinned at 100%. Small/idle segments finished in seconds, masking it.

`pollsByTask[taskId]` is already sorted by `start`, and a single task's polls never overlap (a task is never polled concurrently), so at most one poll's interval can contain the wake. Replaced the linear scan with a **binary search for the rightmost poll with `start <= wake.timestamp`**, preserving the original first-match semantics exactly.

**Verification:**
- Differential test on the demo trace: old vs new produce **byte-for-byte identical** output across **71,949** scheduling delays.
- 40k-poll microbenchmark: **1437ms → 24ms (60×)**, and the quadratic blowup is visible (20k→40k makes the old code ~4× slower; the new code ~2×).
- `test_directory_scale.js` full pipeline: **67.8s → 18.8s (3.6×)** on cached data, same `1,438,980` delays, same worst poll (`17.7ms`). Parse times unchanged (apples-to-apples).

## Bug 2 — "BLOCKING CALLS" conflated idle parking with real blocking

`analyze.js`, off-CPU sample grouping + the BLOCKING CALLS report. Off-CPU (scheduler / context-switch) samples were grouped with no filter for whether the sample occurred **inside a poll** (a task voluntarily blocked mid-poll = real blocking) vs **between polls** (a worker parked because it had no work = idle). On a Tokio multi-thread runtime an idle worker parks via a futex/condvar wait, so a mostly-idle runtime rendered as:

```
BLOCKING CALLS (scheduling/off-CPU samples)
  306669 off-CPU sample(s)
  306669 samples (100.0%) — leaf: __schedule
         blocked by: futex_wait_queue (kernel)
```

i.e. "100% blocked on a futex (lock contention)" when ~95% of those samples were idle worker parking. Actively misleading for root-cause analysis.

The signal already existed: `attachCpuSamples` knows whether a sample landed inside a poll. This PR records that as `sample.inPoll` and splits the bucket:
- in-poll → **real blocking**, attributed per task spawn location, with call stacks
- not-in-poll → **idle-park** (not blocking)

New report:
```
BLOCKING CALLS (scheduling/off-CPU samples)
  5356 off-CPU sample(s): 741 IN-POLL (real blocking), 4615 idle-park
  NOTE: idle-park = a worker with no work parked between polls (itself a futex/condvar
        wait); it is NOT blocking. Only IN-POLL samples are a task blocked mid-poll.

  IN-POLL blocking by task spawn location:
      580 (78.3%) — examples/metrics-service/src/axum_traced.rs:246:32
      ...
```

**Caveat (documented in code + report):** an async lock wait (`lock().await` returning `Pending`) ends the poll, so its subsequent off-CPU time is tagged between-polls (idle), not in-poll. The in-poll bucket captures synchronous blocking but not `.await`-style async lock waits, so the "idle-park" label shouldn't itself be over-trusted.

### Both analysis paths fixed (per maintainer note)

`analyzeTraces` has two paths that independently compute the off-CPU grouping: single-file → in-process `accumulateTrace`; directory → `analyzeWorkerMain` subprocess → `mergePartial`. Patching only one would leave the other silently wrong. Both now go through a **shared `groupOffCpuSamples` helper** and converge on the same `finalizeAccumulator` result shape; verified to produce **identical** output on the demo trace (single-file vs directory: same 741/4615 split, same per-location attribution).

New result fields (`inPollGroups`, `offCpuInPollCount`, `offCpuIdleCount`, `inPollByLoc`) are documented in the `dial9-trace-analysis` SKILL.md schema; `schedGroups` is kept unchanged for backward compatibility.

## Tests

- `test_trace_analysis.js`: **+4 checks** — `inPoll` flag matches poll attachment, off-CPU split is exhaustive, mid-poll-wake adjustment (drives the branch the demo trace doesn't), and gap-wake non-adjustment. 65 → 69 checks, all green.
- `test_all_skills_snippets.js`: 76 passed, 0 failed (the schema-contract check verifies the new fields are documented + correctly shaped).
- `test_directory_parse.js` (subprocess merge path) and `test_directory_scale.js`: green.

Note: a pre-existing, unrelated failure in `dial9-red-flags/scripts/red_flag_scan.js:159` reproduces identically on `main` and is out of scope for this PR.