### PR TITLE
docs(agents): relax workflow-specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,14 @@ Failing to update it will cause the viewer to fail when loading the demo.
 
 ## Agent skills
 
+### Trace analysis skills
+
+When analyzing dial9 traces or helping users use the viewer, discover the available trace-analysis skills with:
+
+```bash
+cargo run -p dial9-viewer -- agents
+```
+
 ### Issue tracker
 
 GitHub Issues on `dial9-rs/dial9-tokio-telemetry`. See `docs/agents/issue-tracker.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,17 +54,18 @@ the wire (not a compiled-in schema) to decode events.
 
 ## Coding practices
 
-**Never use `unwrap_or(0)`, `unwrap_or_default()`, or similar "fallback to
-zero/sentinel" patterns.** These hide bugs by silently producing plausible but
-wrong values. Always consider the actual error condition: propagate the error,
-return `Option`, log and skip, or panic if the invariant is truly unrecoverable.
+**Do not hide missing data or errors with plausible defaults like `unwrap_or(0)`
+or `unwrap_or_default()`.** Use an explicit semantic default only when it is
+truly valid for the domain, such as an empty collection. Otherwise, handle the
+actual condition: propagate the error, return `Option`, log and skip, or panic if
+the invariant is truly unrecoverable.
 
 Avoid dropping an error without logging it. Use `tracing` for logging.
 ```
 let _ = ...
 ```
 
-**ALWAYS rate-limit logging that can fire from a loop or repeated error path.** Any `warn!`/`error!` reachable from a background task loop, retry loop, or per-request hot path MUST be wrapped in `rate_limited!`:
+**Rate-limit logging that can fire repeatedly from loops or high-volume paths.** Any repeated `warn!`/`error!` reachable from a background task loop, retry loop, or other unbounded error path should be wrapped in `rate_limited!`:
 ```rust
 rate_limited!(Duration::from_secs(60), {
     tracing::warn!("...: {e}");
@@ -74,7 +75,7 @@ Unguarded logging in loops causes log spam that degrades observability and can i
 
 ## Running tests
 
-- Always run `cargo nextest run` to run tests.
+- For Rust behavior changes, run `cargo nextest run`.
 - For final verification of Rust changes, run `cargo nextest run --stress-duration 20s`. The package is expected to have no flaky tests; report any apparent flake instead of ignoring it.
 - **JS/HTML-only changes** (no `.rs` files touched, no trace format changes): you do NOT need to run the full Rust test suite or the stress test. Run the relevant JS tests under `dial9-viewer/ui/test_*.js` with `node <test>` and a quick `cargo build -p dial9-viewer` to confirm `rust-embed` picks up any new files. Skip `cargo nextest` / stress run.
 - **Adding a new `dial9-viewer/ui/test_*.js` file:** CI does NOT auto-discover JS tests. You MUST register the new file in `scripts/e2e-trace-tests.sh` (the `trace-integrity` CI job runs that script), or it will never run in CI. See `dial9-viewer/ui/README.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,6 @@
 # Agent Guidelines
 
-- You MUST use Red/Green TDD.
-- BEFORE COMMITING: `cargo nextest run --stress-duration 20s`. The package has no flaky tests. If you find a flaky test, you created it.
-- **JS/HTML-only changes** (no `.rs` files touched, no trace format changes): you do NOT need to run the full Rust test suite or the stress test. Run the relevant JS tests under `dial9-viewer/ui/test_*.js` with `node <test>` and a quick `cargo build -p dial9-viewer` to confirm `rust-embed` picks up any new files. Skip `cargo nextest` / stress run.
-- **Adding a new `dial9-viewer/ui/test_*.js` file:** CI does NOT auto-discover JS tests. You MUST register the new file in `scripts/e2e-trace-tests.sh` (the `trace-integrity` CI job runs that script), or it will never run in CI. See `dial9-viewer/ui/README.md`.
+- Prefer Red/Green TDD for non-trivial behavior changes unless the user explicitly requests a different workflow.
 
 ## API Design
 
@@ -77,17 +74,20 @@ Unguarded logging in loops causes log spam that degrades observability and can i
 
 ## Running tests
 
-- Always run `cargo nextest run` to run tests
+- Always run `cargo nextest run` to run tests.
+- For final verification of Rust changes, run `cargo nextest run --stress-duration 20s`. The package is expected to have no flaky tests; report any apparent flake instead of ignoring it.
+- **JS/HTML-only changes** (no `.rs` files touched, no trace format changes): you do NOT need to run the full Rust test suite or the stress test. Run the relevant JS tests under `dial9-viewer/ui/test_*.js` with `node <test>` and a quick `cargo build -p dial9-viewer` to confirm `rust-embed` picks up any new files. Skip `cargo nextest` / stress run.
+- **Adding a new `dial9-viewer/ui/test_*.js` file:** CI does NOT auto-discover JS tests. You MUST register the new file in `scripts/e2e-trace-tests.sh` (the `trace-integrity` CI job runs that script), or it will never run in CI. See `dial9-viewer/ui/README.md`.
 - Shuttle tests are NOT included in `cargo nextest run`. They require a separate invocation: `./scripts/test-shuttle.sh`. Always run this when modifying code under `#[cfg(all(test, shuttle))]` or the flush/source paths.
 
-## Ownership
+## Scope
 
-- You own all code you are working on. There is no such thing as a "pre-existing failure" or something that is "not your problem." If you see a warning or failure, fix it.
+- If you encounter unrelated or pre-existing warnings/failures, report them clearly and ask before fixing. Fix them immediately only when they block the requested work.
 
-## Pre-commit checks
+## Formatting and linting
 
-- You MUST run `cargo fmt --check` and `cargo clippy --all-targets --all-features` before every commit. Both must be clean.
-- **Preserve doc comments and inline comments.** Before presenting a PR, diff your changes and verify you have not accidentally deleted documentation comments (`///`, `//!`), inline explanatory comments (`//`), or module-level docs. Refactors that move code must carry all associated comments with it.
+- For Rust code changes, run `cargo fmt --check` and `cargo clippy --all-targets --all-features`. Report if you did not run them.
+- **Preserve doc comments and inline comments.** When reviewing your diff, verify you have not accidentally deleted documentation comments (`///`, `//!`), inline explanatory comments (`//`), or module-level docs. Refactors that move code must carry all associated comments with it.
 
 ## Demo Trace
 
@@ -110,8 +110,6 @@ rm -f dial9-viewer/ui/demo-trace.bin
 cargo build --release -p metrics-service
 AWS_PROFILE=your-profile cargo run --release -p metrics-service --bin metrics-service -- --trace-path sched-trace.bin --demo
 cp sched-trace.*.bin dial9-viewer/ui/demo-trace.bin
-git add dial9-viewer/ui/demo-trace.bin
-git commit -m "Regenerate demo trace after format changes"
 ```
 
 The demo trace is used for:
@@ -121,14 +119,9 @@ The demo trace is used for:
 
 Failing to update it will cause the viewer to fail when loading the demo.
 
-## Meta
+## Repository management
 
-- Never declare done after pushing or opening a PR until CI is green. Check CI status and fix any failures before moving on.
-- **Do not stack PRs** (PR B targeting PR A's branch). The merge queue rewrites commits, so stacked PRs always end up with merge conflicts. Instead, wait for the first PR to merge, then rebase the second onto `main`.
-
-## Ways of working
-- After finishing your work use showboat to demonstrate what you have done. include key code, tests, and what was changed.
-- Use a progress doc to keep track of what you are doing. progress docs are just for you. when we are ready for PR, we unstage the progress docs
+- Only when explicitly asked to open or manage PRs: do not stack PRs (PR B targeting PR A's branch). The merge queue rewrites commits, so stacked PRs always end up with merge conflicts. Instead, wait for the first PR to merge, then rebase the second onto `main`.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # Agent Guidelines
 
-- Prefer Red/Green TDD for non-trivial behavior changes unless the user explicitly requests a different workflow.
-
 ## API Design
 
 This is a published library with backwards compatibility requirements. Follow
@@ -73,8 +71,9 @@ rate_limited!(Duration::from_secs(60), {
 ```
 Unguarded logging in loops causes log spam that degrades observability and can itself become a performance problem. One-time paths (startup, shutdown, per-thread init) are exempt.
 
-## Running tests
+## Testing
 
+- Behavior changes should include focused tests that fail without the change; if tests are not practical, state why.
 - For Rust behavior changes, run `cargo nextest run`.
 - For final verification of Rust changes, run `cargo nextest run --stress-duration 20s`. The package is expected to have no flaky tests; report any apparent flake instead of ignoring it.
 - **JS/HTML-only changes** (no `.rs` files touched, no trace format changes): you do NOT need to run the full Rust test suite or the stress test. Run the relevant JS tests under `dial9-viewer/ui/test_*.js` with `node <test>` and a quick `cargo build -p dial9-viewer` to confirm `rust-embed` picks up any new files. Skip `cargo nextest` / stress run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
# Changes

- Minimal changes required to relax `AGENTS.md` instructions.
  - Users of coding agents that recognize that instruction file will fight less the coding agent.
- Create a `CLAUDE.md` with an `@AGENTS.md` instruction to make the Claude Code experience equal to other coding agents.
  - Claude Code users will notice the model now follows instructions more strictly.
- Added a tiny mention on how to discover the viewer skills.

## CLAUDE.md

Seems like `@AGENTS.md` is resolved by the agent harness. `@` is special in `CLAUDE.md`. It seems to solve the inconsistency pointed in the issue.

Tested using the drastic example of the issue:

<img width="2032" height="1162" alt="Screenshot 2026-06-17 at 10 40 36 PM" src="https://github.com/user-attachments/assets/04441ed8-01ac-4cf8-bb19-c6a867309745" />

No tool call, no exploration. Just an immediate answer rejecting the user prompt.

Claude docs says these are basically "imports":

<img width="779" height="280" alt="Screenshot 2026-06-17 at 11 30 05 PM" src="https://github.com/user-attachments/assets/a04de74c-6c29-45c4-9988-58aba0e46113" />

## Note

From now on, even Claude Code users should notice the model follows instructions better (like, for real this time).

Be careful when wrtting new rules or editing existing ones. Saying something like `You MUST ALWAYS do this` will have a real impact now.

Be mindful with your changes, and tune them as needed later.

# Other

Closes #550 