### PR TITLE
Fix flaky eviction_cleans_up_processed_gz_segments test

### DIFF
--- a/dial9-tokio-telemetry/src/telemetry/writer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/writer.rs
@@ -1617,6 +1617,56 @@ mod tests {
         assert!(!seg0_gz.exists(), "trace.0.bin.gz should have been evicted");
     }
 
+    /// Eviction must never drop below the most-recent segment, even when that
+    /// single segment alone exceeds `max_total_size`. In that case it retains
+    /// the segment on disk (so on-disk usage legitimately exceeds the budget)
+    /// and signals "stop writing" by transitioning to `Finished`.
+    ///
+    /// This is the floor that makes an end-to-end `on-disk bytes <=
+    /// max_total_size` assertion unsound — see `tests/writeback_no_leaked_gz.rs`.
+    #[test]
+    fn test_eviction_keeps_most_recent_segment_when_over_budget() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("trace");
+        let one_event = single_event_file_size();
+        // No rotation (huge per-file size) so the single active segment is the
+        // only one; a budget smaller than one segment forces the floor.
+        let max_file_size = u64::MAX;
+        let max_total_size = one_event / 2;
+        assert!(
+            max_total_size < one_event,
+            "test setup: budget must be smaller than a single segment"
+        );
+        let mut writer = DiskWriter::new(&base, max_file_size, max_total_size).unwrap();
+
+        writer.write_encoded_batch(&test_batch()).unwrap();
+        // The lone active segment already exceeds the total budget.
+        assert!(
+            writer.total_size() > max_total_size,
+            "single segment ({}) should exceed budget ({max_total_size})",
+            writer.total_size()
+        );
+
+        // Eviction has no closed segments to drop and must NOT delete the
+        // current (most-recent) segment. It signals "stop" instead.
+        writer.evict_oldest().unwrap();
+
+        assert!(
+            matches!(writer.state, WriterState::Finished),
+            "writer should stop once even the most-recent segment exceeds budget"
+        );
+        // The most-recent segment is retained on disk despite exceeding the
+        // budget — eviction never drops below one segment.
+        assert!(
+            std::path::Path::new(&writer.current_active_path()).exists(),
+            "the most-recent segment must not be evicted"
+        );
+        assert!(
+            total_disk_usage(dir.path()) > max_total_size,
+            "retained segment is expected to push on-disk usage over the budget"
+        );
+    }
+
     // ---- Time-based rotation tests ----
 
     #[tokio::test(start_paused = true)]

--- a/dial9-tokio-telemetry/tests/writeback_no_leaked_gz.rs
+++ b/dial9-tokio-telemetry/tests/writeback_no_leaked_gz.rs
@@ -87,67 +87,34 @@ fn eviction_cleans_up_processed_gz_segments() {
         "expected no unprocessed .bin files after graceful shutdown, found: {bin_files:?}"
     );
 
-    // The writer's eviction budget is ~4 segments (max_total_size / max_file_size).
+    // Coarse leak detection. This e2e test's unique job is to prove the *real*
+    // pipeline doesn't leak: the background worker gzip-renames each sealed
+    // `.bin` segment to `.bin.gz`, and eviction must then delete those renamed
+    // files.
+    //
+    // We deliberately do NOT assert an exact on-disk byte budget here. Real
+    // CPU-profile segment sizes and gzip ratios are nondeterministic, and
+    // eviction always retains the most-recent segment — which can itself exceed
+    // the entire budget (a single logical unit can be larger than
+    // `max_file_size`, and gzip framing overhead on incompressible data can
+    // push a segment above its uncompressed size). Asserting compressed bytes
+    // `<= max_total_size` flaked in CI for exactly these reasons. The precise
+    // eviction/budget contract — including the keep-most-recent floor and the
+    // `.bin` -> `.bin.gz` cleanup — is covered deterministically by the writer
+    // unit tests: `test_rotating_writer_eviction`,
+    // `test_eviction_removes_gz_variant`, and
+    // `test_eviction_keeps_most_recent_segment_when_over_budget`.
+    //
+    // The qualitative invariant a leak *would* violate is that disk usage stays
+    // bounded and does not grow with the amount produced. The workload above
+    // generated far more than `max_total_size` of trace data across many
+    // rotations; if eviction failed to remove renamed `.bin.gz` files they
+    // would accumulate one per rotation (dozens), rather than the handful the
+    // budget allows.
     assert!(
         gz_files.len() <= max_number_files as usize,
-        "expected less or equal than max number of gz files {}",
+        "retained {} .bin.gz files (eviction budget is ~{max_number_files} \
+         segments) — processed segments are leaking. Files: {gz_files:?}",
         gz_files.len()
-    );
-
-    // Total compressed size on disk, for diagnostics in the assertion message.
-    let total_gz_bytes: u64 = gz_files
-        .iter()
-        .map(|p| std::fs::metadata(p).unwrap().len())
-        .sum();
-
-    // The on-disk `.bin.gz` total cannot be compared directly against
-    // `max_total_size`. Eviction (`SegmentWriter::evict_oldest`) accounts for
-    // the budget in *uncompressed* segment bytes (`total_size()` sums each
-    // segment's `bytes_written()`), and it *always retains at least the
-    // most-recent segment*. Two consequences break a naive `total <= budget`
-    // check, and both have flaked in CI:
-    //   * A single logical unit (e.g. one CPU-profile stack sample) can exceed
-    //     `max_file_size`, so the most-recent segment alone can be larger than
-    //     the whole budget — eviction never drops below one segment. (An
-    //     over-budget segment is only ever retained while it is the most-recent
-    //     one: once it rotates and becomes a closed segment, eviction drops it
-    //     immediately because `total_size()` then exceeds the budget.)
-    //   * gzip framing overhead on poorly-compressible profiling data can push
-    //     the compressed size a few bytes above the uncompressed budget.
-    //
-    // The invariant eviction *does* guarantee is that, once the always-retained
-    // most-recent segment (highest index) is set aside, the remaining (older)
-    // segments fit within the budget. A real leak — old `.bin.gz` files that
-    // eviction failed to delete after renaming `.bin` -> `.bin.gz` — would
-    // accumulate and blow this bound, so we still catch the regression this
-    // test exists to guard against.
-    //
-    // Segments are named `trace.<index>.bin.gz`; the most-recent has the
-    // highest index.
-    fn segment_index(path: &std::path::Path) -> u64 {
-        let name = path.file_name().unwrap().to_string_lossy();
-        let stem = name
-            .strip_suffix(".bin.gz")
-            .expect("gz files are collected by their .bin.gz suffix");
-        stem.rsplit('.')
-            .next()
-            .and_then(|s| s.parse::<u64>().ok())
-            .expect("trace segment files should be named trace.<index>.bin.gz")
-    }
-
-    let newest_index = gz_files.iter().map(|p| segment_index(p)).max();
-    let evictable_gz_bytes: u64 = gz_files
-        .iter()
-        .filter(|p| Some(segment_index(p)) != newest_index)
-        .map(|p| std::fs::metadata(p).unwrap().len())
-        .sum();
-
-    assert!(
-        evictable_gz_bytes <= max_total_size,
-        "after setting aside the always-retained most-recent segment, the \
-         remaining .bin.gz size on disk ({evictable_gz_bytes} bytes; \
-         {total_gz_bytes} bytes total) exceeds the configured budget \
-         ({max_total_size} bytes) — processed segments are leaking. \
-         Files: {gz_files:?}"
     );
 }

--- a/dial9-tokio-telemetry/tests/writeback_no_leaked_gz.rs
+++ b/dial9-tokio-telemetry/tests/writeback_no_leaked_gz.rs
@@ -94,17 +94,60 @@ fn eviction_cleans_up_processed_gz_segments() {
         gz_files.len()
     );
 
-    // Compute total size of .gz files on disk.
+    // Total compressed size on disk, for diagnostics in the assertion message.
     let total_gz_bytes: u64 = gz_files
         .iter()
         .map(|p| std::fs::metadata(p).unwrap().len())
         .sum();
 
-    // The total compressed size on disk must be smaller or equal to the max total size
+    // The on-disk `.bin.gz` total cannot be compared directly against
+    // `max_total_size`. Eviction (`SegmentWriter::evict_oldest`) accounts for
+    // the budget in *uncompressed* segment bytes (`total_size()` sums each
+    // segment's `bytes_written()`), and it *always retains at least the
+    // most-recent segment*. Two consequences break a naive `total <= budget`
+    // check, and both have flaked in CI:
+    //   * A single logical unit (e.g. one CPU-profile stack sample) can exceed
+    //     `max_file_size`, so the most-recent segment alone can be larger than
+    //     the whole budget — eviction never drops below one segment. (An
+    //     over-budget segment is only ever retained while it is the most-recent
+    //     one: once it rotates and becomes a closed segment, eviction drops it
+    //     immediately because `total_size()` then exceeds the budget.)
+    //   * gzip framing overhead on poorly-compressible profiling data can push
+    //     the compressed size a few bytes above the uncompressed budget.
+    //
+    // The invariant eviction *does* guarantee is that, once the always-retained
+    // most-recent segment (highest index) is set aside, the remaining (older)
+    // segments fit within the budget. A real leak — old `.bin.gz` files that
+    // eviction failed to delete after renaming `.bin` -> `.bin.gz` — would
+    // accumulate and blow this bound, so we still catch the regression this
+    // test exists to guard against.
+    //
+    // Segments are named `trace.<index>.bin.gz`; the most-recent has the
+    // highest index.
+    fn segment_index(path: &std::path::Path) -> u64 {
+        let name = path.file_name().unwrap().to_string_lossy();
+        let stem = name
+            .strip_suffix(".bin.gz")
+            .expect("gz files are collected by their .bin.gz suffix");
+        stem.rsplit('.')
+            .next()
+            .and_then(|s| s.parse::<u64>().ok())
+            .expect("trace segment files should be named trace.<index>.bin.gz")
+    }
+
+    let newest_index = gz_files.iter().map(|p| segment_index(p)).max();
+    let evictable_gz_bytes: u64 = gz_files
+        .iter()
+        .filter(|p| Some(segment_index(p)) != newest_index)
+        .map(|p| std::fs::metadata(p).unwrap().len())
+        .sum();
+
     assert!(
-        total_gz_bytes <= max_total_size,
-        "total .bin.gz size on disk ({total_gz_bytes} bytes) exceeds the configured \
-         budget ({max_total_size} bytes) — processed segments are leaking. \
+        evictable_gz_bytes <= max_total_size,
+        "after setting aside the always-retained most-recent segment, the \
+         remaining .bin.gz size on disk ({evictable_gz_bytes} bytes; \
+         {total_gz_bytes} bytes total) exceeds the configured budget \
+         ({max_total_size} bytes) — processed segments are leaking. \
          Files: {gz_files:?}"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `eviction_cleans_up_processed_gz_segments`
(`dial9-tokio-telemetry/tests/writeback_no_leaked_gz.rs`), the #3 entry in the
flaky-test tracking issue #520.

The test summed the **compressed** `.bin.gz` bytes on disk and asserted the
total was `<= max_total_size`. It flaked 3× in CI on ubuntu-latest nightly:

| Run | Total | Files |
|-----|-------|-------|
| [27315149069](https://github.com/dial9-rs/dial9/actions/runs/27315149069) (merge queue) | 17628 B | `[trace.3.bin.gz]` |
| [26523007049](https://github.com/dial9-rs/dial9/actions/runs/26523007049) (main) | 17469 B | `[trace.4.bin.gz]` |
| [27316398839](https://github.com/dial9-rs/dial9/actions/runs/27316398839) (main) | 16437 B | `[trace.3.bin.gz, trace.4.bin.gz]` |

## Root cause — a test bug, not a leak

The assertion conflated two different budgets:

- `SegmentWriter::evict_oldest` enforces the budget on **uncompressed** segment
  bytes (`total_size()` sums each segment's `bytes_written()`), whereas `seal()`
  gzip-compresses segments on disk.
- Eviction **always retains at least the most-recent segment**. A single
  logical unit (e.g. one CPU-profile stack sample) can exceed `max_file_size`,
  so the retained most-recent segment alone can be larger than the entire
  budget (the 17.6 KB single-file cases). gzip framing overhead on
  poorly-compressible profiling data can also push the compressed total a few
  bytes above the uncompressed budget (the +53 B case).

## Fix — split responsibilities by what each layer can guarantee

Rather than have the e2e test re-derive the writer's internal eviction
invariant (which couples the test to implementation details), the precise
contract lives in deterministic unit tests, and the e2e test asserts only the
coarse property that uniquely needs the real wired pipeline.

**e2e test** (`eviction_cleans_up_processed_gz_segments`): asserts the
qualitative invariant a leak would violate — the background worker
gzip-renames `.bin` → `.bin.gz`, eviction deletes the renamed files, and disk
usage stays *bounded* and doesn't grow with the amount produced. Checks "no
leftover `.bin`" + "gz file count within the eviction budget". A real leak
accumulates one gz per rotation (dozens); the flake was a few bytes / one
oversized segment — the coarse bound separates these cleanly and never flakes.
The precise byte-budget assertion is removed.

**Unit tests** (`writer.rs`, deterministic — segment sizes controlled): the
precise budget contract is covered by the existing `test_rotating_writer_eviction`
and `test_eviction_removes_gz_variant` (which already simulates the
`.bin` → `.bin.gz` rename and asserts cleanup). Added
`test_eviction_keeps_most_recent_segment_when_over_budget` to lock the floor
that caused the flake: when a single segment alone exceeds `max_total_size`,
eviction retains it (on-disk usage legitimately exceeds the budget) and the
writer transitions to `Finished`.

## Verification

- `cargo nextest run -p dial9-tokio-telemetry --lib telemetry::writer::` — **61/61 pass**
- `cargo nextest run ... --test writeback_no_leaked_gz` — pass
- `cargo nextest run ... --test writeback_no_leaked_gz --stress-duration 60s` — **17/17 iterations passed**
- `cargo clippy -p dial9-tokio-telemetry --all-targets --all-features` — clean
- `cargo fmt --check` — clean

Tracking: #520 (section 3)
