### PR TITLE
test(tracing-layer): Make multi-worker assertion deterministic

### DIFF
--- a/dial9-tokio-telemetry/tests/tracing_layer.rs
+++ b/dial9-tokio-telemetry/tests/tracing_layer.rs
@@ -7,6 +7,7 @@ use dial9_tokio_telemetry::telemetry::{DiskWriter, TracedRuntime};
 use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
 use dial9_trace_format::types::FieldValueRef;
 use std::collections::HashSet;
+use std::sync::{Arc, Barrier};
 use std::time::Duration;
 use tracing_subscriber::prelude::*;
 
@@ -141,8 +142,11 @@ fn span_events_appear_in_trace() {
             let _enter = span.enter();
         }
 
-        #[tracing::instrument(fields(user_id = 42))]
-        async fn handle_request() {
+        #[tracing::instrument(fields(user_id = 42), skip(barrier))]
+        async fn handle_request(barrier: Option<Arc<Barrier>>) {
+            if let Some(b) = barrier {
+                b.wait();
+            }
             inner_op("redis").await;
             inner_op("redis").await;
         }
@@ -152,10 +156,15 @@ fn span_events_appear_in_trace() {
             tokio::task::yield_now().await;
         }
 
-        // Spawn across multiple workers for concurrency coverage
+        // Spawn across multiple workers for concurrency coverage. Two of the
+        // tasks share a blocking Barrier so they are guaranteed to run on two
+        // distinct workers (see handle_request), making the multi-worker
+        // assertion deterministic rather than dependent on scheduler placement.
+        let barrier = Arc::new(Barrier::new(2));
         let mut handles = Vec::new();
-        for _ in 0..10 {
-            handles.push(tokio::spawn(handle_request()));
+        for i in 0..10 {
+            let b = (i < 2).then(|| Arc::clone(&barrier));
+            handles.push(tokio::spawn(handle_request(b)));
         }
         for h in handles {
             h.await.unwrap();


### PR DESCRIPTION
closes #474 

## Summary
`span_events_appear_in_trace` relied on the scheduler spreading spawned tasks across workers, which only held under load and flaked otherwise. Gate two tasks on a shared `Barrier` so they probably run on two distinct workers regardless of placement.