### PR TITLE
improve s3 browser

### DIFF
--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -156,17 +156,27 @@
                     }
                 }
 
-                // Update title
-                const name = traceUrl.split("/").pop() || "trace";
+                // Update title. Prefer the structured svc/host metadata passed
+                // by the S3 browser; otherwise fall back to the trace filename.
+                const svc = params.get("svc");
+                const host = params.get("host");
+                const segs = params.get("segs");
+                const fromTime = params.get("from");
+                const toTime = params.get("to");
+                const label = svc
+                    ? svc + (host ? ` @ ${host}` : "")
+                    : (traceUrl.split("/").pop() || "trace");
                 const durMs = startNs != null && endNs != null
                     ? ((endNs - startNs) / 1e6).toFixed(2)
                     : null;
-                document.title = `Flamegraph \u2014 ${name}` + (durMs ? ` (${durMs}ms)` : "");
-                titleEl.textContent = "Flamegraph";
-                statsEl.textContent =
-                    `${allSamples.length} samples` +
-                    (durMs ? ` \u00b7 ${durMs}ms selected` : "") +
-                    (timeRangeMatched ? "" : " (full trace \u2014 selected region could not be reproduced)");
+                document.title = `Flamegraph \u2014 ${label}` + (durMs ? ` (${durMs}ms)` : "");
+                titleEl.textContent = `Flamegraph \u2014 ${label}`;
+                const titleBits = [`${allSamples.length} samples`];
+                if (segs) titleBits.push(`${segs} segment${segs !== "1" ? "s" : ""}`);
+                if (fromTime) titleBits.push(toTime && toTime !== fromTime ? `${fromTime} \u2192 ${toTime}` : fromTime);
+                if (durMs) titleBits.push(`${durMs}ms selected`);
+                if (!timeRangeMatched) titleBits.push("full trace \u2014 selected region could not be reproduced");
+                statsEl.textContent = titleBits.join(" \u00b7 ");
 
                 loadingEl.classList.add("hidden");
                 containerEl.style.display = "flex";

--- a/dial9-viewer/ui/heatmap.js
+++ b/dial9-viewer/ui/heatmap.js
@@ -11,6 +11,13 @@
 // out clearly. Real per-event density would require downloading and decoding
 // every segment, which is not viable for a browse listing.
 //
+// A segment's end is `last_modified` (S3 upload time), which runs a second or
+// two past the next segment's start because of upload lag. Left as-is, those
+// trailing bytes get counted in BOTH segments at the seam — double-counting
+// density into a bright boundary artifact. tileSegments() clamps each end to
+// the next start so consecutive segments tile instead of overlap; the leftover
+// holes (genuine missing coverage) are surfaced by segmentGaps().
+//
 // All functions here are pure and unit-tested in test_heatmap.js. Rendering and
 // pointer interaction live in index.html and call into these helpers.
 
@@ -113,6 +120,42 @@ function accumulateDensity(segments, t0, t1, width) {
     return cols;
 }
 
+// Return density-rendering copies of a row's segments with each segment's end
+// clamped to the next segment's start, so consecutive segments tile instead of
+// overlapping at the seam (see the file header for why ends overshoot). Input
+// need not be sorted; a sorted copy drives the clamp. The original `end` is
+// preserved on `realEnd` so callers that need the true file extent (selection,
+// gap detection) are unaffected. Bytes are NOT rescaled: clamping shortens the
+// span so the same bytes spread over slightly less time — a small, uniform
+// density bump that is far less misleading than the double-count it removes.
+function tileSegments(rowSegments) {
+    const sorted = [...rowSegments].sort((a, b) => a.start - b.start);
+    return sorted.map((seg, i) => {
+        const next = sorted[i + 1];
+        let end = seg.end;
+        // Clamp only on real overlap, and never past the start (segmentSpan
+        // gives a zero/negative span its MIN_SEGMENT_SECONDS floor).
+        if (next && next.start > seg.start && next.start < end) end = next.start;
+        return { ...seg, end, realEnd: seg.end };
+    });
+}
+
+// Genuine coverage gaps within a row: intervals [end_i, start_{i+1}] where the
+// next segment starts after the current one's real end. Normal back-to-back
+// rotation overlaps (upload lag) so it yields no gap; only real missing
+// coverage (a host that stopped reporting for a while) does. Input need not be
+// sorted. Returns [{ start, end }] in seconds, sorted by start.
+function segmentGaps(rowSegments) {
+    const sorted = [...rowSegments].sort((a, b) => a.start - b.start);
+    const out = [];
+    for (let i = 0; i < sorted.length - 1; i++) {
+        const end = segmentSpan(sorted[i]).end;
+        const nextStart = sorted[i + 1].start;
+        if (nextStart > end) out.push({ start: end, end: nextStart });
+    }
+    return out;
+}
+
 // Segments whose [start, end) span touches the query range [t0, t1] in seconds.
 // The start is inclusive so a point query (t0 === t1, used for a single click)
 // landing exactly on a segment's start still selects it; the end stays
@@ -164,6 +207,8 @@ if (typeof module !== "undefined" && module.exports) {
         segmentSpan,
         groupByHost,
         bootTransitions,
+        tileSegments,
+        segmentGaps,
         accumulateDensity,
         segmentsOverlapping,
         totalBytes,

--- a/dial9-viewer/ui/heatmap.js
+++ b/dial9-viewer/ui/heatmap.js
@@ -1,0 +1,168 @@
+"use strict";
+
+// Pure data helpers for the S3 browser density timeline / heatmap.
+//
+// The browse view only has S3 object-listing metadata available (key, size,
+// last_modified) plus the trace-start epoch parsed from the key. We therefore
+// approximate "data density" by spreading each segment's byte size uniformly
+// across the wall-clock interval it covers ([start, end]); summing those
+// contributions per pixel column yields a bytes-per-time signal that makes a
+// rotation spike (e.g. one minute with 50 MB while the rest have ~1 MB) stand
+// out clearly. Real per-event density would require downloading and decoding
+// every segment, which is not viable for a browse listing.
+//
+// All functions here are pure and unit-tested in test_heatmap.js. Rendering and
+// pointer interaction live in index.html and call into these helpers.
+
+// Maximum total bytes we allow opening in the trace viewer at once. Opening a
+// very wide time range would download hundreds of MB and overwhelm the viewer,
+// so we cap it and nudge the user toward narrow (1–2 minute) selections.
+const MAX_OPEN_BYTES = 100 * 1024 * 1024;
+
+// Minimum duration (seconds) attributed to a segment whose end time is unknown
+// or not strictly after its start, so a zero-width segment still renders as a
+// localized spike instead of vanishing.
+const MIN_SEGMENT_SECONDS = 1;
+
+// Normalize a segment's [start, end] span in seconds, guaranteeing end > start.
+function segmentSpan(seg) {
+    const start = seg.start;
+    let end = seg.end;
+    if (!(end > start)) end = start + MIN_SEGMENT_SECONDS;
+    return { start, end };
+}
+
+// Group normalized segments into one row per service/host. A change in boot_id
+// does NOT create a separate row — boot transitions are surfaced as in-row
+// markers via bootTransitions(). Returns rows sorted by label, each with its
+// segments sorted by start time.
+//
+// A normalized segment is: { key, size, start, end, service, host, bootId }
+// where start/end are epoch seconds.
+function groupByHost(segments) {
+    const rows = new Map();
+    for (const seg of segments) {
+        const key = (seg.service || "") + "\u0000" + (seg.host || "");
+        let row = rows.get(key);
+        if (!row) {
+            row = {
+                service: seg.service || "",
+                host: seg.host || "",
+                label: (seg.service || "") + " / " + (seg.host || ""),
+                segments: [],
+                totalBytes: 0,
+            };
+            rows.set(key, row);
+        }
+        row.segments.push(seg);
+        row.totalBytes += seg.size || 0;
+    }
+    const out = [...rows.values()];
+    for (const row of out) row.segments.sort((a, b) => a.start - b.start);
+    out.sort((a, b) => a.label.localeCompare(b.label));
+    return out;
+}
+
+// Detect boot_id transitions within a row's segments (which need not be
+// pre-sorted; a sorted copy is used). Returns [{ time, fromBoot, toBoot }] at
+// the start of each segment whose boot id differs from the previous non-empty
+// boot id. Segments without a boot id (legacy layout) produce no transitions.
+function bootTransitions(rowSegments) {
+    const sorted = [...rowSegments].sort((a, b) => a.start - b.start);
+    const out = [];
+    let prev = null;
+    for (const seg of sorted) {
+        const boot = seg.bootId || "";
+        if (!boot) continue;
+        if (prev !== null && boot !== prev) {
+            out.push({ time: seg.start, fromBoot: prev, toBoot: boot });
+        }
+        prev = boot;
+    }
+    return out;
+}
+
+// Accumulate bytes-per-pixel-column for a row over [t0, t1] (seconds) into a
+// Float64Array of length `width`. Each segment's bytes are spread uniformly in
+// time across its [start, end] span; each pixel column receives the portion of
+// bytes whose time falls within that column's sub-interval. Columns all share
+// the same time width, so the resulting values are directly comparable for
+// color normalization.
+function accumulateDensity(segments, t0, t1, width) {
+    const cols = new Float64Array(Math.max(0, width));
+    if (!(t1 > t0) || width <= 0) return cols;
+    const secPerCol = (t1 - t0) / width;
+    for (const seg of segments) {
+        const { start, end } = segmentSpan(seg);
+        const span = end - start; // > 0 by construction
+        const rate = (seg.size || 0) / span; // bytes per second
+        const cs = Math.max(start, t0);
+        const ce = Math.min(end, t1);
+        if (!(ce > cs)) continue;
+        let c0 = Math.floor((cs - t0) / secPerCol);
+        let c1 = Math.floor((ce - t0) / secPerCol);
+        if (c0 < 0) c0 = 0;
+        if (c1 >= width) c1 = width - 1;
+        for (let c = c0; c <= c1; c++) {
+            const colStart = t0 + c * secPerCol;
+            const colEnd = colStart + secPerCol;
+            const ov = Math.min(ce, colEnd) - Math.max(cs, colStart);
+            if (ov > 0) cols[c] += rate * ov; // bytes attributable to this column
+        }
+    }
+    return cols;
+}
+
+// Segments overlapping the half-open time range [t0, t1) in seconds.
+function segmentsOverlapping(segments, t0, t1) {
+    return segments.filter((seg) => {
+        const { start, end } = segmentSpan(seg);
+        return start < t1 && end > t0;
+    });
+}
+
+// Total byte size of a set of segments (used for the open-size cap).
+function totalBytes(segments) {
+    return segments.reduce((sum, seg) => sum + (seg.size || 0), 0);
+}
+
+// Map a normalized density value in [0, 1] to a CSS color. A value of 0 (no
+// data) returns the page background; positive values ramp dim-blue → purple →
+// red → yellow. A perceptual sqrt curve keeps a low baseline visible while
+// letting spikes saturate toward the bright end so they are easy to spot.
+function densityColor(norm) {
+    if (!(norm > 0)) return "rgb(26,26,46)"; // #1a1a2e page background
+    const t = Math.sqrt(Math.min(norm, 1));
+    const stops = [
+        [0.0, 42, 42, 90], // dim blue
+        [0.35, 108, 99, 255], // #6c63ff purple (theme accent)
+        [0.7, 255, 107, 107], // #ff6b6b red
+        [1.0, 255, 217, 61], // #ffd93d yellow
+    ];
+    for (let i = 1; i < stops.length; i++) {
+        if (t <= stops[i][0]) {
+            const a = stops[i - 1];
+            const b = stops[i];
+            const f = (t - a[0]) / (b[0] - a[0]);
+            const r = Math.round(a[1] + (b[1] - a[1]) * f);
+            const g = Math.round(a[2] + (b[2] - a[2]) * f);
+            const bl = Math.round(a[3] + (b[3] - a[3]) * f);
+            return `rgb(${r},${g},${bl})`;
+        }
+    }
+    return "rgb(255,217,61)";
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        MAX_OPEN_BYTES,
+        MIN_SEGMENT_SECONDS,
+        segmentSpan,
+        groupByHost,
+        bootTransitions,
+        accumulateDensity,
+        segmentsOverlapping,
+        totalBytes,
+        densityColor,
+    };
+}

--- a/dial9-viewer/ui/heatmap.js
+++ b/dial9-viewer/ui/heatmap.js
@@ -113,11 +113,15 @@ function accumulateDensity(segments, t0, t1, width) {
     return cols;
 }
 
-// Segments overlapping the half-open time range [t0, t1) in seconds.
+// Segments whose [start, end) span touches the query range [t0, t1] in seconds.
+// The start is inclusive so a point query (t0 === t1, used for a single click)
+// landing exactly on a segment's start still selects it; the end stays
+// exclusive so a click on the boundary between two adjacent segments picks the
+// later one (the segment that starts there) rather than both.
 function segmentsOverlapping(segments, t0, t1) {
     return segments.filter((seg) => {
         const { start, end } = segmentSpan(seg);
-        return start < t1 && end > t0;
+        return start <= t1 && end > t0;
     });
 }
 

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -244,8 +244,8 @@
         <button class="primary" id="view-btn" onclick="viewSelected()" disabled>
             View Selected in Trace Viewer
         </button>
-        <button id="cpu-btn" onclick="viewCpuProfile()" disabled style="display:none">
-            CPU Profiling
+        <button id="cpu-btn" onclick="viewCpuProfile()" disabled title="Open a CPU flamegraph of the selected segments">
+            🔥 Flamegraph
         </button>
         <span id="selection-warn" style="color:#ff6b6b;font-size:0.8em"></span>
         <span class="count" id="selection-count"></span>
@@ -982,9 +982,22 @@
         setHeatmapSelection(null);
     });
 
-    // CPU Profiling button — wired in Stage 3 (filtered flamegraph trace).
+    // CPU Profiling button: open a flamegraph of the selected segments. The
+    // flamegraph view builds from the trace's CpuSampleEvents (and resolves
+    // symbols from SymbolTableEntry), ignoring all other event types, so we
+    // serve the full trace via /api/trace — no server-side event filtering is
+    // needed for a working flamegraph. The selection is already size-capped.
     function viewCpuProfile() {
-        /* implemented in Stage 3 */
+        if (!heatmapSelection || !heatmapSelection.keys.length) return;
+        const bucket = bucketInput.value.trim();
+        if (!bucket) { alert('Bucket is required'); return; }
+        const params = new URLSearchParams();
+        params.set('bucket', bucket);
+        for (const key of heatmapSelection.keys) {
+            params.append('keys', key);
+        }
+        const traceUrl = '/api/trace?' + params.toString();
+        window.open('flamegraph.html?trace=' + encodeURIComponent(traceUrl), '_blank');
     }
 
     // ── Raw search mode ──
@@ -1103,7 +1116,7 @@
             }
             const over = sel.bytes > MAX_OPEN_BYTES;
             viewBtn.disabled = over;
-            cpuBtn.disabled = false;
+            cpuBtn.disabled = over;
             warn.textContent = over
                 ? `Too large to open (${formatSize(sel.bytes)} > 100 MB) — narrow your selection.`
                 : '';

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -75,6 +75,44 @@
         .host-card .hostname { font-size: 1em; font-weight: 600; }
         .host-card .meta { font-size: 0.8em; color: #888; margin-top: 6px; }
 
+        /* Density heatmap timeline */
+        #heatmap-view { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+        #heatmap-hint {
+            padding: 8px 20px; font-size: 0.8em; color: #888;
+            border-bottom: 1px solid #222; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;
+        }
+        #heatmap-hint .legend { display: inline-flex; align-items: center; gap: 6px; }
+        #heatmap-hint .legend .bar {
+            width: 90px; height: 10px; border-radius: 2px;
+            background: linear-gradient(to right, #2a2a5a, #6c63ff, #ff6b6b, #ffd93d);
+        }
+        #heatmap-body { flex: 1; overflow: auto; display: flex; min-height: 0; }
+        #heatmap-labels { flex-shrink: 0; width: 220px; border-right: 2px solid #3a3a5e; }
+        #heatmap-labels .row {
+            height: 26px; line-height: 26px; padding: 0 8px;
+            font-size: 0.78em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+            border-bottom: 1px solid #2a2a4a; color: #cfcfe6;
+        }
+        #heatmap-labels .row:nth-child(odd) { background: #20203e; }
+        #heatmap-labels .row:nth-child(even) { background: #191932; }
+        #heatmap-labels .row.sel { background: #2f2f6a; }
+        #heatmap-labels .row .svc { color: #7ec8e3; }
+        #heatmap-labels .row .boot { color: #00e5ff; font-size: 0.85em; }
+        #heatmap-plot { flex: 1; position: relative; min-width: 0; }
+        #heatmap-canvas { display: block; width: 100%; cursor: crosshair; }
+        #heatmap-sel {
+            position: absolute; top: 0; pointer-events: none; display: none;
+            background: rgba(108,99,255,0.22); border: 1px solid #6c63ff;
+        }
+        #heatmap-axis {
+            flex-shrink: 0; height: 22px; position: relative;
+            border-top: 1px solid #222; font-size: 0.72em; color: #888;
+        }
+        #heatmap-axis .tick { position: absolute; top: 3px; transform: translateX(-50%); white-space: nowrap; }
+        #heatmap-axis .tick::before {
+            content: ''; position: absolute; top: -3px; left: 50%; width: 1px; height: 4px; background: #444;
+        }
+
         /* Segment list */
         .segment-panel { padding: 12px 20px; flex: 1; overflow-y: auto; }
         .segment-panel .back-link {
@@ -146,13 +184,26 @@
     </div>
 
     <div class="main-area" id="main-area">
-        <!-- Browse mode: status / host grid / segment list -->
+        <!-- Browse mode: status / density heatmap timeline -->
         <div id="browse-view">
             <div class="status" id="browse-status">
                 Select a time range and click Search to find traces.
             </div>
-            <div class="host-grid" id="host-grid" style="display:none"></div>
-            <div class="segment-panel" id="segment-panel" style="display:none"></div>
+            <div id="heatmap-view" style="display:none">
+                <div id="heatmap-hint">
+                    <span>Drag across the timeline to select a window, then open it or profile it.</span>
+                    <span class="legend">low <span class="bar"></span> high data density</span>
+                    <span style="color:#00e5ff">▏ boot change</span>
+                </div>
+                <div id="heatmap-body">
+                    <div id="heatmap-labels"></div>
+                    <div id="heatmap-plot">
+                        <canvas id="heatmap-canvas"></canvas>
+                        <div id="heatmap-sel"></div>
+                    </div>
+                </div>
+                <div id="heatmap-axis"></div>
+            </div>
         </div>
 
         <!-- Raw search mode (hidden by default) -->
@@ -186,11 +237,17 @@
     </div>
 
     <div class="actions" id="actions-bar">
-        <button onclick="rawSelectAll(true)">Select All</button>
-        <button onclick="rawSelectAll(false)">Deselect All</button>
+        <span id="raw-actions" style="display:none;gap:8px">
+            <button onclick="rawSelectAll(true)">Select All</button>
+            <button onclick="rawSelectAll(false)">Deselect All</button>
+        </span>
         <button class="primary" id="view-btn" onclick="viewSelected()" disabled>
             View Selected in Trace Viewer
         </button>
+        <button id="cpu-btn" onclick="viewCpuProfile()" disabled style="display:none">
+            CPU Profiling
+        </button>
+        <span id="selection-warn" style="color:#ff6b6b;font-size:0.8em"></span>
         <span class="count" id="selection-count"></span>
     </div>
 
@@ -202,6 +259,7 @@
         <span style="color:#555;font-size:0.8em;margin-left:auto">drop a .bin file to open viewer</span>
     </footer>
 
+    <script src="heatmap.js"></script>
     <script>
     // ── ?trace= passthrough: redirect to viewer ──
     (function() {
@@ -230,15 +288,20 @@
     // ── State ──
     let useLocalTz = false;
     let allObjects = [];       // all objects from time-range search
-    let hostGroups = {};       // { "service/host": [objects] }
-    let selectedHost = null;   // currently selected host key
+    let heatmapSegments = [];  // normalized segments for the timeline
+    let heatmapRows = [];      // groupByHost(heatmapSegments)
+    let heatmapDomain = null;  // { tMin, tMax } in epoch seconds
+    let heatmapCols = [];      // per-row Float64Array of bytes-per-column
+    let heatmapColMax = 0;     // global max column value (for normalization)
+    let heatmapSelection = null; // { keys:[], bytes, t0, t1 }
     let rawObjects = [];       // raw search results
     let currentTab = 'browse';
 
+    const ROW_H = 26;          // px height of each host row in the heatmap
+
     const bucketInput = document.getElementById('bucket-input');
     const browseStatus = document.getElementById('browse-status');
-    const hostGrid = document.getElementById('host-grid');
-    const segmentPanel = document.getElementById('segment-panel');
+    const heatmapView = document.getElementById('heatmap-view');
 
     // ── Init: load config ──
     const params = new URLSearchParams(window.location.search);
@@ -266,11 +329,22 @@
             serverHasPrefix = true;
             updateSearchReady();
         }
-        discoverPrefixes();
-    }).catch(() => { discoverPrefixes(); });
+        discoverPrefixes().then(autoSearch);
+    }).catch(() => { discoverPrefixes().then(autoSearch); });
 
     // Default to last 1 hour
     setQuickRange(1);
+
+    // On page load, automatically run the last-1hr search so the heatmap is
+    // populated without an extra click.
+    let autoSearched = false;
+    function autoSearch() {
+        if (autoSearched) return;
+        autoSearched = true;
+        if (bucketInput.value.trim() && !document.getElementById('search-btn').disabled) {
+            doTimeRangeSearch();
+        }
+    }
 
     // ── Auto-discover prefixes ──
     async function discoverPrefixes() {
@@ -337,8 +411,7 @@
 
         // Re-render current view
         if (currentTab === 'browse') {
-            if (selectedHost) showSegments(selectedHost);
-            else if (Object.keys(hostGroups).length) renderHostGrid();
+            if (heatmapRows.length) renderHeatmap();
         } else {
             renderRawTable(rawObjects);
         }
@@ -484,6 +557,9 @@
         document.getElementById('tab-raw').classList.toggle('active', tab === 'raw');
         document.getElementById('browse-view').style.display = tab === 'browse' ? '' : 'none';
         document.getElementById('raw-view').style.display = tab === 'raw' ? '' : 'none';
+        // Raw mode has Select All/Deselect; browse mode has the CPU Profiling button.
+        document.getElementById('raw-actions').style.display = tab === 'raw' ? 'flex' : 'none';
+        document.getElementById('cpu-btn').style.display = tab === 'browse' ? '' : 'none';
         updateSelectionCount();
     }
 
@@ -522,9 +598,8 @@
         browseStatus.textContent = `Searching ${prefixes.length} hour(s)…`;
         browseStatus.className = 'status';
         browseStatus.style.display = '';
-        hostGrid.style.display = 'none';
-        segmentPanel.style.display = 'none';
-        selectedHost = null;
+        heatmapView.style.display = 'none';
+        setHeatmapSelection(null);
 
         try {
             // Fire parallel queries for each hour prefix
@@ -554,7 +629,8 @@
 
             if (allObjects.length === 0) {
                 browseStatus.className = 'status';
-                hostGroups = {};
+                heatmapRows = [];
+                heatmapView.style.display = 'none';
                 // Show sample keys to help the user understand the bucket layout
                 try {
                     const sampleResp = await fetch(`/api/search?bucket=${encodeURIComponent(bucket)}&q=`);
@@ -571,135 +647,344 @@
                 return;
             }
 
-            // Group by service/host[/boot]. A new boot_id indicates a
-            // separate process run — keeping runs distinct prevents
-            // segment-index duplicates when a service restarts.
-            hostGroups = {};
-            for (const obj of allObjects) {
+            // Build normalized segments for the density timeline. A segment's
+            // wall-clock span is [trace-start epoch, last_modified]; bytes are
+            // spread uniformly across it when rendering density.
+            heatmapSegments = allObjects.map(obj => {
                 const p = parseKey(obj.key);
-                const groupKey = p.bootId
-                    ? p.service + '/' + p.host + '/' + p.bootId
-                    : p.service + '/' + p.host;
-                if (!hostGroups[groupKey]) hostGroups[groupKey] = { service: p.service, host: p.host, bootId: p.bootId, objects: [] };
-                hostGroups[groupKey].objects.push(obj);
-            }
+                const start = p.epoch;
+                const end = obj.last_modified
+                    ? new Date(obj.last_modified).getTime() / 1000
+                    : start;
+                return {
+                    key: obj.key, size: obj.size, start, end,
+                    service: p.service, host: p.host, bootId: p.bootId,
+                };
+            }).filter(s => s.start > 0);
+
+            heatmapRows = groupByHost(heatmapSegments);
 
             browseStatus.style.display = 'none';
-            renderHostGrid();
+            renderHeatmap();
         } catch (err) {
             browseStatus.textContent = 'Error: ' + err.message;
             browseStatus.className = 'status error';
         }
     }
 
-    // ── Host grid ──
-    function renderHostGrid() {
-        hostGrid.innerHTML = '';
-        hostGrid.style.display = '';
-        segmentPanel.style.display = 'none';
-        selectedHost = null;
+    // ── Density heatmap timeline ──
+    const LABEL_W = 220; // must match #heatmap-labels width in CSS
 
-        const groups = Object.values(hostGroups).sort((a, b) =>
-            ((a.service + a.host + (a.bootId || '')).localeCompare(b.service + b.host + (b.bootId || ''))));
+    function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+    function timeToX(t, tMin, tMax, W) { return (t - tMin) / (tMax - tMin) * W; }
+    function xToTime(x, tMin, tMax, W) { return tMin + (x / W) * (tMax - tMin); }
 
-        for (const g of groups) {
-            const epochs = g.objects.map(o => parseKey(o.key).epoch).filter(e => e > 0);
-            const minEpoch = epochs.length ? Math.min(...epochs) : 0;
-            const endTimes = g.objects.map(o => o.last_modified ? new Date(o.last_modified).getTime() / 1000 : 0).filter(e => e > 0);
-            const maxEnd = endTimes.length ? Math.max(...endTimes) : 0;
-            const totalSize = g.objects.reduce((s, o) => s + o.size, 0);
+    function fmtTick(epoch) {
+        const d = new Date(epoch * 1000);
+        const pad = n => String(n).padStart(2, '0');
+        return useLocalTz
+            ? pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds())
+            : pad(d.getUTCHours()) + ':' + pad(d.getUTCMinutes()) + ':' + pad(d.getUTCSeconds());
+    }
 
-            const bootLine = g.bootId ? `<div class="meta" style="font-size:0.75em;color:#7a7ab0">boot ${esc(g.bootId)}</div>` : '';
-            const card = document.createElement('div');
-            card.className = 'host-card';
-            card.innerHTML = `
-                <div class="svc">${esc(g.service)}</div>
-                <div class="hostname">${esc(g.host)}</div>
-                ${bootLine}
-                <div class="meta">
-                    ${g.objects.length} segment${g.objects.length !== 1 ? 's' : ''} · ${formatSize(totalSize)}<br>
-                    ${formatEpoch(minEpoch)}${maxEnd ? ' → ' + formatEpoch(maxEnd) : ''}
-                </div>
-            `;
-            const gk = g.bootId ? g.service + '/' + g.host + '/' + g.bootId : g.service + '/' + g.host;
-            card.addEventListener('click', () => showSegments(gk));
-            hostGrid.appendChild(card);
+    // Precomputed 256-entry density color ramp. Building a color string per
+    // pixel column was the hot path in drawHeatmapCanvas; quantizing to 256
+    // buckets lets us reuse strings (and, with run-length coalescing, collapse
+    // adjacent equal-color columns into a single fillRect).
+    let densityPalette = null;
+    function densityPaletteColor(norm) {
+        if (!densityPalette) {
+            densityPalette = new Array(256);
+            for (let i = 0; i < 256; i++) densityPalette[i] = densityColor(i / 255);
+        }
+        const idx = norm >= 1 ? 255 : (norm <= 0 ? 0 : (norm * 255) | 0);
+        return densityPalette[idx];
+    }
+
+    function renderHeatmap() {
+        setHeatmapSelection(null);
+        const labels = document.getElementById('heatmap-labels');
+        labels.innerHTML = '';
+
+        if (!heatmapRows.length) {
+            heatmapView.style.display = 'none';
+            browseStatus.style.display = '';
+            browseStatus.className = 'status';
+            browseStatus.textContent = 'No traces found in this time range.';
+            return;
+        }
+        browseStatus.style.display = 'none';
+        heatmapView.style.display = '';
+
+        // Domain = data extent across all segments.
+        let tMin = Infinity, tMax = -Infinity;
+        for (const s of heatmapSegments) {
+            const span = segmentSpan(s);
+            if (span.start < tMin) tMin = span.start;
+            if (span.end > tMax) tMax = span.end;
+        }
+        if (!(tMax > tMin)) tMax = tMin + 1;
+        heatmapDomain = { tMin, tMax };
+
+        // Host labels (one row per service/host; boot count annotated).
+        for (const row of heatmapRows) {
+            const boots = bootTransitions(row.segments);
+            const div = document.createElement('div');
+            div.className = 'row';
+            const bootNote = boots.length
+                ? ` <span class="boot" title="boot id changes ${boots.length} time(s) in this window">▏${boots.length + 1} boots</span>`
+                : '';
+            div.innerHTML = `<span class="svc">${esc(row.service)}</span> / ${esc(row.host)}${bootNote}`;
+            div.title = row.label;
+            labels.appendChild(div);
+        }
+
+        drawHeatmapCanvas();
+    }
+
+    function drawHeatmapCanvas() {
+        if (!heatmapDomain || !heatmapRows.length) return;
+        const plot = document.getElementById('heatmap-plot');
+        const canvas = document.getElementById('heatmap-canvas');
+        const W = Math.max(50, Math.floor(plot.clientWidth));
+        const H = heatmapRows.length * ROW_H;
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = Math.floor(W * dpr);
+        canvas.height = Math.floor(H * dpr);
+        canvas.style.width = W + 'px';
+        canvas.style.height = H + 'px';
+        const ctx = canvas.getContext('2d');
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        ctx.clearRect(0, 0, W, H);
+
+        const { tMin, tMax } = heatmapDomain;
+
+        // Pass 1: per-row density columns + global max (for normalization).
+        heatmapCols = heatmapRows.map(r => accumulateDensity(r.segments, tMin, tMax, W));
+        heatmapColMax = 0;
+        for (const cols of heatmapCols) {
+            for (let i = 0; i < cols.length; i++) {
+                if (cols[i] > heatmapColMax) heatmapColMax = cols[i];
+            }
+        }
+
+        // Pass 2: draw each row's strip, then boot-change markers on top.
+        for (let r = 0; r < heatmapRows.length; r++) {
+            const cols = heatmapCols[r];
+            const y = r * ROW_H;
+            // Alternating base background so empty rows stay visually distinct.
+            ctx.fillStyle = (r % 2) ? '#20203e' : '#191932';
+            ctx.fillRect(0, y, W, ROW_H);
+            // Paint density as coalesced runs of identical color (a precomputed
+            // palette + run-length merge keeps this fast even with many rows;
+            // empty columns fall through to the base background above).
+            let runStart = -1;
+            let runColor = null;
+            for (let x = 0; x < W; x++) {
+                const norm = heatmapColMax > 0 ? cols[x] / heatmapColMax : 0;
+                const color = norm > 0 ? densityPaletteColor(norm) : null;
+                if (color !== runColor) {
+                    if (runColor !== null) {
+                        ctx.fillStyle = runColor;
+                        ctx.fillRect(runStart, y, x - runStart, ROW_H);
+                    }
+                    runColor = color;
+                    runStart = x;
+                }
+            }
+            if (runColor !== null) {
+                ctx.fillStyle = runColor;
+                ctx.fillRect(runStart, y, W - runStart, ROW_H);
+            }
+            // Boot-change dividers: a consistent dashed cyan line so they read
+            // as boundaries, never as a data spike.
+            ctx.save();
+            ctx.strokeStyle = '#00e5ff';
+            ctx.lineWidth = 1;
+            ctx.setLineDash([4, 3]);
+            for (const b of bootTransitions(heatmapRows[r].segments)) {
+                const bx = Math.round(timeToX(b.time, tMin, tMax, W)) + 0.5;
+                ctx.beginPath();
+                ctx.moveTo(bx, y + 1);
+                ctx.lineTo(bx, y + ROW_H - 1);
+                ctx.stroke();
+            }
+            ctx.restore();
+            // Row separator.
+            ctx.fillStyle = '#3a3a5e';
+            ctx.fillRect(0, y + ROW_H - 1, W, 1);
+        }
+
+        drawHeatmapAxis(W);
+    }
+
+    function drawHeatmapAxis(W) {
+        const axis = document.getElementById('heatmap-axis');
+        axis.innerHTML = '';
+        const { tMin, tMax } = heatmapDomain;
+        const n = clamp(Math.floor(W / 130), 2, 8);
+        for (let i = 0; i <= n; i++) {
+            const frac = i / n;
+            const tick = document.createElement('div');
+            tick.className = 'tick';
+            tick.style.left = (LABEL_W + frac * W) + 'px';
+            tick.textContent = fmtTick(tMin + frac * (tMax - tMin));
+            axis.appendChild(tick);
         }
     }
 
-    // ── Segment list for a selected host ──
-    function showSegments(groupKey) {
-        selectedHost = groupKey;
-        hostGrid.style.display = 'none';
-        segmentPanel.style.display = '';
+    // ── Region selection on the heatmap ──
+    (function setupHeatmapInteraction() {
+        const plot = document.getElementById('heatmap-plot');
+        const sel = document.getElementById('heatmap-sel');
+        let dragging = false, startX = 0, startY = 0;
 
-        const g = hostGroups[groupKey];
-        if (!g) return;
-
-        // Sort segments by epoch
-        const sorted = [...g.objects].sort((a, b) => parseKey(a.key).epoch - parseKey(b.key).epoch);
-
-        segmentPanel.innerHTML = `
-            <span class="back-link" onclick="renderHostGrid()">← Back to hosts</span>
-            <h3>${esc(g.service)} / ${esc(g.host)}${g.bootId ? ' <span style="color:#7a7ab0;font-weight:400;font-size:0.85em">(boot ' + esc(g.bootId) + ')</span>' : ''}</h3>
-            <div style="margin-bottom:8px;display:flex;gap:8px;align-items:center">
-                <button onclick="segSelectAll(true)">Select All</button>
-                <button onclick="segSelectAll(false)">Deselect All</button>
-                <button class="primary" onclick="viewSelected()" id="seg-view-btn">
-                    View Selected in Trace Viewer
-                </button>
-                <span class="count" id="seg-count"></span>
-            </div>
-            <table>
-                <thead>
-                    <tr>
-                        <th style="width:30px"><input type="checkbox" id="seg-select-all" checked /></th>
-                        <th>Trace Start</th>
-                        <th>Seg #</th>
-                        <th>Size</th>
-                        <th>Uploaded</th>
-                    </tr>
-                </thead>
-                <tbody id="seg-body"></tbody>
-            </table>
-        `;
-
-        const tbody = document.getElementById('seg-body');
-        for (const obj of sorted) {
-            const p = parseKey(obj.key);
-            const tr = document.createElement('tr');
-            tr.innerHTML = `
-                <td><input type="checkbox" class="seg-cb" data-key="${esc(obj.key)}" checked /></td>
-                <td>${esc(p.traceStart)}</td>
-                <td>${esc(p.segIndex)}</td>
-                <td class="size">${formatSize(obj.size)}</td>
-                <td class="date">${formatDate(obj.last_modified)}</td>
-            `;
-            tr.querySelector('.seg-cb').addEventListener('change', updateSegCount);
-            tbody.appendChild(tr);
+        function localXY(e) {
+            const rect = plot.getBoundingClientRect();
+            const H = heatmapRows.length * ROW_H;
+            return {
+                x: clamp(e.clientX - rect.left, 0, rect.width),
+                y: clamp(e.clientY - rect.top, 0, H),
+            };
         }
 
-        document.getElementById('seg-select-all').addEventListener('change', (e) => {
-            segSelectAll(e.target.checked);
+        plot.addEventListener('mousedown', (e) => {
+            if (!heatmapRows.length) return;
+            dragging = true;
+            const { x, y } = localXY(e);
+            startX = x; startY = y;
+            sel.style.display = 'block';
+            sel.style.left = x + 'px'; sel.style.width = '0px';
+            sel.style.top = y + 'px'; sel.style.height = '0px';
+            e.preventDefault();
         });
-        updateSegCount();
+        window.addEventListener('mousemove', (e) => {
+            if (!dragging) return;
+            const { x, y } = localXY(e);
+            const l = Math.min(x, startX), r = Math.max(x, startX);
+            const t = Math.min(y, startY), b = Math.max(y, startY);
+            sel.style.left = l + 'px'; sel.style.width = (r - l) + 'px';
+            sel.style.top = t + 'px'; sel.style.height = (b - t) + 'px';
+        });
+        window.addEventListener('mouseup', (e) => {
+            if (!dragging) return;
+            dragging = false;
+            const { x, y } = localXY(e);
+            const dx = Math.abs(x - startX), dy = Math.abs(y - startY);
+            if (dx < 4 && dy < 4) {
+                selectSegmentAt(startX, startY); // treat as a click
+            } else {
+                finalizeSelection(Math.min(x, startX), Math.max(x, startX), Math.min(y, startY), Math.max(y, startY));
+            }
+        });
+    })();
+
+    // Position the persistent selection rectangle over whole rows [r0,r1] and
+    // the time span [t0,t1], so it is clear which rows/time the selection covers.
+    function showSelRect(t0, t1, r0, r1) {
+        const canvas = document.getElementById('heatmap-canvas');
+        const sel = document.getElementById('heatmap-sel');
+        const W = canvas.clientWidth || parseFloat(canvas.style.width) || 1;
+        const { tMin, tMax } = heatmapDomain;
+        const x0 = timeToX(t0, tMin, tMax, W);
+        const x1 = timeToX(t1, tMin, tMax, W);
+        sel.style.display = 'block';
+        sel.style.left = x0 + 'px';
+        sel.style.width = Math.max(2, x1 - x0) + 'px';
+        sel.style.top = (r0 * ROW_H) + 'px';
+        sel.style.height = ((r1 - r0 + 1) * ROW_H) + 'px';
     }
 
-    function segSelectAll(checked) {
-        document.querySelectorAll('.seg-cb').forEach(cb => { cb.checked = checked; });
-        const sa = document.getElementById('seg-select-all');
-        if (sa) sa.checked = checked;
-        updateSegCount();
+    // Single-click: select the one segment under the cursor (the trace file
+    // whose wall-clock span contains that time on that host row).
+    function selectSegmentAt(x, y) {
+        if (!heatmapDomain) return;
+        const r = Math.floor(y / ROW_H);
+        if (r < 0 || r >= heatmapRows.length) { setHeatmapSelection(null); return; }
+        const canvas = document.getElementById('heatmap-canvas');
+        const W = canvas.clientWidth || parseFloat(canvas.style.width) || 1;
+        const { tMin, tMax } = heatmapDomain;
+        const t = xToTime(x, tMin, tMax, W);
+        const hits = segmentsOverlapping(heatmapRows[r].segments, t, t);
+        if (!hits.length) { setHeatmapSelection(null); return; }
+        // If multiple segments cover the instant, prefer the one whose start is
+        // nearest (most specific) to the click.
+        hits.sort((a, b) => Math.abs(a.start - t) - Math.abs(b.start - t));
+        const seg = hits[0];
+        const span = segmentSpan(seg);
+        setHeatmapSelection({ keys: [seg.key], bytes: seg.size, t0: span.start, t1: span.end, rows: [r, r] });
     }
 
-    function updateSegCount() {
-        const keys = getSegSelectedKeys();
-        const el = document.getElementById('seg-count');
-        if (el) el.textContent = keys.length ? `${keys.length} selected` : '';
+    function finalizeSelection(x0, x1, y0, y1) {
+        if (!heatmapDomain || x1 - x0 < 3) { setHeatmapSelection(null); return; }
+        const canvas = document.getElementById('heatmap-canvas');
+        const W = canvas.clientWidth || parseFloat(canvas.style.width) || 1;
+        const { tMin, tMax } = heatmapDomain;
+        const dragT0 = xToTime(x0, tMin, tMax, W);
+        const dragT1 = xToTime(x1, tMin, tMax, W);
+        let r0 = Math.max(0, Math.floor(y0 / ROW_H));
+        let r1 = Math.min(heatmapRows.length - 1, Math.floor((y1 - 0.001) / ROW_H));
+        const segs = [];
+        for (let r = r0; r <= r1; r++) {
+            for (const s of segmentsOverlapping(heatmapRows[r].segments, dragT0, dragT1)) segs.push(s);
+        }
+        if (!segs.length) { setHeatmapSelection(null); return; }
+        // Opening fetches WHOLE segment files (S3 cannot return a sub-range and
+        // the viewer shows each file's full extent), so snap the selection to
+        // the actual [min start, max end] of those files. The box then honestly
+        // reflects the time range that will open rather than the raw drag.
+        let t0 = Infinity, t1 = -Infinity;
+        for (const s of segs) {
+            const span = segmentSpan(s);
+            if (span.start < t0) t0 = span.start;
+            if (span.end > t1) t1 = span.end;
+        }
+        setHeatmapSelection({ keys: segs.map(s => s.key), bytes: totalBytes(segs), t0, t1, rows: [r0, r1] });
     }
 
-    function getSegSelectedKeys() {
-        return Array.from(document.querySelectorAll('.seg-cb:checked')).map(cb => cb.dataset.key);
+    function setHeatmapSelection(s) {
+        heatmapSelection = s;
+        const heatSel = document.getElementById('heatmap-sel');
+        // Highlight the selected host-label rows.
+        const labelRows = document.querySelectorAll('#heatmap-labels .row');
+        labelRows.forEach((el, i) => {
+            const inSel = s && s.rows && i >= s.rows[0] && i <= s.rows[1];
+            el.classList.toggle('sel', !!inSel);
+        });
+        if (!s || !s.keys.length) {
+            if (heatSel) heatSel.style.display = 'none';
+        } else if (s.rows) {
+            showSelRect(s.t0, s.t1, s.rows[0], s.rows[1]);
+        }
+        if (currentTab === 'browse') updateSelectionCount();
+    }
+
+    // Redraw the canvas (and re-measure width) on window resize.
+    let resizeTimer = null;
+    window.addEventListener('resize', () => {
+        if (currentTab !== 'browse' || !heatmapRows.length) return;
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(() => {
+            drawHeatmapCanvas();
+            if (heatmapSelection && heatmapSelection.rows) {
+                showSelRect(heatmapSelection.t0, heatmapSelection.t1,
+                    heatmapSelection.rows[0], heatmapSelection.rows[1]);
+            }
+        }, 100);
+    });
+
+    // Clicking anywhere outside the timeline and the actions bar clears the
+    // current selection. (Clicks inside the plot are handled by its own
+    // mousedown/up; clicks on the action buttons must preserve the selection.)
+    document.addEventListener('click', (e) => {
+        if (currentTab !== 'browse' || !heatmapSelection) return;
+        if (e.target.closest('#heatmap-view') || e.target.closest('#actions-bar')) return;
+        setHeatmapSelection(null);
+    });
+
+    // CPU Profiling button — wired in Stage 3 (filtered flamegraph trace).
+    function viewCpuProfile() {
+        /* implemented in Stage 3 */
     }
 
     // ── Raw search mode ──
@@ -793,19 +1078,45 @@
 
     // ── Selection & view ──
     function getSelectedKeys() {
-        // In browse mode with segments showing, use seg checkboxes
-        if (currentTab === 'browse' && selectedHost) {
-            return getSegSelectedKeys();
+        // Browse mode: keys come from the heatmap region selection.
+        if (currentTab === 'browse') {
+            return heatmapSelection ? heatmapSelection.keys : [];
         }
-        // In raw mode, use raw checkboxes
+        // Raw mode: use raw checkboxes.
         return Array.from(document.querySelectorAll('.raw-cb:checked')).map(cb => cb.dataset.key);
     }
 
     function updateSelectionCount() {
+        const viewBtn = document.getElementById('view-btn');
+        const cpuBtn = document.getElementById('cpu-btn');
+        const warn = document.getElementById('selection-warn');
+        const count = document.getElementById('selection-count');
+
+        if (currentTab === 'browse') {
+            const sel = heatmapSelection;
+            if (!sel || !sel.keys.length) {
+                viewBtn.disabled = true;
+                cpuBtn.disabled = true;
+                warn.textContent = '';
+                count.textContent = '';
+                return;
+            }
+            const over = sel.bytes > MAX_OPEN_BYTES;
+            viewBtn.disabled = over;
+            cpuBtn.disabled = false;
+            warn.textContent = over
+                ? `Too large to open (${formatSize(sel.bytes)} > 100 MB) — narrow your selection.`
+                : '';
+            const win = sel.t0 && sel.t1 ? ` · ${fmtTick(sel.t0)}–${fmtTick(sel.t1)}` : '';
+            count.textContent = `${sel.keys.length} segment${sel.keys.length !== 1 ? 's' : ''} · ${formatSize(sel.bytes)}${win}`;
+            return;
+        }
+
+        // Raw mode
         const keys = getSelectedKeys();
-        const el = document.getElementById('selection-count');
-        el.textContent = keys.length ? `${keys.length} selected` : '';
-        document.getElementById('view-btn').disabled = keys.length === 0;
+        warn.textContent = '';
+        count.textContent = keys.length ? `${keys.length} selected` : '';
+        viewBtn.disabled = keys.length === 0;
     }
 
     function viewSelected() {

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -87,9 +87,17 @@
             border-bottom: 1px solid #222; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;
         }
         #heatmap-hint .legend { display: inline-flex; align-items: center; gap: 6px; }
+        #heatmap-reset-zoom { padding: 2px 10px; font-size: 0.95em; }
         #heatmap-hint .legend .bar {
             width: 90px; height: 10px; border-radius: 2px;
             background: linear-gradient(to right, #2a2a5a, #6c63ff, #ff6b6b, #ffd93d);
+        }
+        #heatmap-hint .legend .gap-swatch {
+            width: 16px; height: 12px; border-radius: 2px;
+            border-left: 1px solid rgba(150,150,190,0.6); border-right: 1px solid rgba(150,150,190,0.6);
+            background-color: #15152a;
+            background-image: repeating-linear-gradient(-45deg,
+                rgba(120,120,160,0.35) 0 1px, transparent 1px 6px);
         }
         #heatmap-body { flex: 1; overflow: auto; display: flex; min-height: 0; }
         #heatmap-labels { flex-shrink: 0; width: var(--heatmap-label-w); border-right: 2px solid #3a3a5e; }
@@ -108,6 +116,11 @@
         #heatmap-sel {
             position: absolute; top: 0; pointer-events: none; display: none;
             background: rgba(108,99,255,0.22); border: 1px solid #6c63ff;
+        }
+        /* Zoom rubber-band: cyan, left/right edges only, to read as a time cut. */
+        #heatmap-sel.zoom {
+            background: rgba(0,229,255,0.12);
+            border: none; border-left: 1px solid #00e5ff; border-right: 1px solid #00e5ff;
         }
         #heatmap-axis {
             flex-shrink: 0; height: 22px; position: relative;
@@ -196,9 +209,11 @@
             </div>
             <div id="heatmap-view" style="display:none">
                 <div id="heatmap-hint">
-                    <span>Drag across the timeline to select a window, then open it or profile it.</span>
+                    <span>Drag to select a window, then open or profile it. <b>⌥ Option+drag</b> to zoom, double-click to reset.</span>
                     <span class="legend">low <span class="bar"></span> high data density</span>
+                    <span class="legend"><span class="gap-swatch"></span> gap (no data)</span>
                     <span style="color:#00e5ff">▏ boot change</span>
+                    <button id="heatmap-reset-zoom" style="display:none" onclick="resetHeatmapZoom()">Reset zoom</button>
                 </div>
                 <div id="heatmap-body">
                     <div id="heatmap-labels"></div>
@@ -295,7 +310,8 @@
     let allObjects = [];       // all objects from time-range search
     let heatmapSegments = [];  // normalized segments for the timeline
     let heatmapRows = [];      // groupByHost(heatmapSegments)
-    let heatmapDomain = null;  // { tMin, tMax } in epoch seconds
+    let heatmapDomain = null;  // { tMin, tMax } currently displayed (may be zoomed)
+    let heatmapFullDomain = null; // full data extent; restored on zoom reset
     let heatmapCols = [];      // per-row Float64Array of bytes-per-column
     let heatmapColMax = 0;     // global max column value (for normalization)
     let heatmapSelection = null; // { keys:[], bytes, t0, t1 }
@@ -733,7 +749,17 @@
             if (span.end > tMax) tMax = span.end;
         }
         if (!(tMax > tMin)) tMax = tMin + 1;
+        heatmapFullDomain = { tMin, tMax };
         heatmapDomain = { tMin, tMax };
+        updateZoomResetBtn();
+
+        // Precompute per-row density inputs once (reused across zoom/resize
+        // redraws): segments tiled so upload-lag overlaps don't double-count,
+        // plus the genuine coverage gaps between them.
+        for (const row of heatmapRows) {
+            row.tiled = tileSegments(row.segments);
+            row.gaps = segmentGaps(row.segments);
+        }
 
         // Host labels (one row per service/host; boot count annotated).
         for (const row of heatmapRows) {
@@ -769,7 +795,9 @@
         const { tMin, tMax } = heatmapDomain;
 
         // Pass 1: per-row density columns + global max (for normalization).
-        heatmapCols = heatmapRows.map(r => accumulateDensity(r.segments, tMin, tMax, W));
+        // Uses tiled segments (ends clamped to the next start) so upload-lag
+        // overlaps at segment seams don't double-count into a bright artifact.
+        heatmapCols = heatmapRows.map(r => accumulateDensity(r.tiled || r.segments, tMin, tMax, W));
         heatmapColMax = 0;
         for (const cols of heatmapCols) {
             for (let i = 0; i < cols.length; i++) {
@@ -804,6 +832,38 @@
             if (runColor !== null) {
                 ctx.fillStyle = runColor;
                 ctx.fillRect(runStart, y, W - runStart, ROW_H);
+            }
+            // Coverage gaps: a host that stopped reporting leaves a real hole
+            // between segments (vs. the seamless rotation overlaps the tiling
+            // removed). Mark each with a faint hatched band plus thin edge ticks
+            // so it reads as "no data here", distinct from low-but-present
+            // density. Sub-pixel gaps still get a 1px tick so they're not lost.
+            for (const g of (heatmapRows[r].gaps || [])) {
+                const gx0 = timeToX(Math.max(g.start, tMin), tMin, tMax, W);
+                const gx1 = timeToX(Math.min(g.end, tMax), tMin, tMax, W);
+                if (gx1 < 0 || gx0 > W) continue;
+                const lo = Math.max(0, gx0), hi = Math.min(W, gx1);
+                const gw = Math.max(1, hi - lo);
+                ctx.save();
+                ctx.beginPath();
+                ctx.rect(lo, y + 1, gw, ROW_H - 2);
+                ctx.clip();
+                ctx.fillStyle = '#15152a';
+                ctx.fillRect(lo, y + 1, gw, ROW_H - 2);
+                // Diagonal hatch.
+                ctx.strokeStyle = 'rgba(120,120,160,0.35)';
+                ctx.lineWidth = 1;
+                ctx.beginPath();
+                for (let hx = lo - ROW_H; hx < hi + ROW_H; hx += 6) {
+                    ctx.moveTo(hx, y + ROW_H);
+                    ctx.lineTo(hx + ROW_H, y);
+                }
+                ctx.stroke();
+                ctx.restore();
+                // Edge ticks frame the hole so even a 1px gap stays visible.
+                ctx.fillStyle = 'rgba(150,150,190,0.6)';
+                ctx.fillRect(Math.round(lo), y + 1, 1, ROW_H - 2);
+                if (hi - lo > 2) ctx.fillRect(Math.round(hi) - 1, y + 1, 1, ROW_H - 2);
             }
             // Boot-change dividers: a consistent dashed cyan line so they read
             // as boundaries, never as a data spike.
@@ -842,11 +902,13 @@
         }
     }
 
-    // ── Region selection on the heatmap ──
+    // ── Region selection / zoom on the heatmap ──
+    // Plain drag selects a region (to open or profile); Option/Alt+drag zooms
+    // the time axis to the dragged span; double-click resets the zoom.
     (function setupHeatmapInteraction() {
         const plot = document.getElementById('heatmap-plot');
         const sel = document.getElementById('heatmap-sel');
-        let dragging = false, startX = 0, startY = 0;
+        let dragging = false, zooming = false, startX = 0, startY = 0;
 
         function localXY(e) {
             const rect = plot.getBoundingClientRect();
@@ -864,25 +926,39 @@
         plot.addEventListener('mousedown', (e) => {
             if (!heatmapRows.length) return;
             dragging = true;
+            zooming = e.altKey;
             const { x, y } = localXY(e);
             startX = x; startY = y;
+            const H = heatmapRows.length * ROW_H;
+            sel.classList.toggle('zoom', zooming);
             sel.style.display = 'block';
             sel.style.left = x + 'px'; sel.style.width = '0px';
-            sel.style.top = y + 'px'; sel.style.height = '0px';
+            // A zoom drag is purely horizontal, so its rubber-band spans all rows.
+            sel.style.top = (zooming ? 0 : y) + 'px';
+            sel.style.height = (zooming ? H : 0) + 'px';
             e.preventDefault();
         });
         window.addEventListener('mousemove', (e) => {
             if (!dragging) return;
             const { x, y } = localXY(e);
             const l = Math.min(x, startX), r = Math.max(x, startX);
-            const t = Math.min(y, startY), b = Math.max(y, startY);
             sel.style.left = l + 'px'; sel.style.width = (r - l) + 'px';
-            sel.style.top = t + 'px'; sel.style.height = (b - t) + 'px';
+            if (!zooming) {
+                const t = Math.min(y, startY), b = Math.max(y, startY);
+                sel.style.top = t + 'px'; sel.style.height = (b - t) + 'px';
+            }
         });
         window.addEventListener('mouseup', (e) => {
             if (!dragging) return;
             dragging = false;
+            sel.classList.remove('zoom');
             const { x, y } = localXY(e);
+            if (zooming) {
+                zooming = false;
+                sel.style.display = 'none'; // rubber-band was transient
+                zoomToX(Math.min(x, startX), Math.max(x, startX));
+                return;
+            }
             const dx = Math.abs(x - startX), dy = Math.abs(y - startY);
             if (dx < 4 && dy < 4) {
                 selectSegmentAt(startX, startY); // treat as a click
@@ -890,7 +966,48 @@
                 finalizeSelection(Math.min(x, startX), Math.max(x, startX), Math.min(y, startY), Math.max(y, startY));
             }
         });
+        // Double-click anywhere on the plot resets to the full time range.
+        plot.addEventListener('dblclick', () => resetHeatmapZoom());
     })();
+
+    // Zoom the displayed time domain to the pixel range [x0, x1]. Ignores drags
+    // too narrow to be intentional. The whole heatmap is re-rendered against the
+    // new domain (density re-normalizes to the visible window, so a region that
+    // looked flat when zoomed out reveals its internal structure).
+    function zoomToX(x0, x1) {
+        if (!heatmapDomain || x1 - x0 < 4) return;
+        const canvas = document.getElementById('heatmap-canvas');
+        const W = canvas.clientWidth || parseFloat(canvas.style.width) || 1;
+        const { tMin, tMax } = heatmapDomain;
+        let t0 = xToTime(x0, tMin, tMax, W);
+        let t1 = xToTime(x1, tMin, tMax, W);
+        if (!(t1 > t0)) return;
+        heatmapDomain = { tMin: t0, tMax: t1 };
+        setHeatmapSelection(null);
+        drawHeatmapCanvas();
+        updateZoomResetBtn();
+    }
+
+    // Restore the full data extent (no-op if not currently zoomed).
+    function resetHeatmapZoom() {
+        if (!heatmapFullDomain) return;
+        const { tMin, tMax } = heatmapFullDomain;
+        if (heatmapDomain && heatmapDomain.tMin === tMin && heatmapDomain.tMax === tMax) return;
+        heatmapDomain = { tMin, tMax };
+        setHeatmapSelection(null);
+        drawHeatmapCanvas();
+        updateZoomResetBtn();
+    }
+
+    // Show the "Reset zoom" control only while a sub-range is displayed.
+    function updateZoomResetBtn() {
+        const btn = document.getElementById('heatmap-reset-zoom');
+        if (!btn) return;
+        const zoomed = heatmapFullDomain && heatmapDomain &&
+            (heatmapDomain.tMin !== heatmapFullDomain.tMin ||
+             heatmapDomain.tMax !== heatmapFullDomain.tMax);
+        btn.style.display = zoomed ? '' : 'none';
+    }
 
     // Position the persistent selection rectangle over whole rows [r0,r1] and
     // the time span [t0,t1], so it is clear which rows/time the selection covers.

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>dial9 Trace Browser</title>
     <style>
+        :root {
+            /* Width of the heatmap host-label column. Read from JS (see LABEL_W)
+               so the timeline axis ticks line up with the canvas left edge. */
+            --heatmap-label-w: 220px;
+        }
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
@@ -87,7 +92,7 @@
             background: linear-gradient(to right, #2a2a5a, #6c63ff, #ff6b6b, #ffd93d);
         }
         #heatmap-body { flex: 1; overflow: auto; display: flex; min-height: 0; }
-        #heatmap-labels { flex-shrink: 0; width: 220px; border-right: 2px solid #3a3a5e; }
+        #heatmap-labels { flex-shrink: 0; width: var(--heatmap-label-w); border-right: 2px solid #3a3a5e; }
         #heatmap-labels .row {
             height: 26px; line-height: 26px; padding: 0 8px;
             font-size: 0.78em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
@@ -673,7 +678,11 @@
     }
 
     // ── Density heatmap timeline ──
-    const LABEL_W = 220; // must match #heatmap-labels width in CSS
+    // Read the label-column width from the --heatmap-label-w CSS custom property
+    // so the JS axis layout and the CSS column width share a single source.
+    const LABEL_W = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--heatmap-label-w')
+    ) || 220;
 
     function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
     function timeToX(t, tMin, tMax, W) { return (t - tMin) / (tMax - tMin) * W; }
@@ -842,8 +851,12 @@
         function localXY(e) {
             const rect = plot.getBoundingClientRect();
             const H = heatmapRows.length * ROW_H;
+            // Clamp x to the canvas width (what the time<->x helpers map against),
+            // not the plot's bounding rect, so the far-right edge lines up exactly.
+            const canvas = document.getElementById('heatmap-canvas');
+            const W = canvas.clientWidth || rect.width;
             return {
-                x: clamp(e.clientX - rect.left, 0, rect.width),
+                x: clamp(e.clientX - rect.left, 0, W),
                 y: clamp(e.clientY - rect.top, 0, H),
             };
         }
@@ -982,6 +995,27 @@
         setHeatmapSelection(null);
     });
 
+    // Structured title metadata (svc / host / time window / segment count)
+    // derived from a set of selected keys. Both the trace viewer and the
+    // flamegraph render this in their header, so it lives in one helper.
+    function traceTitleParams(keys) {
+        const parsed = keys.map(k => parseKey(k));
+        const services = [...new Set(parsed.map(p => p.service).filter(Boolean))];
+        const hosts = [...new Set(parsed.map(p => p.host).filter(Boolean))];
+        const epochs = parsed.map(p => p.epoch).filter(e => e > 0).sort((a, b) => a - b);
+        const params = new URLSearchParams();
+        if (services.length) params.set('svc', services.join(', '));
+        if (hosts.length === 1) params.set('host', hosts[0]);
+        if (epochs.length >= 2) {
+            params.set('from', formatEpoch(epochs[0]));
+            params.set('to', formatEpoch(epochs[epochs.length - 1]));
+        } else if (epochs.length === 1) {
+            params.set('from', formatEpoch(epochs[0]));
+        }
+        params.set('segs', String(keys.length));
+        return params;
+    }
+
     // CPU Profiling button: open a flamegraph of the selected segments. The
     // flamegraph view builds from the trace's CpuSampleEvents (and resolves
     // symbols from SymbolTableEntry), ignoring all other event types, so we
@@ -991,13 +1025,16 @@
         if (!heatmapSelection || !heatmapSelection.keys.length) return;
         const bucket = bucketInput.value.trim();
         if (!bucket) { alert('Bucket is required'); return; }
+        const keys = heatmapSelection.keys;
         const params = new URLSearchParams();
         params.set('bucket', bucket);
-        for (const key of heatmapSelection.keys) {
+        for (const key of keys) {
             params.append('keys', key);
         }
         const traceUrl = '/api/trace?' + params.toString();
-        window.open('flamegraph.html?trace=' + encodeURIComponent(traceUrl), '_blank');
+        const fgParams = traceTitleParams(keys);
+        fgParams.set('trace', traceUrl);
+        window.open('flamegraph.html?' + fgParams.toString(), '_blank');
     }
 
     // ── Raw search mode ──
@@ -1140,22 +1177,9 @@
         const keysParams = keys.map(k => `keys=${encodeURIComponent(k)}`).join('&');
         const traceUrl = `/api/trace?bucket=${encodeURIComponent(bucket)}&${keysParams}`;
 
-        // Pass structured metadata for the viewer title
-        const parsed = keys.map(k => parseKey(k));
-        const services = [...new Set(parsed.map(p => p.service).filter(Boolean))];
-        const hosts = [...new Set(parsed.map(p => p.host).filter(Boolean))];
-        const epochs = parsed.map(p => p.epoch).filter(e => e > 0).sort((a, b) => a - b);
-        const titleParams = new URLSearchParams();
+        // Pass structured metadata for the viewer title.
+        const titleParams = traceTitleParams(keys);
         titleParams.set('trace', traceUrl);
-        if (services.length) titleParams.set('svc', services.join(', '));
-        if (hosts.length === 1) titleParams.set('host', hosts[0]);
-        if (epochs.length >= 2) {
-            titleParams.set('from', formatEpoch(epochs[0]));
-            titleParams.set('to', formatEpoch(epochs[epochs.length - 1]));
-        } else if (epochs.length === 1) {
-            titleParams.set('from', formatEpoch(epochs[0]));
-        }
-        titleParams.set('segs', String(keys.length));
 
         window.open(`viewer.html?${titleParams.toString()}`, '_blank');
     }

--- a/dial9-viewer/ui/test_heatmap.js
+++ b/dial9-viewer/ui/test_heatmap.js
@@ -7,6 +7,8 @@ const {
     MAX_OPEN_BYTES,
     groupByHost,
     bootTransitions,
+    tileSegments,
+    segmentGaps,
     accumulateDensity,
     segmentsOverlapping,
     totalBytes,
@@ -116,6 +118,50 @@ function seg(o) {
     const cols = accumulateDensity([seg({ size: 800, start: 0, end: 80 })], 40, 80, 4);
     const sum = cols.reduce((a, b) => a + b, 0);
     approx(sum, 400, 1e-6, "accumulateDensity: partial overlap attributes only the in-range bytes");
+}
+
+// ── tileSegments & segmentGaps ──
+{
+    // Upload-lag overlap: each segment's end (last_modified) runs past the next
+    // segment's start. tileSegments clamps the end to the next start; the raw
+    // overlap would double-count density at the seam.
+    const segs = [
+        seg({ key: "a", size: 100, start: 0, end: 17 }),  // ends 2s into b
+        seg({ key: "b", size: 100, start: 15, end: 32 }), // ends 2s into c
+        seg({ key: "c", size: 100, start: 30, end: 47 }),
+    ];
+    const tiled = tileSegments(segs);
+    ok(tiled[0].end === 15 && tiled[1].end === 30,
+        "tileSegments: ends clamped to the next start");
+    ok(tiled[2].end === 47, "tileSegments: last segment keeps its end");
+    ok(tiled[0].realEnd === 17 && tiled[1].realEnd === 32,
+        "tileSegments: real end preserved for selection/gaps");
+    ok(segmentGaps(segs).length === 0, "segmentGaps: overlapping rotation has no gap");
+
+    // The seam column is no longer brighter than a body column once tiled.
+    const cols = accumulateDensity(tiled, 0, 47, 47);
+    const seam = cols[15]; // the a/b boundary second
+    const body = cols[5];
+    ok(seam <= body * 1.2,
+        `tileSegments: seam no longer spikes (seam ${seam.toFixed(1)} vs body ${body.toFixed(1)})`);
+
+    // A real coverage hole (next starts after this one's real end) is a gap.
+    const withHole = [
+        seg({ key: "a", size: 100, start: 0, end: 17 }),
+        seg({ key: "b", size: 100, start: 60, end: 77 }), // 43s hole after a
+    ];
+    const gaps = segmentGaps(withHole);
+    ok(gaps.length === 1 && gaps[0].start === 17 && gaps[0].end === 60,
+        "segmentGaps: real coverage hole detected with [end, nextStart]");
+    // Tiling must not invent coverage across the hole.
+    ok(tileSegments(withHole)[0].end === 17,
+        "tileSegments: no clamp across a real gap (next start is past end)");
+
+    // Inputs need not be pre-sorted.
+    const unsorted = [seg({ start: 30, end: 47 }), seg({ start: 0, end: 17 }), seg({ start: 15, end: 32 })];
+    const ts = tileSegments(unsorted);
+    ok(ts[0].start === 0 && ts[1].start === 15 && ts[2].start === 30,
+        "tileSegments: sorts before clamping");
 }
 
 // ── segmentsOverlapping & totalBytes ──

--- a/dial9-viewer/ui/test_heatmap.js
+++ b/dial9-viewer/ui/test_heatmap.js
@@ -130,6 +130,15 @@ function seg(o) {
         "segmentsOverlapping: picks overlapping segments");
     ok(totalBytes(sel) === 30, "totalBytes: sums selected sizes");
     ok(segmentsOverlapping(segs, 200, 300).length === 0, "segmentsOverlapping: none outside range");
+
+    // A point query (single click) exactly on a segment's start must select it
+    // rather than fall through the crack between adjacent segments.
+    const atStart = segmentsOverlapping(segs, 60, 60);
+    ok(atStart.length === 1 && atStart[0].key === "b",
+        "segmentsOverlapping: click on a segment's start selects that segment");
+    const atZero = segmentsOverlapping(segs, 0, 0);
+    ok(atZero.length === 1 && atZero[0].key === "a",
+        "segmentsOverlapping: click on the very first start still selects");
 }
 
 // ── densityColor ──

--- a/dial9-viewer/ui/test_heatmap.js
+++ b/dial9-viewer/ui/test_heatmap.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+"use strict";
+
+// Unit tests for the S3 browser density-timeline helpers in heatmap.js.
+
+const {
+    MAX_OPEN_BYTES,
+    groupByHost,
+    bootTransitions,
+    accumulateDensity,
+    segmentsOverlapping,
+    totalBytes,
+    densityColor,
+} = require("./heatmap.js");
+
+let failed = 0;
+let passed = 0;
+
+function ok(cond, label) {
+    if (cond) {
+        passed++;
+        console.log(`✓ ${label}`);
+    } else {
+        failed++;
+        console.error(`✗ ${label}`);
+    }
+}
+
+function approx(a, b, eps, label) {
+    ok(Math.abs(a - b) <= (eps ?? 1e-6), `${label} (got ${a}, want ~${b})`);
+}
+
+function seg(o) {
+    return Object.assign(
+        { key: "k", size: 0, start: 0, end: 0, service: "svc", host: "h", bootId: "" },
+        o,
+    );
+}
+
+// ── groupByHost ──
+{
+    const rows = groupByHost([
+        seg({ service: "api", host: "h2", size: 10, start: 5 }),
+        seg({ service: "api", host: "h1", size: 20, start: 1 }),
+        seg({ service: "api", host: "h1", size: 30, start: 3, bootId: "bbbb" }),
+    ]);
+    ok(rows.length === 2, "groupByHost: two host rows");
+    ok(rows[0].host === "h1" && rows[1].host === "h2", "groupByHost: sorted by label");
+    ok(rows[0].segments.length === 2, "groupByHost: h1 has both segments (boot not split)");
+    ok(rows[0].totalBytes === 50, "groupByHost: totalBytes summed");
+    ok(
+        rows[0].segments[0].start <= rows[0].segments[1].start,
+        "groupByHost: segments sorted by start",
+    );
+}
+
+// ── bootTransitions ──
+{
+    const t = bootTransitions([
+        seg({ start: 1, bootId: "aaaa" }),
+        seg({ start: 2, bootId: "aaaa" }),
+        seg({ start: 3, bootId: "bbbb" }),
+        seg({ start: 4, bootId: "bbbb" }),
+        seg({ start: 5, bootId: "cccc" }),
+    ]);
+    ok(t.length === 2, "bootTransitions: two transitions");
+    ok(t[0].time === 3 && t[0].fromBoot === "aaaa" && t[0].toBoot === "bbbb", "bootTransitions: first");
+    ok(t[1].time === 5 && t[1].toBoot === "cccc", "bootTransitions: second");
+
+    ok(bootTransitions([seg({ start: 1 }), seg({ start: 2 })]).length === 0,
+        "bootTransitions: none without boot ids (legacy)");
+}
+
+// ── accumulateDensity ──
+{
+    // One segment spanning the whole range, 400 bytes, width 4 → 100 per col.
+    const cols = accumulateDensity([seg({ size: 400, start: 0, end: 4 })], 0, 4, 4);
+    ok(cols.length === 4, "accumulateDensity: width respected");
+    approx(cols[0], 100, 1e-6, "accumulateDensity: uniform col 0");
+    approx(cols[3], 100, 1e-6, "accumulateDensity: uniform col 3");
+    const sum = cols.reduce((a, b) => a + b, 0);
+    approx(sum, 400, 1e-6, "accumulateDensity: total bytes conserved");
+}
+{
+    // Baseline 1MB/min across 10 cols + a 50MB spike in one minute. The spike
+    // column must dominate and be ~50x the baseline columns.
+    const segs = [];
+    for (let i = 0; i < 10; i++) {
+        segs.push(seg({ size: 1e6, start: i * 60, end: (i + 1) * 60, key: "b" + i }));
+    }
+    // spike: 50MB in minute index 4
+    segs[4] = seg({ size: 50e6, start: 4 * 60, end: 5 * 60, key: "spike" });
+    const cols = accumulateDensity(segs, 0, 600, 10);
+    let maxIdx = 0;
+    for (let i = 1; i < cols.length; i++) if (cols[i] > cols[maxIdx]) maxIdx = i;
+    ok(maxIdx === 4, "accumulateDensity: spike lands in the right column");
+    approx(cols[4] / cols[0], 50, 0.001, "accumulateDensity: spike is ~50x baseline");
+}
+{
+    // Out-of-range / degenerate inputs are safe.
+    ok(accumulateDensity([], 0, 10, 5).every((v) => v === 0), "accumulateDensity: empty → zeros");
+    ok(accumulateDensity([seg({ size: 100, start: 0, end: 1 })], 5, 5, 4).length === 4,
+        "accumulateDensity: zero-width range → zeros length kept");
+}
+{
+    // A segment with end <= start is given MIN_SEGMENT_SECONDS so its bytes
+    // still land as a localized spike rather than vanishing.
+    const cols = accumulateDensity([seg({ size: 500, start: 10, end: 10 })], 0, 20, 20);
+    const sum = cols.reduce((a, b) => a + b, 0);
+    approx(sum, 500, 1e-6, "accumulateDensity: zero-duration segment still contributes its bytes");
+    ok(cols[10] > 0 && cols[15] === 0, "accumulateDensity: zero-duration spike is localized at its start");
+}
+{
+    // Only the in-range portion of a segment's bytes is attributed when it
+    // partially overlaps [t0,t1]: half of a uniformly-spread segment.
+    const cols = accumulateDensity([seg({ size: 800, start: 0, end: 80 })], 40, 80, 4);
+    const sum = cols.reduce((a, b) => a + b, 0);
+    approx(sum, 400, 1e-6, "accumulateDensity: partial overlap attributes only the in-range bytes");
+}
+
+// ── segmentsOverlapping & totalBytes ──
+{
+    const segs = [
+        seg({ key: "a", size: 10, start: 0, end: 60 }),
+        seg({ key: "b", size: 20, start: 60, end: 120 }),
+        seg({ key: "c", size: 40, start: 120, end: 180 }),
+    ];
+    const sel = segmentsOverlapping(segs, 30, 90);
+    ok(sel.length === 2 && sel[0].key === "a" && sel[1].key === "b",
+        "segmentsOverlapping: picks overlapping segments");
+    ok(totalBytes(sel) === 30, "totalBytes: sums selected sizes");
+    ok(segmentsOverlapping(segs, 200, 300).length === 0, "segmentsOverlapping: none outside range");
+}
+
+// ── densityColor ──
+{
+    ok(densityColor(0) === "rgb(26,26,46)", "densityColor: 0 → background");
+    ok(densityColor(-1) === "rgb(26,26,46)", "densityColor: negative → background");
+    const lum = (c) => {
+        const [r, g, b] = c.match(/\d+/g).map(Number);
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    };
+    const low = densityColor(0.05);
+    const mid = densityColor(0.4);
+    const hi = densityColor(1);
+    ok(low !== "rgb(26,26,46)", "densityColor: small positive is visible (not background)");
+    ok(lum(low) < lum(mid) && lum(mid) < lum(hi), "densityColor: brighter with higher density");
+    ok(densityColor(1) === "rgb(255,217,61)", "densityColor: 1 → hot yellow");
+}
+
+// ── constants ──
+ok(MAX_OPEN_BYTES === 100 * 1024 * 1024, "MAX_OPEN_BYTES is 100 MiB");
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -109,7 +109,7 @@
             #stack-sidebar {
                 width: min(640px, 50vw);
                 min-width: 200px;
-                max-width: 70vw;
+                max-width: 92vw;
                 background: #1a1a2e;
                 display: none;
                 flex-direction: column;
@@ -658,6 +658,7 @@
                     <span id="poi-counter" style="font-size:0.85em;color:#888"></span>
                     <span style="width:1px;height:20px;background:#444;margin:0 8px"></span>
                     <button id="btn-sched-panel" style="background:#3a1a1a;border-color:#ff4444;color:#ff8a65">⚠ Blocking Calls</button>
+                    <button id="btn-cpu-flamegraph" style="display:none;background:#2a1a2a;border-color:#b388ff;color:#d0bcff;white-space:nowrap" title="Show a CPU flamegraph for the whole trace">🔥 Flamegraph</button>
                     <button id="btn-heap-flamegraph" style="display:none;background:#1a2a1a;border-color:#4caf50;color:#81c784;white-space:nowrap" title="Show heap allocation flamegraph">🔥 Heap</button>
                     <button id="btn-uninstrumented-info" style="display:none;background:#1e2050;border-color:#6c63ff;color:#d0ccff;white-space:nowrap" title="Some tasks lack wake tracking — click for details">ⓘ Blind spawns</button>
                     <button id="btn-set-range" title="Set time range filter (reloads with only events in range)">Set Range</button>
@@ -1693,6 +1694,14 @@
                 btnHeap.style.display = hasAllocEvents ? "" : "none";
                 if (hasAllocEvents) {
                     btnHeap.textContent = `🔥 Heap (${trace.allocEvents.length})`;
+                }
+
+                // Show CPU flamegraph button (whole-trace) if CPU samples exist.
+                const hasCpu = hasCpuProfileSamples(trace.cpuSamples);
+                const btnCpu = document.getElementById("btn-cpu-flamegraph");
+                btnCpu.style.display = hasCpu ? "" : "none";
+                if (hasCpu) {
+                    btnCpu.textContent = `🔥 Flamegraph (${trace.cpuSamples.length})`;
                 }
 
                 showToast("shift-drag-hint", "⇧ Shift+drag to select a region", "info", 0, true);
@@ -3468,6 +3477,10 @@
             document.getElementById("sort-by-worst").addEventListener("change", () => updatePointsOfInterest({ autoJump: true }));
             document.getElementById("btn-sched-panel").addEventListener("click", showSchedPanel);
             document.getElementById("btn-heap-flamegraph").addEventListener("click", () => showHeapFlamegraph());
+            document.getElementById("btn-cpu-flamegraph").addEventListener("click", () => {
+                // Whole-trace CPU flamegraph: select the full time range.
+                showFlamegraph(minTs, maxTs);
+            });
             document.getElementById("btn-uninstrumented-info").addEventListener("click", (e) => {
                 showUninstrumentedPopup(e.target);
             });
@@ -4150,7 +4163,7 @@
                     const dx = startX - e.clientX; // dragging left = wider
                     const newW = Math.min(
                         Math.max(200, startW + dx),
-                        window.innerWidth * 0.7
+                        window.innerWidth * 0.92
                     );
                     sidebar.style.width = newW + "px";
                     if (trace && !resizeRafId) {
@@ -4871,7 +4884,15 @@
             const fgContainer = document.getElementById("fg-container");
             const fgInstance = FlamegraphRenderer.createFlamegraph(fgContainer);
 
-            // Open the stack sidebar showing a flamegraph built from `samples`.
+            // When a flamegraph is first opened, default the stack sidebar to a
+            // large fraction of the viewport (it otherwise opens at a narrow
+            // ~50vw). The user can still drag it back via the resize handle.
+            const FLAMEGRAPH_DEFAULT_VW = 0.78;
+            function widenSidebarForFlamegraph() {
+                const sidebar = document.getElementById("stack-sidebar");
+                sidebar.style.width = Math.round(window.innerWidth * FLAMEGRAPH_DEFAULT_VW) + "px";
+            }
+
             // Used by `showTaskDumpStack`, `showIdleTimeFlamegraph`, and any
             // other caller that just wants "here's a pile of callchains, render
             // them as a flamegraph in the sidebar".
@@ -4895,6 +4916,7 @@
                 body.appendChild(fgContainer);
                 const wasHidden = sidebar.style.display !== "flex";
                 sidebar.style.display = "flex";
+                if (wasHidden) widenSidebarForFlamegraph();
                 if (wasHidden && trace) requestAnimationFrame(renderAll);
                 requestAnimationFrame(() => {
                     fgInstance.setData(samples, trace.callframeSymbols, fgOpts);
@@ -5122,6 +5144,7 @@
                 body.appendChild(fgContainer);
                 const wasHidden = sidebar.style.display !== "flex";
                 sidebar.style.display = "flex";
+                if (wasHidden) widenSidebarForFlamegraph();
                 if (wasHidden && trace) requestAnimationFrame(renderAll);
                 requestAnimationFrame(() => {
                     fgInstance.setData(samplesForMode(heapMode), trace.callframeSymbols, heapFgOpts(heapMode));
@@ -5176,6 +5199,7 @@
                 clearToasts();
                 const wasHidden = sidebar.style.display !== "flex";
                 sidebar.style.display = "flex";
+                if (wasHidden) widenSidebarForFlamegraph();
                 if (wasHidden && trace) requestAnimationFrame(renderAll);
 
                 // Give the container a frame to get its layout, then render


### PR DESCRIPTION
<img width="1704" height="341" alt="Screenshot 2026-06-12 at 3 28 39 PM" src="https://github.com/user-attachments/assets/d6b71857-0c7b-4aa9-a98f-25e2c268df3a" />

instead of having to click into a node, it now shows you all the nodes in a table. the nodes are color coded by the size of the files which is a rough proxy for traffic.

There are a couple of other driveby changes as well:
1. flamegraph buttons on both the browser page & the viewer to jump right to a flamegraph for the entire time duration
2. the flamegraph panel now pops open much wider so its easier to see