### PR TITLE
Add dial9-flamegraph + dial9-flamegraph-diff skills

### DIFF
--- a/dial9-viewer/skills/dial9-flamegraph-diff/SKILL.md
+++ b/dial9-viewer/skills/dial9-flamegraph-diff/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: dial9-flamegraph-diff
+description: Compare two dial9 on-CPU profiles and report what got hotter or colder — as a ranked text/JSON "top movers" list and/or a red/blue differential flamegraph. Use to compare two time periods (before/after a deploy, peak vs trough, incident vs baseline), two hosts/nodes, or one node vs the fleet. Builds on dial9-flamegraph's folded stacks.
+---
+
+# dial9 differential flamegraph
+
+Answers "**what changed** between these two captures." Works on any two sets of
+segments folded the same way — the two sides can be:
+
+- **Two time periods** — before vs after a deploy, peak vs trough, during-incident
+  vs baseline-hour, today vs last-week. (The single most useful comparison.)
+- **Two hosts / nodes** — is one box behaving differently from another?
+- **One node vs the fleet** — is this host an outlier?
+
+Output is either a **ranked mover list** (text or JSON — what an agent reasons
+over) or a **red/blue differential flamegraph SVG** (what a human eyeballs).
+Red = hotter in B (candidate), blue = hotter in A (baseline).
+
+## Prerequisites
+
+Same as `dial9-flamegraph` (dial9 toolkit + segments). `diff_folded.js` itself is
+**dependency-free** — it only needs Node — so the ranked report works with no
+renderer installed. The SVG path additionally needs `inferno` (`inferno-flamegraph`).
+
+## Workflow
+
+### 1. Fold each side identically
+Use `fold.js` / `merge_folded.js` from the `dial9-flamegraph` skill. **Both sides
+MUST be folded at the same granularity** (both full, or both `--max-depth N`) or
+stacks won't line up and everything reads as "changed."
+
+```bash
+# Example: TWO TIME PERIODS for the same service.
+#   A = baseline window, B = the window you're investigating.
+node fold.js /tmp/traces/2026-06-18_1000/  > A.folded     # baseline hour
+node fold.js /tmp/traces/2026-06-18_1600/  > B.folded     # suspect hour
+```
+Other framings are just different segment sets on each side:
+- **host vs host:** `A` = all of host-1's segments, `B` = all of host-2's.
+- **node vs fleet:** `A` = the whole fleet's segments, `B` = the one node.
+
+(For big sets, pre-fold each segment with `fold.js --json` once and assemble each
+side with `merge_folded.js` — see the dial9-flamegraph skill.)
+
+### 2a. Ranked movers (for agents / quick read)
+```bash
+node diff_folded.js A.folded B.folded            # top 25 movers, normalized
+node diff_folded.js --json --top 50 A.folded B.folded
+```
+Reports each stack's share-of-profile delta in percentage points (+ = hotter in
+B). Profiles are normalized to equal weight first, so you compare **shape**, not
+raw sample volume. By default it drops stacks whose leaf is an unsymbolized `0x…`
+address (they never match across captures and would dominate the ranking); it
+prints how many it dropped, and `--raw` keeps them.
+
+### 2b. Differential flamegraph SVG (for humans)
+```bash
+node diff_folded.js --inferno A.folded B.folded > diff.folded
+inferno-flamegraph --title "DIFF: B vs A (normalized)" \
+  --subtitle "red = hotter in B, blue = hotter in A" diff.folded > diff.svg
+```
+`--inferno` emits inferno's differential-folded format (`stack baseline candidate`,
+with A scaled to B's total). Add `--negate` to `inferno-flamegraph` to flip hues.
+
+### 3. Deliver
+Write `diff.svg` to a durable path. **Always state which side is A (baseline) and
+which is B, and what red/blue mean** — misreading the direction is the #1 diff
+mistake.
+
+## Reading it
+- **Red tower** = B spends more on-CPU time there → new/grown cost (regression, or
+  higher load on that path in the candidate window/node).
+- **Blue tower** = A spent more → shrunk/removed cost.
+- **Mostly flat/grey** = same shape. For two hosts in one fleet this is the
+  expected, healthy result — evidence they're interchangeable.
+- One-color-everywhere usually means the two sides weren't normalized or were
+  folded at different depths.
+
+## Gotchas
+- **Order matters:** `diff_folded.js A B` ⇒ A is baseline, B is candidate. Be deliberate.
+- **Cross-capture time predicates are invalid.** Timestamps come from different
+  monotonic clocks per trace, so you can't filter a union by absolute time across
+  segments — diff works because it aggregates by callchain, not time. To diff two
+  *time periods*, fold each period's segments separately (as above), don't try to
+  time-slice one merged fold.
+- On-CPU only (see dial9-flamegraph) — a diff can't reveal changes in blocking
+  time on captures with schedule profiling off.
+
+## Related
+- `dial9-flamegraph` — produce the folded inputs and single-profile flamegraphs.
+- `dial9-s3-analysis` — discover/download the segments for each side.

--- a/dial9-viewer/skills/dial9-flamegraph-diff/scripts/diff_folded.js
+++ b/dial9-viewer/skills/dial9-flamegraph-diff/scripts/diff_folded.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// diff_folded.js — compare two folded-stack profiles (A = baseline, B = candidate).
+//
+// Produces, by default, a ranked "top movers" report: which stacks got hotter
+// (red, more on-CPU time in B) or colder (blue, more in A), after normalizing
+// the two profiles to equal total weight so you compare SHAPE, not volume.
+// This is the form an agent reasons over — no renderer required.
+//
+// Usage:
+//   node diff_folded.js A.folded B.folded                 # ranked top-movers report
+//   node diff_folded.js --json A.folded B.folded           # same data as JSON
+//   node diff_folded.js --inferno A.folded B.folded > d.folded
+//        # emit inferno differential-folded (`stack baseline candidate`) for
+//        # `inferno-flamegraph` to render as a red/blue differential SVG
+//   node diff_folded.js --top 40 A.folded B.folded         # show N movers (default 25)
+//   node diff_folded.js --raw A.folded B.folded            # keep unsymbolized 0x… leaf frames
+//
+// Folded inputs come from fold.js / merge_folded.js. Both sides MUST be folded
+// at the same granularity (both full, or both --max-depth N) or stacks won't align.
+//
+// NOTE: by default the ranked report drops stacks whose LEAF is an unsymbolized
+// raw address (0x…). Those are per-process stack/JIT addresses that never match
+// across two different captures, so they always show up as spurious top movers.
+// They are NOT dropped from --inferno output (rendering should show everything);
+// pass --raw to keep them in the ranked report too.
+
+const fs = require("fs");
+
+function load(file) {
+  const map = new Map();
+  const txt = fs.readFileSync(file, "utf8");
+  for (const line of txt.split("\n")) {
+    if (!line.trim()) continue;
+    const sp = line.lastIndexOf(" ");
+    if (sp < 0) continue;
+    const stack = line.slice(0, sp);
+    const n = parseInt(line.slice(sp + 1), 10);
+    if (!Number.isFinite(n)) continue;
+    map.set(stack, (map.get(stack) || 0) + n);
+  }
+  return map;
+}
+
+function total(map) {
+  let t = 0;
+  for (const v of map.values()) t += v;
+  return t;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  let asJson = false,
+    inferno = false,
+    raw = false,
+    top = 25;
+  const files = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--json") asJson = true;
+    else if (argv[i] === "--inferno") inferno = true;
+    else if (argv[i] === "--raw") raw = true;
+    else if (argv[i] === "--top") top = parseInt(argv[++i], 10);
+    else files.push(argv[i]);
+  }
+  if (files.length !== 2) {
+    console.error("usage: node diff_folded.js [--json|--inferno|--top N] <A.folded> <B.folded>");
+    process.exit(2);
+  }
+  const A = load(files[0]),
+    B = load(files[1]);
+  const tA = total(A),
+    tB = total(B);
+  if (!tA || !tB) {
+    console.error("one side has zero samples");
+    process.exit(1);
+  }
+
+  // inferno differential-folded: `stack baselineCount candidateCount`.
+  // Use B's native counts and A scaled to B's total (so widths are comparable).
+  if (inferno) {
+    const keys = new Set([...A.keys(), ...B.keys()]);
+    const lines = [];
+    for (const k of keys) {
+      const a = Math.round((A.get(k) || 0) * (tB / tA));
+      const b = B.get(k) || 0;
+      lines.push(`${k} ${a} ${b}`);
+    }
+    process.stdout.write(lines.join("\n") + "\n");
+    return;
+  }
+
+  // Normalized deltas: share-of-profile in B minus share in A (percentage points).
+  const isRawAddr = (stack) => /^0x[0-9a-f]+$/i.test(stack.split(";").pop());
+  const keys = new Set([...A.keys(), ...B.keys()]);
+  const rows = [];
+  let droppedRaw = 0;
+  for (const k of keys) {
+    if (!raw && isRawAddr(k)) {
+      droppedRaw++;
+      continue;
+    }
+    const sa = (A.get(k) || 0) / tA;
+    const sb = (B.get(k) || 0) / tB;
+    rows.push({ stack: k, deltaPct: (sb - sa) * 100, shareA: sa * 100, shareB: sb * 100 });
+  }
+  rows.sort((x, y) => Math.abs(y.deltaPct) - Math.abs(x.deltaPct));
+
+  if (asJson) {
+    process.stdout.write(
+      JSON.stringify(
+        { totalA: tA, totalB: tB, droppedRawAddrStacks: droppedRaw, movers: rows.slice(0, top) },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const leaf = (s) => s.split(";").pop();
+  console.log(`A (baseline) = ${files[0]}  [${tA} on-CPU samples]`);
+  console.log(`B (candidate)= ${files[1]}  [${tB} on-CPU samples]`);
+  if (droppedRaw)
+    console.log(`(dropped ${droppedRaw} stacks with unsymbolized 0x… leaves; pass --raw to keep)`);
+  console.log(`Normalized to equal weight. +red = hotter in B, -blue = hotter in A.\n`);
+  console.log(`  Δpp     A%     B%   leaf  (full stack truncated)`);
+  for (const r of rows.slice(0, top)) {
+    const sign = r.deltaPct >= 0 ? "+" : "";
+    console.log(
+      `${sign}${r.deltaPct.toFixed(2).padStart(6)}  ${r.shareA.toFixed(2).padStart(5)}  ${r.shareB
+        .toFixed(2)
+        .padStart(5)}   ${leaf(r.stack)}`,
+    );
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { load, total };

--- a/dial9-viewer/skills/dial9-flamegraph/SKILL.md
+++ b/dial9-viewer/skills/dial9-flamegraph/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: dial9-flamegraph
+description: Render an SVG (or speedscope) flamegraph of on-CPU time from dial9 trace segments, outside the viewer. Use when an agent or CI needs a standalone flamegraph file from .bin.gz traces, wants to aggregate an arbitrary union of segments (across hosts/times), or needs folded stacks for custom analysis. For the interactive in-browser flamegraph use the viewer; for comparing two profiles use dial9-flamegraph-diff.
+---
+
+# dial9 → standalone flamegraph
+
+The dial9 viewer renders flamegraphs interactively in the browser. This skill is
+the **headless** path: turn trace segments into a self-contained flamegraph file
+(or folded stacks) from the command line — for agents, reports, CI artifacts, or
+aggregating an arbitrary set of segments the viewer's time-window model can't
+express (e.g. "all 6 hosts × 10 spread-out minutes").
+
+It profiles **on-CPU** time (`cpuSample.source === 0`) with fully symbolized
+Rust/Tokio stacks.
+
+## The pivot: folded stacks
+
+Everything here goes through **folded** format — one line per unique stack:
+
+```
+<root>;<caller>;...;<leaf> <count>
+```
+
+Folded is the lingua franca of flamegraph tooling (flamegraph.pl, inferno,
+speedscope all read it), and it's also what `dial9-flamegraph-diff` and any
+custom stack analysis consume. `fold.js` is the only dial9-specific step; after
+that you're in standard-tooling land.
+
+## Prerequisites
+
+1. **dial9 toolkit** (provides `trace_parser.js` + `decode.js`, which `fold.js` reuses):
+   ```bash
+   dial9 agents skills /tmp/d9-skills       # unpack all skills incl. dial9-toolkit + this one
+   node /tmp/d9-skills/dial9-flamegraph/scripts/fold.js <trace>
+   ```
+   `fold.js` resolves the parser as a sibling first, then from the `dial9-toolkit`
+   skill's `scripts/`, then `ui/` — so running it from an unpacked skills dir (or
+   the source tree) works without copying files around.
+2. **A renderer.** Either:
+   - **inferno** (Rust, no browser): `cargo binstall inferno` → `inferno-flamegraph`.
+   - or **speedscope** (`https://speedscope.app`, drag in a folded file), or the
+     classic `flamegraph.pl`. All read the same folded output.
+3. **Trace segments** — `.bin.gz` files. From S3 see `dial9-s3-analysis` for
+   discovery/download (and `dial9 agents skill dial9-s3-analysis`). Each segment
+   is ~one host-minute; parsing is ~10s/segment (CPU-bound).
+
+## Workflow
+
+### 1. Fold segments into stacks
+```bash
+# a file, several files, or a whole directory:
+node fold.js /tmp/d9-traces/seg1.bin.gz /tmp/d9-traces/seg2.bin.gz > profile.folded
+node fold.js /tmp/d9-traces/                                        > profile.folded
+```
+Flags:
+- (default) full symbolized stack, root→leaf.
+- `--max-depth N` — keep only the N frames nearest the leaf (smaller, coarser).
+- `--leaf` — collapse to leaf symbol only (a 1-deep hotspot histogram).
+- `--json` — emit `{stack: count}` JSON instead of folded text.
+
+**Aggregating many segments / many renders:** fold each segment once to `--json`
+(parallelize with `xargs -P`), then merge subsets cheaply without re-parsing:
+```bash
+ls /tmp/d9-traces/*.bin.gz | xargs -P 8 -I{} sh -c 'node fold.js --json "{}" > "{}.json"'
+node merge_folded.js /tmp/d9-traces/*.json > pool.folded
+```
+
+### 2. Render
+```bash
+inferno-flamegraph --title "Shale on-CPU (60 host-minutes)" --colors rust \
+  profile.folded > profile.svg
+```
+Useful flags: `--colors rust|js|java`, `--reverse` (icicle / leaf-rooted, good for
+shared leaf hotspots), `--minwidth 0.5` (drop slivers). Or open the folded file in
+speedscope for an interactive view.
+
+### 3. Deliver
+Write the `.svg` somewhere durable (not a temp dir). It's self-contained and
+interactive (click to zoom, Ctrl-F to search) in any browser.
+
+## Gotchas
+
+- **On-CPU only.** Off-CPU/blocking time needs schedule profiling enabled at
+  capture (`DIAL9_SCHEDULE_PROFILE_ENABLED=true`); without it, parked/blocked
+  time won't appear. Don't describe the result as wall-clock.
+- **`;` in symbols** would corrupt folded format — `fold.js` already maps them to `:`.
+- **`0x…` frames** = unsymbolized addresses (a few leaf/JIT/vsyscall frames); normal.
+- Parsing dominates runtime; cache with `--json` and reuse.
+
+## Related
+- `dial9-flamegraph-diff` — compare two profiles (host vs host, time vs time, node vs fleet).
+- `dial9-s3-analysis` — discover/download trace segments from S3.
+- `dial9-toolkit` — the parser/analysis JS this builds on.

--- a/dial9-viewer/skills/dial9-flamegraph/scripts/fold.js
+++ b/dial9-viewer/skills/dial9-flamegraph/scripts/fold.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// fold.js — collapse dial9 trace segment(s) into FOLDED stacks.
+//
+//   <root>;<caller>;...;<leaf> <count>
+//
+// "Folded" is the lingua franca of flamegraph tooling: flamegraph.pl, inferno
+// (inferno-flamegraph / inferno-diff-folded), and speedscope all read it. So
+// this one script unlocks SVG flamegraphs, differential flamegraphs, and
+// programmatic stack analysis without any dial9-specific renderer.
+//
+// On-CPU samples only (cpuSample.source === 0). Inlined frames are expanded in
+// place via the toolkit's symbolizeChain. The trace stores callchains leaf-first;
+// folded format is root-first, so each chain is reversed.
+//
+// Usage:
+//   node fold.js <file-or-dir> [more files/dirs...] > out.folded
+//   node fold.js --max-depth N <...>   # keep only the N frames nearest the leaf
+//   node fold.js --leaf <...>          # collapse to leaf symbol only (1-deep hotspots)
+//   node fold.js --json <...>          # emit {stack: count} JSON instead of folded text
+//
+// The --json form is for caching: parsing a segment is the slow step (~10s),
+// so fold each segment once to JSON, then merge cheaply (see merge_folded.js)
+// to render any subset/union without re-parsing.
+
+const fs = require("fs");
+const path = require("path");
+
+// Resolve toolkit files: sibling (unpacked skill / `dial9 agents toolkit`),
+// the dial9-toolkit skill scripts, or the ui/ source tree.
+function resolve(name) {
+  const sibling = path.resolve(__dirname, name);
+  if (fs.existsSync(sibling)) return sibling;
+  const toolkit = path.resolve(__dirname, "..", "..", "dial9-toolkit", "scripts", name);
+  if (fs.existsSync(toolkit)) return toolkit;
+  return path.resolve(__dirname, "..", "..", "..", "ui", name);
+}
+
+const { parseTrace, symbolizeChain } = require(resolve("trace_parser.js"));
+
+function clean(sym) {
+  // inferno/flamegraph.pl split frames on ';' — neutralize any in symbol text.
+  return String(sym).replace(/;/g, ":").replace(/\s+/g, " ").trim() || "(anon)";
+}
+
+async function fold(targets, { leafOnly = false, maxDepth = 0 } = {}) {
+  const folded = new Map(); // "root;...;leaf" -> count
+  for (const target of targets) {
+    for await (const trace of parseTrace(target)) {
+      for (const s of trace.cpuSamples || []) {
+        if (s.source !== 0) continue; // on-CPU only
+        let frames = symbolizeChain(s.callchain || [], trace.callframeSymbols).map(
+          (f) => clean(f.symbol),
+        );
+        if (!frames.length) frames = ["(empty)"];
+        frames.reverse(); // leaf-first -> root-first
+        if (leafOnly) frames = [frames[frames.length - 1]];
+        else if (maxDepth > 0 && frames.length > maxDepth)
+          frames = frames.slice(frames.length - maxDepth);
+        const key = frames.join(";");
+        folded.set(key, (folded.get(key) || 0) + 1);
+      }
+    }
+  }
+  return folded;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  let leafOnly = false,
+    maxDepth = 0,
+    asJson = false;
+  const targets = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--leaf") leafOnly = true;
+    else if (argv[i] === "--json") asJson = true;
+    else if (argv[i] === "--max-depth") maxDepth = parseInt(argv[++i], 10);
+    else targets.push(argv[i]);
+  }
+  if (!targets.length) {
+    console.error("usage: node fold.js [--leaf|--max-depth N|--json] <file-or-dir>...");
+    process.exit(2);
+  }
+  const folded = await fold(targets, { leafOnly, maxDepth });
+  if (asJson) {
+    process.stdout.write(JSON.stringify(Object.fromEntries(folded)));
+  } else {
+    const out = [...folded.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([k, v]) => `${k} ${v}`)
+      .join("\n");
+    process.stdout.write(out + "\n");
+  }
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error("fold error:", e.stack || e.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { fold };

--- a/dial9-viewer/skills/dial9-flamegraph/scripts/merge_folded.js
+++ b/dial9-viewer/skills/dial9-flamegraph/scripts/merge_folded.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// merge_folded.js — combine per-segment `fold.js --json` outputs into one
+// folded-text stream (stdout). Lets you render any union/subset of segments
+// without re-parsing the traces.
+//
+// Usage:
+//   node merge_folded.js a.json b.json c.json > pool.folded
+//   node merge_folded.js 'dir/*.json'              # shell-expanded globs are fine
+//
+// Each input is {stack: count} JSON (from `fold.js --json`). Counts sum.
+
+const fs = require("fs");
+
+function loadInto(acc, file) {
+  const h = JSON.parse(fs.readFileSync(file, "utf8"));
+  for (const k in h) acc[k] = (acc[k] || 0) + h[k];
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  if (!files.length) {
+    console.error("usage: node merge_folded.js <fold-json>...  > out.folded");
+    process.exit(2);
+  }
+  const acc = {};
+  for (const f of files) loadInto(acc, f);
+  const out = Object.entries(acc)
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, v]) => `${k} ${v}`)
+    .join("\n");
+  process.stdout.write(out + "\n");
+}
+
+if (require.main === module) main();
+
+module.exports = { loadInto };

--- a/dial9-viewer/skills/dial9-toolkit/scripts/decode.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/decode.js
@@ -7,11 +7,13 @@ const TAG_EVENT = 0x02;
 const TAG_STRING_POOL = 0x03;
 const TAG_STACK_POOL = 0x04;
 const TAG_TIMESTAMP_RESET = 0x05;
+const TAG_SCHEMA_ANNOTATIONS = 0x06;
 
 const FieldType = {
   I64: 1, F64: 2, Bool: 3, String: 4,
   Bytes: 5, PooledStackFrames: 6, PooledString: 7, StackFrames: 8, Varint: 9,
   StringMap: 10, U8: 11, U16: 12, U32: 13,
+  DynamicList: 14, DynamicMap: 15,
 };
 
 function decodeULEB128(view, offset) {
@@ -85,6 +87,33 @@ function decodeFieldValue(view, offset, fieldType) {
     case FieldType.U8: return [view.getUint8(offset), 1];
     case FieldType.U16: return [view.getUint16(offset, true), 2];
     case FieldType.U32: return [view.getUint32(offset, true), 4];
+    case FieldType.DynamicList: {
+      const count = view.getUint32(offset, true);
+      let pos = 4;
+      const items = [];
+      for (let i = 0; i < count; i++) {
+        const tag = view.getUint8(offset + pos); pos += 1;
+        const [val, consumed] = decodeFieldValue(view, offset + pos, tag);
+        items.push(val);
+        pos += consumed;
+      }
+      return [items, pos];
+    }
+    case FieldType.DynamicMap: {
+      const count = view.getUint32(offset, true);
+      let pos = 4;
+      const entries = [];
+      for (let i = 0; i < count; i++) {
+        const keyTag = view.getUint8(offset + pos); pos += 1;
+        const [key, keySize] = decodeFieldValue(view, offset + pos, keyTag);
+        pos += keySize;
+        const valTag = view.getUint8(offset + pos); pos += 1;
+        const [val, valSize] = decodeFieldValue(view, offset + pos, valTag);
+        pos += valSize;
+        entries.push([key, val]);
+      }
+      return [entries, pos];
+    }
     default: throw new Error(`Unknown field type: ${fieldType}`);
   }
 }
@@ -137,6 +166,7 @@ class TraceDecoder {
         case TAG_EVENT: return this._decodeEvent();
         case TAG_STRING_POOL: return this._decodeStringPool();
         case TAG_STACK_POOL: return this._decodeStackPool();
+        case TAG_SCHEMA_ANNOTATIONS: return this._decodeSchemaAnnotations();
         case TAG_TIMESTAMP_RESET: {
           const lo = this._view.getUint32(this._pos, true);
           const hi = this._view.getUint32(this._pos + 4, true);
@@ -217,6 +247,41 @@ class TraceDecoder {
     const result = { type: 'event', typeId, name: schema.name, values };
     if (timestampNs !== null) result.timestamp_ns = timestampNs;
     return result;
+  }
+
+  _decodeSchemaAnnotations() {
+    // Unlike schema/event frames, type_id is LEB128 here.
+    const [typeIdBig, consumed] = decodeULEB128(this._view, this._pos);
+    this._pos += consumed;
+    const typeId = Number(typeIdBig);
+    const count = this._view.getUint16(this._pos, true); this._pos += 2;
+    const td = new TextDecoder();
+    const annotations = [];
+    for (let i = 0; i < count; i++) {
+      const fieldIndex = this._view.getUint16(this._pos, true); this._pos += 2;
+      const keyLen = this._view.getUint16(this._pos, true); this._pos += 2;
+      const key = td.decode(
+        new Uint8Array(this._view.buffer, this._view.byteOffset + this._pos, keyLen));
+      this._pos += keyLen;
+      const valueLen = this._view.getUint32(this._pos, true); this._pos += 4;
+      const value = td.decode(
+        new Uint8Array(this._view.buffer, this._view.byteOffset + this._pos, valueLen));
+      this._pos += valueLen;
+      annotations.push({ fieldIndex, key, value });
+    }
+    // Lenient like the Rust decoder: annotations for an unknown schema are
+    // parsed (to keep the stream aligned) but not attached.
+    const schema = this.schemas.get(typeId);
+    if (schema) {
+      schema.annotations = annotations;
+      const units = {};
+      for (const a of annotations) {
+        const field = schema.fields[a.fieldIndex];
+        if (a.key === 'unit' && field) units[field.name] = a.value;
+      }
+      schema.units = units;
+    }
+    return { type: 'schema_annotations', typeId, annotations };
   }
 
   /** Current byte offset into the buffer. */

--- a/dial9-viewer/ui/test_flamegraph_fold.js
+++ b/dial9-viewer/ui/test_flamegraph_fold.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Tests for the dial9-flamegraph / dial9-flamegraph-diff skill scripts:
+// fold.js (trace -> folded stacks), merge_folded.js, diff_folded.js.
+// Runs against the demo trace, exercising the real parser + symbolizer.
+
+"use strict";
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { test, testAsync, assert, summarize } = require("./test_harness.js");
+
+const demoPath = path.join(__dirname, "demo-trace.bin");
+const flamegraphScripts = path.join(__dirname, "..", "skills", "dial9-flamegraph", "scripts");
+const diffScripts = path.join(__dirname, "..", "skills", "dial9-flamegraph-diff", "scripts");
+
+const { fold } = require(path.join(flamegraphScripts, "fold.js"));
+const { load, total } = require(path.join(diffScripts, "diff_folded.js"));
+
+(async () => {
+  // --- fold.js: full stacks ---
+  const full = await fold([demoPath], {});
+  await testAsync("fold produces folded stacks from the demo trace", async () => {
+    assert(full.size > 0, "expected at least one folded stack");
+    for (const [stack, count] of full) {
+      assert(typeof stack === "string" && stack.length > 0, "stack key must be a non-empty string");
+      assert(Number.isInteger(count) && count > 0, "count must be a positive integer");
+      // Folded format is line-based and `stack <count>` splits on the LAST space,
+      // so a key may contain interior spaces (Rust symbols like `<T as Trait>`)
+      // but never a newline.
+      assert(!stack.includes("\n"), "folded stack key must not contain a newline");
+    }
+  });
+
+  // --- fold.js: leaf vs full granularity ---
+  const leaf = await fold([demoPath], { leafOnly: true });
+  test("leaf folding has no fewer-or-equal distinct keys than full (collapses callers)", () => {
+    assert(leaf.size <= full.size, `leaf=${leaf.size} should be <= full=${full.size}`);
+    assert(leaf.size > 0, "leaf folding produced nothing");
+    for (const stack of leaf.keys()) {
+      assert(!stack.includes(";"), "leaf keys must be a single frame (no ';')");
+    }
+  });
+
+  // --- fold.js: max-depth bounds stack depth ---
+  const d3 = await fold([demoPath], { maxDepth: 3 });
+  test("--max-depth caps frames per stack", () => {
+    for (const stack of d3.keys()) {
+      assert(stack.split(";").length <= 3, `stack exceeded depth 3: ${stack}`);
+    }
+  });
+
+  // --- total sample count is conserved across granularities ---
+  const sum = (m) => [...m.values()].reduce((a, b) => a + b, 0);
+  test("total on-CPU sample count is identical across fold granularities", () => {
+    assert(sum(full) === sum(leaf), `full=${sum(full)} leaf=${sum(leaf)}`);
+    assert(sum(full) === sum(d3), `full=${sum(full)} d3=${sum(d3)}`);
+  });
+
+  // --- merge_folded round-trips through the JSON cache form ---
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "d9fold-"));
+  const jsonA = path.join(tmp, "a.json");
+  fs.writeFileSync(jsonA, JSON.stringify(Object.fromEntries(full)));
+  const { loadInto } = require(path.join(flamegraphScripts, "merge_folded.js"));
+  test("merge_folded sums two copies of the same fold to 2x counts", () => {
+    const acc = {};
+    loadInto(acc, jsonA);
+    loadInto(acc, jsonA);
+    const anyKey = full.keys().next().value;
+    assert(acc[anyKey] === full.get(anyKey) * 2, "merging a fold with itself should double counts");
+  });
+
+  // --- diff_folded: a profile against itself has ~zero movers ---
+  const foldedA = path.join(tmp, "a.folded");
+  fs.writeFileSync(
+    foldedA,
+    [...full.entries()].map(([k, v]) => `${k} ${v}`).join("\n") + "\n",
+  );
+  test("diff load() + total() round-trip the folded text", () => {
+    const m = load(foldedA);
+    assert(m.size === full.size, `loaded ${m.size} stacks, expected ${full.size}`);
+    assert(total(m) === sum(full), "total mismatch after load");
+  });
+
+  // --- diff direction: a synthetic B with one inflated stack shows it as the top mover ---
+  test("diff surfaces an inflated stack as a positive mover in B", () => {
+    const entries = [...full.entries()];
+    const [hotStack] = entries[0];
+    const bEntries = entries.map(([k, v]) => [k, k === hotStack ? v * 5 : v]);
+    const foldedB = path.join(tmp, "b.folded");
+    fs.writeFileSync(foldedB, bEntries.map(([k, v]) => `${k} ${v}`).join("\n") + "\n");
+    const A = load(foldedA);
+    const B = load(foldedB);
+    const tA = total(A);
+    const tB = total(B);
+    const shareA = (A.get(hotStack) || 0) / tA;
+    const shareB = (B.get(hotStack) || 0) / tB;
+    assert(shareB - shareA > 0, "inflated stack should have a larger share in B");
+  });
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+  summarize();
+})();

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -47,6 +47,9 @@ node dial9-viewer/ui/test_trace_analysis.js
 echo "--- Checking multi-component trace fetch (repeatable trace=) ---"
 node dial9-viewer/ui/test_fetch_traces.js
 
+echo "--- Checking flamegraph fold/diff skill scripts ---"
+node dial9-viewer/ui/test_flamegraph_fold.js
+
 echo "--- Checking skills snippets ---"
 node dial9-viewer/ui/test_all_skills_snippets.js
 


### PR DESCRIPTION
## What

Two **headless** (non-viewer) skills for working with on-CPU profiles from trace segments, plus a stale-toolkit fix surfaced along the way.

The viewer already renders flamegraphs interactively in the browser (`ui/flamegraph.js`, embedded by `dial9-html-report`). These skills cover the cases the viewer can't: producing a standalone flamegraph **file** from the CLI, aggregating an **arbitrary union** of segments (e.g. N hosts × M spread-out minutes), and **diffing two profiles** — which the html-report skill explicitly punts on ("Use two separate flamegraphs instead").

### `dial9-flamegraph`
- `fold.js` — collapse segment(s) into **folded stacks** (`root;…;leaf <count>`), the lingua franca of flamegraph.pl / inferno / speedscope. Flags: `--leaf`, `--max-depth N`, `--json` (cache form).
- `merge_folded.js` — assemble cached per-segment `--json` folds into any subset/union without re-parsing (parsing is the slow step).
- Renders to SVG via `inferno-flamegraph`, or open the folded file in speedscope.

### `dial9-flamegraph-diff`
- `diff_folded.js` — compare two profiles and report normalized **"top movers"** (text or JSON), or emit inferno differential-folded for a red/blue diff SVG.
- Designed for **two time periods** (before/after a deploy, peak vs trough, incident vs baseline), **host vs host**, or **node vs fleet**.
- The ranked report is **dependency-free** (Node only); only the SVG path needs inferno.

## Why folded stacks
A folded intermediate is the pivot for both rendering *and* programmatic analysis, so one dial9-specific step (`fold.js`) unlocks the whole standard-tooling ecosystem and lets agents reason over deltas as plain data.

## Also in this PR: a stale `decode.js` fix
While testing against the demo trace I found `skills/dial9-toolkit/scripts/decode.js` was **stale** — missing `TAG_SCHEMA_ANNOTATIONS (0x06)` — so the bundled `analyze.js` (and anything using the unpacked toolkit parser) fails on current traces with `Unknown frame tag: 0x6`. `trace_parser.js` and `trace_analysis.js` were already identical between `ui/` and the toolkit; `decode.js` was the only drift. Synced it from the authoritative `ui/decode.js`. (Happy to split this into its own PR if preferred.)

## Tests
- New `ui/test_flamegraph_fold.js` exercises fold (full/leaf/max-depth, sample-count conservation), merge, and diff (round-trip + direction) against the demo trace.
- Wired into `scripts/e2e-trace-tests.sh` (per the "CI does NOT auto-discover tests" note).
- `cargo build -p dial9-viewer` green; `build.rs` embeds both skills; `dial9 agents skills` emits them and `fold.js` runs end-to-end from the unpack; `cargo fmt --all --check` clean.

## Open questions for reviewers
- inferno is an external dep for the SVG path. Acceptable as an optional renderer, or would you prefer the diff also be wired into the in-browser `buildFlamegraphTree` renderer (a viewer feature, separate effort)? A native S3-browser "diff two nodes / two time windows" view is the natural follow-up.
- Split the `decode.js` sync into its own PR?