### PR TITLE
ci: keep Cargo.lock on nightly (avoid upstream aws-smithy-types/time breakage)

### DIFF
--- a/.github/actions/rust-build/action.yml
+++ b/.github/actions/rust-build/action.yml
@@ -30,9 +30,14 @@ runs:
           env:
               RUSTFLAGS: "--cfg tokio_unstable -C force-frame-pointers=yes"
           run: |
-              if [ "${{ inputs.toolchain }}" = nightly ]; then
-                  rm -fv Cargo.lock
-              fi
+              # NOTE: we intentionally do NOT remove Cargo.lock on nightly.
+              # Removing it floats onto the latest semver-compatible deps, which
+              # (as of 2026-06-12) pulls aws-smithy-types 1.5.0 and fails to
+              # compile with E0119 (conflicting From impls for the `time` crate's
+              # HourBase) — an upstream breakage unrelated to this repo. Building
+              # nightly against the committed Cargo.lock keeps it a pure
+              # nightly-compiler canary. Restore dependency-floating (and this
+              # comment) once the upstream aws-smithy-types/time issue is fixed.
               # tokio's `taskdump` feature only compiles on linux aarch64/x86/x86_64.
               # On macOS drop it from --all-features; leave everything else intact.
               if [ "$RUNNER_OS" = "Linux" ]; then


### PR DESCRIPTION
## Problem

The nightly CI entries delete `Cargo.lock` so they double as a "latest deps" canary. As of 2026-06-12, this floats onto `aws-smithy-types 1.5.0`, which fails to compile:

```
error[E0119]: conflicting implementations of trait `From<format_description::parse::format_item::HourBase>` for type `CanDisable<...HourBase>`
  --> aws-smithy-types-1.5.0/src/timeout.rs:49
```

This is an upstream `time`-crate / rustc interaction bug, not our code. It makes both nightly matrix entries (ubuntu, macos) permanently red. See failing run: https://github.com/dial9-rs/dial9/actions/runs/27439429041

PR #525 already moved nightly out of the required `ci-pass` gate, so this is non-blocking — but it's persistent red noise.

## Fix

Stop deleting `Cargo.lock` on nightly. The job remains a useful **nightly-compiler** canary (catches new warnings, future incompatibilities, etc.) — it just no longer floats dependencies.

Added an inline comment explaining the rationale so a future maintainer knows when to restore the old behavior (once the upstream aws-smithy-types/time issue is resolved).

## What stays the same
- Nightly still runs on both ubuntu and macos
- All other build steps (prlimit, feature handling, cargo test invocations) are unchanged
- Stable/beta builds are unchanged