### PR TITLE
ci: move nightly build out of the ci-pass gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: ["1.94.1", nightly]
+        toolchain: ["1.94.1"]
         # aarch64 Linux exercises arch-specific unwind asm, PAC stripping,
         # and ucontext layout that x86_64 Linux doesn't cover.
         include:
@@ -62,6 +62,28 @@ jobs:
       - uses: ./.github/actions/rust-build
         with:
           toolchain: ${{ matrix.toolchain }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  build-nightly:
+    name: Build (${{ matrix.os }}, nightly)
+    runs-on: ${{ matrix.os }}
+    # Nightly builds against the LATEST dependency versions (the rust-build
+    # action deletes Cargo.lock on nightly). This is an early-warning canary for
+    # toolchain/ecosystem breakage and is intentionally NOT part of `ci-pass`, so
+    # a nightly rustc regression or a freshly published dependency does not block
+    # PRs. Watch it on main; fix forward when it goes red.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/rust-build
+        with:
+          toolchain: nightly
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
   feature-check:


### PR DESCRIPTION
## What

Split the `nightly` toolchain out of the gating `build` matrix into a separate, non-gating `build-nightly` job (`continue-on-error: true`, not in `ci-pass`'s `needs`). The gating `build` job now covers stable `1.94.1` (ubuntu, macos, arm) only.

## Why

The nightly build deletes `Cargo.lock` and resolves to the **latest** dependency versions (see `.github/actions/rust-build`), so it's an early-warning canary for toolchain/ecosystem breakage, not a test of this repo's code. It is currently red repo-wide for two reasons unrelated to any PR's contents:

- **`time-macros 0.2.28`** (published 2026-06-12) fails to compile with `E0119` (conflicting impls in `time`) on stable and nightly. Pulled transitively via `aws-smithy-types` once the lock is regenerated.
- **nightly rustc regression**: `aws-runtime 1.7.4` fails with `E0282` (type-inference change around a `Box::new(...) as _` coercion in `sigv4.rs`).

Neither is caused by PR content, but because `build` is one matrix job, a nightly failure fails (or cancels) the whole job and blocks `ci-pass`.

## Effect

- `ci-pass` no longer depends on nightly, so upstream/nightly breakage doesn't block PRs.
- Nightly still runs and stays visible on `main` as an informational canary; fix-forward when it goes red.
- `Semver checks` is already not part of `ci-pass`, so it's unaffected here.