### PR TITLE
fix(viewer): Scope enclosing spans to event's worker

### DIFF
--- a/dial9-viewer/ui/test_enclosing_spans.js
+++ b/dial9-viewer/ui/test_enclosing_spans.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+"use strict";
+
+// Unit tests for enclosingSpans — the per-worker enclosing-span resolver used
+// by the viewer's Related sidebar.
+//
+// Run with: node test_enclosing_spans.js
+//
+// The old logic matched any span whose overall [start,end] envelope covered the
+// event timestamp. That envelope is the min/max across a span's per-worker
+// segments, so a span polled on another worker falsely "enclosed" events it
+// never executed alongside. enclosingSpans matches the actual per-worker
+// segments and requires the event to carry a worker_id.
+
+const { assert, test, summarize } = require("./test_harness.js");
+const { enclosingSpans } = require("./trace_analysis.js");
+
+// Build a span record matching buildSpanData's shape (only the fields
+// enclosingSpans reads: start, end, spanId, depth, segments).
+function span(spanId, depth, segments) {
+  const start = Math.min(...segments.map(s => s.start));
+  const end = Math.max(...segments.map(s => s.end));
+  return { spanId, depth, start, end, segments };
+}
+
+const ids = spans => spans.map(s => s.spanId);
+
+// Envelope overlap is not enough — only the span actually executing on the
+// event's worker at ts is returned. spanB has a huge envelope (its segment is
+// on worker 1, far in time) but never runs on worker 0 at ts.
+test("envelope overlap alone does not enclose (per-worker match)", () => {
+  const allSpans = [
+    span("A", 0, [{ start: 100, end: 200, workerId: 0 }]),
+    span("B", 0, [{ start: 50, end: 500, workerId: 1 }]),
+  ];
+  const ev = { timestamp: 150, fields: { worker_id: 0 } };
+  assert.deepStrictEqual(ids(enclosingSpans(allSpans, ev)), ["A"]);
+});
+
+// Nested parent/child segments on the same worker -> both returned, outermost
+// (lowest depth) first.
+test("nested stack returned outermost-first", () => {
+  const allSpans = [
+    span("child", 1, [{ start: 120, end: 180, workerId: 0 }]),
+    span("parent", 0, [{ start: 100, end: 200, workerId: 0 }]),
+  ];
+  const ev = { timestamp: 150, fields: { worker_id: 0 } };
+  assert.deepStrictEqual(ids(enclosingSpans(allSpans, ev)), ["parent", "child"]);
+});
+
+// Event with no worker_id (the CPU/resource-usage case from the flush thread)
+// is enclosed by nothing.
+test("event without worker_id has no enclosing spans", () => {
+  const allSpans = [span("A", 0, [{ start: 100, end: 200, workerId: 0 }])];
+  const ev = { timestamp: 150, fields: { cpu_ns: 42 } };
+  assert.deepStrictEqual(enclosingSpans(allSpans, ev), []);
+});
+
+// Event with worker_id whose timestamp falls between the span's segments (span
+// suspended/awaiting then, not executing) -> not enclosed.
+test("span not executing at ts (between segments) does not enclose", () => {
+  const allSpans = [
+    span("A", 0, [
+      { start: 100, end: 200, workerId: 0 },
+      { start: 300, end: 400, workerId: 0 },
+    ]),
+  ];
+  const ev = { timestamp: 250, fields: { worker_id: 0 } };
+  assert.deepStrictEqual(enclosingSpans(allSpans, ev), []);
+});
+
+// worker_id present but pointing at a worker the span never ran on -> none.
+test("span on a different worker does not enclose", () => {
+  const allSpans = [span("A", 0, [{ start: 100, end: 200, workerId: 0 }])];
+  const ev = { timestamp: 150, fields: { worker_id: 3 } };
+  assert.deepStrictEqual(enclosingSpans(allSpans, ev), []);
+});
+
+// worker_id as a string is coerced (event fields may arrive as strings).
+test("string worker_id is coerced to number", () => {
+  const allSpans = [span("A", 0, [{ start: 100, end: 200, workerId: 0 }])];
+  const ev = { timestamp: 150, fields: { worker_id: "0" } };
+  assert.deepStrictEqual(ids(enclosingSpans(allSpans, ev)), ["A"]);
+});
+
+summarize();

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -925,6 +925,35 @@
   }
 
   /**
+   * Spans actively executing on the event's worker at its timestamp, outermost
+   * first — the nested enclosing stack. Enclosure is per-worker: time overlap
+   * alone does not enclose. A span's [start, end] is the min/max across all of
+   * its per-worker segments, so the envelope of a span polled on another worker
+   * can span the event without ever executing on it. Matching the actual
+   * per-worker `segments` avoids that, and on a single worker entered spans are
+   * strictly nested, so the matches form the enclosing chain directly. Events
+   * with no worker context (e.g. process-wide resource samples from the flush
+   * thread, or custom events that do not set worker_id) are enclosed by nothing
+   * and return [].
+   * @param {Array} allSpans spans from buildSpanData (each with `segments` and `depth`)
+   * @param {{timestamp: number, fields: Object}} ev
+   * @returns {Array} enclosing spans, outermost (lowest depth) first
+   */
+  function enclosingSpans(allSpans, ev) {
+    const f = (ev && ev.fields) || {};
+    if (f.worker_id == null) return [];
+    
+    const wid = Number(f.worker_id);
+    if (!Number.isFinite(wid)) return [];
+
+    const ts = ev.timestamp;
+    return allSpans
+      .filter(s => s.segments.some(
+        seg => seg.workerId === wid && seg.start <= ts && seg.end >= ts))
+      .sort((a, b) => (a.depth - b.depth) || (a.start - b.start));
+  }
+
+  /**
    * Compute span panel layout with duration-based y and pixel-grid clustering.
    * @param {{ spans: Array, viewStart: number, viewEnd: number, drawW: number, panelH: number, clusterXPx: number, barH: number }} opts
    * @returns {{ buckets: Array<{spans: Array, representative: Object, x1: number, x2: number, y: number, h: number}> }}
@@ -1153,6 +1182,7 @@
     buildSpanData,
     collectDescendants,
     selectSpanRenderSet,
+    enclosingSpans,
     computeSpanLayout,
     analyzeAllocations,
     pollHeatmapColor,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -919,7 +919,7 @@
         <script src="panel_layout.js"></script>
         <script>
             const { EVENT_TYPES: ET, parseTrace, formatFrame, symbolizeChain, deduplicateSamples } = TraceParser;
-            const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline, computeSchedulingDelays, filterPointsOfInterest, buildSpanData, collectDescendants, selectSpanRenderSet, computeSpanLayout, getTraceTimeRange, hasCpuProfileSamples } = TraceAnalysis;
+            const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline, computeSchedulingDelays, filterPointsOfInterest, buildSpanData, collectDescendants, selectSpanRenderSet, enclosingSpans, computeSpanLayout, getTraceTimeRange, hasCpuProfileSamples } = TraceAnalysis;
 
             function esc(s) {
                 return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -3189,14 +3189,6 @@
             const RELATED_INITIAL = 5;
             const RELATED_STEP = 25;
 
-            // Spans whose [start,end] covers ts, outermost first — the enclosing
-            // hierarchy at the event's timestamp (spans nest via parentSpanId).
-            function spansAtTime(ts) {
-                return allSpans
-                    .filter(s => s.start <= ts && s.end >= ts)
-                    .sort((a, b) => (a.depth - b.depth) || (a.start - b.start));
-            }
-
             // Custom events matching `pred`, sorted by time. [] when none loaded.
             function customEventsWhere(pred) {
                 if (!trace || !trace.customEvents) return [];
@@ -3233,7 +3225,7 @@
                 if (!ev) return `<div class="related-empty">No event selected.</div>`;
 
                 const taskId = taskForEvent(ev);
-                const spans = spansAtTime(ev.timestamp);
+                const spans = enclosingSpans(allSpans, ev);
                 const innerSpan = spans.length ? spans[spans.length - 1] : null;
 
                 const empty = `<div class="related-empty">none</div>`;

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -56,4 +56,7 @@ node dial9-viewer/ui/test_all_skills_snippets.js
 echo "--- Checking prefix detection ---"
 node dial9-viewer/ui/test_prefix_detection.js
 
+echo "--- Checking enclosing spans (per-worker) ---"
+node dial9-viewer/ui/test_enclosing_spans.js
+
 echo "All E2E trace checks passed."


### PR DESCRIPTION
Follow up #552

## Summary
spansAtTime matched any span whose [start,end] envelope covered the event timestamp. That envelope is the min/max across a span's per-worker segments, so a span polled on another worker falsely enclosed events it never ran alongside. Worst case: process resource usage events (emitted from the flush thread, no worker_id) showed a stack of unrelated spans.

Replace with enclosingSpans, matching the actual per-worker segment and requiring the event to carry worker_id. Events with no worker context get no enclosing spans.