### PR TITLE
Add POST route to upload then serve a trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,7 @@ dependencies = [
  "aws-sdk-s3",
  "axum",
  "axum-extra",
+ "bon",
  "clap",
  "flate2",
  "futures",
@@ -1638,6 +1639,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -34,12 +34,14 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 rust-embed = { version = "8", features = ["mime-guess"] }
 mime_guess = "2"
-tower-http = { version = "0.6", features = ["fs"] }
+tower-http = { version = "0.6", features = ["fs", "cors"] }
+uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "http-1x", "rt-tokio", "sigv4a"] }
 anyhow = "1"
+bon = "3"
 s3s = { version = "0.13.0", optional = true }
 s3s-fs = { version = "0.13.0", optional = true }
 s3s-aws = { version = "0.13.0", optional = true }

--- a/dial9-viewer/src/cli.rs
+++ b/dial9-viewer/src/cli.rs
@@ -47,6 +47,12 @@ enum Commands {
         /// Dev mode: serve UI files from disk for faster iteration
         #[arg(long)]
         dev: bool,
+
+        /// Enable the temporary trace-upload feature: lets another site POST a
+        /// trace (`POST /api/upload`) and have the viewer serve it back once.
+        /// Off by default; there is no auth, so only enable on a trusted network.
+        #[arg(long)]
+        enable_upload: bool,
     },
     /// Tools for working with agent-generated HTML reports
     Report {
@@ -140,8 +146,17 @@ pub async fn run() -> anyhow::Result<()> {
             prefix,
             local_dir,
             dev,
+            enable_upload,
         } => {
-            return crate::serve(port, bucket, prefix, local_dir, dev).await;
+            return crate::serve(crate::ServeConfig {
+                port,
+                bucket,
+                prefix,
+                local_dir,
+                dev,
+                enable_upload,
+            })
+            .await;
         }
         Commands::Report { action } => match action {
             ReportAction::Serve { path, port } => {

--- a/dial9-viewer/src/lib.rs
+++ b/dial9-viewer/src/lib.rs
@@ -23,12 +23,25 @@ async fn detect_bucket_region(bucket: &str) -> Option<String> {
     }
 }
 
+/// Configuration for the `serve` subcommand, assembled from CLI args.
+pub(crate) struct ServeConfig {
+    pub port: u16,
+    pub bucket: Option<String>,
+    pub prefix: Option<String>,
+    pub local_dir: Option<PathBuf>,
+    pub dev: bool,
+    pub enable_upload: bool,
+}
+
 pub(crate) async fn serve(
-    port: u16,
-    bucket: Option<String>,
-    prefix: Option<String>,
-    local_dir: Option<PathBuf>,
-    dev: bool,
+    ServeConfig {
+        port,
+        bucket,
+        prefix,
+        local_dir,
+        dev,
+        enable_upload,
+    }: ServeConfig,
 ) -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -101,6 +114,15 @@ pub(crate) async fn serve(
             state = state.with_dev_ui_dir(d);
         }
         state
+    };
+
+    let app_state = if enable_upload {
+        tracing::info!(
+            "trace-upload feature enabled (POST /api/upload); no auth — trusted network only"
+        );
+        app_state.with_uploads(server::UploadLimits::default())
+    } else {
+        app_state
     };
 
     let app = server::router(app_state);

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -1,16 +1,21 @@
 use crate::storage::StorageBackend;
 use axum::Router;
 use axum::body::Body;
+use axum::extract::DefaultBodyLimit;
 use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use rust_embed::Embed;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tower_http::cors::CorsLayer;
 
 mod config;
 mod prefixes;
 mod search;
 mod trace;
+mod upload;
+
+pub use upload::{UploadLimits, UploadStore};
 
 #[derive(Embed)]
 #[folder = "ui/"]
@@ -24,6 +29,9 @@ pub struct AppState {
     pub default_prefix: Option<String>,
     /// When set, serve UI files from disk instead of embedded assets.
     pub dev_ui_dir: Option<PathBuf>,
+    /// In-memory store of temporary, POSTed traces. `None` (the default) means
+    /// the trace-upload feature is disabled and its routes are not registered.
+    pub uploads: Option<Arc<UploadStore>>,
 }
 
 impl AppState {
@@ -37,11 +45,19 @@ impl AppState {
             default_bucket,
             default_prefix,
             dev_ui_dir: None,
+            uploads: None,
         }
     }
 
     pub fn with_dev_ui_dir(mut self, dir: PathBuf) -> Self {
         self.dev_ui_dir = Some(dir);
+        self
+    }
+
+    /// Enable the temporary trace-upload feature with the given caps. Without
+    /// this, `POST /api/upload` and `GET /api/uploaded/{id}` are not registered.
+    pub fn with_uploads(mut self, limits: UploadLimits) -> Self {
+        self.uploads = Some(Arc::new(UploadStore::new(limits)));
         self
     }
 }
@@ -80,10 +96,34 @@ async fn serve_embedded(uri: axum::http::Uri) -> Response {
 }
 
 fn api_router(state: AppState) -> Router {
+    // Body limit for the upload route. When uploads are disabled there's no
+    // configured store, so fall back to the default cap — the handler rejects
+    // the request with 404 anyway, this just bounds buffering until it does.
+    let upload_body_limit = state
+        .uploads
+        .as_ref()
+        .map(|u| u.max_upload_bytes())
+        .unwrap_or_else(|| UploadLimits::default().max_upload_bytes());
+
+    // The upload route gets its own (large) body limit; other routes keep
+    // axum's conservative default. The trace-upload feature is opt-in
+    // (`dial9 serve --enable-upload`): the routes are always present, but when
+    // uploads are disabled the handlers return 404, as if the feature were
+    // absent. (Registering unconditionally keeps the status deterministic
+    // regardless of the static-file fallback, which 405s POSTs in dev mode.)
+    let upload_route = Router::new()
+        .route("/upload", axum::routing::post(upload::upload_trace))
+        .layer(DefaultBodyLimit::max(upload_body_limit));
+
     Router::new()
         .route("/config", axum::routing::get(config::get_config))
         .route("/prefixes", axum::routing::get(prefixes::list_prefixes))
         .route("/search", axum::routing::get(search::search))
         .route("/trace", axum::routing::get(trace::get_trace))
+        .route("/uploaded/{id}", axum::routing::get(upload::get_uploaded))
+        .merge(upload_route)
+        // Permissive CORS so a page on another origin can POST a trace and read
+        // it back via fetch(); also answers the OPTIONS preflight automatically.
+        .layer(CorsLayer::permissive())
         .with_state(state)
 }

--- a/dial9-viewer/src/server/upload.rs
+++ b/dial9-viewer/src/server/upload.rs
@@ -1,0 +1,363 @@
+//! Temporary in-memory trace uploads.
+//!
+//! Lets another site `POST` a trace file to the viewer and get back a link its
+//! users can open. Uploads live only in memory: they are bounded by per-upload
+//! size, total-bytes, and count caps, and are reclaimed by a TTL. Each upload is
+//! **single-use** — the first successful `GET` removes it, so a reload or a
+//! second tab will 404. There is no auth; safety relies on the caps plus where
+//! the viewer is deployed on the network.
+//!
+//! The bytes are stored and served verbatim (gzipped or raw). The viewer's
+//! fetch path already sniffs and gunzips client-side, exactly as it does for any
+//! other `?trace=<url>`, so no server-side decoding happens here.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use axum::body::{Body, Bytes};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use crate::server::AppState;
+
+/// gzip magic (RFC 1952): a gzipped trace starts with these two bytes.
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+/// Trace-format magic `TRC\0` (see `dial9-trace-format` `codec::MAGIC`). A raw,
+/// uncompressed trace starts with these four bytes.
+const TRACE_MAGIC: [u8; 4] = [0x54, 0x52, 0x43, 0x00];
+
+/// Caps on the in-memory upload store. Defaults are sized for a viewer host with
+/// a few GiB of headroom; tests construct small limits to exercise the reject
+/// paths cheaply.
+///
+/// Built via [`UploadLimits::builder`]. Fields are private with defaults so new
+/// caps can be added later without breaking callers (per the crate's API rules).
+#[derive(Debug, Clone, Copy, bon::Builder)]
+pub struct UploadLimits {
+    /// Maximum size of a single uploaded trace (default 256 MiB).
+    #[builder(default = 256 * 1024 * 1024)]
+    max_upload_bytes: usize,
+    /// Maximum total bytes held across all live uploads (default 1 GiB).
+    #[builder(default = 1024 * 1024 * 1024)]
+    max_total_bytes: usize,
+    /// Maximum number of live uploads (default 100).
+    #[builder(default = 100)]
+    max_uploads: usize,
+    /// How long an unfetched upload is retained before it is reclaimed
+    /// (default 1 hour).
+    #[builder(default = Duration::from_secs(60 * 60))]
+    ttl: Duration,
+}
+
+impl Default for UploadLimits {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+impl UploadLimits {
+    /// Maximum size of a single uploaded trace, in bytes.
+    pub fn max_upload_bytes(&self) -> usize {
+        self.max_upload_bytes
+    }
+}
+
+struct StoredUpload {
+    bytes: Vec<u8>,
+    expires_at: Instant,
+}
+
+/// In-memory store of temporary uploads, guarded by a `std::sync::Mutex`. The
+/// lock is only ever held for synchronous map operations, never across `.await`.
+pub struct UploadStore {
+    limits: UploadLimits,
+    inner: Mutex<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    entries: HashMap<String, StoredUpload>,
+    total_bytes: usize,
+}
+
+/// Why an upload could not be accepted.
+#[derive(Debug)]
+enum InsertError {
+    /// The store is at its byte or count capacity.
+    CapacityExceeded,
+}
+
+impl UploadStore {
+    pub fn new(limits: UploadLimits) -> Self {
+        Self {
+            limits,
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    pub fn max_upload_bytes(&self) -> usize {
+        self.limits.max_upload_bytes
+    }
+
+    /// Store `bytes` under a fresh id, returning the id. Purges expired entries
+    /// first, then rejects if the new upload would exceed the byte or count cap.
+    fn insert(&self, bytes: Vec<u8>, now: Instant) -> Result<String, InsertError> {
+        let len = bytes.len();
+        let mut inner = self.inner.lock().expect("upload store mutex poisoned");
+
+        // Lazily reclaim anything that has expired before checking capacity.
+        inner.purge_expired(now);
+
+        // Per-upload size is also bounded at the HTTP layer (DefaultBodyLimit),
+        // but enforce it here too so the store that owns the limit is the source
+        // of truth and any future caller of `insert` stays bounded.
+        if len > self.limits.max_upload_bytes
+            || inner.entries.len() >= self.limits.max_uploads
+            || inner.total_bytes.saturating_add(len) > self.limits.max_total_bytes
+        {
+            return Err(InsertError::CapacityExceeded);
+        }
+
+        // uuid v4 is collision-safe in practice; loop defensively rather than
+        // risk silently overwriting (and leaking the byte count of) an entry.
+        let id = loop {
+            let candidate = uuid::Uuid::new_v4().to_string();
+            if !inner.entries.contains_key(&candidate) {
+                break candidate;
+            }
+        };
+
+        inner.total_bytes += len;
+        inner.entries.insert(
+            id.clone(),
+            StoredUpload {
+                bytes,
+                expires_at: now + self.limits.ttl,
+            },
+        );
+        Ok(id)
+    }
+
+    /// Remove and return the upload for `id` if present and not expired
+    /// (single-use). Returns `None` for unknown or expired ids.
+    fn take(&self, id: &str, now: Instant) -> Option<Vec<u8>> {
+        let mut inner = self.inner.lock().expect("upload store mutex poisoned");
+        let entry = inner.entries.remove(id)?;
+        inner.total_bytes -= entry.bytes.len();
+        if entry.expires_at <= now {
+            // Expired: we've already removed it, so just report it as gone.
+            return None;
+        }
+        Some(entry.bytes)
+    }
+}
+
+impl Inner {
+    fn purge_expired(&mut self, now: Instant) {
+        let mut freed = 0;
+        self.entries.retain(|_, entry| {
+            let keep = entry.expires_at > now;
+            if !keep {
+                freed += entry.bytes.len();
+            }
+            keep
+        });
+        self.total_bytes -= freed;
+    }
+}
+
+#[derive(Serialize)]
+struct UploadResponse {
+    /// The generated id for the uploaded trace.
+    id: String,
+    /// Relative URL that serves the raw trace bytes (single-use).
+    trace_url: String,
+    /// Relative URL the caller can redirect users to in order to view the trace.
+    viewer_url: String,
+}
+
+/// `POST /api/upload` — store the request body as a temporary trace.
+///
+/// The body must be a gzipped (`1f 8b`) or raw (`TRC\0`) trace. Returns JSON
+/// with relative URLs; the caller prepends the viewer's origin (which it just
+/// POSTed to). Relative URLs survive proxies and unknown public hostnames.
+pub async fn upload_trace(
+    State(state): State<AppState>,
+    body: Bytes,
+) -> Result<Response, (StatusCode, String)> {
+    if body.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "empty body".to_string()));
+    }
+
+    let is_gzip = body.starts_with(&GZIP_MAGIC);
+    let is_trace = body.starts_with(&TRACE_MAGIC);
+    if !is_gzip && !is_trace {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "body is not a trace: expected gzip or 'TRC\\0' magic".to_string(),
+        ));
+    }
+
+    // Routes are only mounted when uploads are enabled, so this is always
+    // `Some` in practice; treat a missing store as the feature being off.
+    let store = state
+        .uploads
+        .as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "uploads disabled".to_string()))?;
+
+    let now = Instant::now();
+    let id = store
+        .insert(body.to_vec(), now)
+        .map_err(|InsertError::CapacityExceeded| {
+            (
+                StatusCode::INSUFFICIENT_STORAGE,
+                "upload store is full; try again later".to_string(),
+            )
+        })?;
+
+    let trace_url = format!("/api/uploaded/{id}");
+    let viewer_url = format!("/viewer.html?trace={}", urlencode_component(&trace_url));
+    tracing::info!(%id, bytes = body.len(), "stored temporary trace upload");
+
+    let resp = UploadResponse {
+        id,
+        trace_url,
+        viewer_url,
+    };
+    Ok((StatusCode::OK, axum::Json(resp)).into_response())
+}
+
+/// `GET /api/uploaded/{id}` — serve a previously uploaded trace, then delete it
+/// (single-use). 404 if the id is unknown or expired.
+pub async fn get_uploaded(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Response, (StatusCode, String)> {
+    let store = state
+        .uploads
+        .as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "uploads disabled".to_string()))?;
+
+    match store.take(&id, Instant::now()) {
+        Some(bytes) => Ok(Response::builder()
+            .header("content-type", "application/octet-stream")
+            .header("content-disposition", "attachment; filename=\"trace.bin\"")
+            .body(Body::from(bytes))
+            .expect("static headers and owned body are always valid")
+            .into_response()),
+        None => Err((StatusCode::NOT_FOUND, "no such upload".to_string())),
+    }
+}
+
+/// Percent-encode the characters that matter inside a single query-param value.
+/// Kept tiny and local so we don't pull in a URL-encoding dependency just to
+/// escape a path we control (only `/` realistically appears).
+fn urlencode_component(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> UploadStore {
+        UploadStore::new(UploadLimits::default())
+    }
+
+    #[test]
+    fn insert_then_take_round_trips() {
+        let s = store();
+        let now = Instant::now();
+        let id = s.insert(b"TRC\0hello".to_vec(), now).unwrap();
+        assert_eq!(s.take(&id, now).as_deref(), Some(&b"TRC\0hello"[..]));
+    }
+
+    #[test]
+    fn take_is_single_use() {
+        let s = store();
+        let now = Instant::now();
+        let id = s.insert(b"TRC\0".to_vec(), now).unwrap();
+        assert!(s.take(&id, now).is_some());
+        assert!(s.take(&id, now).is_none());
+    }
+
+    #[test]
+    fn expired_entry_is_not_returned() {
+        let s = UploadStore::new(UploadLimits::builder().ttl(Duration::from_secs(10)).build());
+        let now = Instant::now();
+        let id = s.insert(b"TRC\0".to_vec(), now).unwrap();
+        let later = now + Duration::from_secs(11);
+        assert!(s.take(&id, later).is_none());
+    }
+
+    #[test]
+    fn count_cap_rejects_then_purge_frees_room() {
+        let s = UploadStore::new(
+            UploadLimits::builder()
+                .max_uploads(1)
+                .ttl(Duration::from_secs(10))
+                .build(),
+        );
+        let now = Instant::now();
+        s.insert(b"TRC\0".to_vec(), now).unwrap();
+        assert!(matches!(
+            s.insert(b"TRC\0".to_vec(), now),
+            Err(InsertError::CapacityExceeded)
+        ));
+        // Once the first entry expires, an insert purges it and succeeds.
+        let later = now + Duration::from_secs(11);
+        assert!(s.insert(b"TRC\0".to_vec(), later).is_ok());
+    }
+
+    #[test]
+    fn total_bytes_cap_rejects() {
+        let s = UploadStore::new(UploadLimits::builder().max_total_bytes(8).build());
+        let now = Instant::now();
+        s.insert(vec![0u8; 6], now).unwrap();
+        assert!(matches!(
+            s.insert(vec![0u8; 6], now),
+            Err(InsertError::CapacityExceeded)
+        ));
+    }
+
+    #[test]
+    fn per_upload_size_cap_rejects() {
+        let s = UploadStore::new(UploadLimits::builder().max_upload_bytes(8).build());
+        let now = Instant::now();
+        assert!(matches!(
+            s.insert(vec![0u8; 9], now),
+            Err(InsertError::CapacityExceeded)
+        ));
+        // At the limit is allowed.
+        assert!(s.insert(vec![0u8; 8], now).is_ok());
+    }
+
+    #[test]
+    fn total_bytes_decremented_on_take() {
+        let s = store();
+        let now = Instant::now();
+        let id = s.insert(vec![0u8; 100], now).unwrap();
+        s.take(&id, now);
+        assert_eq!(s.inner.lock().unwrap().total_bytes, 0);
+    }
+
+    #[test]
+    fn urlencode_escapes_slashes() {
+        assert_eq!(
+            urlencode_component("/api/uploaded/x"),
+            "%2Fapi%2Fuploaded%2Fx"
+        );
+    }
+}

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -1,5 +1,5 @@
 use assert2::check;
-use dial9_viewer::server::{AppState, router};
+use dial9_viewer::server::{AppState, UploadLimits, router};
 use dial9_viewer::storage::{LocalBackend, ObjectInfo, S3Backend, StorageBackend, StorageError};
 use std::future::Future;
 use std::pin::Pin;
@@ -707,6 +707,283 @@ async fn local_path_traversal_rejected() {
         .unwrap();
     // Should fail — either not found or error, but not 200
     check!(resp.status().as_u16() != 200);
+}
+
+// --- trace upload tests ---
+
+/// A minimal but valid trace prefix: the `TRC\0` magic the upload validator
+/// looks for. The bytes after it don't matter for the upload path (the viewer
+/// decodes client-side), so we just need recognizable content to round-trip.
+const TRACE_MAGIC_BYTES: &[u8] = b"TRC\0sample-trace-bytes";
+
+/// An `AppState` with the (opt-in) upload feature enabled at default caps.
+fn upload_state() -> AppState {
+    AppState::new(Arc::new(FakeBackend), None, None).with_uploads(UploadLimits::default())
+}
+
+/// Uploads are opt-in: without `.with_uploads(...)` (i.e. no `--enable-upload`),
+/// the upload routes are not registered and both endpoints 404.
+#[tokio::test]
+async fn upload_disabled_by_default() {
+    let state = AppState::new(Arc::new(FakeBackend), None, None);
+    let base = start_server(state).await;
+    let client = reqwest::Client::new();
+
+    let post = client
+        .post(format!("{base}/api/upload"))
+        .body(TRACE_MAGIC_BYTES.to_vec())
+        .send()
+        .await
+        .unwrap();
+    check!(post.status().as_u16() == 404);
+
+    let get = client
+        .get(format!("{base}/api/uploaded/anything"))
+        .send()
+        .await
+        .unwrap();
+    check!(get.status().as_u16() == 404);
+}
+
+/// POST a trace, then GET it back via the returned `trace_url`. The bytes must
+/// survive verbatim.
+#[tokio::test]
+async fn upload_round_trips() {
+    let base = start_server(upload_state()).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/upload"))
+        .body(TRACE_MAGIC_BYTES.to_vec())
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let trace_url = body["trace_url"].as_str().unwrap();
+    check!(body["id"].as_str().is_some());
+    check!(trace_url.starts_with("/api/uploaded/"));
+    // viewer_url points the viewer at the trace via the existing ?trace= param.
+    check!(
+        body["viewer_url"]
+            .as_str()
+            .unwrap()
+            .starts_with("/viewer.html?trace=%2Fapi%2Fuploaded%2F")
+    );
+
+    let trace_resp = client
+        .get(format!("{base}{trace_url}"))
+        .send()
+        .await
+        .unwrap();
+    check!(trace_resp.status().as_u16() == 200);
+    let fetched = trace_resp.bytes().await.unwrap();
+    check!(fetched.as_ref() == TRACE_MAGIC_BYTES);
+}
+
+/// The second GET of an uploaded trace 404s — uploads are single-use.
+#[tokio::test]
+async fn upload_is_single_use() {
+    let base = start_server(upload_state()).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/upload"))
+        .body(TRACE_MAGIC_BYTES.to_vec())
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let trace_url = body["trace_url"].as_str().unwrap().to_string();
+
+    let first = client
+        .get(format!("{base}{trace_url}"))
+        .send()
+        .await
+        .unwrap();
+    check!(first.status().as_u16() == 200);
+
+    let second = client
+        .get(format!("{base}{trace_url}"))
+        .send()
+        .await
+        .unwrap();
+    check!(second.status().as_u16() == 404);
+}
+
+/// GET of an id that was never uploaded 404s.
+#[tokio::test]
+async fn uploaded_unknown_id_not_found() {
+    let base = start_server(upload_state()).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/api/uploaded/does-not-exist"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 404);
+}
+
+/// Empty bodies and bytes lacking the gzip/`TRC\0` magic are rejected with 400.
+#[tokio::test]
+async fn upload_rejects_invalid_bodies() {
+    let base = start_server(upload_state()).await;
+    let client = reqwest::Client::new();
+
+    let empty = client
+        .post(format!("{base}/api/upload"))
+        .body(Vec::<u8>::new())
+        .send()
+        .await
+        .unwrap();
+    check!(empty.status().as_u16() == 400);
+
+    let junk = client
+        .post(format!("{base}/api/upload"))
+        .body(b"not a trace at all".to_vec())
+        .send()
+        .await
+        .unwrap();
+    check!(junk.status().as_u16() == 400);
+}
+
+/// A gzipped body is accepted (matches how traces are stored on the wire).
+#[tokio::test]
+async fn upload_accepts_gzipped_body() {
+    let base = start_server(upload_state()).await;
+    let client = reqwest::Client::new();
+
+    let gz = gzip_bytes(b"TRC\0whatever");
+    let resp = client
+        .post(format!("{base}/api/upload"))
+        .body(gz.clone())
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+
+    // Stored verbatim: the bytes come back gzipped, the viewer gunzips client-side.
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let trace_url = body["trace_url"].as_str().unwrap();
+    let fetched = client
+        .get(format!("{base}{trace_url}"))
+        .send()
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    check!(fetched.as_ref() == gz.as_slice());
+}
+
+/// A body larger than the per-upload limit is rejected by the body-limit layer
+/// (413 Payload Too Large).
+#[tokio::test]
+async fn upload_rejects_oversized_body() {
+    let limits = UploadLimits::builder().max_upload_bytes(64).build();
+    let state = AppState::new(Arc::new(FakeBackend), None, None).with_uploads(limits);
+    let base = start_server(state).await;
+    let client = reqwest::Client::new();
+
+    let mut big = b"TRC\0".to_vec();
+    big.resize(256, 0);
+    let resp = client
+        .post(format!("{base}/api/upload"))
+        .body(big)
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 413);
+}
+
+/// Once the count cap is reached, further uploads are rejected with 507.
+#[tokio::test]
+async fn upload_rejects_when_full() {
+    let limits = UploadLimits::builder().max_uploads(1).build();
+    let state = AppState::new(Arc::new(FakeBackend), None, None).with_uploads(limits);
+    let base = start_server(state).await;
+    let client = reqwest::Client::new();
+
+    let first = client
+        .post(format!("{base}/api/upload"))
+        .body(TRACE_MAGIC_BYTES.to_vec())
+        .send()
+        .await
+        .unwrap();
+    check!(first.status().as_u16() == 200);
+
+    let second = client
+        .post(format!("{base}/api/upload"))
+        .body(TRACE_MAGIC_BYTES.to_vec())
+        .send()
+        .await
+        .unwrap();
+    check!(second.status().as_u16() == 507);
+}
+
+/// Once the total-bytes cap is reached, further uploads are rejected with 507
+/// (exercises the byte cap over HTTP, distinct from the count cap above).
+#[tokio::test]
+async fn upload_rejects_when_total_bytes_full() {
+    // Big enough per-upload limit to accept one body, but a tiny total budget
+    // so the second body tips it over.
+    let limits = UploadLimits::builder()
+        .max_total_bytes(TRACE_MAGIC_BYTES.len())
+        .build();
+    let state = AppState::new(Arc::new(FakeBackend), None, None).with_uploads(limits);
+    let base = start_server(state).await;
+    let client = reqwest::Client::new();
+
+    let first = client
+        .post(format!("{base}/api/upload"))
+        .body(TRACE_MAGIC_BYTES.to_vec())
+        .send()
+        .await
+        .unwrap();
+    check!(first.status().as_u16() == 200);
+
+    // Without fetching the first (which would free its bytes), the second 507s.
+    let second = client
+        .post(format!("{base}/api/upload"))
+        .body(TRACE_MAGIC_BYTES.to_vec())
+        .send()
+        .await
+        .unwrap();
+    check!(second.status().as_u16() == 507);
+}
+
+/// A cross-origin preflight (OPTIONS) is answered with permissive CORS headers,
+/// and the actual POST response carries `access-control-allow-origin`.
+#[tokio::test]
+async fn upload_supports_cors() {
+    let base = start_server(upload_state()).await;
+    let client = reqwest::Client::new();
+
+    let preflight = client
+        .request(reqwest::Method::OPTIONS, format!("{base}/api/upload"))
+        .header("Origin", "https://example.com")
+        .header("Access-Control-Request-Method", "POST")
+        .send()
+        .await
+        .unwrap();
+    check!(preflight.status().is_success());
+    check!(
+        preflight
+            .headers()
+            .contains_key("access-control-allow-origin")
+    );
+
+    let posted = client
+        .post(format!("{base}/api/upload"))
+        .header("Origin", "https://example.com")
+        .body(TRACE_MAGIC_BYTES.to_vec())
+        .send()
+        .await
+        .unwrap();
+    check!(posted.status().as_u16() == 200);
+    check!(posted.headers().contains_key("access-control-allow-origin"));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This allows you to `POST` a trace file to the viewer then serve it back immediately which is very helpful for use cases where you have access to trace binary data in one place and really just want to view it without an upload/download dance.

The `POST` request returns JSON:
```json
  {
    "id": "6106710a-cbec-4d74-bab9-3f95ed64b28a",
    "trace_url": "/api/uploaded/6106710a-cbec-4d74-bab9-3f95ed64b28a",
    "viewer_url": "/viewer.html?trace=%2Fapi%2Fuploaded%2F6106710a-cbec-4d74-bab9-3f95ed64b28a"
  }
```