### PR TITLE
Make trace= viewer param repeatable, ungzipping each component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - You MUST use Red/Green TDD.
 - BEFORE COMMITING: `cargo nextest run --stress-duration 20s`. The package has no flaky tests. If you find a flaky test, you created it.
 - **JS/HTML-only changes** (no `.rs` files touched, no trace format changes): you do NOT need to run the full Rust test suite or the stress test. Run the relevant JS tests under `dial9-viewer/ui/test_*.js` with `node <test>` and a quick `cargo build -p dial9-viewer` to confirm `rust-embed` picks up any new files. Skip `cargo nextest` / stress run.
+- **Adding a new `dial9-viewer/ui/test_*.js` file:** CI does NOT auto-discover JS tests. You MUST register the new file in `scripts/e2e-trace-tests.sh` (the `trace-integrity` CI job runs that script), or it will never run in CI. See `dial9-viewer/ui/README.md`.
 
 ## API Design
 

--- a/dial9-viewer/ui/README.md
+++ b/dial9-viewer/ui/README.md
@@ -1,0 +1,36 @@
+# dial9-viewer UI
+
+Static HTML/JS frontend for the trace viewer, embedded into the `dial9-viewer`
+binary via `rust-embed` and served by the server (`../src/server/`). In dev,
+the assets are served from disk by `../src/bin/dev_server.rs`.
+
+Key files:
+
+- `index.html` — landing page / S3 browser. Builds `/api/trace` URLs and opens
+  the viewer or flamegraph.
+- `viewer.html` — main trace viewer.
+- `flamegraph.html` — standalone CPU-profile flamegraph view.
+- `decode.js` — low-level binary trace-frame decoder (`TraceDecoder`).
+- `trace_parser.js` — higher-level parser (`parseTrace`, `fetchTraces`, …)
+  built on `decode.js`. Works in both the browser and Node.
+
+## The `trace=` query parameter
+
+`trace=` is **repeatable**. Each value is fetched independently and may be
+individually gzipped (unlike `/api/trace`, which gunzips server-side before
+returning a single response). `TraceParser.fetchTraces()` fetches every
+component, runs each through `maybeGunzip`, and concatenates the raw bytes.
+The decoder treats a concatenated stream as multiple segments — a mid-stream
+`TRC\0` header resets the frame parser — so the combined buffer parses as one
+trace. Read all values with `params.getAll('trace')`, never `params.get`.
+
+## Tests — IMPORTANT for agents
+
+Tests are plain Node scripts named `test_*.js` (run with `node test_foo.js`),
+most using the shared `test_harness.js`.
+
+**CI does NOT auto-discover these tests.** They are listed explicitly in
+`../../scripts/e2e-trace-tests.sh`, which the `trace-integrity` job in
+`.github/workflows/ci.yml` runs. If you add a new `test_*.js`, you MUST add a
+line for it in `scripts/e2e-trace-tests.sh` or it will never run in CI — adding
+the file alone is not enough.

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -78,7 +78,9 @@
         <script>
             (async function () {
                 const params = new URLSearchParams(window.location.search);
-                const traceUrl = params.get("trace");
+                // `trace` is repeatable — each value is a separate (possibly
+                // gzipped) component to fetch and concatenate.
+                const traceUrls = params.getAll("trace");
                 const startNs = params.get("start") != null ? Number(params.get("start")) : null;
                 const endNs = params.get("end") != null ? Number(params.get("end")) : null;
 
@@ -94,18 +96,19 @@
                     errorEl.textContent = msg;
                 }
 
-                if (!traceUrl) {
+                if (!traceUrls.length) {
                     showError("No trace URL provided. Use ?trace=<url>&start=<ns>&end=<ns>");
                     return;
                 }
 
-                // Fetch trace
+                // Fetch trace(s): each component is fetched and gunzipped
+                // independently, then concatenated into one buffer.
                 let buffer;
                 try {
-                    loadingEl.textContent = "Fetching trace\u2026";
-                    const resp = await fetch(traceUrl);
-                    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-                    buffer = await resp.arrayBuffer();
+                    loadingEl.textContent = traceUrls.length > 1
+                        ? `Fetching ${traceUrls.length} traces\u2026`
+                        : "Fetching trace\u2026";
+                    buffer = await TraceParser.fetchTraces(traceUrls);
                 } catch (err) {
                     showError("Failed to fetch trace: " + err.message);
                     return;
@@ -165,7 +168,7 @@
                 const toTime = params.get("to");
                 const label = svc
                     ? svc + (host ? ` @ ${host}` : "")
-                    : (traceUrl.split("/").pop() || "trace");
+                    : (traceUrls[0].split("/").pop() || "trace");
                 const durMs = startNs != null && endNs != null
                     ? ((endNs - startNs) / 1e6).toFixed(2)
                     : null;

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -281,10 +281,14 @@
 
     <script src="heatmap.js"></script>
     <script>
-    // ── ?trace= passthrough: redirect to viewer ──
+    // ── ?trace= passthrough: redirect to viewer (preserving all params,
+    //    including repeated `trace=` components) ──
     (function() {
-        const t = new URLSearchParams(window.location.search).get('trace');
-        if (t) { window.location.replace('viewer.html?trace=' + encodeURIComponent(t)); return; }
+        const qs = window.location.search;
+        if (new URLSearchParams(qs).has('trace')) {
+            window.location.replace('viewer.html' + qs);
+            return;
+        }
     })();
 
     // ── Demo trace button ──

--- a/dial9-viewer/ui/test_fetch_traces.js
+++ b/dial9-viewer/ui/test_fetch_traces.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+"use strict";
+
+// Tests for fetchTraces: the `trace=` query parameter is repeatable, and each
+// component is fetched and gunzipped independently before concatenation.
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+const { assert, testAsync, summarize } = require("./test_harness.js");
+const { fetchTraces, parseTrace } = require("./trace_parser.js");
+
+// Minimal fetch() mock: maps a URL → bytes (Buffer/Uint8Array) and returns a
+// Response-like object exposing arrayBuffer(). Supports an error URL too.
+function installFetchMock(urlToBytes) {
+  const original = global.fetch;
+  global.fetch = async (url) => {
+    if (!(url in urlToBytes)) {
+      return { ok: false, status: 404, async arrayBuffer() { return new ArrayBuffer(0); } };
+    }
+    const bytes = urlToBytes[url];
+    const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return {
+      ok: true,
+      status: 200,
+      async arrayBuffer() {
+        return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+      },
+    };
+  };
+  return () => { global.fetch = original; };
+}
+
+// Normalize to a plain Uint8Array so deepStrictEqual doesn't trip on the
+// Buffer-vs-Uint8Array type tag (Node Buffers are Uint8Array subclasses).
+function bytesOf(buf) {
+  const u8 = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  return Uint8Array.from(u8);
+}
+
+async function main() {
+  const tracePath = path.join(__dirname, "demo-trace.bin");
+  if (!fs.existsSync(tracePath)) {
+    console.error(`Trace file not found: ${tracePath}`);
+    process.exit(1);
+  }
+
+  const fileBytes = fs.readFileSync(tracePath);
+  const rawTrace = fileBytes[0] === 0x1f && fileBytes[1] === 0x8b
+    ? zlib.gunzipSync(fileBytes)
+    : Buffer.from(fileBytes);
+  const gzTrace = zlib.gzipSync(rawTrace);
+
+  // Reference parse of a single raw trace.
+  const single = await parseTrace(rawTrace);
+  const singleEvents = single.events.length;
+  console.log(`Single trace: ${singleEvents} events`);
+
+  // ── Test 1: single raw URL round-trips unchanged ──
+  await testAsync("single raw component", async () => {
+    const restore = installFetchMock({ "/a": rawTrace });
+    try {
+      const buf = await fetchTraces("/a");
+      assert.deepStrictEqual(bytesOf(buf), bytesOf(rawTrace));
+    } finally { restore(); }
+  });
+
+  // ── Test 2: single gzipped URL is ungzipped to raw bytes ──
+  await testAsync("single gzipped component is ungzipped", async () => {
+    const restore = installFetchMock({ "/a.gz": gzTrace });
+    try {
+      const buf = await fetchTraces(["/a.gz"]);
+      assert.deepStrictEqual(bytesOf(buf), bytesOf(rawTrace));
+    } finally { restore(); }
+  });
+
+  // ── Test 3: mixed gzipped + raw components, each ungzipped individually,
+  //    then concatenated in order. The concatenated stream must parse as one
+  //    trace with double the events (decoder resets on mid-stream TRC\0). ──
+  await testAsync("mixed gzip/raw components concatenate and parse", async () => {
+    const restore = installFetchMock({ "/gz": gzTrace, "/raw": rawTrace });
+    try {
+      const buf = await fetchTraces(["/gz", "/raw"]);
+      const expectedLen = rawTrace.length * 2;
+      assert.strictEqual(buf.byteLength, expectedLen, "concatenated length");
+      // First half == raw trace, second half == raw trace.
+      const out = bytesOf(buf);
+      assert.deepStrictEqual(out.slice(0, rawTrace.length), bytesOf(rawTrace));
+      assert.deepStrictEqual(out.slice(rawTrace.length), bytesOf(rawTrace));
+
+      const parsed = await parseTrace(buf);
+      assert.strictEqual(parsed.events.length, singleEvents * 2,
+        `expected ${singleEvents * 2} events, got ${parsed.events.length}`);
+    } finally { restore(); }
+  });
+
+  // ── Test 4: order is preserved ──
+  await testAsync("component order is preserved", async () => {
+    const a = new Uint8Array([1, 2, 3]);
+    const b = new Uint8Array([4, 5]);
+    const c = new Uint8Array([6]);
+    const restore = installFetchMock({ "/a": a, "/b": b, "/c": c });
+    try {
+      const buf = await fetchTraces(["/a", "/b", "/c"]);
+      assert.deepStrictEqual(bytesOf(buf), new Uint8Array([1, 2, 3, 4, 5, 6]));
+    } finally { restore(); }
+  });
+
+  // ── Test 5: a failed component rejects with an informative error ──
+  await testAsync("failed fetch rejects", async () => {
+    const restore = installFetchMock({ "/ok": rawTrace });
+    try {
+      let threw = false;
+      try {
+        await fetchTraces(["/ok", "/missing"]);
+      } catch (e) {
+        threw = true;
+        assert.ok(/404/.test(e.message), `error mentions status: ${e.message}`);
+      }
+      assert.ok(threw, "expected fetchTraces to reject");
+    } finally { restore(); }
+  });
+
+  summarize();
+}
+
+main();

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -49,6 +49,43 @@
   }
 
   /**
+   * Fetch one or more trace URLs, gunzip each component individually, and
+   * concatenate them into a single ArrayBuffer.
+   *
+   * The `trace` query parameter is repeatable: each component is fetched
+   * independently and may be gzipped on its own (unlike `/api/trace`, which
+   * gunzips server-side before serving). We therefore ungzip every component
+   * here, then concatenate the raw bytes. The trace decoder treats a
+   * concatenated stream as multiple segments — a mid-stream `TRC\0` header
+   * resets the frame parser — so the combined buffer parses as one trace.
+   *
+   * @param {string|string[]} urls one URL or a list of URLs (order preserved)
+   * @param {{signal?: AbortSignal}} [opts]
+   * @returns {Promise<ArrayBuffer>}
+   */
+  async function fetchTraces(urls, opts = {}) {
+    const list = Array.isArray(urls) ? urls : [urls];
+    const parts = await Promise.all(
+      list.map(async (url) => {
+        const resp = await fetch(url, { signal: opts.signal });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${url}`);
+        const raw = await maybeGunzip(await resp.arrayBuffer());
+        return raw instanceof ArrayBuffer ? new Uint8Array(raw) : raw;
+      })
+    );
+    if (parts.length === 1) return parts[0].buffer;
+    let total = 0;
+    for (const p of parts) total += p.length;
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const p of parts) {
+      out.set(p, off);
+      off += p.length;
+    }
+    return out.buffer;
+  }
+
+  /**
    * @typedef {{
    *   eventType: number,
    *   timestamp: number,
@@ -1103,6 +1140,7 @@
       OFF_WORKER_WORKER_ID,
       parseTrace,
       parseOne,
+      fetchTraces,
       formatFrame,
       symbolizeChain,
       deduplicateSamples,
@@ -1113,6 +1151,7 @@
       EVENT_TYPES,
       OFF_WORKER_WORKER_ID,
       parseTrace,
+      fetchTraces,
       formatFrame,
       symbolizeChain,
       deduplicateSamples,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1283,14 +1283,18 @@
                 document.getElementById("load-demo")?.addEventListener("click", onLoadDemo);
             }
 
-            async function loadTraceFromUrl(url) {
+            // `urls` may be a single URL or a list (one per repeated `trace=`).
+            // Each component is fetched and gunzipped independently, then the raw
+            // buffers are concatenated into one trace (see fetchTraces).
+            async function loadTraceFromUrl(urls) {
+                const list = Array.isArray(urls) ? urls : [urls];
                 try {
-                    updateLoadProgress("Fetching…");
-                    const response = await fetch(url, { signal: loadAbortController?.signal });
-                    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-                    const arrayBuffer = await response.arrayBuffer();
+                    updateLoadProgress(list.length > 1 ? `Fetching ${list.length} traces…` : "Fetching…");
+                    const arrayBuffer = await TraceParser.fetchTraces(list, { signal: loadAbortController?.signal });
                     loadAbortController = null;
-                    const name = urlParams.get('svc') || url.split('/').pop()?.split('?')[0] || 'trace.bin';
+                    const name = urlParams.get('svc')
+                        || list[0].split('/').pop()?.split('?')[0]
+                        || 'trace.bin';
                     await parseAndShowTrace(arrayBuffer, name, getParseOptions());
                 } catch (err) {
                     if (err.name === 'AbortError') return;
@@ -1314,9 +1318,10 @@
                 clearRangeBtn.style.display = (startNs != null || endNs != null) ? "" : "none";
             }
 
-            // Check for URL parameter on load
+            // Check for URL parameter on load. `trace` is repeatable — each
+            // value is a separate (possibly gzipped) component to concatenate.
             const urlParams = new URLSearchParams(window.location.search);
-            const traceUrl = urlParams.get('trace');
+            const traceUrls = urlParams.getAll('trace');
 
             /** Build parseTrace options from current URL time range params. */
             function getParseOptions() {
@@ -1340,9 +1345,9 @@
                 window.history.replaceState(null, '', newUrl);
             }
 
-            if (traceUrl) {
-                showLoadingState('Loading trace…');
-                loadTraceFromUrl(traceUrl);
+            if (traceUrls.length) {
+                showLoadingState(traceUrls.length > 1 ? `Loading ${traceUrls.length} traces…` : 'Loading trace…');
+                loadTraceFromUrl(traceUrls);
             }
 
             function onLoadDemo(e) {
@@ -5214,18 +5219,19 @@
 
             function handleFgPopout() {
                 const params = new URLSearchParams(window.location.search);
-                let traceUrl = params.get("trace");
+                let traceUrls = params.getAll("trace");
                 let isBlobUrl = false;
-                if (!traceUrl && currentTraceBuffer) {
+                if (!traceUrls.length && currentTraceBuffer) {
                     const blob = new Blob([currentTraceBuffer]);
-                    traceUrl = URL.createObjectURL(blob);
+                    traceUrls = [URL.createObjectURL(blob)];
                     isBlobUrl = true;
                 }
-                if (!traceUrl) {
+                if (!traceUrls.length) {
                     showToast("popout-no-url", "Pop-out requires a loaded trace", "error", 3000);
                     return;
                 }
-                let url = `flamegraph.html?trace=${encodeURIComponent(traceUrl)}&start=${Math.round(fgSelStart)}&end=${Math.round(fgSelEnd)}`;
+                const traceQs = traceUrls.map(u => `trace=${encodeURIComponent(u)}`).join("&");
+                let url = `flamegraph.html?${traceQs}&start=${Math.round(fgSelStart)}&end=${Math.round(fgSelEnd)}`;
                 const z = fgInstance.getZoomPath();
                 if (z.worker.length > 0) url += `&worker-zoom=${encodeURIComponent(z.worker.join("\t"))}`;
                 if (z.offworker.length > 0) url += `&offworker-zoom=${encodeURIComponent(z.offworker.join("\t"))}`;

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -44,6 +44,9 @@ node dial9-viewer/ui/test_task_lifecycle.js
 echo "--- Checking trace analysis ---"
 node dial9-viewer/ui/test_trace_analysis.js
 
+echo "--- Checking multi-component trace fetch (repeatable trace=) ---"
+node dial9-viewer/ui/test_fetch_traces.js
+
 echo "--- Checking skills snippets ---"
 node dial9-viewer/ui/test_all_skills_snippets.js
 


### PR DESCRIPTION
## What

Make the `trace=` query parameter **repeatable** in the trace viewer (`viewer.html`) and standalone flamegraph (`flamegraph.html`), so you can load several trace components in one URL:

```
viewer.html?trace=<url1>&trace=<url2>&trace=<url3.gz>
```

## Why this needed work

The decoder already concatenates raw trace streams (a mid-stream `TRC\0` header resets the frame parser, so segments parse as one trace), and the `/api/trace` endpoint already gunzips its S3 objects server-side. The gap was on the fetch side: when components are fetched as **independent** `trace=` URLs, each one may be gzipped on its own, and nothing ungzipped them before concatenation.

## How

- **`trace_parser.js`**: new exported `fetchTraces(urls, opts)` — fetches each URL (in parallel, honoring an `AbortSignal`), runs each component through the existing `maybeGunzip`, then concatenates the raw bytes into one `ArrayBuffer`. Exported from both the Node and browser export blocks.
- **`viewer.html`**: reads `urlParams.getAll('trace')`; `loadTraceFromUrl` takes a single URL or a list and delegates to `fetchTraces`. Pop-out forwards all `trace=` params to the flamegraph.
- **`flamegraph.html`**: reads `params.getAll("trace")` and fetches via `fetchTraces`.
- **`index.html`**: the `?trace=` passthrough now forwards the whole query string, preserving every repeated `trace=` value.

## Tests

- **`test_fetch_traces.js`** (new): single raw, single gzipped→ungzipped, mixed gzip/raw concatenation that parses as one trace with 2× the events, order preservation, and fetch-error propagation. Mocks `fetch`, so no network.
- Registered the new test in **`scripts/e2e-trace-tests.sh`** (the `trace-integrity` CI job runs it) — CI does not auto-discover JS tests.
- Existing JS suite still green; `cargo build -p dial9-viewer` confirms `rust-embed` picks up the new files.

## Docs

Added `dial9-viewer/ui/README.md` and a note in `AGENTS.md` documenting that new `test_*.js` files must be registered in `e2e-trace-tests.sh`, since CI won't find them otherwise.