### PR TITLE
refactor: setup dial9-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,7 @@ jobs:
           cargo package \
             -p dial9-trace-format-derive \
             -p dial9-trace-format \
+            -p dial9-core \
             -p dial9-perf-self-profile \
             -p dial9-macro \
             -p dial9-tokio-telemetry \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dial9-core"
+version = "0.4.0-alpha.1"
+dependencies = [
+ "crossbeam-queue",
+ "shuttle",
+]
+
+[[package]]
 name = "dial9-macro"
 version = "0.3.7"
 dependencies = [
@@ -1542,6 +1550,7 @@ dependencies = [
  "clap",
  "criterion",
  "crossbeam-queue",
+ "dial9-core",
  "dial9-macro",
  "dial9-perf-self-profile",
  "dial9-tokio-telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "dial9-core",
     "dial9-tokio-telemetry",
     "dial9-trace-format",
     "dial9-trace-format-derive",
@@ -22,6 +23,7 @@ repository = "https://github.com/dial9-rs/dial9-tokio-telemetry"
 
 [workspace.dependencies]
 libc = "0.2"
+dial9-core = { version = "0.4.0-alpha.1", path = "dial9-core" }
 dial9-perf-self-profile = { version = "0.4.4", path = "perf-self-profile" }
 dial9-trace-format = { version = "0.4.1", path = "dial9-trace-format" }
 dial9-trace-format-derive = { version = "0.4.1", path = "dial9-trace-format-derive" }

--- a/dial9-core/Cargo.toml
+++ b/dial9-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dial9-core"
+version = "0.4.0-alpha.1"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Telemetry event bus for dial9"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(shuttle)"] }
+
+[dependencies]
+crossbeam-queue = "0.3"
+shuttle = { version = "0.9.1", optional = true }
+
+[features]
+_shuttle = ["dep:shuttle"]

--- a/dial9-core/src/lib.rs
+++ b/dial9-core/src/lib.rs
@@ -1,0 +1,6 @@
+/// Cfg-gated concurrency primitives (std / shuttle).
+pub mod primitives;
+/// Per-call-site rate limiting for log lines.
+pub mod rate_limit;
+/// Geometric/Poisson sampling primitives (RNG, exponential draws).
+pub mod sampling;

--- a/dial9-core/src/lib.rs
+++ b/dial9-core/src/lib.rs
@@ -1,6 +1,12 @@
 /// Cfg-gated concurrency primitives (std / shuttle).
+///
+/// `pub` so sibling crates share one shuttle shim, but not part of the public
+/// API.
+#[doc(hidden)]
 pub mod primitives;
 /// Per-call-site rate limiting for log lines.
+#[doc(hidden)]
 pub mod rate_limit;
 /// Geometric/Poisson sampling primitives (RNG, exponential draws).
+#[doc(hidden)]
 pub mod sampling;

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -8,21 +8,21 @@
 // ── std path (production) ───────────────────────────────────────────────────
 
 #[cfg(not(shuttle))]
-pub(crate) mod sync {
-    pub(crate) use std::sync::atomic;
-    pub(crate) use std::sync::mpsc;
+pub mod sync {
+    pub use std::sync::atomic;
+    pub use std::sync::mpsc;
     #[allow(unused_imports)]
-    pub(crate) use std::sync::{Arc, Barrier, Mutex, Weak};
+    pub use std::sync::{Arc, Barrier, Mutex, Weak};
 }
 
 #[cfg(not(shuttle))]
-pub(crate) mod thread {
+pub mod thread {
     #[allow(unused_imports)]
-    pub(crate) use std::thread::{JoinHandle, sleep, spawn};
+    pub use std::thread::{JoinHandle, sleep, spawn};
 
     /// Spawn a named thread. Uses `std::thread::Builder` in production,
     /// falls back to plain `spawn` under shuttle (which has no Builder).
-    pub(crate) fn spawn_named<F, T>(name: &str, f: F) -> JoinHandle<T>
+    pub fn spawn_named<F, T>(name: &str, f: F) -> JoinHandle<T>
     where
         F: FnOnce() -> T + Send + 'static,
         T: Send + 'static,
@@ -35,19 +35,20 @@ pub(crate) mod thread {
 }
 
 #[cfg(not(shuttle))]
+#[macro_export]
 macro_rules! define_thread_local {
     ($($tt:tt)*) => { std::thread_local! { $($tt)* } };
 }
 #[cfg(not(shuttle))]
-pub(crate) use define_thread_local as thread_local;
+pub use crate::define_thread_local as thread_local;
 
 // ── shuttle path (deterministic testing) ────────────────────────────────────
 
 #[cfg(shuttle)]
-pub(crate) mod sync {
-    pub(crate) use shuttle::sync::atomic;
+pub mod sync {
+    pub use shuttle::sync::atomic;
     #[allow(unused_imports)]
-    pub(crate) use shuttle::sync::{Arc, Barrier, Mutex, Weak};
+    pub use shuttle::sync::{Arc, Barrier, Mutex, Weak};
 
     /// Wrapper around shuttle's mpsc that adds random timeouts to
     /// `recv_timeout`. Shuttle's built-in `recv_timeout` ignores the
@@ -55,10 +56,10 @@ pub(crate) mod sync {
     /// never loops. This wrapper randomly returns `Timeout` so shuttle
     /// can explore interleavings where the flush loop actually runs
     /// multiple cycles.
-    pub(crate) mod mpsc {
-        pub(crate) use shuttle::sync::mpsc::{RecvTimeoutError, SyncSender};
+    pub mod mpsc {
+        pub use shuttle::sync::mpsc::{RecvTimeoutError, SyncSender};
 
-        pub(crate) struct Receiver<T> {
+        pub struct Receiver<T> {
             inner: shuttle::sync::mpsc::Receiver<T>,
         }
 
@@ -67,7 +68,7 @@ pub(crate) mod sync {
         unsafe impl<T: Send> Send for Receiver<T> {}
 
         impl<T> Receiver<T> {
-            pub(crate) fn recv_timeout(
+            pub fn recv_timeout(
                 &self,
                 _timeout: std::time::Duration,
             ) -> Result<T, RecvTimeoutError> {
@@ -92,7 +93,7 @@ pub(crate) mod sync {
                 }
             }
 
-            pub(crate) fn recv(&self) -> Result<T, shuttle::sync::mpsc::RecvError> {
+            pub fn recv(&self) -> Result<T, shuttle::sync::mpsc::RecvError> {
                 self.inner.recv()
             }
         }
@@ -100,7 +101,7 @@ pub(crate) mod sync {
         use shuttle::rand::Rng;
 
         /// Wraps shuttle's `sync_channel` to return our `Receiver` wrapper.
-        pub(crate) fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
+        pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
             let (tx, rx) = shuttle::sync::mpsc::sync_channel(bound);
             (tx, Receiver { inner: rx })
         }
@@ -108,11 +109,11 @@ pub(crate) mod sync {
 }
 
 #[cfg(shuttle)]
-pub(crate) mod thread {
+pub mod thread {
     #[allow(unused_imports)]
-    pub(crate) use shuttle::thread::{JoinHandle, sleep, spawn};
+    pub use shuttle::thread::{JoinHandle, sleep, spawn};
 
-    pub(crate) fn spawn_named<F, T>(_name: &str, f: F) -> JoinHandle<T>
+    pub fn spawn_named<F, T>(_name: &str, f: F) -> JoinHandle<T>
     where
         F: FnOnce() -> T + Send + 'static,
         T: Send + 'static,
@@ -122,45 +123,46 @@ pub(crate) mod thread {
 }
 
 #[cfg(shuttle)]
+#[macro_export]
 macro_rules! define_thread_local {
     ($($tt:tt)*) => { shuttle::thread_local! { $($tt)* } };
 }
 #[cfg(shuttle)]
-pub(crate) use define_thread_local as thread_local;
+pub use crate::define_thread_local as thread_local;
 
 #[cfg(not(shuttle))]
-pub(crate) mod fs {
+pub mod fs {
     use std::io::{self, Write};
     use std::path::Path;
 
-    pub(crate) fn create_dir_all(path: &Path) -> io::Result<()> {
+    pub fn create_dir_all(path: &Path) -> io::Result<()> {
         std::fs::create_dir_all(path)
     }
-    pub(crate) fn rename(from: &Path, to: &Path) -> io::Result<()> {
+    pub fn rename(from: &Path, to: &Path) -> io::Result<()> {
         std::fs::rename(from, to)
     }
-    pub(crate) fn remove_file(path: &Path) -> io::Result<()> {
+    pub fn remove_file(path: &Path) -> io::Result<()> {
         std::fs::remove_file(path)
     }
-    pub(crate) fn remove_dir(path: &Path) -> io::Result<()> {
+    pub fn remove_dir(path: &Path) -> io::Result<()> {
         std::fs::remove_dir(path)
     }
-    pub(crate) fn read_dir(path: &Path) -> io::Result<std::fs::ReadDir> {
+    pub fn read_dir(path: &Path) -> io::Result<std::fs::ReadDir> {
         std::fs::read_dir(path)
     }
-    pub(crate) fn metadata(path: &Path) -> io::Result<std::fs::Metadata> {
+    pub fn metadata(path: &Path) -> io::Result<std::fs::Metadata> {
         std::fs::metadata(path)
     }
-    pub(crate) fn read(path: &Path) -> io::Result<Vec<u8>> {
+    pub fn read(path: &Path) -> io::Result<Vec<u8>> {
         std::fs::read(path)
     }
 
     /// Active-segment file handle.
     #[derive(Debug)]
-    pub(crate) struct File(std::fs::File);
+    pub struct File(std::fs::File);
 
     impl File {
-        pub(crate) fn create(path: &Path) -> io::Result<File> {
+        pub fn create(path: &Path) -> io::Result<File> {
             std::fs::File::create(path).map(File)
         }
     }
@@ -178,7 +180,7 @@ pub(crate) mod fs {
 }
 
 #[cfg(shuttle)]
-pub(crate) mod fs {
+pub mod fs {
     use std::cell::Cell;
     use std::io::{self, ErrorKind, Write};
     use std::path::Path;
@@ -187,7 +189,7 @@ pub(crate) mod fs {
 
     /// How to fail filesystem operations during a shuttle run.
     #[derive(Clone, Copy, Debug)]
-    pub(crate) enum FaultPolicy {
+    pub enum FaultPolicy {
         /// Delegate to real `std::fs`, nothing fails.
         None,
         /// Every fallible op returns `PermissionDenied`.
@@ -204,12 +206,12 @@ pub(crate) mod fs {
     /// Arm `policy`: the returned guard restores the previous one on drop so a
     /// fault can't leak into the next shuttle iteration.
     #[must_use]
-    pub(crate) fn set_fault(policy: FaultPolicy) -> FaultGuard {
+    pub fn set_fault(policy: FaultPolicy) -> FaultGuard {
         let prev = FAULT.with(|f| f.replace(policy));
         FaultGuard { prev }
     }
 
-    pub(crate) struct FaultGuard {
+    pub struct FaultGuard {
         prev: FaultPolicy,
     }
 
@@ -232,31 +234,31 @@ pub(crate) mod fs {
         }
     }
 
-    pub(crate) fn create_dir_all(path: &Path) -> io::Result<()> {
+    pub fn create_dir_all(path: &Path) -> io::Result<()> {
         check()?;
         std::fs::create_dir_all(path)
     }
-    pub(crate) fn rename(from: &Path, to: &Path) -> io::Result<()> {
+    pub fn rename(from: &Path, to: &Path) -> io::Result<()> {
         check()?;
         std::fs::rename(from, to)
     }
-    pub(crate) fn remove_file(path: &Path) -> io::Result<()> {
+    pub fn remove_file(path: &Path) -> io::Result<()> {
         check()?;
         std::fs::remove_file(path)
     }
-    pub(crate) fn remove_dir(path: &Path) -> io::Result<()> {
+    pub fn remove_dir(path: &Path) -> io::Result<()> {
         check()?;
         std::fs::remove_dir(path)
     }
-    pub(crate) fn read_dir(path: &Path) -> io::Result<std::fs::ReadDir> {
+    pub fn read_dir(path: &Path) -> io::Result<std::fs::ReadDir> {
         check()?;
         std::fs::read_dir(path)
     }
-    pub(crate) fn metadata(path: &Path) -> io::Result<std::fs::Metadata> {
+    pub fn metadata(path: &Path) -> io::Result<std::fs::Metadata> {
         check()?;
         std::fs::metadata(path)
     }
-    pub(crate) fn read(path: &Path) -> io::Result<Vec<u8>> {
+    pub fn read(path: &Path) -> io::Result<Vec<u8>> {
         check()?;
         std::fs::read(path)
     }
@@ -264,10 +266,10 @@ pub(crate) mod fs {
     /// Active-segment file handle whose `write`/`flush` honor the armed fault
     /// policy. `create` is never faulted, so a writer can always be built.
     #[derive(Debug)]
-    pub(crate) struct File(std::fs::File);
+    pub struct File(std::fs::File);
 
     impl File {
-        pub(crate) fn create(path: &Path) -> io::Result<File> {
+        pub fn create(path: &Path) -> io::Result<File> {
             std::fs::File::create(path).map(File)
         }
     }
@@ -290,44 +292,44 @@ pub(crate) mod fs {
 /// under shuttle it uses a `Mutex<VecDeque>` so the scheduler can control
 /// access.
 #[cfg(not(shuttle))]
-pub(crate) struct BoundedQueue<T> {
+pub struct BoundedQueue<T> {
     inner: crossbeam_queue::ArrayQueue<T>,
 }
 
 #[cfg(not(shuttle))]
 impl<T> BoundedQueue<T> {
-    pub(crate) fn new(capacity: usize) -> Self {
+    pub fn new(capacity: usize) -> Self {
         Self {
             inner: crossbeam_queue::ArrayQueue::new(capacity),
         }
     }
 
     /// Push a value, evicting the oldest if full. Returns the evicted value.
-    pub(crate) fn force_push(&self, value: T) -> Option<T> {
+    pub fn force_push(&self, value: T) -> Option<T> {
         self.inner.force_push(value)
     }
 
-    pub(crate) fn pop(&self) -> Option<T> {
+    pub fn pop(&self) -> Option<T> {
         self.inner.pop()
     }
 }
 
 #[cfg(shuttle)]
-pub(crate) struct BoundedQueue<T> {
+pub struct BoundedQueue<T> {
     inner: shuttle::sync::Mutex<std::collections::VecDeque<T>>,
     capacity: usize,
 }
 
 #[cfg(shuttle)]
 impl<T> BoundedQueue<T> {
-    pub(crate) fn new(capacity: usize) -> Self {
+    pub fn new(capacity: usize) -> Self {
         Self {
             inner: shuttle::sync::Mutex::new(std::collections::VecDeque::with_capacity(capacity)),
             capacity,
         }
     }
 
-    pub(crate) fn force_push(&self, value: T) -> Option<T> {
+    pub fn force_push(&self, value: T) -> Option<T> {
         let mut q = self.inner.lock().unwrap();
         let evicted = if q.len() >= self.capacity {
             q.pop_front()
@@ -338,7 +340,7 @@ impl<T> BoundedQueue<T> {
         evicted
     }
 
-    pub(crate) fn pop(&self) -> Option<T> {
+    pub fn pop(&self) -> Option<T> {
         self.inner.lock().unwrap().pop_front()
     }
 }

--- a/dial9-core/src/rate_limit.rs
+++ b/dial9-core/src/rate_limit.rs
@@ -6,12 +6,13 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 #[doc(hidden)]
-pub(crate) fn time_since_epoch() -> Duration {
+pub fn time_since_epoch() -> Duration {
     static EPOCH: OnceLock<Instant> = OnceLock::new();
     Instant::now().duration_since(*EPOCH.get_or_init(Instant::now))
 }
 
 /// Evaluate `$call` at most once every `$interval` per call site.
+#[macro_export]
 macro_rules! rate_limited {
     ($interval:expr, $call:expr) => {{
         use std::sync::atomic::{AtomicU64, Ordering};
@@ -34,4 +35,4 @@ macro_rules! rate_limited {
     }};
 }
 
-pub(crate) use rate_limited;
+pub use crate::rate_limited;

--- a/dial9-core/src/sampling.rs
+++ b/dial9-core/src/sampling.rs
@@ -7,14 +7,14 @@
 //! native unit.
 
 /// Minimal splitmix64 PRNG. Fast, no dependencies, good enough for sampling.
-pub(crate) struct SplitMix64(u64);
+pub struct SplitMix64(u64);
 
 impl SplitMix64 {
-    pub(crate) const fn new(seed: u64) -> Self {
+    pub const fn new(seed: u64) -> Self {
         Self(seed)
     }
 
-    pub(crate) fn next_u64(&mut self) -> u64 {
+    pub fn next_u64(&mut self) -> u64 {
         self.0 = self.0.wrapping_add(0x9e3779b97f4a7c15);
         let mut z = self.0;
         z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
@@ -28,7 +28,7 @@ impl SplitMix64 {
     ///
     /// The unit is whatever the caller treats `mean` as (nanoseconds,
     /// bytes, etc.).
-    pub(crate) fn draw_exponential(&mut self, mean: u64) -> u64 {
+    pub fn draw_exponential(&mut self, mean: u64) -> u64 {
         // Generate a uniform float in (0, 1] — avoid exact 0 to prevent ln(0).
         let u = (self.next_u64() >> 11) as f64 / ((1u64 << 53) as f64);
         let u = if u == 0.0 { f64::MIN_POSITIVE } else { u };

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -65,6 +65,7 @@ metrique = { version = "0.1.23", features = ["local-format"] }
 metrique-timesource = "0.1"
 dial9-macro = { workspace = true }
 shuttle = { version = "0.9.1", optional = true }
+dial9-core = { workspace = true }
 
 [features]
 analysis = []
@@ -76,6 +77,7 @@ linux-socket = [
 ]
 _shuttle = [
     "dep:shuttle",
+    "dial9-core/_shuttle",
     "metrique-timesource/custom-timesource",
     "metrique-timesource/test-util",
 ]

--- a/dial9-tokio-telemetry/src/lib.rs
+++ b/dial9-tokio-telemetry/src/lib.rs
@@ -13,9 +13,7 @@ pub mod background_task;
 #[cfg(feature = "memory-profiling")]
 pub mod memory_profiling;
 pub(crate) mod metrics;
-pub(crate) mod primitives;
-pub(crate) mod rate_limit;
-pub(crate) mod sampling;
+pub(crate) use dial9_core::{primitives, rate_limit, sampling};
 #[cfg(feature = "taskdump")]
 pub(crate) mod task_dumped;
 /// Core telemetry types, recording, and trace I/O.


### PR DESCRIPTION
prep for #510, part of #356.

### Summary

Scaffolding only. Creates the `dial9-core` crate and moves the leaf utilities (`primitives`, `rate_limit`, `sampling`) into it. 
`dial9-tokio-telemetry` now depends on `dial9-core` and re-exports them, so nothing else moves yet, the
bus (collector, flush loop, writer, Handle, Source) will land next.

These re-exports are `pub` in core so sibling crates share one shuttle shim, but
they're internal plumbing, not public API, so they're `#[doc(hidden)]`.

No breaking changes here, the moved modules are re-exported `pub(crate)` from `dial9-tokio-telemetry`,
its public API is unchanged. `dial9-core` is a new crate.
