### PR TITLE
viewer: parallel download + streaming decode (faster trace loads)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
  "aws-smithy-types",
  "axum",
  "axum-extra",
+ "bytes",
  "clap",
  "flate2",
  "futures",

--- a/dial9-trace-format/js/decode.js
+++ b/dial9-trace-format/js/decode.js
@@ -130,6 +130,68 @@ class TraceDecoder {
     this.stackPool = new Map();
     this.version = 0;
     this._timestampBaseNs = 0n;
+    // Streaming mode. When false (default, whole-buffer decode), a frame that
+    // runs off the end of the buffer is a truncated tail: `nextFrame()` stops
+    // gracefully at EOF. When true, the same condition means "the buffer holds
+    // only a partial frame; more bytes are coming" — `nextFrame()` returns null
+    // WITHOUT consuming the partial frame and sets `needMoreBytes`, so the
+    // streaming caller can roll back, append more bytes, and retry.
+    this._streaming = false;
+    // Set by `nextFrame()` (streaming mode only) when it returned null because
+    // the trailing bytes are an incomplete frame rather than a real EOF.
+    this.needMoreBytes = false;
+  }
+
+  /**
+   * Enable streaming mode (see the `_streaming` field). In this mode a frame
+   * that runs past the end of the accumulated buffer is treated as incomplete
+   * (more bytes coming) rather than as a truncated EOF tail.
+   */
+  enableStreaming() {
+    this._streaming = true;
+  }
+
+  /**
+   * Replace the underlying buffer with a (typically longer) one that shares the
+   * same already-decoded prefix, preserving decode position and accumulated
+   * decoder state (schemas, pools, timestamp base, version). Used by the
+   * streaming parser to grow the readable window as chunks arrive without
+   * re-decoding what was already produced.
+   */
+  setBuffer(buffer) {
+    const ab = buffer instanceof ArrayBuffer ? buffer : buffer.buffer;
+    const off = buffer.byteOffset || 0;
+    const len = buffer.byteLength;
+    this._view = new DataView(ab, off, len);
+  }
+
+  /**
+   * Snapshot the positional decode state so the streaming caller can roll back
+   * after an incomplete frame. Only `_pos` and `_timestampBaseNs` are mutated
+   * mid-frame: schema/pool maps are updated with idempotent `.set()` calls
+   * (re-decoding the same frame overwrites with identical values), but the
+   * timestamp base is ADDITIVE — re-decoding a delta-encoded event without a
+   * rollback would double-apply the delta. See `_decodeEvent`.
+   */
+  snapshot() {
+    return { pos: this._pos, timestampBaseNs: this._timestampBaseNs };
+  }
+
+  /** Restore a snapshot produced by `snapshot()`. */
+  restore(snap) {
+    this._pos = snap.pos;
+    this._timestampBaseNs = snap.timestampBaseNs;
+  }
+
+  /**
+   * Reset the read position to the start of the current buffer WITHOUT
+   * touching accumulated decoder state (schemas, pools, timestamp base,
+   * version). Used by the streaming parser after it drops the consumed prefix
+   * and re-wraps the decoder over the unconsumed tail (which now starts at
+   * offset 0). See `setBuffer`.
+   */
+  rewindToStart() {
+    this._pos = 0;
   }
 
   decodeHeader() {
@@ -142,11 +204,21 @@ class TraceDecoder {
   }
 
   nextFrame() {
+    this.needMoreBytes = false;
     if (this._pos >= this._view.byteLength) return null;
     try {
       const tag = this._view.getUint8(this._pos);
       // Mid-stream header = reset frame (concatenated thread-local batch)
-      if (tag === MAGIC[0] && this._pos + 5 <= this._view.byteLength) {
+      if (tag === MAGIC[0]) {
+        if (this._pos + 5 > this._view.byteLength) {
+          // A would-be header straddles the end of the buffer. We can't tell
+          // yet whether it's a real header or a coincidental 0x54 frame tag
+          // until more bytes arrive. In streaming mode, ask for them; in
+          // whole-buffer mode this is a truncated tail.
+          if (this._streaming) { this.needMoreBytes = true; return null; }
+          this._pos = this._view.byteLength;
+          return null;
+        }
         let isHeader = true;
         for (let i = 1; i < 4; i++) {
           if (this._view.getUint8(this._pos + i) !== MAGIC[i]) { isHeader = false; break; }
@@ -178,6 +250,13 @@ class TraceDecoder {
       }
     } catch (e) {
       if (e instanceof RangeError) {
+        if (this._streaming) {
+          // The buffer holds only part of this frame; more bytes are coming.
+          // Leave `_pos` untouched — the streaming caller rolls back via the
+          // snapshot it took before this call — and ask for more data.
+          this.needMoreBytes = true;
+          return null;
+        }
         // Truncated frame at end of segment; stop gracefully.
         this._pos = this._view.byteLength;
         return null;

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -26,6 +26,7 @@ required-features = ["dev-server"]
 [dependencies]
 axum = "0.8"
 axum-extra = { version = "0.10", features = ["query"] }
+bytes = "1"
 clap = { version = "4", features = ["derive"] }
 flate2 = "1"
 futures = "0.3"

--- a/dial9-viewer/skills/dial9-trace-loading/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-loading/SKILL.md
@@ -163,8 +163,9 @@ Start the viewer (`dial9-viewer --bucket BUCKET`, default port 3000), then fetch
 const resp = await fetch('http://localhost:3000/api/search?bucket=BUCKET&q=2026-04-09/19');
 const objects = await resp.json(); // [{key, size, last_modified}, ...]
 
-// Single file: fetch and parse one trace
-const traceResp = await fetch(`http://localhost:3000/api/trace?bucket=BUCKET&keys=${encodeURIComponent(objects[0].key)}`);
+// Single file: fetch and parse one trace. /api/object serves the file's raw
+// (still-gzipped) bytes; parseTrace decompresses transparently.
+const traceResp = await fetch(`http://localhost:3000/api/object?bucket=BUCKET&key=${encodeURIComponent(objects[0].key)}`);
 const buf = Buffer.from(await traceResp.arrayBuffer());
 const trace = await parseTrace(buf);
 
@@ -176,7 +177,7 @@ fs.mkdirSync(dir, { recursive: true });
 const limit = 20;
 for (let i = 0; i < objects.length; i += limit) {
   await Promise.all(objects.slice(i, i + limit).map(async (obj) => {
-    const r = await fetch(`http://localhost:3000/api/trace?bucket=BUCKET&keys=${encodeURIComponent(obj.key)}`);
+    const r = await fetch(`http://localhost:3000/api/object?bucket=BUCKET&key=${encodeURIComponent(obj.key)}`);
     fs.writeFileSync(`${dir}/${obj.key.split('/').pop()}`, Buffer.from(await r.arrayBuffer()));
   }));
 }
@@ -184,6 +185,10 @@ for await (const trace of parseTrace(dir)) {
   // analyze each trace
 }
 ```
+
+> **Note:** `GET /api/trace?bucket=&keys=a&keys=b` (server-side gunzip +
+> concatenate) still exists but is **deprecated and slated for removal**. Prefer
+> `/api/object` (one file per request, raw bytes), which transfers far less data.
 
 ## Merging multiple trace files
 

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -190,6 +190,9 @@ fn api_router(state: AppState) -> Router {
         )
         .route("/prefixes", axum::routing::get(prefixes::list_prefixes))
         .route("/search", axum::routing::get(search::search))
+        .route("/object", axum::routing::get(trace::get_object))
+        // DEPRECATED (slated for removal): superseded by /object, which serves a
+        // single object's raw bytes so the browser merges/gunzips client-side.
         .route("/trace", axum::routing::get(trace::get_trace))
         .with_state(state)
 }

--- a/dial9-viewer/src/server/trace.rs
+++ b/dial9-viewer/src/server/trace.rs
@@ -4,6 +4,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum_extra::extract::Query;
 use flate2::read::GzDecoder;
+use futures::TryStreamExt;
 use futures::future::join_all;
 use serde::Deserialize;
 use std::io::Read;
@@ -28,6 +29,18 @@ pub struct ObjectParams {
 /// file in parallel and gunzips each client-side (see `fetchTraces` in
 /// `trace_parser.js`). Keeping the bytes compressed on the wire is the whole
 /// point — far less network transfer than the old server-side-merged response.
+///
+/// The body is streamed straight from the backend (see
+/// [`StorageBackend::get_object_stream`]) rather than buffered: bytes reach the
+/// browser as S3 delivers them, removing the ~2s time-to-first-byte stall the
+/// old `collect()`-then-send path imposed.
+///
+/// IMPORTANT: we deliberately do NOT set `content-encoding: gzip` even though
+/// the object is gzip-compressed. We serve the raw gzip bytes opaquely and the
+/// browser gunzips them itself via `DecompressionStream` in `fetchTraceStream`.
+/// Setting `content-encoding: gzip` would make the browser transparently
+/// decompress the body, and the client-side decoder would then double-handle
+/// (or fail on) already-decompressed bytes.
 pub async fn get_object(
     State(state): State<AppState>,
     creds: MaybeCreds,
@@ -45,14 +58,32 @@ pub async fn get_object(
         return Err((StatusCode::BAD_REQUEST, "key is required".to_string()));
     }
 
-    let data = backend
-        .get_object(&bucket, &key)
+    // Setup errors (not found / auth) surface here, before any body streams, so
+    // they still map to the right status. Mid-stream errors (below) cannot.
+    let object = backend
+        .get_object_stream(&bucket, &key)
         .await
         .map_err(storage_error_response)?;
 
-    Ok(Response::builder()
-        .header("content-type", "application/octet-stream")
-        .body(Body::from(data))
+    // Log a chunk error rather than dropping it: once streaming has begun the
+    // status line is already sent, so this is the only signal that the response
+    // was truncated. Per-request (not in a loop), so a plain warn! is fine.
+    let body_stream = object.stream.inspect_err(move |e| {
+        tracing::warn!(
+            bucket = %bucket,
+            key = %key,
+            error = %e,
+            "error mid-stream while serving /api/object; response is truncated"
+        );
+    });
+
+    let mut builder = Response::builder().header("content-type", "application/octet-stream");
+    if let Some(len) = object.content_length {
+        builder = builder.header("content-length", len);
+    }
+
+    Ok(builder
+        .body(Body::from_stream(body_stream))
         .unwrap()
         .into_response())
 }

--- a/dial9-viewer/src/server/trace.rs
+++ b/dial9-viewer/src/server/trace.rs
@@ -15,6 +15,49 @@ use crate::server::error::storage_error_response;
 const MAX_KEYS: usize = 100;
 
 #[derive(Deserialize)]
+pub struct ObjectParams {
+    /// A single S3 key (e.g. ?key=2026-04-09/.../123-0.bin.gz)
+    pub key: String,
+    pub bucket: Option<String>,
+}
+
+/// `GET /api/object?bucket=&key=` — stream a single object's bytes verbatim.
+///
+/// Unlike [`get_trace`], this does NOT decompress: a `.bin.gz` object is served
+/// still-gzipped. The viewer fetches one `trace=/api/object?…` component per
+/// file in parallel and gunzips each client-side (see `fetchTraces` in
+/// `trace_parser.js`). Keeping the bytes compressed on the wire is the whole
+/// point — far less network transfer than the old server-side-merged response.
+pub async fn get_object(
+    State(state): State<AppState>,
+    creds: MaybeCreds,
+    Query(params): Query<ObjectParams>,
+) -> Result<Response, (StatusCode, String)> {
+    let backend = state.resolve(creds)?;
+
+    let bucket = params
+        .bucket
+        .or(state.default_bucket.clone())
+        .ok_or((StatusCode::BAD_REQUEST, "bucket is required".to_string()))?;
+
+    let key = params.key;
+    if key.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "key is required".to_string()));
+    }
+
+    let data = backend
+        .get_object(&bucket, &key)
+        .await
+        .map_err(storage_error_response)?;
+
+    Ok(Response::builder()
+        .header("content-type", "application/octet-stream")
+        .body(Body::from(data))
+        .unwrap()
+        .into_response())
+}
+
+#[derive(Deserialize)]
 pub struct TraceParams {
     /// S3 keys (repeated query param: ?keys=a&keys=b)
     #[serde(default)]
@@ -22,6 +65,15 @@ pub struct TraceParams {
     pub bucket: Option<String>,
 }
 
+/// `GET /api/trace?bucket=&keys=a&keys=b` — fetch every key, gunzip each, and
+/// concatenate into one uncompressed response.
+///
+/// DEPRECATED: scheduled for removal. The viewer no longer links here; it now
+/// emits one `trace=/api/object?…` component per file and lets the browser
+/// download them in parallel and gunzip client-side ([`get_object`]). This
+/// endpoint forces the backend to decompress and buffer the whole merged trace,
+/// which transfers far more bytes. It remains only for out-of-tree callers (the
+/// `dial9-trace-loading` skill); new code should use `/api/object`.
 pub async fn get_trace(
     State(state): State<AppState>,
     creds: MaybeCreds,

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -27,6 +27,12 @@ pub struct ObjectInfo {
 /// The chunk error type is [`std::io::Error`] so the stream composes directly
 /// with [`axum::body::Body::from_stream`] (whose error bound is
 /// `Into<BoxError>`).
+///
+/// `#[non_exhaustive]`: adding a field later (e.g. `content_type`) must not be a
+/// breaking change for out-of-crate `StorageBackend` implementors. It is only
+/// ever constructed inside this crate, where struct-literal construction still
+/// works.
+#[non_exhaustive]
 pub struct ObjectStream {
     /// The object's bytes, chunk by chunk, as they arrive from the backend.
     pub stream: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>,

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+use futures::Stream;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -9,6 +11,29 @@ pub struct ObjectInfo {
     pub key: String,
     pub size: i64,
     pub last_modified: Option<String>,
+}
+
+/// A handle to an object's bytes that can be streamed to the client as they
+/// arrive, rather than buffered in full first.
+///
+/// This exists to remove the time-to-first-byte (TTFB) stall on `/api/object`:
+/// the old buffered path called `ByteStream::collect()`, which pulled the entire
+/// object out of S3 into a `Vec<u8>` before a single byte could be written to
+/// the browser (measured ~2s TTFB on real traces). With a streamed body, bytes
+/// flow to the browser as S3 delivers them, so the server↔S3 download overlaps
+/// with the browser↔server transfer (and the browser's incremental
+/// gunzip+decode in `fetchTraceStream`).
+///
+/// The chunk error type is [`std::io::Error`] so the stream composes directly
+/// with [`axum::body::Body::from_stream`] (whose error bound is
+/// `Into<BoxError>`).
+pub struct ObjectStream {
+    /// The object's bytes, chunk by chunk, as they arrive from the backend.
+    pub stream: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>,
+    /// The object's total size, if known up front (S3 returns `Content-Length`
+    /// on `GetObject`). Forwarded as the response `content-length` header so the
+    /// browser can show real download progress.
+    pub content_length: Option<i64>,
 }
 
 /// Abstraction over trace storage (S3, local FS, etc.)
@@ -38,6 +63,39 @@ pub trait StorageBackend: Send + Sync {
         bucket: &str,
         key: &str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, StorageError>> + Send + '_>>;
+
+    /// Like [`get_object`](StorageBackend::get_object), but returns the body as a
+    /// stream so the HTTP layer can forward bytes to the client as they arrive
+    /// instead of buffering the whole object first. See [`ObjectStream`] for the
+    /// TTFB rationale.
+    ///
+    /// Setup errors (object not found, auth failure, etc.) surface from the
+    /// returned future *before* any body streams — so the HTTP layer can still
+    /// map them to a 404/401/403 status. Errors encountered mid-stream (after
+    /// the status line and headers have already been sent) arrive as
+    /// `Err(io::Error)` items on the stream and can no longer change the status.
+    ///
+    /// The default implementation buffers via `get_object` and wraps the result
+    /// in a single-chunk stream. This is correct (just not incremental) and is
+    /// the right behavior for backends with no TTFB problem — e.g. local file
+    /// reads — so [`LocalBackend`] and test backends need no override.
+    fn get_object_stream(
+        &self,
+        bucket: &str,
+        key: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<ObjectStream, StorageError>> + Send + '_>> {
+        let bucket = bucket.to_string();
+        let key = key.to_string();
+        Box::pin(async move {
+            let data = self.get_object(&bucket, &key).await?;
+            let content_length = Some(data.len() as i64);
+            let stream = futures::stream::once(async move { Ok(Bytes::from(data)) });
+            Ok(ObjectStream {
+                stream: Box::pin(stream),
+                content_length,
+            })
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -386,6 +444,63 @@ impl StorageBackend for S3Backend {
                 .map_err(|e| StorageError::Other(e.to_string()))?;
 
             Ok(bytes.to_vec())
+        })
+    }
+
+    /// Stream the object body straight from S3 instead of buffering it. The
+    /// `GetObject` request (and thus NoSuchKey / auth / not-found classification)
+    /// still completes synchronously in the returned future, so the HTTP layer
+    /// gets the right status before any body streams. The body is then handed
+    /// back as a chunk stream — we do NOT call `.collect()`.
+    fn get_object_stream(
+        &self,
+        bucket: &str,
+        key: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<ObjectStream, StorageError>> + Send + '_>> {
+        let bucket = bucket.to_string();
+        let key = key.to_string();
+        Box::pin(async move {
+            let resp = self
+                .client
+                .get_object()
+                .bucket(&bucket)
+                .key(&key)
+                .send()
+                .await
+                .map_err(|e| {
+                    use aws_sdk_s3::operation::get_object::GetObjectError;
+
+                    // Classify before unwrapping the service error so auth
+                    // failures (which arrive as the redirect/4xx service error)
+                    // collapse to Unauthorized rather than leaking the message.
+                    let classified = classify_s3_error(&e);
+                    match e.into_service_error() {
+                        GetObjectError::NoSuchKey(_) => {
+                            StorageError::NotFound(format!("{bucket}/{key}"))
+                        }
+                        _ => classified,
+                    }
+                })?;
+
+            let content_length = resp.content_length();
+
+            // Drive the body via the always-public `ByteStream::next()` (the
+            // `Stream` impl on `ByteStream` itself is feature-gated/private in
+            // this SDK). `unfold` yields one chunk per poll, mapping the SDK
+            // chunk error into `io::Error` so the stream composes with
+            // `Body::from_stream`. No `.collect()` — bytes flow as they arrive.
+            let stream = futures::stream::unfold(resp.body, |mut body| async move {
+                match body.next().await {
+                    Some(Ok(chunk)) => Some((Ok(chunk), body)),
+                    Some(Err(e)) => Some((Err(std::io::Error::other(e)), body)),
+                    None => None,
+                }
+            });
+
+            Ok(ObjectStream {
+                stream: Box::pin(stream),
+                content_length,
+            })
         })
     }
 }

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -491,6 +491,30 @@ async fn object_serves_uncompressed_bytes() {
     check!(body.as_ref() == data);
 }
 
+/// A large object must stream back byte-for-byte intact. Because the handler
+/// now uses `Body::from_stream` instead of buffering, this exercises the
+/// multi-chunk path: the s3s fake delivers the body in several `ByteStream`
+/// chunks and they must reassemble exactly. Kept to a few MB so it stays cheap.
+#[tokio::test]
+async fn object_streams_large_object_intact() {
+    let (s3, base, _dir) = setup_s3_test("obj-bucket", Some("obj-bucket".into()), None).await;
+    let client = reqwest::Client::new();
+
+    // 4MB of non-trivial bytes so a single read can't accidentally satisfy it.
+    let big: Vec<u8> = (0..4 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+    put_object(&s3, "obj-bucket", "big.bin", &big).await;
+
+    let resp = client
+        .get(format!("{base}/api/object?key=big.bin"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    check!(body.len() == big.len());
+    check!(body.as_ref() == big.as_slice());
+}
+
 #[tokio::test]
 async fn object_requires_key() {
     let state = AppState::new(Arc::new(FakeBackend), Some("test-bucket".into()), None);

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -444,6 +444,94 @@ async fn trace_handles_uncompressed_data() {
     check!(body.as_ref() == data);
 }
 
+// --- /api/object (raw single-object passthrough) tests ---
+
+/// The defining property of /api/object: it serves a `.bin.gz` object's bytes
+/// VERBATIM, still gzipped — it must NOT decompress (that's the browser's job
+/// via fetchTraces). Contrast with /api/trace, which gunzips server-side.
+#[tokio::test]
+async fn object_serves_raw_gzipped_bytes() {
+    let (s3, base, _dir) = setup_s3_test("obj-bucket", Some("obj-bucket".into()), None).await;
+    let client = reqwest::Client::new();
+
+    let plaintext = b"DECOMPRESSED_TRACE_BODY";
+    let gzipped = gzip_bytes(plaintext);
+    put_object(&s3, "obj-bucket", "seg.bin.gz", &gzipped).await;
+
+    let resp = client
+        .get(format!("{base}/api/object?key=seg.bin.gz"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    // Bytes are the raw gzip stream, NOT the decompressed plaintext.
+    check!(body.as_ref() == gzipped.as_slice());
+    check!(body.as_ref() != plaintext.as_slice());
+    // Sanity: a gzip stream starts with the 0x1f 0x8b magic.
+    check!(body.len() >= 2 && body[0] == 0x1f && body[1] == 0x8b);
+}
+
+/// An uncompressed object is returned verbatim too.
+#[tokio::test]
+async fn object_serves_uncompressed_bytes() {
+    let (s3, base, _dir) = setup_s3_test("obj-bucket", Some("obj-bucket".into()), None).await;
+    let client = reqwest::Client::new();
+
+    let data = b"raw uncompressed object";
+    put_object(&s3, "obj-bucket", "raw.bin", data).await;
+
+    let resp = client
+        .get(format!("{base}/api/object?key=raw.bin"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    check!(body.as_ref() == data);
+}
+
+#[tokio::test]
+async fn object_requires_key() {
+    let state = AppState::new(Arc::new(FakeBackend), Some("test-bucket".into()), None);
+    let base = start_server(state).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/api/object?key=&bucket=test-bucket"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 400);
+}
+
+/// BYO credentials: /api/object must be served by the header-supplied ephemeral
+/// backend (the s3s fake), not the erroring default backend.
+#[tokio::test]
+async fn byo_credentials_serve_object_from_headers() {
+    let (s3, base, _dir) = setup_byo_test("byo-bucket").await;
+    let client = reqwest::Client::new();
+
+    let data = b"BYO_OBJECT_BYTES";
+    let gzipped = gzip_bytes(data);
+    put_object(&s3, "byo-bucket", "seg.bin.gz", &gzipped).await;
+
+    let resp = client
+        .get(format!(
+            "{base}/api/object?key=seg.bin.gz&bucket=byo-bucket"
+        ))
+        .header(H_AKID, "test")
+        .header(H_SECRET, "test")
+        .header(H_REGION, "us-east-1")
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    // Served raw (still gzipped) by the ephemeral backend.
+    check!(body.as_ref() == gzipped.as_slice());
+}
+
 /// Full end-to-end smoke test: simulates the browser flow.
 /// 1. Upload gzipped trace segments to fake S3
 /// 2. Search for them via /api/search
@@ -850,6 +938,55 @@ async fn local_trace_not_found() {
         .await
         .unwrap();
     check!(resp.status().as_u16() == 404);
+}
+
+/// /api/object on the local backend serves the file's raw (gzipped) bytes
+/// without decompressing.
+#[tokio::test]
+async fn local_object_serves_raw_bytes() {
+    let dir = setup_local_dir();
+    let base = start_server(local_state(dir.path())).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!(
+            "{base}/api/object?key=2026-04-09/1910/svc/host/123-0.bin.gz"
+        ))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    // The on-disk file is gzip(b"trace seg 0"); served verbatim.
+    check!(body.as_ref() == gzip_bytes(b"trace seg 0").as_slice());
+}
+
+#[tokio::test]
+async fn local_object_not_found() {
+    let dir = setup_local_dir();
+    let base = start_server(local_state(dir.path())).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/api/object?key=nonexistent.bin"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 404);
+}
+
+#[tokio::test]
+async fn local_object_path_traversal_rejected() {
+    let dir = setup_local_dir();
+    let base = start_server(local_state(dir.path())).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/api/object?key=../../../etc/passwd"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() != 200);
 }
 
 #[tokio::test]

--- a/dial9-viewer/ui/README.md
+++ b/dial9-viewer/ui/README.md
@@ -6,8 +6,8 @@ the assets are served from disk by `../src/bin/dev_server.rs`.
 
 Key files:
 
-- `index.html` — landing page / S3 browser. Builds `/api/trace` URLs and opens
-  the viewer or flamegraph.
+- `index.html` — landing page / S3 browser. Emits one `trace=/api/object?…`
+  component per selected file and opens the viewer or flamegraph.
 - `viewer.html` — main trace viewer.
 - `flamegraph.html` — standalone CPU-profile flamegraph view.
 - `decode.js` — low-level binary trace-frame decoder (`TraceDecoder`).
@@ -17,12 +17,26 @@ Key files:
 ## The `trace=` query parameter
 
 `trace=` is **repeatable**. Each value is fetched independently and may be
-individually gzipped (unlike `/api/trace`, which gunzips server-side before
-returning a single response). `TraceParser.fetchTraces()` fetches every
-component, runs each through `maybeGunzip`, and concatenates the raw bytes.
-The decoder treats a concatenated stream as multiple segments — a mid-stream
+individually gzipped. `TraceParser.fetchTraces()` fetches every component (in
+parallel), runs each through `maybeGunzip`, and concatenates the raw bytes. The
+decoder treats a concatenated stream as multiple segments — a mid-stream
 `TRC\0` header resets the frame parser — so the combined buffer parses as one
 trace. Read all values with `params.getAll('trace')`, never `params.get`.
+
+For S3-backed traces, `index.html` points each `trace=` at
+`/api/object?bucket=&key=`, which serves one file's raw (still-gzipped) bytes.
+The browser thus downloads the files in parallel and decompresses them
+client-side — far less network transfer than a single merged response.
+
+### `/api/trace` (deprecated)
+
+`GET /api/trace?bucket=&keys=a&keys=b` fetches every key, gunzips each
+server-side, and returns one concatenated **uncompressed** blob. This is
+**deprecated and slated for removal**: it transfers far more bytes (the merged,
+decompressed trace) and serializes the work on the backend. The UI no longer
+links to it; it remains only for out-of-tree callers (e.g. the
+`dial9-trace-loading` skill). New code should fetch individual objects via
+`/api/object` and let `fetchTraces` merge them.
 
 ## Tests — IMPORTANT for agents
 

--- a/dial9-viewer/ui/bench_parse.js
+++ b/dial9-viewer/ui/bench_parse.js
@@ -1,0 +1,149 @@
+// bench_parse.js — diagnostic parse-speed benchmark for the trace decoder.
+//
+// Measures whole-buffer parse vs. streaming parse (parseTraceStream) at a range
+// of chunk sizes, with and without the per-chunk progress yield, so we can see
+// where streaming overhead comes from and iterate on it with real data.
+//
+// Usage:
+//   node bench_parse.js [trace.bin|trace.bin.gz] [--iters N] [--quick]
+//
+// Defaults to demo-trace.bin in this directory. Prints a table of
+// milliseconds + events/sec; the streaming rows show overhead vs the
+// whole-buffer baseline.
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+const { parseTrace, parseTraceStream } = require("./trace_parser.js");
+
+function parseArgs(argv) {
+  const args = { file: null, iters: 3, quick: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--iters") args.iters = Number(argv[++i]);
+    else if (a === "--quick") args.quick = true;
+    else if (!a.startsWith("--")) args.file = a;
+  }
+  return args;
+}
+
+/** Decompress if gzipped, returning raw trace bytes as a Uint8Array. */
+function loadRaw(file) {
+  const buf = fs.readFileSync(file);
+  if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
+    return new Uint8Array(zlib.gunzipSync(buf));
+  }
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+/** Async iterable that yields `raw` in fixed-size chunks. Models the network /
+ *  DecompressionStream feeding the decoder chunk-by-chunk. `delayMs` optionally
+ *  simulates per-chunk arrival latency (0 = arrive as fast as the CPU drains). */
+function chunkedSource(raw, chunkSize, delayMs = 0) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (let off = 0; off < raw.length; off += chunkSize) {
+        const end = Math.min(off + chunkSize, raw.length);
+        // Copy so each chunk is its own exactly-sized buffer (like a real
+        // stream chunk), not a view into `raw`.
+        const chunk = raw.slice(off, end);
+        if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+        yield chunk;
+      }
+    },
+  };
+}
+
+function fmtMs(ms) {
+  return ms.toFixed(0).padStart(7) + " ms";
+}
+function fmtRate(events, ms) {
+  const perSec = events / (ms / 1000);
+  return (perSec / 1e6).toFixed(2).padStart(6) + " M ev/s";
+}
+
+async function timeIt(fn, iters) {
+  const samples = [];
+  let result = null;
+  for (let i = 0; i < iters; i++) {
+    const t0 = process.hrtime.bigint();
+    result = await fn();
+    const t1 = process.hrtime.bigint();
+    samples.push(Number(t1 - t0) / 1e6);
+  }
+  samples.sort((a, b) => a - b);
+  return { ms: samples[Math.floor(samples.length / 2)], result }; // median
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const file = args.file || path.join(__dirname, "demo-trace.bin");
+  const raw = loadRaw(file);
+
+  console.log(`\nTrace: ${file}`);
+  console.log(`Raw size: ${(raw.length / 1048576).toFixed(2)} MB · iters: ${args.iters} (median reported)\n`);
+
+  // Baseline: whole-buffer parse.
+  const base = await timeIt(() => parseTrace(raw.slice()), args.iters);
+  const events = base.result.events.length;
+  console.log(`Events: ${events.toLocaleString()} · CPU samples: ${base.result.cpuSamples.length.toLocaleString()}\n`);
+
+  const baseMs = base.ms;
+  console.log("mode                              time         rate        overhead");
+  console.log("─".repeat(72));
+  console.log(
+    `whole-buffer (baseline)        ${fmtMs(baseMs)}   ${fmtRate(events, baseMs)}        —`
+  );
+
+  const KB = 1024, MB = 1024 * 1024;
+  const chunkSizes = args.quick
+    ? [64 * KB, 1 * MB]
+    : [16 * KB, 64 * KB, 256 * KB, 1 * MB, 4 * MB];
+
+  for (const yield_ of [false, true]) {
+    console.log(
+      `\n  streaming · progress-yield ${yield_ ? "ON " : "OFF"} (onParseProgress set):`
+    );
+    for (const cs of chunkSizes) {
+      // onParseProgress presence is what triggers the progress yield in
+      // parseTraceStream, so toggle it to isolate the yield cost.
+      const opts = yield_ ? { onParseProgress: () => {} } : {};
+      const { ms, result } = await timeIt(
+        () => parseTraceStream(chunkedSource(raw, cs), opts),
+        args.iters
+      );
+      const ok = result.events.length === events;
+      const label = `chunk ${(cs / KB).toString().padStart(5)}KB`;
+      const ovh = `${(((ms - baseMs) / baseMs) * 100).toFixed(0)}%`.padStart(6);
+      console.log(
+        `    ${label}                ${fmtMs(ms)}   ${fmtRate(events, ms)}     ${ovh}${ok ? "" : "  ✗ EVENT COUNT MISMATCH"}`
+      );
+    }
+  }
+
+  // The browser's DecompressionStream("gzip") feeds ~16KB chunks with
+  // onParseProgress set (the viewer always sets it). This is the real-world
+  // case parseTraceStream must handle well: it feeds 16KB chunks through the
+  // SAME parseTraceStream the viewer uses. With the internal MIN_DRAIN_BYTES
+  // batching it should sit near the whole-buffer baseline, not ~1.7x it.
+  console.log(
+    "\n  ⮑ browser path: 16KB source (DecompressionStream-like) + progress-yield ON:"
+  );
+  {
+    const { ms, result } = await timeIt(
+      () => parseTraceStream(chunkedSource(raw, 16 * KB), { onParseProgress: () => {} }),
+      args.iters
+    );
+    const ok = result.events.length === events;
+    const ovh = `${(((ms - baseMs) / baseMs) * 100).toFixed(0)}%`.padStart(6);
+    console.log(
+      `    16KB chunks (batched)      ${fmtMs(ms)}   ${fmtRate(events, ms)}     ${ovh}${ok ? "" : "  ✗ EVENT COUNT MISMATCH"}`
+    );
+  }
+  console.log("");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -102,16 +102,26 @@
                     return;
                 }
 
-                // Fetch trace(s): each component is fetched and gunzipped
-                // independently, then concatenated into one buffer.
-                let buffer;
+                // Load the trace. For a single URL we STREAM: download and
+                // decode overlap, hiding most of the parse time behind the
+                // download. For multiple repeated `trace=` components we fall
+                // back to the buffered fetch+concatenate path (each component is
+                // fetched and gunzipped independently, then concatenated).
+                const credHeaders = window.Dial9Creds ? Dial9Creds.headers() : {};
+                let trace;
                 try {
-                    loadingEl.textContent = traceUrls.length > 1
-                        ? `Fetching ${traceUrls.length} traces\u2026`
-                        : "Fetching trace\u2026";
-                    // Attach bring-your-own-credentials headers if present.
-                    const credHeaders = window.Dial9Creds ? Dial9Creds.headers() : {};
-                    buffer = await TraceParser.fetchTraces(traceUrls, { headers: credHeaders });
+                    if (traceUrls.length === 1 && TraceParser.canStreamDecode()) {
+                        loadingEl.textContent = "Loading trace\u2026";
+                        const stream = await TraceParser.fetchTraceStream(traceUrls[0], { headers: credHeaders });
+                        trace = await TraceParser.parseTraceStream(stream);
+                    } else {
+                        loadingEl.textContent = traceUrls.length > 1
+                            ? `Fetching ${traceUrls.length} traces\u2026`
+                            : "Fetching trace\u2026";
+                        const buffer = await TraceParser.fetchTraces(traceUrls, { headers: credHeaders });
+                        loadingEl.textContent = "Parsing trace\u2026";
+                        trace = await TraceParser.parseTrace(buffer);
+                    }
                 } catch (err) {
                     if (/HTTP 401/.test(err.message) && window.Dial9Creds && !Dial9Creds.has()) {
                         showError(
@@ -119,18 +129,8 @@
                             "home page after applying your credentials."
                         );
                     } else {
-                        showError("Failed to fetch trace: " + err.message);
+                        showError("Failed to load trace: " + err.message);
                     }
-                    return;
-                }
-
-                // Parse trace
-                let trace;
-                try {
-                    loadingEl.textContent = "Parsing trace\u2026";
-                    trace = await TraceParser.parseTrace(buffer);
-                } catch (err) {
-                    showError("Failed to parse trace: " + err.message);
                     return;
                 }
 

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -1472,24 +1472,34 @@
         return params;
     }
 
+    // Build one viewer `trace=` component per selected key, each pointing at
+    // /api/object (which serves that single file's raw, still-gzipped bytes).
+    // The viewer and flamegraph read all repeated `trace=` params, download
+    // them in parallel, and gunzip + concatenate client-side (see fetchTraces
+    // in trace_parser.js). This replaced a single /api/trace URL that forced
+    // the backend to fetch every file, gunzip them, and merge into one large
+    // uncompressed response — far more bytes over the wire and much slower.
+    function objectTraceUrls(bucket, keys) {
+        return keys.map(key => {
+            const p = new URLSearchParams();
+            p.set('bucket', bucket);
+            p.set('key', key);
+            return '/api/object?' + p.toString();
+        });
+    }
+
     // CPU Profiling button: open a flamegraph of the selected segments. The
     // flamegraph view builds from the trace's CpuSampleEvents (and resolves
     // symbols from SymbolTableEntry), ignoring all other event types, so we
-    // serve the full trace via /api/trace — no server-side event filtering is
-    // needed for a working flamegraph. The selection is already size-capped.
+    // serve each whole file — no server-side event filtering is needed for a
+    // working flamegraph. The selection is already size-capped.
     function viewCpuProfile() {
         if (!heatmapSelection || !heatmapSelection.keys.length) return;
         const bucket = bucketInput.value.trim();
         if (!bucket) { alert('Bucket is required'); return; }
         const keys = heatmapSelection.keys;
-        const params = new URLSearchParams();
-        params.set('bucket', bucket);
-        for (const key of keys) {
-            params.append('keys', key);
-        }
-        const traceUrl = '/api/trace?' + params.toString();
         const fgParams = traceTitleParams(keys);
-        fgParams.set('trace', traceUrl);
+        for (const url of objectTraceUrls(bucket, keys)) fgParams.append('trace', url);
         window.open('flamegraph.html?' + fgParams.toString(), '_blank');
     }
 
@@ -1630,12 +1640,11 @@
         if (keys.length === 0) return;
 
         const bucket = bucketInput.value.trim();
-        const keysParams = keys.map(k => `keys=${encodeURIComponent(k)}`).join('&');
-        const traceUrl = `/api/trace?bucket=${encodeURIComponent(bucket)}&${keysParams}`;
 
-        // Pass structured metadata for the viewer title.
+        // Pass structured metadata for the viewer title, plus one trace=
+        // component per file (downloaded in parallel + gunzipped client-side).
         const titleParams = traceTitleParams(keys);
-        titleParams.set('trace', traceUrl);
+        for (const url of objectTraceUrls(bucket, keys)) titleParams.append('trace', url);
 
         window.open(`viewer.html?${titleParams.toString()}`, '_blank');
     }

--- a/dial9-viewer/ui/test_stream_parse.js
+++ b/dial9-viewer/ui/test_stream_parse.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+"use strict";
+
+// Tests for the streaming trace decoder (parseTraceStream).
+//
+// The streaming parser must produce a ParsedTrace byte-for-byte identical to
+// parseTrace() on the same concatenated bytes, no matter how the bytes are
+// chunked. The risky part is the transactional frame decode in
+// TraceDecoder.nextFrame(): a chunk boundary that falls mid-event (or mid
+// TRC\0 header) must be detected as "need more bytes", rolled back, and
+// re-attempted once the next chunk arrives — never silently dropped.
+//
+// We exercise adversarial chunk boundaries: size 1 (every byte boundary), a
+// few fixed small sizes, prime sizes, and boundaries deliberately placed
+// inside event timestamps and inside a mid-stream TRC\0 header.
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+const { assert, testAsync, summarize } = require("./test_harness.js");
+const { parseTrace, parseTraceStream } = require("./trace_parser.js");
+
+// Yield an async iterable of fixed-size Uint8Array chunks over `bytes`.
+function chunked(bytes, size) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (let i = 0; i < bytes.length; i += size) {
+        yield bytes.subarray(i, Math.min(i + size, bytes.length));
+      }
+    },
+  };
+}
+
+// Yield an async iterable using an explicit list of boundary offsets. The
+// boundaries are sorted and de-duplicated so the emitted chunks always cover
+// `bytes` contiguously in order (a buggy unsorted list would silently reorder
+// or drop bytes and mask real failures).
+function chunkedAt(bytes, boundaries) {
+  const inner = [...new Set(boundaries.filter((b) => b > 0 && b < bytes.length))]
+    .sort((a, b) => a - b);
+  const offs = [0, ...inner, bytes.length];
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (let i = 1; i < offs.length; i++) {
+        if (offs[i] > offs[i - 1]) yield bytes.subarray(offs[i - 1], offs[i]);
+      }
+    },
+  };
+}
+
+// Serialize a ParsedTrace into a stable, comparable plain object. Maps are
+// turned into sorted entry arrays so deepStrictEqual doesn't depend on Map
+// insertion order (it shouldn't differ, but this makes failures legible and
+// robust). BigInts are stringified.
+function canonical(trace) {
+  const mapEntries = (m) => [...m.entries()].sort((a, b) => {
+    const ka = String(a[0]), kb = String(b[0]);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
+  return JSON.parse(JSON.stringify({
+    magic: trace.magic,
+    version: trace.version,
+    events: trace.events,
+    minTs: trace.minTs,
+    maxTs: trace.maxTs,
+    recordMinTs: trace.recordMinTs,
+    recordMaxTs: trace.recordMaxTs,
+    truncated: trace.truncated,
+    timeFiltered: trace.timeFiltered,
+    filterStartTime: trace.filterStartTime,
+    filterEndTime: trace.filterEndTime,
+    cpuSamples: trace.cpuSamples,
+    allocEvents: trace.allocEvents,
+    freeEvents: trace.freeEvents,
+    memoryOverflows: trace.memoryOverflows,
+    customEvents: trace.customEvents,
+    clockSyncAnchors: trace.clockSyncAnchors,
+    clockOffsetNs: trace.clockOffsetNs,
+    blockInPlaceGaps: trace.blockInPlaceGaps,
+    spawnLocations: mapEntries(trace.spawnLocations),
+    taskSpawnLocs: mapEntries(trace.taskSpawnLocs),
+    taskSpawnTimes: mapEntries(trace.taskSpawnTimes),
+    taskTerminateTimes: mapEntries(trace.taskTerminateTimes),
+    taskInstrumented: mapEntries(trace.taskInstrumented),
+    callframeSymbols: mapEntries(trace.callframeSymbols),
+    threadNames: mapEntries(trace.threadNames),
+    tidToWorker: mapEntries(trace.tidToWorker),
+    runtimeWorkers: mapEntries(trace.runtimeWorkers),
+    taskDumps: mapEntries(trace.taskDumps),
+  }, (_, v) => (typeof v === "bigint" ? v.toString() : v)));
+}
+
+async function main() {
+  const tracePath = path.join(__dirname, "demo-trace.bin");
+  if (!fs.existsSync(tracePath)) {
+    console.error(`Trace file not found: ${tracePath}`);
+    process.exit(1);
+  }
+
+  const fileBytes = fs.readFileSync(tracePath);
+  const rawTrace =
+    fileBytes[0] === 0x1f && fileBytes[1] === 0x8b
+      ? zlib.gunzipSync(fileBytes)
+      : Buffer.from(fileBytes);
+  const raw = Uint8Array.from(rawTrace); // plain Uint8Array (subarray-safe)
+
+  // Reference parse of the whole (gunzipped) buffer.
+  const reference = await parseTrace(raw);
+  const refCanon = canonical(reference);
+  console.log(
+    `Reference: ${reference.events.length} events, ` +
+      `${reference.cpuSamples.length} cpu samples, ` +
+      `${raw.length} raw bytes`
+  );
+  assert.ok(reference.events.length > 0, "reference has events");
+
+  // Find offsets of every TRC\0 mid-stream header. Skip the leading header at
+  // 0. (These byte patterns can also appear inside frame payloads; that's
+  // fine — splitting there still exercises the rollback path.)
+  function headerOffsetsIn(bytes) {
+    const offs = [];
+    for (let i = 1; i + 4 <= bytes.length; i++) {
+      if (bytes[i] === 0x54 && bytes[i + 1] === 0x52 && bytes[i + 2] === 0x43 && bytes[i + 3] === 0x00) {
+        offs.push(i);
+      }
+    }
+    return offs;
+  }
+  const headerOffsets = headerOffsetsIn(raw);
+  console.log(`Found ${headerOffsets.length} mid-stream TRC\\0 header pattern(s)`);
+
+  async function streamCanon(iterable) {
+    const t = await parseTraceStream(iterable);
+    return canonical(t);
+  }
+
+  // Assert that streaming `bytes` (any prefix of the trace) with the given
+  // chunking yields the same ParsedTrace as parsing the whole `bytes` buffer.
+  // The buffered parser and the stream parser must handle a truncated tail
+  // identically, so this works for arbitrary byte slices.
+  async function assertStreamMatches(bytes, iterable) {
+    const ref = canonical(await parseTrace(bytes));
+    const got = await streamCanon(iterable);
+    assert.deepStrictEqual(got, ref);
+  }
+
+  // A prefix big enough to span several segments (TRC\0 resets), every event
+  // type, pools, and symbols — but small enough that byte-by-byte chunking is
+  // fast. We pick a prefix that ends just before a mid-stream header so the
+  // truncation is clean, falling back to ~1MB.
+  let prefixEnd = Math.min(1_000_000, raw.length);
+  for (const h of headerOffsets) {
+    if (h >= 200_000 && h <= 1_200_000) { prefixEnd = h; break; }
+  }
+  const prefix = raw.subarray(0, prefixEnd);
+  const prefixHeaders = headerOffsetsIn(prefix);
+  console.log(
+    `Adversarial prefix: ${prefix.length} bytes, ${prefixHeaders.length} segment header(s)`
+  );
+
+  // ── Test: chunk size 1 (every single-byte boundary, maximally adversarial)
+  //    over the prefix — exercises rollback at every byte offset. ──
+  await testAsync("chunk size 1 (byte-by-byte) over prefix matches", async () => {
+    await assertStreamMatches(prefix, chunked(prefix, 1));
+  });
+
+  // ── Test: tiny prime chunk sizes over the prefix ──
+  for (const size of [2, 3, 5, 7, 13]) {
+    await testAsync(`chunk size ${size} over prefix matches`, async () => {
+      await assertStreamMatches(prefix, chunked(prefix, size));
+    });
+  }
+
+  // ── Test: a spread of fixed chunk sizes over the FULL buffer ──
+  for (const size of [64, 256, 1024, 4096, 65536, 1 << 20]) {
+    await testAsync(`chunk size ${size} (full trace) matches reference`, async () => {
+      const got = await streamCanon(chunked(raw, size));
+      assert.deepStrictEqual(got, refCanon);
+    });
+  }
+
+  // ── Test: one giant chunk (whole buffer in a single read) ──
+  await testAsync("single whole-buffer chunk matches reference", async () => {
+    const got = await streamCanon(chunked(raw, raw.length));
+    assert.deepStrictEqual(got, refCanon);
+  });
+
+  // ── Test: boundary placed inside a mid-stream TRC\0 header (partial header
+  //    straddling the chunk boundary) on the full buffer. ──
+  if (headerOffsets.length > 0) {
+    const h = headerOffsets[0];
+    for (const off of [h, h + 1, h + 2, h + 3, h + 4]) {
+      await testAsync(`boundary inside/at TRC\\0 header at +${off - h}`, async () => {
+        const got = await streamCanon(chunkedAt(raw, [off]));
+        assert.deepStrictEqual(got, refCanon);
+      });
+    }
+    // Boundaries inside EVERY mid-stream header at once.
+    await testAsync("boundary inside every TRC\\0 header at once", async () => {
+      const got = await streamCanon(chunkedAt(raw, headerOffsets.flatMap((x) => [x + 1, x + 2, x + 3])));
+      assert.deepStrictEqual(got, refCanon);
+    });
+  }
+
+  // ── Test: boundaries placed mid-event over the prefix. Event frames are
+  //    TAG_EVENT(0x02) followed by a 2-byte type_id and (for timestamped
+  //    events) a 3-byte delta. Split 1..4 bytes after each 0x02 byte to land
+  //    inside the type_id / timestamp delta. Many of these land mid-event;
+  //    any that land between frames are still valid splits. ──
+  await testAsync("boundaries mid-event (after 0x02 tags) over prefix match", async () => {
+    const boundaries = [];
+    for (let i = 5; i < prefix.length; i++) {
+      if (prefix[i] === 0x02) {
+        for (const d of [1, 2, 3, 4]) {
+          if (i + d < prefix.length) boundaries.push(i + d);
+        }
+      }
+    }
+    await assertStreamMatches(prefix, chunkedAt(prefix, boundaries));
+  });
+
+  // ── Test: gzipped input, decoded after gunzip, fed chunked into the stream
+  //    parser. (fetchTraceStream does the gunzip; here we gunzip then chunk the
+  //    post-gunzip bytes, which is exactly what the stream parser consumes.) ──
+  await testAsync("gzip round-trip: gunzip then chunked stream matches reference", async () => {
+    const gz = zlib.gzipSync(Buffer.from(raw));
+    const regunzipped = Uint8Array.from(zlib.gunzipSync(gz));
+    const got = await streamCanon(chunked(regunzipped, 1000));
+    assert.deepStrictEqual(got, refCanon);
+  });
+
+  // ── Test: empty / header-only streams error like the buffered parser ──
+  await testAsync("empty stream throws Invalid trace header", async () => {
+    let threw = false;
+    try {
+      await parseTraceStream(chunked(new Uint8Array(0), 1));
+    } catch (e) {
+      threw = /Invalid trace header/.test(e.message);
+    }
+    assert.ok(threw, "expected Invalid trace header");
+  });
+
+  // ── Test: time-range filtering is honored identically when streaming ──
+  await testAsync("time-range filtered stream matches filtered reference", async () => {
+    const mid = reference.recordMinTs != null && reference.recordMaxTs != null
+      ? Math.floor((reference.recordMinTs + reference.recordMaxTs) / 2)
+      : null;
+    if (mid == null) return; // no time bounds; skip
+    const opts = { startTime: reference.recordMinTs, endTime: mid };
+    const refFiltered = canonical(await parseTrace(raw, opts));
+    const streamFiltered = canonical(await parseTraceStream(chunked(raw, 333), opts));
+    assert.deepStrictEqual(streamFiltered, refFiltered);
+  });
+
+  summarize();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/dial9-viewer/ui/test_trace_analysis.js
+++ b/dial9-viewer/ui/test_trace_analysis.js
@@ -20,6 +20,10 @@ const {
   getTraceTimeRange,
   hasCpuProfileSamples,
   analyzeAllocations,
+  makeBarCoalescer,
+  computePollWakes,
+  pixelDownsampleSpans,
+  pixelCoverage,
 } = require("./trace_analysis.js");
 
 async function main() {
@@ -745,7 +749,23 @@ async function main() {
     const beta = allSpans.find(s => s.spanName === "beta");
     if (!alpha || !beta) fail("Missing alpha or beta span");
     if (alpha.start !== 1000 || beta.start !== 2000) fail("Span intervals not distinct");
-    pass("Recycled span IDs produce separate intervals");
+    // The viewer's per-lane highlight loop relies on grouping allSpans by
+    // spanId into a multimap (spansByIdAll) and lighting up EVERY instance —
+    // not a single last-wins entry. Assert that recycled id 1 indeed yields
+    // two grouped instances, so the highlight stays correct under recycling.
+    const byId = new Map();
+    for (const s of allSpans) {
+      let b = byId.get(s.spanId);
+      if (!b) { b = []; byId.set(s.spanId, b); }
+      b.push(s);
+    }
+    // spanId is keyed exactly as stored on the span objects (a string here),
+    // the same value the viewer puts in selectedSpanIds — so the multimap key
+    // is alpha.spanId, not a numeric literal.
+    if ((byId.get(alpha.spanId) || []).length !== 2)
+      fail(`Expected id ${JSON.stringify(alpha.spanId)} to group 2 recycled spans, got ${(byId.get(alpha.spanId) || []).length}`);
+    if (alpha.spanId !== beta.spanId) fail("Recycled spans should share the same spanId key");
+    pass("Recycled span IDs produce separate intervals (and group by id)");
   }
 
   function testBuildSpanDataPerCallsiteSchema() {
@@ -1168,6 +1188,320 @@ async function main() {
 
   console.log("\nblock-in-place active-span suppression:");
   testBlockInPlaceActiveSpanSuppression();
+
+  console.log("\ncomputePollWakes:");
+  testPollWakesMatchesBruteForce();
+  testPollWakesNoWakes();
+  testPollWakesMidPollBump();
+
+  // Reference O(P^2) implementation — the original viewer loop, kept here to
+  // prove the binary-search version produces identical results.
+  function pollWakesBruteForce(polls, wakes) {
+    const out = [];
+    for (let pi = 0; pi < polls.length; pi++) {
+      const s = polls[pi];
+      let best = null;
+      if (wakes.length) {
+        let lo = 0, hi = wakes.length - 1, bi = -1;
+        while (lo <= hi) {
+          const mid = (lo + hi) >> 1;
+          if (wakes[mid].timestamp <= s.start) { bi = mid; lo = mid + 1; }
+          else hi = mid - 1;
+        }
+        if (bi >= 0) {
+          const w = wakes[bi];
+          let effectiveWake = w.timestamp;
+          for (let j = 0; j < pi; j++) {
+            if (w.timestamp >= polls[j].start && w.timestamp <= polls[j].end) {
+              effectiveWake = polls[j].end;
+              break;
+            }
+          }
+          const delay = s.start - effectiveWake;
+          if (delay >= 0 && delay < 1e9) best = { wake: w, effectiveWake };
+        }
+      }
+      out.push(best);
+    }
+    return out;
+  }
+
+  function testPollWakesMatchesBruteForce() {
+    // Deterministic pseudo-random non-overlapping polls + scattered wakes.
+    const polls = [];
+    let t = 0;
+    let seed = 12345;
+    const rnd = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+    for (let i = 0; i < 400; i++) {
+      const gap = Math.floor(rnd() * 50);
+      const dur = 1 + Math.floor(rnd() * 80);
+      const start = t + gap;
+      polls.push({ start, end: start + dur });
+      t = start + dur;
+    }
+    const wakes = [];
+    for (let i = 0; i < 600; i++) {
+      wakes.push({ timestamp: Math.floor(rnd() * t), wakerTaskId: i });
+    }
+    wakes.sort((a, b) => a.timestamp - b.timestamp);
+
+    const fast = computePollWakes(polls, wakes);
+    const slow = pollWakesBruteForce(polls, wakes);
+    if (fast.length !== slow.length) fail(`pollWakes: length mismatch ${fast.length} vs ${slow.length}`);
+    for (let i = 0; i < slow.length; i++) {
+      const a = fast[i], b = slow[i];
+      if ((a == null) !== (b == null)) fail(`pollWakes[${i}]: null mismatch`);
+      if (a && b) {
+        if (a.effectiveWake !== b.effectiveWake)
+          fail(`pollWakes[${i}]: effectiveWake ${a.effectiveWake} vs ${b.effectiveWake}`);
+        if (a.wake.wakerTaskId !== b.wake.wakerTaskId)
+          fail(`pollWakes[${i}]: wake mismatch`);
+      }
+    }
+    pass("binary-search computePollWakes matches O(P^2) reference (400 polls, 600 wakes)");
+  }
+
+  function testPollWakesNoWakes() {
+    const polls = [{ start: 0, end: 10 }, { start: 20, end: 30 }];
+    const out = computePollWakes(polls, []);
+    if (out.length !== 2 || out[0] !== null || out[1] !== null)
+      fail("pollWakes: empty wakes should yield all-null");
+    pass("no wakes yields all-null result");
+  }
+
+  function testPollWakesMidPollBump() {
+    // Wake at t=5 lands inside poll[0] [0,10]; poll[1] starts at 20.
+    // effectiveWake for poll[1] must bump to poll[0].end (10), not 5.
+    const polls = [{ start: 0, end: 10 }, { start: 20, end: 30 }];
+    const wakes = [{ timestamp: 5, wakerTaskId: 99 }];
+    const out = computePollWakes(polls, wakes);
+    // poll[0]: wake at 5 <= start 0? no — rightmost wake <= 0 is none → null.
+    if (out[0] !== null) fail("pollWakes: poll[0] should have no qualifying wake");
+    if (!out[1] || out[1].effectiveWake !== 10)
+      fail(`pollWakes: poll[1] effectiveWake should bump to 10, got ${out[1] && out[1].effectiveWake}`);
+    pass("wake landing mid-earlier-poll bumps effectiveWake to that poll's end");
+  }
+
+  console.log("\npixelDownsampleSpans:");
+  const _dur = (s) => s.end - s.start;
+  function ffvByStart(spans, vs) {
+    let lo = 0, hi = spans.length - 1;
+    while (lo <= hi) { const m = (lo + hi) >> 1; if (spans[m].end < vs) lo = m + 1; else hi = m - 1; }
+    return lo;
+  }
+  testDownsampleBoundsOutputByPixels();
+  testDownsampleKeepsLongestPerColumn();
+  testDownsamplePassThroughWhenSparse();
+  testDownsampleStartIdxAndBreak();
+  testDownsampleEmpty();
+
+  function testDownsampleBoundsOutputByPixels() {
+    // 100k spans over a 200px lane → at most 200 representatives.
+    const spans = [];
+    for (let i = 0; i < 100000; i++) spans.push({ start: i, end: i + 1 });
+    const reps = pixelDownsampleSpans(spans, 0, 0, 100000, 200, _dur);
+    if (reps.length > 200) fail(`downsample: expected ≤200 reps, got ${reps.length}`);
+    if (reps.length < 1) fail("downsample: expected some reps");
+    pass(`100k spans over 200px → ${reps.length} reps (≤200)`);
+  }
+
+  function testDownsampleKeepsLongestPerColumn() {
+    // Three spans in the same pixel column; the longest must be the rep.
+    // viewDur=1000 over pw=10 → 100ns per pixel. All three start in [0,100).
+    const spans = [
+      { start: 0,  end: 5,  id: "a" },
+      { start: 10, end: 90, id: "b" }, // longest
+      { start: 20, end: 25, id: "c" },
+    ];
+    const reps = pixelDownsampleSpans(spans, 0, 0, 1000, 10, _dur);
+    if (reps.length !== 1) fail(`downsample: expected 1 rep in column, got ${reps.length}`);
+    if (reps[0].id !== "b") fail(`downsample: expected longest 'b', got '${reps[0].id}'`);
+    pass("longest span wins its pixel column");
+  }
+
+  function testDownsamplePassThroughWhenSparse() {
+    // Spans already spread > 1px apart: all survive, order preserved.
+    const spans = [
+      { start: 0,   end: 10 },
+      { start: 500, end: 510 },
+      { start: 999, end: 1000 },
+    ];
+    const reps = pixelDownsampleSpans(spans, 0, 0, 1000, 1000, _dur);
+    if (reps.length !== 3) fail(`downsample: expected 3 reps when sparse, got ${reps.length}`);
+    if (reps[0].start !== 0 || reps[2].start !== 999) fail("downsample: order/identity not preserved");
+    pass("sparse spans pass through unchanged");
+  }
+
+  function testDownsampleStartIdxAndBreak() {
+    // startIdx skips earlier spans; iteration breaks past viewEnd.
+    const spans = [];
+    for (let i = 0; i < 1000; i++) spans.push({ start: i * 10, end: i * 10 + 5 });
+    // view [2000, 3000]; binary-search start, downsample over wide pw so no merging.
+    const startIdx = ffvByStart(spans, 2000);
+    const reps = pixelDownsampleSpans(spans, startIdx, 2000, 3000, 100000, _dur);
+    for (const r of reps) {
+      if (r.start > 3000) fail(`downsample: rep past viewEnd (${r.start})`);
+      if (r.end < 2000) fail(`downsample: rep before viewStart (${r.end})`);
+    }
+    if (reps.length < 1) fail("downsample: expected reps in window");
+    pass("respects startIdx and breaks past viewEnd");
+  }
+
+  function testDownsampleEmpty() {
+    if (pixelDownsampleSpans([], 0, 0, 1000, 100, _dur).length !== 0) fail("downsample: empty in → empty out");
+    if (pixelDownsampleSpans([{start:0,end:1}], 0, 0, 0, 100, _dur).length !== 0) fail("downsample: zero viewDur → empty");
+    if (pixelDownsampleSpans([{start:0,end:1}], 0, 0, 1000, 0, _dur).length !== 0) fail("downsample: zero pw → empty");
+    pass("empty / degenerate inputs yield no reps");
+  }
+
+  console.log("\npixelCoverage:");
+  testCoverageFullColumn();
+  testCoverageHalf();
+  testCoverageSparseStaysSparse();
+  testCoverageSpanAcrossColumns();
+  testCoverageClampedToView();
+  testCoverageDegenerate();
+
+  function approx(a, b, eps) { return Math.abs(a - b) <= (eps || 1e-9); }
+
+  function testCoverageFullColumn() {
+    // One span exactly filling the whole view → every column ≈ 1.
+    const cov = pixelCoverage([{ start: 0, end: 100 }], 0, 0, 100, 10);
+    for (let i = 0; i < cov.length; i++)
+      if (!approx(cov[i], 1)) fail(`coverage: col ${i} expected ~1, got ${cov[i]}`);
+    pass("span filling the view → all columns fully covered");
+  }
+
+  function testCoverageHalf() {
+    // 100ns view over 10px = 10ns/px. A span covering [0,50) fills cols 0-4,
+    // leaves cols 5-9 empty.
+    const cov = pixelCoverage([{ start: 0, end: 50 }], 0, 0, 100, 10);
+    for (let i = 0; i < 5; i++) if (!approx(cov[i], 1)) fail(`coverage: col ${i} expected ~1, got ${cov[i]}`);
+    for (let i = 5; i < 10; i++) if (!approx(cov[i], 0)) fail(`coverage: col ${i} expected 0, got ${cov[i]}`);
+    pass("half-covered view → half the columns full, half empty");
+  }
+
+  function testCoverageSparseStaysSparse() {
+    // 10 tiny polls (1ns each) scattered across a 1000ns view at 10px.
+    // Each column is 100ns wide; total covered time per column ≪ 1 → faint,
+    // NOT solid. This is the misleading-solid-band case the helper fixes.
+    const polls = [];
+    for (let i = 0; i < 10; i++) polls.push({ start: i * 100, end: i * 100 + 1 });
+    const cov = pixelCoverage(polls, 0, 0, 1000, 10);
+    for (let i = 0; i < cov.length; i++) {
+      if (cov[i] > 0.05) fail(`coverage: sparse col ${i} should be faint, got ${cov[i]}`);
+      if (cov[i] <= 0) fail(`coverage: sparse col ${i} should be > 0 (one poll present)`);
+    }
+    pass("sparse polls produce faint (≪1) coverage, not a solid band");
+  }
+
+  function testCoverageSpanAcrossColumns() {
+    // Span [5,25) over 100ns/10px (10ns/col): col0 covered [5,10)=0.5,
+    // col1 fully [10,20)=1.0, col2 [20,25)=0.5.
+    const cov = pixelCoverage([{ start: 5, end: 25 }], 0, 0, 100, 10);
+    if (!approx(cov[0], 0.5)) fail(`coverage: col0 expected 0.5, got ${cov[0]}`);
+    if (!approx(cov[1], 1.0)) fail(`coverage: col1 expected 1.0, got ${cov[1]}`);
+    if (!approx(cov[2], 0.5)) fail(`coverage: col2 expected 0.5, got ${cov[2]}`);
+    for (let i = 3; i < 10; i++) if (!approx(cov[i], 0)) fail(`coverage: col ${i} expected 0`);
+    pass("span straddling columns splits coverage proportionally");
+  }
+
+  function testCoverageClampedToView() {
+    // Span extends beyond both edges; only the in-view portion counts and
+    // no value exceeds 1.
+    const cov = pixelCoverage([{ start: -1000, end: 1000 }], 0, 0, 100, 10);
+    for (let i = 0; i < cov.length; i++) {
+      if (cov[i] > 1) fail(`coverage: col ${i} exceeds 1 (${cov[i]})`);
+      if (!approx(cov[i], 1)) fail(`coverage: col ${i} expected ~1, got ${cov[i]}`);
+    }
+    pass("spans wider than the view clamp to ≤1 per column");
+  }
+
+  function testCoverageDegenerate() {
+    if (pixelCoverage([], 0, 0, 100, 10).some(v => v !== 0)) fail("coverage: empty → all zero");
+    if (pixelCoverage([{start:0,end:1}], 0, 0, 0, 10).length !== 0 &&
+        pixelCoverage([{start:0,end:1}], 0, 0, 0, 10).some(v => v !== 0)) fail("coverage: zero viewDur");
+    if (pixelCoverage([{start:0,end:1}], 0, 0, 100, 0).length !== 0) fail("coverage: zero pw → empty");
+    pass("degenerate inputs yield empty/zero coverage");
+  }
+
+  console.log("\nmakeBarCoalescer:");
+  testCoalescerMergesSubPixelRun();
+  testCoalescerBreaksOnColorChange();
+  testCoalescerBreaksOnGap();
+  testCoalescerMinWidth();
+  testCoalescerEmpty();
+  testCoalescerExtendsRunRightEdge();
+
+  function collectRuns(pushFn, minWidth) {
+    const runs = [];
+    const c = makeBarCoalescer((x, w, color) => runs.push({ x, w, color }), minWidth);
+    pushFn(c);
+    c.flush();
+    return runs;
+  }
+
+  function testCoalescerMergesSubPixelRun() {
+    // 50 same-color sub-pixel bars all landing in [10, 11) must collapse to
+    // a single fillRect, not 50 of them.
+    const runs = collectRuns((c) => {
+      for (let i = 0; i < 50; i++) c.push(10, 10.2, "#abc");
+    });
+    if (runs.length !== 1) fail(`coalescer: expected 1 run, got ${runs.length}`);
+    if (runs[0].color !== "#abc") fail("coalescer: wrong color");
+    pass("sub-pixel same-color burst collapses to one rect");
+  }
+
+  function testCoalescerBreaksOnColorChange() {
+    const runs = collectRuns((c) => {
+      c.push(0, 5, "#aaa");
+      c.push(5, 10, "#bbb");
+      c.push(10, 15, "#aaa");
+    });
+    if (runs.length !== 3) fail(`coalescer: expected 3 runs on color change, got ${runs.length}`);
+    if (runs.map(r => r.color).join() !== "#aaa,#bbb,#aaa")
+      fail("coalescer: colors out of order");
+    pass("adjacent bars of different colors stay separate");
+  }
+
+  function testCoalescerBreaksOnGap() {
+    // Same color but a >1px gap between them must NOT merge.
+    const runs = collectRuns((c) => {
+      c.push(0, 5, "#aaa");
+      c.push(20, 25, "#aaa");
+    });
+    if (runs.length !== 2) fail(`coalescer: expected 2 runs across gap, got ${runs.length}`);
+    pass("same-color bars separated by a gap stay separate");
+  }
+
+  function testCoalescerMinWidth() {
+    const runs = collectRuns((c) => c.push(10, 10, "#aaa")); // zero-width bar
+    if (runs.length !== 1) fail("coalescer: expected 1 run");
+    if (runs[0].w !== 1) fail(`coalescer: expected min width 1, got ${runs[0].w}`);
+    const wide = collectRuns((c) => c.push(10, 10, "#aaa"), 3);
+    if (wide[0].w !== 3) fail(`coalescer: expected min width 3, got ${wide[0].w}`);
+    pass("min width enforced for sub-pixel runs");
+  }
+
+  function testCoalescerEmpty() {
+    const runs = collectRuns(() => {});
+    if (runs.length !== 0) fail(`coalescer: expected 0 runs, got ${runs.length}`);
+    pass("no pushes emits nothing");
+  }
+
+  function testCoalescerExtendsRunRightEdge() {
+    // Overlapping/adjacent same-color bars extend the run; the emitted rect
+    // spans the union [0, 30).
+    const runs = collectRuns((c) => {
+      c.push(0, 10, "#aaa");
+      c.push(8, 20, "#aaa");
+      c.push(20, 30, "#aaa");
+    });
+    if (runs.length !== 1) fail(`coalescer: expected 1 merged run, got ${runs.length}`);
+    if (runs[0].x !== 0 || runs[0].w !== 30)
+      fail(`coalescer: expected x=0 w=30, got x=${runs[0].x} w=${runs[0].w}`);
+    pass("contiguous same-color bars merge to their union");
+  }
 
   console.log("\nanalyzeAllocations:");
   testAnalyzeAllocationsEmpty();

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -113,6 +113,14 @@
   // into a single fillRect; with 16 quantization bins per decade-spanning
   // log scale, runs of "approximately equal" polls still fold into one
   // rectangle, which keeps zoomed-out rendering fast.
+  // Per-bin color cache, keyed by `${NBINS}:${bin}`. The quantized color
+  // depends ONLY on the bin index (≤ NBINS distinct values), but computing it
+  // is expensive: log10 + pow + 5-stop interpolation + 3× hex formatting. This
+  // function is called once PER POLL PER RENDER (millions of times on a large
+  // trace), so without caching the formatting/interpolation dominated frame
+  // time (~1.2s for 3.5M polls — measured). Caching collapses that to one
+  // log10 + a multiply + an array lookup per poll.
+  const _quantColorCache = new Map();
   function pollHeatmapColorQuantized(durationNs, bins) {
     const NBINS = bins || 24;
     const stops = POLL_HEATMAP_STOPS;
@@ -125,9 +133,186 @@
     if (lg > maxLg) lg = maxLg;
     const t = (lg - minLg) / (maxLg - minLg);
     const bin = Math.min(NBINS - 1, Math.floor(t * NBINS));
-    const lgBin = minLg + (bin / (NBINS - 1)) * (maxLg - minLg);
-    const dBin = Math.pow(10, lgBin);
-    return pollHeatmapColor(dBin);
+    const key = NBINS * 1000 + bin; // small int key; NBINS is tiny
+    let color = _quantColorCache.get(key);
+    if (color === undefined) {
+      const lgBin = minLg + (bin / (NBINS - 1)) * (maxLg - minLg);
+      const dBin = Math.pow(10, lgBin);
+      color = pollHeatmapColor(dBin);
+      _quantColorCache.set(key, color);
+    }
+    return color;
+  }
+
+  /**
+   * Stateful merger that collapses adjacent same-color pixel-space bars (and
+   * bursts of sub-pixel bars) into one rectangle per contiguous run.
+   *
+   * The viewer draws one bar per poll. A busy worker can have thousands of
+   * polls landing in the same handful of pixel columns; emitting a separate
+   * (min-width-1px) fillRect for each repaints the same column over and over,
+   * which is pure overdraw — invisible to the user but expensive on the main
+   * thread (this dominated the "drawing animation frames" cost). Folding them
+   * into per-run rectangles makes draw cost scale with visible pixels, not
+   * poll count. pollColor() is quantized so approximately-equal polls share a
+   * color string and fold together.
+   *
+   * Returned as a {push, flush} pair (rather than a whole-array loop) so the
+   * caller keeps its own iteration control — the binary-searched start index
+   * and the early `break` once past the view's right edge, both of which keep
+   * zoomed-in panning O(visible) instead of O(all polls).
+   *
+   * Bars MUST be pushed in ascending x1 order. A new run starts when a bar's
+   * color differs from the current run OR it begins more than one pixel past
+   * the current run's right edge (a real gap). Within a run the right edge is
+   * extended; the emitted width is `max(right - left, minWidth)` so a run made
+   * only of sub-pixel bars is still at least `minWidth` wide. Call `flush()`
+   * once after the last `push` to emit the final run.
+   *
+   * @param {function} emit      (left, width, color) -> void; called per run.
+   * @param {number} [minWidth]  Minimum rendered width per run (default 1).
+   */
+  function makeBarCoalescer(emit, minWidth) {
+    const minW = minWidth || 1;
+    let runStart = 0, runEnd = -2, runColor = null;
+    return {
+      push(x1, x2, color) {
+        // Continue the current run only if same color AND the new bar starts
+        // within 1px of the run's right edge (no visible gap between them).
+        if (color === runColor && x1 <= runEnd + 1) {
+          if (x2 > runEnd) runEnd = x2;
+        } else {
+          if (runColor !== null) {
+            emit(runStart, Math.max(runEnd - runStart, minW), runColor);
+          }
+          runStart = x1;
+          runEnd = x2;
+          runColor = color;
+        }
+      },
+      flush() {
+        if (runColor !== null) {
+          emit(runStart, Math.max(runEnd - runStart, minW), runColor);
+          runColor = null;
+        }
+      },
+    };
+  }
+
+  /**
+   * Pixel-level LOD downsampling for a sorted span array.
+   *
+   * Fully zoomed out, a worker lane can have millions of spans (polls, parks,
+   * active periods) mapping onto ~1500 pixels. Drawing one fillRect per span is
+   * ~99.9% overdraw — invisible but multi-second (measured: ~2M fillRects,
+   * ~1.5s/render). This returns at most ONE representative span per pixel
+   * column: the span with the largest `weight` (e.g. longest duration) whose
+   * START falls in that column. The caller then draws each representative with
+   * its own real geometry and color, exactly as it drew every span before —
+   * just over ≤ pw representatives instead of millions.
+   *
+   * Why "longest starting in this column" is the right representative: a long
+   * span visually dominates its pixel (and the ones it covers), which is what a
+   * profiler view should surface when zoomed out. A span starts in exactly one
+   * column, so the representative count is ≤ (visible columns) ≤ pw. Long spans
+   * keep their true width because the caller draws span.start→span.end.
+   *
+   * Spans MUST be sorted ascending by `start`. Iteration starts at `startIdx`
+   * (from findFirstVisible) and breaks once a span starts past `viewEnd`, so
+   * the scan is O(visible spans) and the OUTPUT is O(pixels).
+   *
+   * @param {Array} spans          sorted-by-start span array
+   * @param {number} startIdx      first index to consider (findFirstVisible)
+   * @param {number} viewStart     ns at left edge
+   * @param {number} viewEnd       ns at right edge
+   * @param {number} pw            pixel width of the lane
+   * @param {function} weightOf    span -> number (larger wins the pixel column)
+   * @returns {Array} representative spans (subset of `spans`, still sorted)
+   */
+  function pixelDownsampleSpans(spans, startIdx, viewStart, viewEnd, pw, weightOf) {
+    const out = [];
+    if (pw <= 0 || viewEnd <= viewStart) return out;
+    const span2px = pw / (viewEnd - viewStart);
+    let curPx = -1, bestSpan = null, bestW = -Infinity;
+    for (let i = startIdx; i < spans.length; i++) {
+      const s = spans[i];
+      if (s.start > viewEnd) break;
+      let px = ((s.start - viewStart) * span2px) | 0;
+      if (px < 0) px = 0;
+      else if (px >= pw) px = pw - 1;
+      if (px !== curPx) {
+        if (bestSpan !== null) out.push(bestSpan);
+        curPx = px;
+        bestSpan = s;
+        bestW = weightOf(s);
+      } else {
+        const wgt = weightOf(s);
+        if (wgt > bestW) { bestW = wgt; bestSpan = s; }
+      }
+    }
+    if (bestSpan !== null) out.push(bestSpan);
+    return out;
+  }
+
+  /**
+   * Per-pixel coverage histogram for a sorted, non-overlapping span array.
+   *
+   * Drawing each span at a 1px-minimum width (and dropping sub-pixel gaps)
+   * makes a sparse, mostly-idle timeline look like one solid continuous bar
+   * when zoomed out: thousands of tiny polls each inflate to a full pixel and
+   * abut, while the gaps between them vanish. This instead computes, for each
+   * of `pw` pixel columns, the FRACTION of that column's wall-clock time
+   * actually covered by spans (0..1). The caller maps coverage→opacity so a
+   * busy column reads solid and a 5%-busy column reads faint — an honest
+   * density view rather than a misleading solid block.
+   *
+   * Spans MUST be sorted ascending by `start` and be non-overlapping (a single
+   * task's polls satisfy this). A span straddling column boundaries is split
+   * across columns proportionally. Returns a Float64Array of length `pw` with
+   * values in [0, 1]. Scan is O(visible spans + pw).
+   *
+   * @param {Array<{start:number,end:number}>} spans  sorted, non-overlapping
+   * @param {number} startIdx   first index to consider (findFirstVisible)
+   * @param {number} viewStart  ns at left edge
+   * @param {number} viewEnd    ns at right edge
+   * @param {number} pw         pixel width
+   * @returns {Float64Array} coverage per pixel column, each in [0,1]
+   */
+  function pixelCoverage(spans, startIdx, viewStart, viewEnd, pw) {
+    const cov = new Float64Array(pw > 0 ? pw : 0);
+    if (pw <= 0 || viewEnd <= viewStart) return cov;
+    const nsPerPx = (viewEnd - viewStart) / pw;
+    for (let i = startIdx; i < spans.length; i++) {
+      const s = spans[i];
+      if (s.start > viewEnd) break;
+      if (s.end < viewStart) continue;
+      // Clamp the span to the visible window.
+      const a = s.start < viewStart ? viewStart : s.start;
+      const b = s.end > viewEnd ? viewEnd : s.end;
+      if (b <= a) continue;
+      // Pixel columns this clamped span touches.
+      let pxA = ((a - viewStart) / nsPerPx) | 0;
+      let pxB = ((b - viewStart) / nsPerPx) | 0;
+      if (pxA < 0) pxA = 0;
+      if (pxB >= pw) pxB = pw - 1;
+      if (pxA === pxB) {
+        // Whole span inside one column: add its time fraction of the column.
+        cov[pxA] += (b - a) / nsPerPx;
+      } else {
+        // First (partial) column.
+        const firstColEnd = viewStart + (pxA + 1) * nsPerPx;
+        cov[pxA] += (firstColEnd - a) / nsPerPx;
+        // Fully-covered middle columns.
+        for (let p = pxA + 1; p < pxB; p++) cov[p] += 1;
+        // Last (partial) column.
+        const lastColStart = viewStart + pxB * nsPerPx;
+        cov[pxB] += (b - lastColStart) / nsPerPx;
+      }
+    }
+    // Floating-point accumulation can nudge a fully-covered column slightly
+    // over 1; clamp so callers can treat the value as an opacity directly.
+    for (let p = 0; p < pw; p++) if (cov[p] > 1) cov[p] = 1;
+    return cov;
   }
 
   /**
@@ -506,6 +691,61 @@
     }
     schedDelays.sort((a, b) => a.wakeTime - b.wakeTime);
     return schedDelays;
+  }
+
+  /**
+   * For each poll of a selected task, find the most recent wake at or before
+   * the poll's start, plus the "effective wake" time used to measure the
+   * wake→poll scheduling delay.
+   *
+   * If that wake actually arrived while an EARLIER poll of the same task was
+   * still running (the task was woken again mid-poll), the wait doesn't begin
+   * until that earlier poll ends — so `effectiveWake` is bumped to that poll's
+   * `end`.
+   *
+   * `polls` MUST be the task's polls sorted ascending by `start`; a single
+   * task is polled on one worker at a time, so they are non-overlapping.
+   * `wakes` MUST be sorted ascending by `timestamp`. Both lookups are binary
+   * searches, so the whole pass is O(P·logP + P·logW) — NOT the O(P²) that a
+   * per-poll linear scan over earlier polls costs for a task polled millions
+   * of times. (This mirrors the binary-search fix in computeSchedulingDelays.)
+   *
+   * @param {Array<{start:number,end:number}>} polls  task polls, sorted by start
+   * @param {Array<{timestamp:number}>} wakes          task wakes, sorted by timestamp
+   * @returns {Array<{wake:Object, effectiveWake:number}|null>} parallel to `polls`
+   */
+  function computePollWakes(polls, wakes) {
+    const result = new Array(polls.length).fill(null);
+    if (!wakes || wakes.length === 0) return result;
+    for (let pi = 0; pi < polls.length; pi++) {
+      const s = polls[pi];
+      // Rightmost wake at or before this poll's start.
+      let lo = 0, hi = wakes.length - 1, bi = -1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (wakes[mid].timestamp <= s.start) { bi = mid; lo = mid + 1; }
+        else hi = mid - 1;
+      }
+      if (bi < 0) continue;
+      const wake = wakes[bi];
+      let effectiveWake = wake.timestamp;
+      // Did that wake land inside an EARLIER poll (index < pi)? Among earlier
+      // polls, only the rightmost whose start <= wake.timestamp can contain it
+      // (they are non-overlapping), so binary search that one poll instead of
+      // scanning every earlier poll.
+      let plo = 0, phi = pi - 1, pbest = -1;
+      while (plo <= phi) {
+        const pmid = (plo + phi) >> 1;
+        if (polls[pmid].start <= wake.timestamp) { pbest = pmid; plo = pmid + 1; }
+        else phi = pmid - 1;
+      }
+      if (pbest >= 0 && wake.timestamp <= polls[pbest].end) {
+        effectiveWake = polls[pbest].end;
+      }
+      const delay = s.start - effectiveWake;
+      if (delay >= 0 && delay < 1e9) result[pi] = { wake, effectiveWake };
+    }
+    return result;
   }
 
   /**
@@ -1144,6 +1384,7 @@
     attachCpuSamples,
     buildActiveTaskTimeline,
     computeSchedulingDelays,
+    computePollWakes,
     filterPointsOfInterest,
     buildFlamegraphTree,
     flattenFlamegraph,
@@ -1157,6 +1398,9 @@
     analyzeAllocations,
     pollHeatmapColor,
     pollHeatmapColorQuantized,
+    makeBarCoalescer,
+    pixelDownsampleSpans,
+    pixelCoverage,
   };
 
   if (typeof module !== "undefined" && module.exports) {

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -74,11 +74,12 @@
    * concatenate them into a single ArrayBuffer.
    *
    * The `trace` query parameter is repeatable: each component is fetched
-   * independently and may be gzipped on its own (unlike `/api/trace`, which
-   * gunzips server-side before serving). We therefore ungzip every component
-   * here, then concatenate the raw bytes. The trace decoder treats a
-   * concatenated stream as multiple segments — a mid-stream `TRC\0` header
-   * resets the frame parser — so the combined buffer parses as one trace.
+   * independently (in parallel) and may be gzipped on its own — the S3 browser
+   * points each at `/api/object`, which serves one file's raw, still-gzipped
+   * bytes. We therefore ungzip every component here, then concatenate the raw
+   * bytes. The trace decoder treats a concatenated stream as multiple segments
+   * — a mid-stream `TRC\0` header resets the frame parser — so the combined
+   * buffer parses as one trace.
    *
    * @param {string|string[]} urls one URL or a list of URLs (order preserved)
    * @param {{signal?: AbortSignal, headers?: Object}} [opts] `headers` is

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -975,11 +975,21 @@
     // to/below the whole-buffer baseline. The 5-byte header is still decoded as
     // soon as it arrives so a tiny trace (well under 256KB) still parses.
     const MIN_DRAIN_BYTES = 256 * 1024;
-    // Yield a macrotask (setTimeout(0)) to the browser on this byte cadence
-    // rather than once per chunk, mirroring parseTraceBuffer's YIELD_BYTES.
-    // onProgress still fires on every batch drain so the spinner counter stays
-    // current; only the (relatively expensive) repaint yield is throttled.
-    const YIELD_BYTES = 100 * 1024; // yield to browser every ~100KB decoded
+    // Yield a macrotask (setTimeout(0)) to the browser on a wall-clock cadence
+    // rather than per-chunk or per-byte. KEY FACT: the `for await` over `chunks`
+    // already awaits each decompressed chunk, so the network read +
+    // DecompressionStream pump make progress on their own — the macrotask yield
+    // does NOT drive download/parse overlap. Its ONLY purpose is to hand the
+    // main thread back to the browser so it can repaint the spinner. Each yield
+    // therefore permits (roughly) one repaint, and a byte cadence fired ~100
+    // times for a 10MB trace — ~100 paints during an ~8s parse. Throttling by
+    // elapsed wall-clock time instead caps paints to a few per second
+    // regardless of trace size, with zero effect on overlap or decode output.
+    // We don't drop the yield entirely: the spinner must still tick a few
+    // times/sec so the user sees progress. onProgress still fires on EVERY
+    // batch drain (cheap) so the event/byte counters stay current; only the
+    // (relatively expensive) repaint yield is rate-limited.
+    const PAINT_INTERVAL_MS = 200; // at most ~5 repaint yields per second
 
     // Unconsumed-tail accumulator. The decoder reads pooled strings/stacks via
     // its `stringPool`/`stackPool` maps (resolved values are copied into the
@@ -1057,7 +1067,12 @@
       drainComplete();
     }
 
-    let lastYieldPos = 0; // consumedBytes at the last macrotask yield
+    // Wall-clock source that works in browser and Node. Node 16+ exposes a
+    // global `performance`, but guard anyway in case it's absent.
+    const nowMs = (typeof performance !== "undefined" && performance.now)
+      ? () => performance.now()
+      : () => Date.now();
+    let lastYieldMs = nowMs(); // wall-clock time of the last macrotask yield
     for await (const rawChunk of chunks) {
       const chunk = rawChunk instanceof Uint8Array
         ? rawChunk
@@ -1082,11 +1097,14 @@
           totalBytes: consumedBytes + acc.length,
           eventCount: state.events.length,
         });
-        // Yield so the browser can paint the spinner, but only on the coarse
-        // YIELD_BYTES cadence — not once per (tiny) chunk, whose macrotask
-        // round-trips were a large part of the streaming overhead.
-        if (consumedBytes - lastYieldPos >= YIELD_BYTES) {
-          lastYieldPos = consumedBytes;
+        // Yield so the browser can paint the spinner, but only once at least
+        // PAINT_INTERVAL_MS of wall-clock time has elapsed since the last
+        // yield — not once per (tiny) chunk and not on a byte cadence. Because
+        // the `for await` above already pumps the network/decompression, this
+        // throttle reduces repaints without slowing download/parse overlap.
+        const t = nowMs();
+        if (t - lastYieldMs >= PAINT_INTERVAL_MS) {
+          lastYieldMs = t;
           await new Promise((r) => setTimeout(r, 0));
         }
       }

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -956,8 +956,9 @@
    *
    * @param {AsyncIterable<Uint8Array>} chunks raw trace bytes (post-gunzip)
    * @param {Object} [options] same options as {@link parseTrace}, plus
-   *   `onParseProgress({bytesRead, totalBytes, eventCount})` (totalBytes is the
-   *   bytes received so far — unknown until the stream ends).
+   *   `onParseProgress({bytesRead, totalBytes, eventCount})`. `totalBytes` is
+   *   `null` here — when streaming we don't know the trace's full size until the
+   *   stream ends, so callers must not compute a percentage from it.
    * @returns {Promise<ParsedTrace>}
    */
   async function parseTraceStream(chunks, options) {
@@ -1094,7 +1095,11 @@
       if (onProgress) {
         onProgress({
           bytesRead: consumedBytes,
-          totalBytes: consumedBytes + acc.length,
+          // Total is unknown while streaming (we haven't seen the whole trace),
+          // so report null rather than `consumedBytes + acc.length` — `acc` is
+          // just the small undrained tail, which would peg any percentage at
+          // ~99% the entire time.
+          totalBytes: null,
           eventCount: state.events.length,
         });
         // Yield so the browser can paint the spinner, but only once at least
@@ -1117,7 +1122,7 @@
       if (onProgress) {
         onProgress({
           bytesRead: consumedBytes,
-          totalBytes: consumedBytes + acc.length,
+          totalBytes: null, // unknown while streaming — see note above
           eventCount: state.events.length,
         });
       }

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -118,6 +118,86 @@
   }
 
   /**
+   * Whether the current runtime can stream a `fetch` response body and gunzip
+   * it incrementally. Node test runtimes (and older browsers) lack a real
+   * streaming `response.body` or `DecompressionStream`; callers fall back to
+   * the buffered `fetchTraces` + `parseTraceBuffer` path there.
+   */
+  function canStreamDecode() {
+    return typeof ReadableStream !== "undefined" &&
+      typeof DecompressionStream !== "undefined";
+  }
+
+  /**
+   * Fetch a single trace URL and return an async iterable of raw (gunzipped, if
+   * the body was gzipped) `Uint8Array` chunks. Pair with
+   * {@link parseTraceStream} so download and decode overlap.
+   *
+   * We peek the first chunk's first two bytes for the gzip magic (1f 8b). If
+   * present, the remaining body is piped through `DecompressionStream("gzip")`
+   * after re-feeding the peeked chunk; otherwise chunks pass through raw.
+   * `headers` follow the same same-origin credential-withholding rule as
+   * {@link fetchTraces}.
+   *
+   * @param {string} url single trace URL
+   * @param {{signal?: AbortSignal, headers?: Object}} [opts]
+   * @returns {Promise<AsyncIterable<Uint8Array>>}
+   */
+  async function fetchTraceStream(url, opts = {}) {
+    const headers = isSameOrigin(url) ? opts.headers : undefined;
+    const resp = await fetch(url, { signal: opts.signal, headers });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${url}`);
+
+    const reader = resp.body.getReader();
+    // Read the first non-empty chunk to sniff the gzip magic.
+    let first = null;
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value && value.byteLength > 0) {
+        first = value instanceof Uint8Array ? value : new Uint8Array(value);
+        break;
+      }
+    }
+
+    const isGzip = first != null && first.length >= 2 &&
+      first[0] === 0x1f && first[1] === 0x8b;
+
+    // A ReadableStream that re-emits the peeked first chunk then drains the
+    // rest of the body reader.
+    const rawStream = new ReadableStream({
+      start(controller) {
+        if (first != null) controller.enqueue(first);
+      },
+      async pull(controller) {
+        const { value, done } = await reader.read();
+        if (done) { controller.close(); return; }
+        if (value && value.byteLength > 0) controller.enqueue(value);
+      },
+      cancel(reason) { return reader.cancel(reason); },
+    });
+
+    const byteStream = isGzip
+      ? rawStream.pipeThrough(new DecompressionStream("gzip"))
+      : rawStream;
+
+    return {
+      [Symbol.asyncIterator]() {
+        const r = byteStream.getReader();
+        return {
+          async next() {
+            const { value, done } = await r.read();
+            if (done) return { done: true, value: undefined };
+            const u8 = value instanceof Uint8Array ? value : new Uint8Array(value);
+            return { done: false, value: u8 };
+          },
+          async return() { await r.cancel(); return { done: true, value: undefined }; },
+        };
+      },
+    };
+  }
+
+  /**
    * @typedef {{
    *   eventType: number,
    *   timestamp: number,
@@ -375,105 +455,120 @@
     return iterable;
   }
 
-  /** @private Parse a binary trace buffer. */
-  async function parseTraceBuffer(buffer, options) {
-    buffer = await maybeGunzip(buffer);
+  const UNCAPPED_FRAMES = new Set([
+    "TaskSpawnEvent",
+    "TaskTerminateEvent",
+    "CpuSampleEvent",
+    "TaskDumpEvent",
+    "SymbolTableEntry",
+    "SegmentMetadataEvent",
+    "ClockSyncEvent",
+  ]);
+  const TRACE_BOUND_EXCLUDED_FRAMES = new Set([
+    "SymbolTableEntry",
+    "SegmentMetadataEvent",
+    "ClockSyncEvent",
+  ]);
+  // Legacy classifier: epoch ns are ~1e18, monotonic ns are much smaller.
+  // 2020 is a practical floor that separates those ranges.
+  const LEGACY_EPOCH_FLOOR_MS = 1_577_836_800_000; // 2020-01-01
+
+  /**
+   * @private Build the mutable accumulator that {@link processFrame} fills and
+   * {@link finalizeParse} drains. Shared by the whole-buffer
+   * ({@link parseTraceBuffer}) and streaming ({@link parseTraceStream}) paths
+   * so there is exactly one copy of the frame-handling and post-processing
+   * logic. Returns the same `ParsedTrace` for the same concatenated bytes
+   * regardless of how those bytes were chunked.
+   */
+  function createParseState(options) {
     const maxEvents = (options && options.maxEvents != null) ? options.maxEvents : MAX_EVENTS;
     const startTime = (options && options.startTime != null) ? options.startTime : 0;
     const endTime = (options && options.endTime != null) ? options.endTime : Infinity;
     const hasTimeFilter = startTime > 0 || endTime < Infinity;
-    const onProgress = (options && options.onParseProgress) || null;
-    const YIELD_BYTES = 100 * 1024; // yield to browser every 100KB
-    const TD = getTraceDecoder();
-    const dec = new TD(
-      buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer
-    );
-    if (!dec.decodeHeader()) throw new Error("Invalid trace header");
-    const totalBytes = dec.byteLength;
+    return {
+      maxEvents, startTime, endTime, hasTimeFilter,
+      events: [],
+      spawnLocations: new Map(),
+      taskSpawnLocs: new Map(),
+      taskSpawnTimes: new Map(),
+      taskTerminateTimes: new Map(),
+      taskInstrumented: new Map(), // taskId -> bool (true if spawned via TelemetryHandle::spawn)
+      callframeSymbols: new Map(),
+      cpuSamples: [],
+      allocEvents: [],
+      freeEvents: [],
+      memoryOverflows: [],
+      threadNames: new Map(),
+      tidToWorker: new Map(), // tid → workerId (stable mapping from park/unpark events)
+      runtimeWorkers: new Map(), // runtime name → [workerId, ...]
+      taskDumps: new Map(), // taskId → [{timestamp, callchain}] sorted by timestamp
+      customEvents: [], // unrecognized event types: {name, timestamp, fields}
+      // { monotonicNs, realtimeNs } anchors used to recover wall clock.
+      clockSyncAnchors: [],
+      legacySegmentMetaWallNs: null,
+      // Smallest monotonic ts seen across all event frames.
+      // Used as the monotonic timestamp for the legacy synthesized anchor.
+      minMonoTs: null,
+      recordMinTs: Infinity,
+      recordMaxTs: -Infinity,
+    };
+  }
 
-    const events = [];
-    const spawnLocations = new Map();
-    const taskSpawnLocs = new Map();
-    const taskSpawnTimes = new Map();
-    const taskTerminateTimes = new Map();
-    const taskInstrumented = new Map(); // taskId -> bool (true if spawned via TelemetryHandle::spawn)
-    const callframeSymbols = new Map();
-    const cpuSamples = [];
-    const allocEvents = [];
-    const freeEvents = [];
-    const memoryOverflows = [];
-    const threadNames = new Map();
-    const tidToWorker = new Map(); // tid → workerId (stable mapping from park/unpark events)
-    const runtimeWorkers = new Map(); // runtime name → [workerId, ...]
-    const taskDumps = new Map(); // taskId → [{timestamp, callchain}] sorted by timestamp
-    const customEvents = []; // unrecognized event types: {name, timestamp, fields}
-    // { monotonicNs, realtimeNs } anchors used to recover wall clock.
-    const clockSyncAnchors = [];
-    // Legacy classifier: epoch ns are ~1e18, monotonic ns are much smaller.
-    // 2020 is a practical floor that separates those ranges.
-    const LEGACY_EPOCH_FLOOR_MS = 1_577_836_800_000; // 2020-01-01
-    let legacySegmentMetaWallNs = null;
-    // Smallest monotonic ts seen across all event frames.
-    // Used as the monotonic timestamp for the legacy synthesized anchor.
-    let minMonoTs = null;
-
-    const capped = () => events.length >= maxEvents;
-    const UNCAPPED_FRAMES = new Set([
-      "TaskSpawnEvent",
-      "TaskTerminateEvent",
-      "CpuSampleEvent",
-      "TaskDumpEvent",
-      "SymbolTableEntry",
-      "SegmentMetadataEvent",
-      "ClockSyncEvent",
-    ]);
-    const TRACE_BOUND_EXCLUDED_FRAMES = new Set([
-      "SymbolTableEntry",
-      "SegmentMetadataEvent",
-      "ClockSyncEvent",
-    ]);
-    let recordMinTs = Infinity, recordMaxTs = -Infinity;
-    function includeRecordTimestamp(t) {
-      if (t == null) return;
-      if (t < recordMinTs) recordMinTs = t;
-      if (t > recordMaxTs) recordMaxTs = t;
+  /**
+   * @private Handle a single decoded frame, mutating `state`. `dec` is the
+   * decoder the frame came from (used only to read a custom event's schema
+   * units). This is the single shared switch body — do not duplicate it.
+   */
+  function processFrame(frame, state, dec) {
+    const { startTime, endTime } = state;
+    if (frame.type !== "event") return;
+    const v = frame.values;
+    const ts = num(frame.timestamp_ns);
+    // Track smallest monotonic ts for legacy anchor synthesis.
+    // Skip SegmentMetadata (legacy wall clock) and SymbolTableEntry.
+    if (
+      ts != null &&
+      frame.name !== "SegmentMetadataEvent" &&
+      frame.name !== "SymbolTableEntry" &&
+      (state.minMonoTs == null || ts < state.minMonoTs)
+    ) {
+      state.minMonoTs = ts;
     }
 
-    let lastYieldPos = 0;
-    let frame;
-    while ((frame = dec.nextFrame()) !== null) {
-      // Yield to browser periodically so spinner can update
-      if (onProgress && dec.position - lastYieldPos >= YIELD_BYTES) {
-        lastYieldPos = dec.position;
-        onProgress({ bytesRead: dec.position, totalBytes, eventCount: events.length });
-        await new Promise((r) => setTimeout(r, 0));
+    const capped = state.events.length >= state.maxEvents;
+    if (capped && !UNCAPPED_FRAMES.has(frame.name)) return;
+
+    // Time range filtering: skip events outside the requested range
+    // (uncapped frames like symbols/metadata are always processed)
+    const inTimeRange = ts >= startTime && ts <= endTime;
+    if (!inTimeRange && !UNCAPPED_FRAMES.has(frame.name)) return;
+    if (inTimeRange && !TRACE_BOUND_EXCLUDED_FRAMES.has(frame.name)) {
+      if (ts != null) {
+        if (ts < state.recordMinTs) state.recordMinTs = ts;
+        if (ts > state.recordMaxTs) state.recordMaxTs = ts;
       }
+    }
 
-      if (frame.type !== "event") continue;
-      const v = frame.values;
-      const ts = num(frame.timestamp_ns);
-      // Track smallest monotonic ts for legacy anchor synthesis.
-      // Skip SegmentMetadata (legacy wall clock) and SymbolTableEntry.
-      if (
-        ts != null &&
-        frame.name !== "SegmentMetadataEvent" &&
-        frame.name !== "SymbolTableEntry" &&
-        (minMonoTs == null || ts < minMonoTs)
-      ) {
-        minMonoTs = ts;
-      }
+    const events = state.events;
+    const spawnLocations = state.spawnLocations;
+    const taskSpawnLocs = state.taskSpawnLocs;
+    const taskSpawnTimes = state.taskSpawnTimes;
+    const taskTerminateTimes = state.taskTerminateTimes;
+    const taskInstrumented = state.taskInstrumented;
+    const callframeSymbols = state.callframeSymbols;
+    const cpuSamples = state.cpuSamples;
+    const allocEvents = state.allocEvents;
+    const freeEvents = state.freeEvents;
+    const memoryOverflows = state.memoryOverflows;
+    const threadNames = state.threadNames;
+    const tidToWorker = state.tidToWorker;
+    const runtimeWorkers = state.runtimeWorkers;
+    const taskDumps = state.taskDumps;
+    const customEvents = state.customEvents;
+    const clockSyncAnchors = state.clockSyncAnchors;
 
-      if (capped() && !UNCAPPED_FRAMES.has(frame.name)) continue;
-
-      // Time range filtering: skip events outside the requested range
-      // (uncapped frames like symbols/metadata are always processed)
-      const inTimeRange = ts >= startTime && ts <= endTime;
-      if (!inTimeRange && !UNCAPPED_FRAMES.has(frame.name)) continue;
-      if (inTimeRange && !TRACE_BOUND_EXCLUDED_FRAMES.has(frame.name)) {
-        includeRecordTimestamp(ts);
-      }
-
-      switch (frame.name) {
+    switch (frame.name) {
         case "PollStartEvent": {
           const spawnLoc = v.spawn_loc || null;
           if (spawnLoc) spawnLocations.set(spawnLoc, spawnLoc);
@@ -661,11 +756,11 @@
         case "SegmentMetadataEvent": {
           // If this looks epoch-scale, treat it as legacy wall clock.
           if (
-            legacySegmentMetaWallNs == null &&
+            state.legacySegmentMetaWallNs == null &&
             ts != null &&
             ts / 1e6 >= LEGACY_EPOCH_FLOOR_MS
           ) {
-            legacySegmentMetaWallNs = ts;
+            state.legacySegmentMetaWallNs = ts;
           }
           const entries = v.entries || {};
           for (const [key, val] of Object.entries(entries)) {
@@ -718,19 +813,33 @@
           }
           break;
         }
-      }
     }
+  }
+
+  /**
+   * @private Run the post-frame-loop passes (clock anchors, tid→worker
+   * resolution, block-in-place gaps) and assemble the final `ParsedTrace`.
+   * Identical for the whole-buffer and streaming paths. `version` is read from
+   * the decoder after the last frame.
+   */
+  function finalizeParse(state, version) {
+    const {
+      events, spawnLocations, taskSpawnLocs, taskSpawnTimes, taskTerminateTimes,
+      taskInstrumented, callframeSymbols, cpuSamples, allocEvents, freeEvents,
+      memoryOverflows, threadNames, tidToWorker, runtimeWorkers, taskDumps,
+      customEvents, clockSyncAnchors, maxEvents, startTime, endTime, hasTimeFilter,
+    } = state;
 
     // Legacy fallback: synthesize an anchor from legacy SegmentMetadata wall
     // time + earliest monotonic event timestamp. This is best-effort only.
     if (
       clockSyncAnchors.length === 0 &&
-      legacySegmentMetaWallNs != null &&
-      minMonoTs != null
+      state.legacySegmentMetaWallNs != null &&
+      state.minMonoTs != null
     ) {
       clockSyncAnchors.push({
-        monotonicNs: minMonoTs,
-        realtimeNs: legacySegmentMetaWallNs,
+        monotonicNs: state.minMonoTs,
+        realtimeNs: state.legacySegmentMetaWallNs,
       });
     }
 
@@ -774,12 +883,12 @@
 
     return {
       magic: "D9TF",
-      version: dec.version,
+      version,
       events,
       minTs: events.length > 0 ? evMinTs : null,
       maxTs: events.length > 0 ? evMaxTs : null,
-      recordMinTs: recordMinTs < Infinity ? recordMinTs : null,
-      recordMaxTs: recordMaxTs > -Infinity ? recordMaxTs : null,
+      recordMinTs: state.recordMinTs < Infinity ? state.recordMinTs : null,
+      recordMaxTs: state.recordMaxTs > -Infinity ? state.recordMaxTs : null,
       truncated: events.length >= maxEvents,
       timeFiltered: hasTimeFilter,
       filterStartTime: hasTimeFilter ? startTime : null,
@@ -806,6 +915,155 @@
       clockOffsetNs,
       blockInPlaceGaps,
     };
+  }
+
+  /** @private Parse a binary trace buffer. */
+  async function parseTraceBuffer(buffer, options) {
+    buffer = await maybeGunzip(buffer);
+    const onProgress = (options && options.onParseProgress) || null;
+    const YIELD_BYTES = 100 * 1024; // yield to browser every 100KB
+    const TD = getTraceDecoder();
+    const dec = new TD(
+      buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer
+    );
+    if (!dec.decodeHeader()) throw new Error("Invalid trace header");
+    const totalBytes = dec.byteLength;
+    const state = createParseState(options);
+
+    let lastYieldPos = 0;
+    let frame;
+    while ((frame = dec.nextFrame()) !== null) {
+      // Yield to browser periodically so spinner can update
+      if (onProgress && dec.position - lastYieldPos >= YIELD_BYTES) {
+        lastYieldPos = dec.position;
+        onProgress({ bytesRead: dec.position, totalBytes, eventCount: state.events.length });
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      processFrame(frame, state, dec);
+    }
+
+    return finalizeParse(state, dec.version);
+  }
+
+  /**
+   * Parse a trace from an async stream of raw (already-gunzipped) byte chunks.
+   * Decoding overlaps with the network download: each chunk is appended to a
+   * growable buffer, and all *complete* frames it newly exposes are drained
+   * immediately; an incomplete trailing frame is rolled back and re-attempted
+   * once the next chunk arrives. The same {@link processFrame} /
+   * {@link finalizeParse} logic runs as for {@link parseTraceBuffer}, so the
+   * result is byte-for-byte identical to parsing the concatenated buffer.
+   *
+   * @param {AsyncIterable<Uint8Array>} chunks raw trace bytes (post-gunzip)
+   * @param {Object} [options] same options as {@link parseTrace}, plus
+   *   `onParseProgress({bytesRead, totalBytes, eventCount})` (totalBytes is the
+   *   bytes received so far — unknown until the stream ends).
+   * @returns {Promise<ParsedTrace>}
+   */
+  async function parseTraceStream(chunks, options) {
+    const onProgress = (options && options.onParseProgress) || null;
+    const TD = getTraceDecoder();
+    const state = createParseState(options);
+
+    // Unconsumed-tail accumulator. The decoder reads pooled strings/stacks via
+    // its `stringPool`/`stackPool` maps (resolved values are copied into the
+    // maps), and event field reads only touch the current frame's bytes — never
+    // earlier offsets. So once a frame is fully decoded its bytes are dead, and
+    // we can drop the consumed prefix after each drain. That keeps `acc`
+    // bounded by (largest single frame + one chunk) and makes appends O(tail)
+    // instead of O(total) — avoiding O(n²) blow-up on many small chunks.
+    let acc = new Uint8Array(0);
+    let dec = null;
+    let headerDecoded = false;
+    let sawAnyBytes = false;
+    let consumedBytes = 0; // total bytes already decoded (for progress only)
+
+    function grow(chunk) {
+      if (chunk.length === 0) return;
+      // Always copy into a buffer sized EXACTLY to the accumulated bytes.
+      // Aliasing an incoming chunk (which may be a `subarray` view into a
+      // larger underlying ArrayBuffer) is unsafe: the field decoders build
+      // `new Uint8Array(view.buffer, …, len)` directly on the underlying
+      // buffer, bypassing the DataView's length bound, and would happily read
+      // bytes that lie past the logical end of the stream-so-far. Keeping
+      // `acc.buffer.byteLength === acc.length` makes such over-reads throw
+      // RangeError (→ needMoreBytes), which is exactly the incomplete-frame
+      // signal the streaming loop relies on.
+      const next = new Uint8Array(acc.length + chunk.length);
+      next.set(acc, 0);
+      next.set(chunk, acc.length);
+      acc = next;
+    }
+
+    // Drain every complete frame currently in `acc`, then drop the consumed
+    // prefix so the accumulator holds only the (incomplete) trailing frame.
+    function drainComplete() {
+      for (;;) {
+        const snap = dec.snapshot();
+        const frame = dec.nextFrame();
+        if (frame === null) {
+          if (dec.needMoreBytes) {
+            // Partial frame at the tail: undo any positional advance so the
+            // re-wrapped decoder re-attempts this frame from the same offset.
+            dec.restore(snap);
+          }
+          break;
+        }
+        processFrame(frame, state, dec);
+      }
+      // Drop everything the decoder has already consumed. `dec.position` points
+      // at the start of the incomplete trailing frame (or end-of-buffer).
+      const keepFrom = dec.position;
+      if (keepFrom > 0) {
+        consumedBytes += keepFrom;
+        acc = acc.slice(keepFrom);
+      }
+    }
+
+    for await (const rawChunk of chunks) {
+      const chunk = rawChunk instanceof Uint8Array
+        ? rawChunk
+        : new Uint8Array(rawChunk);
+      if (chunk.length === 0) continue;
+      sawAnyBytes = true;
+      grow(chunk);
+
+      if (!headerDecoded) {
+        // Need at least the 5-byte header before any frames. Wait for more.
+        if (acc.length < 5) continue;
+        dec = new TD(acc);
+        dec.enableStreaming();
+        if (!dec.decodeHeader()) throw new Error("Invalid trace header");
+        headerDecoded = true;
+      } else {
+        // Re-wrap the decoder over the grown tail, rebasing its position to 0
+        // (the consumed prefix was dropped by the previous drainComplete()).
+        // Accumulated state (schemas, pools, timestamp base) is preserved.
+        dec.setBuffer(acc);
+        dec.rewindToStart();
+      }
+
+      drainComplete();
+
+      if (onProgress) {
+        onProgress({
+          bytesRead: consumedBytes,
+          totalBytes: consumedBytes + acc.length,
+          eventCount: state.events.length,
+        });
+        // Yield so the browser can paint the spinner between chunks.
+        await new Promise((r) => setTimeout(r, 0));
+      }
+    }
+
+    if (!sawAnyBytes || !headerDecoded) {
+      throw new Error("Invalid trace header");
+    }
+
+    // Stream ended. Any bytes still pending are a genuinely truncated tail
+    // (the file ended mid-frame) — finalize with whatever we decoded, matching
+    // the whole-buffer decoder's graceful EOF behavior.
+    return finalizeParse(state, dec.version);
   }
 
   // ── Directory parsing (Node-only) ──
@@ -1171,8 +1429,11 @@
       EVENT_TYPES,
       OFF_WORKER_WORKER_ID,
       parseTrace,
+      parseTraceStream,
       parseOne,
       fetchTraces,
+      fetchTraceStream,
+      canStreamDecode,
       formatFrame,
       symbolizeChain,
       deduplicateSamples,
@@ -1183,7 +1444,10 @@
       EVENT_TYPES,
       OFF_WORKER_WORKER_ID,
       parseTrace,
+      parseTraceStream,
       fetchTraces,
+      fetchTraceStream,
+      canStreamDecode,
       formatFrame,
       symbolizeChain,
       deduplicateSamples,

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -965,6 +965,22 @@
     const TD = getTraceDecoder();
     const state = createParseState(options);
 
+    // Coalesce incoming chunks before draining. The browser's
+    // DecompressionStream("gzip") emits tiny ~16KB chunks (measured: ~708
+    // chunks of median/max 16384 bytes for the 10.27MB demo trace). Draining
+    // on every chunk pays a full-tail grow() copy + decode setup ~708 times,
+    // which dominates parse time (~66-78% overhead vs the whole-buffer
+    // baseline). Waiting until ≥256KB of undrained bytes have accumulated
+    // collapses those ~708 grow+drain cycles into ~40 and brings streaming back
+    // to/below the whole-buffer baseline. The 5-byte header is still decoded as
+    // soon as it arrives so a tiny trace (well under 256KB) still parses.
+    const MIN_DRAIN_BYTES = 256 * 1024;
+    // Yield a macrotask (setTimeout(0)) to the browser on this byte cadence
+    // rather than once per chunk, mirroring parseTraceBuffer's YIELD_BYTES.
+    // onProgress still fires on every batch drain so the spinner counter stays
+    // current; only the (relatively expensive) repaint yield is throttled.
+    const YIELD_BYTES = 100 * 1024; // yield to browser every ~100KB decoded
+
     // Unconsumed-tail accumulator. The decoder reads pooled strings/stacks via
     // its `stringPool`/`stackPool` maps (resolved values are copied into the
     // maps), and event field reads only touch the current frame's bytes — never
@@ -1020,17 +1036,13 @@
       }
     }
 
-    for await (const rawChunk of chunks) {
-      const chunk = rawChunk instanceof Uint8Array
-        ? rawChunk
-        : new Uint8Array(rawChunk);
-      if (chunk.length === 0) continue;
-      sawAnyBytes = true;
-      grow(chunk);
-
+    // Decode the header (once ≥5 bytes are buffered) and then drain every
+    // complete frame currently in `acc`. Shared by the batched in-loop path and
+    // the final end-of-stream flush so both go through identical logic.
+    function drainBatch() {
       if (!headerDecoded) {
         // Need at least the 5-byte header before any frames. Wait for more.
-        if (acc.length < 5) continue;
+        if (acc.length < 5) return;
         dec = new TD(acc);
         dec.enableStreaming();
         if (!dec.decodeHeader()) throw new Error("Invalid trace header");
@@ -1042,8 +1054,27 @@
         dec.setBuffer(acc);
         dec.rewindToStart();
       }
-
       drainComplete();
+    }
+
+    let lastYieldPos = 0; // consumedBytes at the last macrotask yield
+    for await (const rawChunk of chunks) {
+      const chunk = rawChunk instanceof Uint8Array
+        ? rawChunk
+        : new Uint8Array(rawChunk);
+      if (chunk.length === 0) continue;
+      sawAnyBytes = true;
+      grow(chunk);
+
+      // Batch tiny chunks: keep accumulating until the undrained tail reaches
+      // MIN_DRAIN_BYTES, then drain once. `acc` only ever holds bytes that have
+      // NOT yet been consumed (drainComplete drops the consumed prefix), so its
+      // length is exactly the pending-but-undrained count. The header is the
+      // one exception — decode it as soon as ≥5 bytes exist so small traces
+      // don't stall waiting for a 256KB batch.
+      if (acc.length < MIN_DRAIN_BYTES && headerDecoded) continue;
+
+      drainBatch();
 
       if (onProgress) {
         onProgress({
@@ -1051,8 +1082,26 @@
           totalBytes: consumedBytes + acc.length,
           eventCount: state.events.length,
         });
-        // Yield so the browser can paint the spinner between chunks.
-        await new Promise((r) => setTimeout(r, 0));
+        // Yield so the browser can paint the spinner, but only on the coarse
+        // YIELD_BYTES cadence — not once per (tiny) chunk, whose macrotask
+        // round-trips were a large part of the streaming overhead.
+        if (consumedBytes - lastYieldPos >= YIELD_BYTES) {
+          lastYieldPos = consumedBytes;
+          await new Promise((r) => setTimeout(r, 0));
+        }
+      }
+    }
+
+    // Drain the final partial batch: bytes that arrived after the last
+    // MIN_DRAIN_BYTES drain (or, for a sub-256KB trace, the only batch).
+    if (acc.length > 0 || (sawAnyBytes && !headerDecoded)) {
+      drainBatch();
+      if (onProgress) {
+        onProgress({
+          bytesRead: consumedBytes,
+          totalBytes: consumedBytes + acc.length,
+          eventCount: state.events.length,
+        });
       }
     }
 

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1393,6 +1393,13 @@
                     resetDropZone();
                     return;
                 }
+                // Trace is rendering: freeze the wall-clock timer. Log the final
+                // elapsed time for easy copy/paste measurement.
+                if (loadStartTime != null) {
+                    const secs = ((performance.now() - loadStartTime) / 1000).toFixed(1);
+                    console.log(`loaded in ${secs}s (events=${trace.events.length})`);
+                }
+                stopLoadTimer();
                 currentTraceBuffer = buffer;
                 currentTraceName = name;
                 showViewer(name);
@@ -1467,12 +1474,46 @@
 
             let loadAbortController = null;
 
+            // Live wall-clock "time to load" timer. Starts the instant a load
+            // begins (showLoadingState, the single earliest point common to
+            // every spinner-showing path: URL stream, multi-URL buffered, file
+            // drop, demo, and re-parse) and ticks up visibly until the trace
+            // renders, so the user can watch elapsed time alongside the event
+            // counter during the download+parse stall. It won't tick during a
+            // long synchronous drain (the main thread is busy) — that's
+            // acceptable and actually informative.
+            let loadStartTime = null;
+            let loadTimerInterval = null;
+
+            /** Render the elapsed-time span; safe to call repeatedly. */
+            function renderLoadElapsed() {
+                const el = document.getElementById("load-elapsed");
+                if (el && loadStartTime != null) {
+                    const secs = (performance.now() - loadStartTime) / 1000;
+                    el.textContent = ` · ${secs.toFixed(1)}s`;
+                }
+            }
+
+            /** Begin the wall-clock timer for the current load (idempotent). */
+            function startLoadTimer() {
+                loadStartTime = performance.now();
+                if (loadTimerInterval) clearInterval(loadTimerInterval);
+                loadTimerInterval = setInterval(renderLoadElapsed, 100);
+            }
+
+            /** Stop and clear the timer so it never leaks or keeps ticking. */
+            function stopLoadTimer() {
+                if (loadTimerInterval) { clearInterval(loadTimerInterval); loadTimerInterval = null; }
+                loadStartTime = null;
+            }
+
             function showLoadingState(label) {
                 loadAbortController = new AbortController();
+                startLoadTimer();
                 dropZone.innerHTML = '';
                 const wrap = document.createElement("div");
                 wrap.style.textAlign = "center";
-                wrap.innerHTML = `<div class="loading-spinner"></div><div style="margin-bottom:8px">${esc(label)}</div><div class="loading-progress" id="load-progress"></div>`;
+                wrap.innerHTML = `<div class="loading-spinner"></div><div style="margin-bottom:8px">${esc(label)}</div><div class="loading-progress"><span id="load-progress"></span><span id="load-elapsed"></span></div>`;
                 const btn = document.createElement("button");
                 btn.textContent = "← Back";
                 btn.style.cssText = "background:#2a2a4a;border:1px solid #444;color:#ccc;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:0.9em;margin-top:12px";
@@ -1480,6 +1521,7 @@
                 wrap.appendChild(btn);
                 wrap.insertAdjacentHTML("beforeend", '<div style="margin-top:8px;font-size:0.8em;color:#666">or press Escape</div>');
                 dropZone.appendChild(wrap);
+                renderLoadElapsed();
             }
 
             function updateLoadProgress(text) {
@@ -1488,11 +1530,18 @@
             }
 
             function cancelLoad() {
+                stopLoadTimer();
                 if (loadAbortController) { loadAbortController.abort(); loadAbortController = null; }
                 resetDropZone();
             }
 
             function resetDropZone() {
+                // Single chokepoint for every load-end-without-render path:
+                // cancelLoad, the catch blocks in parseAndShowTrace /
+                // loadTraceFromUrl, the processTrace-failed early return, and
+                // the Back/reset button. Stop the timer here so it never leaks
+                // or keeps ticking after a load ends. Idempotent.
+                stopLoadTimer();
                 dropZone.innerHTML = `
                     <div>
                         <div style="font-size: 2em; margin-bottom: 12px">📊</div>

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1397,9 +1397,16 @@
 
             /** Finish loading: analyze the parsed trace, retain the buffer for
              *  in-memory re-parse (Set/Clear Range), and show the viewer. */
-            function showParsedTrace(parsed, buffer, name) {
+            async function showParsedTrace(parsed, buffer, name) {
                 trace = parsed;
                 updateLoadProgress(`Analyzing ${trace.events.length.toLocaleString()} events…`);
+                // processTrace() runs synchronously and hogs the main thread for
+                // a couple of seconds on a large trace. Yield for a paint frame
+                // first (double rAF: the callback after the next paint) so the
+                // browser actually renders the "Analyzing…" label before the
+                // blocking work starts — otherwise the label is set but never
+                // shown, and the spinner appears stuck on the last parse line.
+                await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
                 if (!processTrace()) {
                     resetDropZone();
                     return;
@@ -1452,8 +1459,7 @@
                     updateLoadProgress("Decompressing…");
                     const parsed = await parseTrace(buffer, fullOpts);
                     if (loadPerf) loadPerf.parseDoneMs = performance.now();
-                    await new Promise((r) => setTimeout(r, 0));
-                    showParsedTrace(parsed, buffer, name);
+                    await showParsedTrace(parsed, buffer, name);
                 } catch (err) {
                     if (err.name === "AbortError") return;
                     alert("Error: " + err.message);
@@ -1497,8 +1503,7 @@
                     const buffer = new Uint8Array(total);
                     let off = 0;
                     for (const c of captured) { buffer.set(c, off); off += c.length; }
-                    await new Promise((r) => setTimeout(r, 0));
-                    showParsedTrace(parsed, buffer.buffer, name);
+                    await showParsedTrace(parsed, buffer.buffer, name);
                 } catch (err) {
                     if (err.name === "AbortError") return;
                     throw err;

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1376,34 +1376,83 @@
                 showLoadingState(label);
             }
 
+            /** Build the standard onParseProgress callback for the spinner. */
+            function makeParseProgress() {
+                return ({ bytesRead, totalBytes, eventCount }) => {
+                    const pct = totalBytes ? (((bytesRead / totalBytes) * 100) | 0) : 0;
+                    updateLoadProgress(`Parsing: ${pct}% · ${(eventCount / 1000) | 0}k events`);
+                };
+            }
+
+            /** Finish loading: analyze the parsed trace, retain the buffer for
+             *  in-memory re-parse (Set/Clear Range), and show the viewer. */
+            function showParsedTrace(parsed, buffer, name) {
+                trace = parsed;
+                updateLoadProgress(`Analyzing ${trace.events.length.toLocaleString()} events…`);
+                if (!processTrace()) {
+                    resetDropZone();
+                    return;
+                }
+                currentTraceBuffer = buffer;
+                currentTraceName = name;
+                showViewer(name);
+                if (trace.events.length === 0 && hasCpuProfileSamples(trace.cpuSamples)) {
+                    requestAnimationFrame(() => showFlamegraph(minTs, maxTs));
+                }
+            }
+
             /** Parse an already-fetched buffer and show the viewer. */
             async function parseAndShowTrace(buffer, name, opts = {}) {
                 try {
-                    const fullOpts = {
-                        ...opts,
-                        onParseProgress: ({ bytesRead, totalBytes, eventCount }) => {
-                            const pct = ((bytesRead / totalBytes) * 100) | 0;
-                            updateLoadProgress(`Parsing: ${pct}% · ${(eventCount / 1000) | 0}k events`);
-                        },
-                    };
+                    const fullOpts = { ...opts, onParseProgress: makeParseProgress() };
                     updateLoadProgress("Decompressing…");
-                    trace = await parseTrace(buffer, fullOpts);
-                    updateLoadProgress(`Analyzing ${trace.events.length.toLocaleString()} events…`);
+                    const parsed = await parseTrace(buffer, fullOpts);
                     await new Promise((r) => setTimeout(r, 0));
-                    if (!processTrace()) {
-                        resetDropZone();
-                        return;
-                    }
-                    currentTraceBuffer = buffer;
-                    currentTraceName = name;
-                    showViewer(name);
-                    if (trace.events.length === 0 && hasCpuProfileSamples(trace.cpuSamples)) {
-                        requestAnimationFrame(() => showFlamegraph(minTs, maxTs));
-                    }
+                    showParsedTrace(parsed, buffer, name);
                 } catch (err) {
                     if (err.name === "AbortError") return;
                     alert("Error: " + err.message);
                     resetDropZone();
+                }
+            }
+
+            /**
+             * Stream a single trace URL: decode chunks as they download so parse
+             * time overlaps the download (~max(download, parse) instead of their
+             * sum). We capture the gunzipped chunks while parsing so the full
+             * buffer is still available afterwards for in-memory Set/Clear-Range
+             * re-parsing (which never re-fetches).
+             */
+            async function streamAndShowTrace(url, name, opts = {}) {
+                try {
+                    const credHeaders = window.Dial9Creds ? Dial9Creds.headers() : {};
+                    const stream = await TraceParser.fetchTraceStream(url, {
+                        signal: loadAbortController?.signal,
+                        headers: credHeaders,
+                    });
+                    const captured = [];
+                    const capturing = {
+                        async *[Symbol.asyncIterator]() {
+                            for await (const chunk of stream) {
+                                captured.push(chunk);
+                                yield chunk;
+                            }
+                        },
+                    };
+                    const fullOpts = { ...opts, onParseProgress: makeParseProgress() };
+                    const parsed = await TraceParser.parseTraceStream(capturing, fullOpts);
+                    loadAbortController = null;
+                    // Reassemble the full buffer from the captured chunks.
+                    let total = 0;
+                    for (const c of captured) total += c.length;
+                    const buffer = new Uint8Array(total);
+                    let off = 0;
+                    for (const c of captured) { buffer.set(c, off); off += c.length; }
+                    await new Promise((r) => setTimeout(r, 0));
+                    showParsedTrace(parsed, buffer.buffer, name);
+                } catch (err) {
+                    if (err.name === "AbortError") return;
+                    throw err;
                 }
             }
 
@@ -1458,11 +1507,23 @@
             }
 
             // `urls` may be a single URL or a list (one per repeated `trace=`).
-            // Each component is fetched and gunzipped independently, then the raw
-            // buffers are concatenated into one trace (see fetchTraces).
+            // For a single URL we STREAM: download and decode overlap, so the
+            // spinner advances during the download and total load time is about
+            // max(download, parse) rather than their sum. For multiple repeated
+            // `trace=` components we fall back to the buffered fetch+concatenate
+            // path (each component is fetched and gunzipped independently, then
+            // the raw buffers are concatenated into one trace; see fetchTraces).
             async function loadTraceFromUrl(urls) {
                 const list = Array.isArray(urls) ? urls : [urls];
                 try {
+                    const name = urlParams.get('svc')
+                        || list[0].split('/').pop()?.split('?')[0]
+                        || 'trace.bin';
+                    if (list.length === 1 && TraceParser.canStreamDecode()) {
+                        updateLoadProgress("Loading…");
+                        await streamAndShowTrace(list[0], name, getParseOptions());
+                        return;
+                    }
                     updateLoadProgress(list.length > 1 ? `Fetching ${list.length} traces…` : "Fetching…");
                     // Attach bring-your-own-credentials headers if present. A
                     // tab opened directly (not from the browser page) has no
@@ -1473,9 +1534,6 @@
                         headers: credHeaders,
                     });
                     loadAbortController = null;
-                    const name = urlParams.get('svc')
-                        || list[0].split('/').pop()?.split('?')[0]
-                        || 'trace.bin';
                     await parseAndShowTrace(arrayBuffer, name, getParseOptions());
                 } catch (err) {
                     if (err.name === 'AbortError') return;

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1381,8 +1381,17 @@
             /** Build the standard onParseProgress callback for the spinner. */
             function makeParseProgress() {
                 return ({ bytesRead, totalBytes, eventCount }) => {
-                    const pct = totalBytes ? (((bytesRead / totalBytes) * 100) | 0) : 0;
-                    updateLoadProgress(`Parsing: ${pct}% · ${(eventCount / 1000) | 0}k events`);
+                    const events = `${(eventCount / 1000) | 0}k events`;
+                    // Streaming reports totalBytes=null (the full size isn't known
+                    // until the stream ends), so show MB decoded instead of a
+                    // bogus percentage. The buffered path knows the total.
+                    if (totalBytes) {
+                        const pct = ((bytesRead / totalBytes) * 100) | 0;
+                        updateLoadProgress(`Parsing: ${pct}% · ${events}`);
+                    } else {
+                        const mb = (bytesRead / (1024 * 1024)).toFixed(1);
+                        updateLoadProgress(`Parsing: ${mb} MB · ${events}`);
+                    }
                 };
             }
 

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -96,6 +96,13 @@
                 border-radius: 50%;
                 animation: spin 0.8s linear infinite;
                 margin: 0 auto 12px;
+                /* Promote to its own compositor layer so the rotation keeps
+                   running on the compositor thread while the main thread is
+                   blocked (the multi-second synchronous processTrace() crunch
+                   and the coarse parse yields). Without this the spinner
+                   animates on the main thread and visibly freezes/stutters
+                   during load, even though the load itself is short. */
+                will-change: transform;
             }
             .loading-progress {
                 font-size: 0.85em;
@@ -1062,13 +1069,26 @@
             // fade the non-selected polls into the background. Compute the
             // heatmap color and multiply each channel by ~0.4 so the hue is
             // preserved but the bar visually recedes.
+            //
+            // The dim transform depends only on the (quantized, ≤24 distinct)
+            // input color, so memoize by that color string. This runs once per
+            // NON-selected poll per render — millions of times when a task is
+            // selected on a large trace — so the parseInt×3 + hex reassembly
+            // was a measurable chunk of click latency. Cache collapses it to a
+            // Map lookup after the first poll of each bucket.
+            const _dimColorCache = new Map();
             function pollColorDim(startNs, endNs) {
                 const c = TraceAnalysis.pollHeatmapColorQuantized(endNs - startNs);
-                const r = Math.round(parseInt(c.slice(1, 3), 16) * 0.4);
-                const g = Math.round(parseInt(c.slice(3, 5), 16) * 0.4);
-                const b = Math.round(parseInt(c.slice(5, 7), 16) * 0.4);
-                const hex2 = (n) => n.toString(16).padStart(2, "0");
-                return "#" + hex2(r) + hex2(g) + hex2(b);
+                let dim = _dimColorCache.get(c);
+                if (dim === undefined) {
+                    const r = Math.round(parseInt(c.slice(1, 3), 16) * 0.4);
+                    const g = Math.round(parseInt(c.slice(3, 5), 16) * 0.4);
+                    const b = Math.round(parseInt(c.slice(5, 7), 16) * 0.4);
+                    const hex2 = (n) => n.toString(16).padStart(2, "0");
+                    dim = "#" + hex2(r) + hex2(g) + hex2(b);
+                    _dimColorCache.set(c, dim);
+                }
+                return dim;
             }
 
             // ── State ──
@@ -1217,6 +1237,11 @@
             // Span data from custom events (SpanEnterEvent/SpanExitEvent)
             let allSpans = []; // [{start, end, spanId, spanName, fields, parentSpanId, depth, segments: [{start, end, workerId}], activeNs}]
             let spansById = new Map(); // spanId → entry in allSpans (for O(1) ancestor walks)
+            // spanId → ALL spans with that id. Span ids are recycled (see
+            // testBuildSpanDataRecycledId), so a single id can map to multiple
+            // distinct span intervals; the highlight loop must light up every
+            // instance, which spansById (last-wins) cannot do.
+            let spansByIdAll = new Map();
             let spanMeta = new Map(); // spanId → {spanName, fields, parentSpanId}
             let childrenByParent = new Map(); // parentSpanId|null → [childSpanId, ...]
             let spanMaxDepth = 0;
@@ -1705,6 +1730,8 @@
             // value is a separate (possibly gzipped) component to concatenate.
             const urlParams = new URLSearchParams(window.location.search);
             const traceUrls = urlParams.getAll('trace');
+            // Render profiler: ?prof=1 (or window.D9PROF=1 from the console).
+            if (urlParams.get('prof') === '1') window.D9PROF = 1;
 
             /** Build parseTrace options from current URL time range params. */
             function getParseOptions() {
@@ -1802,6 +1829,7 @@
                 // inherit stale state from a previously-loaded trace.
                 allSpans = [];
                 spansById = new Map();
+                spansByIdAll = new Map();
                 spanMeta = new Map();
                 childrenByParent = new Map();
                 unmatchedSpans = [];
@@ -1818,7 +1846,12 @@
                     // Build spanId → span index for O(1) ancestor walks
                     // (used by the lane-click handler and anywhere else that
                     // needs to navigate by parentSpanId).
-                    for (const s of allSpans) spansById.set(s.spanId, s);
+                    for (const s of allSpans) {
+                        spansById.set(s.spanId, s);
+                        let bucket = spansByIdAll.get(s.spanId);
+                        if (!bucket) { bucket = []; spansByIdAll.set(s.spanId, bucket); }
+                        bucket.push(s);
+                    }
                     const totalSegs = allSpans.reduce((s, sp) => s + sp.segments.length, 0);
                     console.log(`Span events: ${allSpans.length} spans (${totalSegs} segments), ${spanMeta.size} unique span IDs, maxDepth=${spanMaxDepth}, ${unmatchedSpans.length} unmatched`);
                 }
@@ -2109,7 +2142,17 @@
 
                 showToast("shift-drag-hint", "⇧ Shift+drag to select a region", "info", 0, true);
                 showToast("option-drag-hint", "⌥ Option+drag to zoom", "info", 0, true);
-                requestAnimationFrame(renderAll);
+                // Render synchronously, NOT via requestAnimationFrame. We just
+                // set the viewer to display:flex above; renderAll() reads
+                // getBoundingClientRect() first, which forces a synchronous
+                // reflow, so the lane canvases have correct widths immediately —
+                // no paint frame is needed to settle layout. Drawing here, in
+                // the same task that revealed the viewer, means the browser's
+                // next paint shows the fully-rendered trace. Deferring to a rAF
+                // instead left one frame where the viewer was visible but the
+                // canvases were still blank — the "empty view flash" between the
+                // spinner and the trace.
+                renderAll();
             }
 
             function updatePointsOfInterest({ autoJump = false } = {}) {
@@ -2355,7 +2398,31 @@
                 return lo;
             }
 
+            // Lightweight render profiler. Enable from the console with
+            // `window.D9PROF = 1` (or `?prof=1`), then interact; each renderAll
+            // prints a per-phase breakdown so a slow click is self-diagnosing
+            // instead of guessed at. Costs nothing when disabled.
+            function _profNow() { return (window.D9PROF ? performance.now() : 0); }
+            function _profMark(acc, label, t0) {
+                if (!window.D9PROF) return t0;
+                const t1 = performance.now();
+                acc.push([label, t1 - t0]);
+                return t1;
+            }
+
+            // Per-pass accumulators for renderLane, summed across all lanes.
+            // Reset each renderAll, printed at the end when D9PROF is on.
+            let _laneProf = null;
+            function _lp(label, t0) {
+                if (!_laneProf) return t0;
+                const t1 = performance.now();
+                _laneProf.t[label] = (_laneProf.t[label] || 0) + (t1 - t0);
+                return t1;
+            }
+
             function renderAll() {
+                const prof = window.D9PROF ? [] : null;
+                _laneProf = window.D9PROF ? { t: {}, polls: 0, fillRects: 0 } : null;
                 const rect = lanesContainer.getBoundingClientRect();
                 const drawW = rect.width - LABEL_W;
                 if (drawW <= 0) return;
@@ -2363,6 +2430,7 @@
                 // Scrollbar width: difference between container and its usable content area
                 const scrollbarW = lanesContainer.offsetWidth - lanesContainer.clientWidth;
 
+                let _t = _profNow();
                 // First pass: calculate max visible queue across all workers
                 window.visibleQueueRanges = {};
                 let maxVisibleQ = 1;
@@ -2376,13 +2444,32 @@
                     }
                 }
                 window.sharedVisibleMaxQ = maxVisibleQ;
+                if (prof) _t = _profMark(prof, "queueMax", _t);
 
                 renderTimeline(drawW - scrollbarW);
+                if (prof) _t = _profMark(prof, "timeline", _t);
                 for (const w of workerIds) renderLane(w, drawW);
+                if (prof) _t = _profMark(prof, `lanes(${workerIds.length})`, _t);
                 renderSpanPanel(scrollbarW);
+                if (prof) _t = _profMark(prof, `spanPanel(allSpans=${allSpans.length})`, _t);
                 renderCustomEventsPanel(scrollbarW);
+                if (prof) _t = _profMark(prof, `customEvents(${genericCustomEvents.length})`, _t);
                 renderTaskDetail(scrollbarW);
+                if (prof) _t = _profMark(prof, "taskDetail", _t);
                 renderQueueChart(drawW, scrollbarW);
+                if (prof) {
+                    _t = _profMark(prof, "queueChart", _t);
+                    const total = prof.reduce((s, [, ms]) => s + ms, 0);
+                    prof.sort((a, b) => b[1] - a[1]);
+                    console.log(`[renderAll] total=${total.toFixed(1)}ms  ` +
+                        prof.map(([l, ms]) => `${l}=${ms.toFixed(1)}`).join("  "));
+                    if (_laneProf) {
+                        const passes = Object.entries(_laneProf.t).sort((a, b) => b[1] - a[1]);
+                        console.log(`  [lanes] polls=${_laneProf.polls} fillRects=${_laneProf.fillRects}  ` +
+                            passes.map(([l, ms]) => `${l}=${ms.toFixed(1)}`).join("  "));
+                    }
+                }
+                _laneProf = null;
 
                 // Keep the selection overlay in sync when sidebar is open
                 if (sidebarSelStart && sidebarSelEnd &&
@@ -2398,6 +2485,20 @@
 
                 // Redraw overlay lines (mouse crosshair + selected-event marker).
                 renderCrosshair();
+            }
+
+            // Coalesced renderAll: collapses multiple requests within one frame
+            // into a single render. Use this for high-frequency event handlers
+            // (mousemove hover, pan) so a burst of events can't queue a backlog
+            // of full renders — which, on a large trace, froze the UI as each
+            // multi-hundred-ms render ran back to back.
+            let _renderRafId = 0;
+            function scheduleRenderAll() {
+                if (_renderRafId) return;
+                _renderRafId = requestAnimationFrame(() => {
+                    _renderRafId = 0;
+                    renderAll();
+                });
             }
 
             function nsToX(ns, drawW) {
@@ -2531,6 +2632,7 @@
              * internal offset) rather than the flex layout used here.
              */
             function renderLane(workerId, drawW) {
+                let _tl = _profNow();
                 const c = laneCanvases[workerId];
                 if (!c) {
                     console.error(`No canvas for worker ${workerId}`);
@@ -2548,6 +2650,9 @@
                 ctx.scale(dpr, dpr);
 
                 const spans = workerSpans[workerId];
+                // Weight fn for pixel-LOD downsampling: longest span wins a
+                // pixel column (it visually dominates when zoomed out).
+                const _spanDur = (s) => s.end - s.start;
                 // Block-in-place gaps for this worker (rendered as overlays).
                 const workerGaps = (trace.blockInPlaceGaps || [])
                     .filter(g => g.workerId === workerId)
@@ -2558,12 +2663,16 @@
                 ctx.fillStyle = "#1a1e2a";
                 ctx.fillRect(0, 0, pw, ph);
 
-                // Color-code active periods by scheduling ratio (v5+ only)
+                // Color-code active periods by scheduling ratio (v5+ only).
+                // Pixel-LOD: when zoomed out there can be millions of active
+                // periods over ~1500px; draw one representative (the longest
+                // starting in each pixel column) instead of one fillRect each.
                 if (trace.hasCpuTime) {
                     const startIdx = findFirstVisible(spans.actives, viewStart);
-                    for (let i = startIdx; i < spans.actives.length; i++) {
-                        const s = spans.actives[i];
-                        if (s.start > viewEnd) break;
+                    const reps = TraceAnalysis.pixelDownsampleSpans(
+                        spans.actives, startIdx, viewStart, viewEnd, pw, _spanDur);
+                    if (_laneProf) _laneProf.fillRects += reps.length;
+                    for (const s of reps) {
                         const x1 = Math.max(0, nsToX(s.start, pw));
                         const x2 = Math.min(pw, nsToX(s.end, pw));
                         const w = Math.max(x2 - x1, 1);
@@ -2599,11 +2708,14 @@
                 }
 
                 // Draw park spans — split into normal park (muted) and scheduling delay (bright red)
+                // Pixel-LOD: one representative park per pixel column (longest
+                // wins) so a worker that parked millions of times stays cheap.
                 {
                 const parkStart = findFirstVisible(spans.parks, viewStart);
-                for (let i = parkStart; i < spans.parks.length; i++) {
-                    const s = spans.parks[i];
-                    if (s.start > viewEnd) break;
+                const parkReps = TraceAnalysis.pixelDownsampleSpans(
+                    spans.parks, parkStart, viewStart, viewEnd, pw, _spanDur);
+                if (_laneProf) _laneProf.fillRects += parkReps.length;
+                for (const s of parkReps) {
                     const x1 = Math.max(0, nsToX(s.start, pw));
                     const x2 = Math.min(pw, nsToX(s.end, pw));
                     const w = Math.max(x2 - x1, 1);
@@ -2643,6 +2755,7 @@
                     }
                 }
                 } // end parks block
+                _tl = _lp("setup+bg+parks", _tl);
 
                 // Draw poll spans (solid blue bars, center band)
                 // When a task is selected, draw in two passes: dim first, selected on top
@@ -2650,64 +2763,51 @@
                     bandH = 20;
                 const poiSpan = (currentPoiIndex >= 0) ? pointsOfInterest[currentPoiIndex].span : null;
                 const pollStart = findFirstVisible(spans.polls, viewStart);
-                const nsPerPx = (viewEnd - viewStart) / pw;
+                // Pixel-LOD downsample THEN coalesce. Fully zoomed out there
+                // are ~millions of polls over ~1500px; drawing one fillRect per
+                // poll was ~99.9% overdraw (measured: ~1.6M fillRects, ~1s/
+                // render). pixelDownsampleSpans keeps one representative per
+                // pixel column (the longest poll starting there), so we draw
+                // ≤ pw bars. The coalescer then merges adjacent same-color
+                // representatives. When a task is selected, bias the weight so
+                // its polls always win their column (otherwise a short selected
+                // poll sharing a pixel with a longer one would vanish).
+                const pollWeight = selectedTaskId
+                    ? (s) => (s.taskId === selectedTaskId ? Infinity : s.end - s.start)
+                    : _spanDur;
+                const pollReps = TraceAnalysis.pixelDownsampleSpans(
+                    spans.polls, pollStart, viewStart, viewEnd, pw, pollWeight);
+                if (_laneProf) _laneProf.polls += pollReps.length;
+                // Coalesce adjacent same-color representatives into one fillRect
+                // per contiguous run. `color(s)` returns the fill, or null to
+                // skip (skipped reps don't break neighboring runs).
+                const drawCoalesced = (color) => {
+                    const merge = TraceAnalysis.makeBarCoalescer((x, w, fill) => {
+                        ctx.fillStyle = fill;
+                        ctx.fillRect(x, bandTop, w, bandH);
+                        if (_laneProf) _laneProf.fillRects++;
+                    });
+                    for (const s of pollReps) {
+                        const fill = color(s);
+                        if (fill == null) continue;
+                        const x1 = Math.max(0, nsToX(s.start, pw));
+                        const x2 = Math.min(pw, nsToX(s.end, pw));
+                        merge.push(x1, x2, fill);
+                    }
+                    merge.flush();
+                };
+                let _tp = _profNow();
                 if (selectedTaskId) {
-                    for (let i = pollStart; i < spans.polls.length; i++) {
-                        const s = spans.polls[i];
-                        if (s.start > viewEnd) break;
-                        if (s.taskId === selectedTaskId) continue;
-                        const x1 = Math.max(0, nsToX(s.start, pw));
-                        const x2 = Math.min(pw, nsToX(s.end, pw));
-                        ctx.fillStyle = pollColorDim(s.start, s.end);
-                        ctx.fillRect(x1, bandTop, Math.max(x2 - x1, 1), bandH);
-                    }
-                    ctx.fillStyle = "#ffeb3b";
-                    for (let i = pollStart; i < spans.polls.length; i++) {
-                        const s = spans.polls[i];
-                        if (s.start > viewEnd) break;
-                        if (s.taskId !== selectedTaskId) continue;
-                        const x1 = Math.max(0, nsToX(s.start, pw));
-                        const x2 = Math.min(pw, nsToX(s.end, pw));
-                        ctx.fillRect(x1, bandTop, Math.max(x2 - x1, 1), bandH);
-                    }
-                } else if (nsPerPx > 5000) {
-                    // LOD: when zoomed out, bucket polls by pixel and draw worst-case color
-                    // Each pixel bucket tracks the max poll duration seen
-                    let prevPx = -2, prevColor = null, runStart = -1;
-                    for (let i = pollStart; i < spans.polls.length; i++) {
-                        const s = spans.polls[i];
-                        if (s.start > viewEnd) break;
-                        const x1 = Math.max(0, nsToX(s.start, pw)) | 0;
-                        const x2 = Math.min(pw, nsToX(s.end, pw)) | 0;
-                        const color = pollColor(s.start, s.end);
-                        if (x1 <= prevPx + 1 && color === prevColor) {
-                            // Extend current run
-                            prevPx = Math.max(prevPx, x2);
-                        } else {
-                            // Flush previous run
-                            if (prevColor) {
-                                ctx.fillStyle = prevColor;
-                                ctx.fillRect(runStart, bandTop, Math.max(prevPx - runStart, 1), bandH);
-                            }
-                            runStart = x1;
-                            prevPx = Math.max(x1, x2);
-                            prevColor = color;
-                        }
-                    }
-                    if (prevColor) {
-                        ctx.fillStyle = prevColor;
-                        ctx.fillRect(runStart, bandTop, Math.max(prevPx - runStart, 1), bandH);
-                    }
+                    // Dim pass: every non-selected poll. Highlight pass: the
+                    // selected task's polls on top, in a single solid color.
+                    drawCoalesced((s) =>
+                        s.taskId === selectedTaskId ? null : pollColorDim(s.start, s.end));
+                    drawCoalesced((s) =>
+                        s.taskId === selectedTaskId ? "#ffeb3b" : null);
                 } else {
-                    for (let i = pollStart; i < spans.polls.length; i++) {
-                        const s = spans.polls[i];
-                        if (s.start > viewEnd) break;
-                        const x1 = Math.max(0, nsToX(s.start, pw));
-                        const x2 = Math.min(pw, nsToX(s.end, pw));
-                        ctx.fillStyle = pollColor(s.start, s.end);
-                        ctx.fillRect(x1, bandTop, Math.max(x2 - x1, 1), bandH);
-                    }
+                    drawCoalesced((s) => pollColor(s.start, s.end));
                 }
+                _tp = _lp("pollDraw", _tp);
                 // Mark open-ended polls with a dashed right edge (block_in_place)
                 for (let i = pollStart; i < spans.polls.length; i++) {
                     const s = spans.polls[i];
@@ -2756,6 +2856,7 @@
                     }
                 }
 
+                _tp = _lp("openEnded+poiEtc", _tp);
                 // Mark CPU sample positions with ticks below the poll band
                 ctx.fillStyle = "#ce93d8";
                 {
@@ -2774,6 +2875,7 @@
                     }
                 }
 
+                _tp = _lp("cpuTicks", _tp);
                 // Mark polls that have sched events with red triangles below the poll band
                 for (let i = pollStart; i < spans.polls.length; i++) {
                     const s = spans.polls[i];
@@ -2805,19 +2907,31 @@
                     }
                 }
 
-                // Highlight polls containing the selected span
+                // Highlight polls containing the selected span. Iterate the
+                // (tiny: focused span + ancestors) selectedSpanIds set and look
+                // each up via spansById, rather than scanning the whole
+                // allSpans array. renderLane runs once per worker, so the old
+                // per-lane allSpans scan was O(workers × allSpans) per render —
+                // hundreds of millions of iterations on a multi-million-span
+                // trace, which made clicking a poll take seconds. This is
+                // O(workers × selectedSpanIds) instead.
                 if (selectedSpanIds.size > 0) {
-                    for (const s of allSpans) {
-                        if (!selectedSpanIds.has(s.spanId)) continue;
-                        for (const seg of s.segments) {
-                            if (seg.workerId !== workerId) continue;
-                            const poll = findSpanAt(spans.polls, seg.start);
-                            if (poll) {
-                                const x1 = Math.max(0, nsToX(poll.start, pw));
-                                const x2 = Math.min(pw, nsToX(poll.end, pw));
-                                ctx.strokeStyle = "#ffeb3b";
-                                ctx.lineWidth = 2;
-                                ctx.strokeRect(x1, bandTop, Math.max(x2 - x1, 4), bandH);
+                    for (const spanId of selectedSpanIds) {
+                        // Recycled ids: highlight every span instance sharing
+                        // this id, matching the old full-allSpans scan exactly.
+                        const matches = spansByIdAll.get(spanId);
+                        if (!matches) continue;
+                        for (const s of matches) {
+                            for (const seg of s.segments) {
+                                if (seg.workerId !== workerId) continue;
+                                const poll = findSpanAt(spans.polls, seg.start);
+                                if (poll) {
+                                    const x1 = Math.max(0, nsToX(poll.start, pw));
+                                    const x2 = Math.min(pw, nsToX(poll.end, pw));
+                                    ctx.strokeStyle = "#ffeb3b";
+                                    ctx.lineWidth = 2;
+                                    ctx.strokeRect(x1, bandTop, Math.max(x2 - x1, 4), bandH);
+                                }
                             }
                         }
                     }
@@ -2843,6 +2957,7 @@
                     }
                 }
 
+                _tp = _lp("schedTris+highlights", _tp);
                 // Overlay local queue depth as a step chart in the bottom portion
                 const samples = workerQueueSamples[workerId];
                 if (samples && samples.length) {
@@ -2890,6 +3005,7 @@
                     ctx.stroke();
                 }
 
+                _tp = _lp("queueStep", _tp);
                 // Separator line between poll band and queue area
                 ctx.strokeStyle = "#333";
                 ctx.lineWidth = 0.5;
@@ -3835,34 +3951,13 @@
                 ctx.font = "9px monospace";
                 ctx.textAlign = "center";
 
-                // For each poll, find the most recent wake before it to show wake→poll delay
-                const pollWakes = []; // parallel to polls: {wake, effectiveWake} or null
-                for (let pi = 0; pi < polls.length; pi++) {
-                    const s = polls[pi];
-                    let best = null;
-                    if (wakes.length) {
-                        let lo = 0, hi = wakes.length - 1, bi = -1;
-                        while (lo <= hi) {
-                            const mid = (lo + hi) >> 1;
-                            if (wakes[mid].timestamp <= s.start) { bi = mid; lo = mid + 1; }
-                            else hi = mid - 1;
-                        }
-                        if (bi >= 0) {
-                            const w = wakes[bi];
-                            // If wake arrived during an earlier poll, effective wait starts at that poll's end
-                            let effectiveWake = w.timestamp;
-                            for (let j = 0; j < pi; j++) {
-                                if (w.timestamp >= polls[j].start && w.timestamp <= polls[j].end) {
-                                    effectiveWake = polls[j].end;
-                                    break;
-                                }
-                            }
-                            const delay = s.start - effectiveWake;
-                            if (delay >= 0 && delay < 1e9) best = { wake: w, effectiveWake };
-                        }
-                    }
-                    pollWakes.push(best);
-                }
+                // For each poll, find the most recent wake before it to show
+                // wake→poll delay. `polls` is sorted by start and a task's polls
+                // never overlap, so the "did the wake land in an earlier poll?"
+                // lookup is a binary search inside computePollWakes — O(P·logP)
+                // rather than the O(P²) a per-poll linear scan over earlier
+                // polls costs for a task polled millions of times.
+                const pollWakes = TraceAnalysis.computePollWakes(polls, wakes);
 
                 // Draw wake→poll scheduling delay regions
                 taskDetailWakeRegions = [];
@@ -3976,24 +4071,60 @@
                     }
                 }
 
-                // Draw poll spans
-                for (const s of polls) {
-                    if (s.end < viewStart || s.start > viewEnd) continue;
-                    const x1 = LABEL_W + Math.max(0, nsToX(s.start, drawW));
-                    const x2 = LABEL_W + Math.min(drawW, nsToX(s.end, drawW));
-                    const w = Math.max(x2 - x1, 1);
-                    ctx.fillStyle = "#4fc3f7";
-                    ctx.fillRect(x1, bandTop, w, bandH);
-                    if (w > 35) {
-                        ctx.fillStyle = "#000";
-                        ctx.fillText(fmtDur(s.end - s.start), x1 + w / 2, bandTop + bandH / 2 + 3);
+                // Draw poll spans. `polls` is sorted by start and non-overlapping.
+                const pollStartIdx = findFirstVisible(polls, viewStart);
+                // Count how many polls are actually visible (cheap: bounded by
+                // the early break). If there are more polls than pixels, drawing
+                // one ≥1px bar each would inflate sub-pixel polls and swallow the
+                // idle gaps between them, painting a solid band that looks like
+                // one long continuous poll even for a mostly-idle task. In that
+                // regime, render a per-pixel COVERAGE histogram instead: opacity
+                // = fraction of the pixel's time spent polling. Busy → solid,
+                // sparse → faint, which is the honest density view.
+                let visiblePolls = 0;
+                for (let i = pollStartIdx; i < polls.length; i++) {
+                    if (polls[i].start > viewEnd) break;
+                    visiblePolls++;
+                }
+                if (visiblePolls > drawW) {
+                    const cov = TraceAnalysis.pixelCoverage(polls, pollStartIdx, viewStart, viewEnd, Math.ceil(drawW));
+                    for (let px = 0; px < cov.length; px++) {
+                        const c = cov[px];
+                        if (c <= 0) continue;
+                        // Map coverage→opacity but keep a visible floor so a
+                        // single sub-pixel poll still registers faintly.
+                        ctx.globalAlpha = Math.min(1, 0.15 + c * 0.85);
+                        ctx.fillStyle = "#4fc3f7";
+                        ctx.fillRect(LABEL_W + px, bandTop, 1, bandH);
                     }
-                    // Hit region for polling section
+                    ctx.globalAlpha = 1;
+                    // One coarse hit region for the whole band (per-poll detail
+                    // isn't meaningful at this density; zoom in for it).
                     taskDetailHitRegions.push({
-                        x1, x2, y1: bandTop, y2: bandTop + bandH,
+                        x1: LABEL_W, x2: LABEL_W + drawW, y1: bandTop, y2: bandTop + bandH,
                         type: "polling",
-                        detail: `Polling — actively executing for ${fmtDur(s.end - s.start)}`,
+                        detail: `Polling — ${visiblePolls.toLocaleString()} polls in view (zoom in for per-poll detail)`,
                     });
+                } else {
+                    for (let i = pollStartIdx; i < polls.length; i++) {
+                        const s = polls[i];
+                        if (s.start > viewEnd) break;
+                        const x1 = LABEL_W + Math.max(0, nsToX(s.start, drawW));
+                        const x2 = LABEL_W + Math.min(drawW, nsToX(s.end, drawW));
+                        const w = Math.max(x2 - x1, 1);
+                        ctx.fillStyle = "#4fc3f7";
+                        ctx.fillRect(x1, bandTop, w, bandH);
+                        if (w > 35) {
+                            ctx.fillStyle = "#000";
+                            ctx.fillText(fmtDur(s.end - s.start), x1 + w / 2, bandTop + bandH / 2 + 3);
+                        }
+                        // Hit region for polling section
+                        taskDetailHitRegions.push({
+                            x1, x2, y1: bandTop, y2: bandTop + bandH,
+                            type: "polling",
+                            detail: `Polling — actively executing for ${fmtDur(s.end - s.start)}`,
+                        });
+                    }
                 }
 
                 // Draw idle gaps between consecutive polls (where no wake→poll delay is shown)
@@ -4658,7 +4789,7 @@
                 }
                 viewStart = Math.max(minTs, newStart);
                 viewEnd = Math.min(maxTs, newEnd);
-                renderAll();
+                scheduleRenderAll();
             });
             window.addEventListener("mouseup", () => {
                 if (regionSelecting) {
@@ -5942,7 +6073,7 @@
                 if (found !== hoveredWakerTaskId) {
                     hoveredWakerTaskId = found;
                     document.getElementById("task-detail").style.cursor = found ? "pointer" : "";
-                    renderAll();
+                    scheduleRenderAll();
                 }
 
                 // Show status for polling/scheduled/idle sections
@@ -5964,7 +6095,7 @@
                 document.getElementById("task-detail-status").textContent = "";
                 if (hoveredWakerTaskId) {
                     hoveredWakerTaskId = null;
-                    renderAll();
+                    scheduleRenderAll();
                 }
             });
             document.getElementById("task-detail").addEventListener("click", (e) => {

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -780,6 +780,7 @@
                     <button id="btn-cpu-flamegraph" style="display:none;background:#2a1a2a;border-color:#b388ff;color:#d0bcff;white-space:nowrap" title="Show a CPU flamegraph for the whole trace">🔥 Flamegraph</button>
                     <button id="btn-heap-flamegraph" style="display:none;background:#1a2a1a;border-color:#4caf50;color:#81c784;white-space:nowrap" title="Show heap allocation flamegraph">🔥 Heap</button>
                     <button id="btn-uninstrumented-info" style="display:none;background:#1e2050;border-color:#6c63ff;color:#d0ccff;white-space:nowrap" title="Some tasks lack wake tracking — click for details">ⓘ Blind spawns</button>
+                    <button id="btn-parse-perf" style="display:none;background:#1e2050;border-color:#6c63ff;color:#d0ccff;white-space:nowrap" title="Show the dial9 fetch &amp; parse time breakdown for this load">⏱ Parse perf</button>
                     <button id="btn-set-range" title="Set time range filter (reloads with only events in range)">Set Range</button>
                     <button id="btn-clear-range" title="Clear time range filter" style="display:none">Clear Range</button>
                     <button id="btn-reset">New File</button>
@@ -862,6 +863,7 @@
                     <div id="fg-container" style="flex:1;display:flex;flex-direction:column;overflow:hidden"></div>
                 </div>
                 <div id="uninstrumented-popup" style="display:none;position:fixed;background:#1a1a2e;border:1px solid #6c63ff;border-radius:8px;padding:12px 16px;z-index:200;max-width:700px;max-height:400px;overflow-y:auto;font-size:0.82em;line-height:1.6;box-shadow:0 4px 20px rgba(0,0,0,0.5);font-family:monospace"></div>
+                <div id="parse-perf-popup" style="display:none;position:fixed;background:#1a1a2e;border:1px solid #6c63ff;border-radius:8px;padding:12px 16px;z-index:200;max-width:420px;max-height:400px;overflow-y:auto;font-size:0.82em;line-height:1.7;box-shadow:0 4px 20px rgba(0,0,0,0.5);font-family:monospace"></div>
             </div>
             <div id="stack-sidebar">
                 <div class="sidebar-resize" id="sidebar-resize-handle"></div>
@@ -1403,6 +1405,32 @@
                 currentTraceBuffer = buffer;
                 currentTraceName = name;
                 showViewer(name);
+                // Record the TOTAL load time including the analysis+render phase
+                // that just ran in showViewer. The live `loadStartTime` timer was
+                // already frozen above (before analysis), so we measure here from
+                // the recorded loadPerf.startMs. A double requestAnimationFrame
+                // defers until after the browser has laid out and painted the
+                // first frame, so totalMs reflects "once the render completes"
+                // rather than just "JS returned". Then refine the inline stats
+                // suffix (showViewer wrote it provisionally / without a total).
+                if (loadPerf) {
+                    loadPerf.events = trace.events.length;
+                    // Best-effort decompressed size. The streaming path passes the
+                    // reassembled gunzipped buffer (exact). The buffered/local/
+                    // reparse paths pass the input buffer fed to the parser.
+                    const buf = buffer;
+                    if (buf != null) {
+                        loadPerf.bytes = buf.byteLength != null
+                            ? buf.byteLength
+                            : (buf.length != null ? buf.length : null);
+                    }
+                    const perf = loadPerf; // capture in case a new load starts
+                    requestAnimationFrame(() => requestAnimationFrame(() => {
+                        if (perf.startMs == null) return;
+                        perf.totalMs = performance.now() - perf.startMs;
+                        updateInlineLoadTime(perf);
+                    }));
+                }
                 if (trace.events.length === 0 && hasCpuProfileSamples(trace.cpuSamples)) {
                     requestAnimationFrame(() => showFlamegraph(minTs, maxTs));
                 }
@@ -1414,6 +1442,7 @@
                     const fullOpts = { ...opts, onParseProgress: makeParseProgress() };
                     updateLoadProgress("Decompressing…");
                     const parsed = await parseTrace(buffer, fullOpts);
+                    if (loadPerf) loadPerf.parseDoneMs = performance.now();
                     await new Promise((r) => setTimeout(r, 0));
                     showParsedTrace(parsed, buffer, name);
                 } catch (err) {
@@ -1447,7 +1476,11 @@
                         },
                     };
                     const fullOpts = { ...opts, onParseProgress: makeParseProgress() };
+                    if (loadPerf) loadPerf.mode = "stream";
                     const parsed = await TraceParser.parseTraceStream(capturing, fullOpts);
+                    // Streaming fuses fetch+parse, so there is no separate fetch
+                    // mark — parseDoneMs covers the combined fetch+parse phase.
+                    if (loadPerf) loadPerf.parseDoneMs = performance.now();
                     loadAbortController = null;
                     // Reassemble the full buffer from the captured chunks.
                     let total = 0;
@@ -1485,6 +1518,22 @@
             let loadStartTime = null;
             let loadTimerInterval = null;
 
+            // Phase-timing record for the current/last load, captured across
+            // ALL load paths (single-URL stream, multi-URL buffered, local file
+            // drop, demo, and in-memory re-parse). All marks use
+            // performance.now() (ms). Unlike the live `loadStartTime` (which is
+            // frozen when the spinner is replaced, BEFORE analysis+render),
+            // `totalMs` here is recorded after showViewer via a double rAF so
+            // it INCLUDES the analysis+render phase. Fields:
+            //   startMs     - load began (showLoadingState)
+            //   fetchDoneMs - buffered fetch returned (buffered mode only)
+            //   parseDoneMs - parsing finished (all modes)
+            //   totalMs     - start → render-complete (set in double-rAF)
+            //   mode        - 'stream' | 'buffered' | 'local' | 'reparse'
+            //   events      - decoded event count
+            //   bytes       - decompressed buffer length (if known)
+            let loadPerf = null;
+
             /** Render the elapsed-time span; safe to call repeatedly. */
             function renderLoadElapsed() {
                 const el = document.getElementById("load-elapsed");
@@ -1498,7 +1547,10 @@
             function startLoadTimer() {
                 loadStartTime = performance.now();
                 if (loadTimerInterval) clearInterval(loadTimerInterval);
-                loadTimerInterval = setInterval(renderLoadElapsed, 100);
+                // 250ms (4x/sec) keeps the elapsed display readable while
+                // repainting less often than the previous 100ms (10x/sec),
+                // matching the coarser paint cadence in parseTraceStream.
+                loadTimerInterval = setInterval(renderLoadElapsed, 250);
             }
 
             /** Stop and clear the timer so it never leaks or keeps ticking. */
@@ -1510,6 +1562,20 @@
             function showLoadingState(label) {
                 loadAbortController = new AbortController();
                 startLoadTimer();
+                // Reset the phase-timing record at the single earliest point
+                // common to every load path. `mode` defaults to 'local' (file
+                // drop / demo-from-blob have no network fetch); the URL paths
+                // overwrite it with 'stream'/'buffered', and reparseWithRange
+                // with 'reparse'.
+                loadPerf = {
+                    startMs: performance.now(),
+                    fetchDoneMs: null,
+                    parseDoneMs: null,
+                    totalMs: null,
+                    mode: "local",
+                    events: null,
+                    bytes: null,
+                };
                 dropZone.innerHTML = '';
                 const wrap = document.createElement("div");
                 wrap.style.textAlign = "center";
@@ -1582,6 +1648,9 @@
                         signal: loadAbortController?.signal,
                         headers: credHeaders,
                     });
+                    // Buffered mode fetches the whole trace before parsing, so
+                    // fetch and parse are separate phases (unlike streaming).
+                    if (loadPerf) { loadPerf.mode = "buffered"; loadPerf.fetchDoneMs = performance.now(); }
                     loadAbortController = null;
                     await parseAndShowTrace(arrayBuffer, name, getParseOptions());
                 } catch (err) {
@@ -1605,6 +1674,10 @@
                 updateUrlTimeRange(startNs, endNs);
                 resetTraceState({ clearUrlRange: false });
                 enterLoadingView(`Loading ${currentTraceName}…`);
+                // In-memory re-parse: no network fetch, parse straight from the
+                // retained buffer. enterLoadingView reset loadPerf to 'local';
+                // tag it 'reparse' so the perf panel reflects what happened.
+                if (loadPerf) loadPerf.mode = "reparse";
 
                 const opts = {};
                 if (startNs != null) opts.startTime = startNs;
@@ -1818,6 +1891,16 @@
                 const truncNote = trace.truncated ? " (truncated)" : "";
                 const filterNote = trace.timeFiltered ? " (time-filtered)" : "";
                 const statsText = `${trace.events.length.toLocaleString()} events · ${workerIds.length} workers · ${durStr}${truncNote}${filterNote}`;
+                // The total load time is finalized after this function returns
+                // (double-rAF in showParsedTrace), so we emit an empty suffix
+                // span here and updateInlineLoadTime() fills it in once known.
+                // If a prior load already recorded a total (e.g. a fast cached
+                // re-show), seed it immediately. Two layouts: svc-metadata
+                // (inside a .tb-meta/.key) and filename (inside .stats).
+                const loadSuffix = (loadPerf && loadPerf.totalMs != null)
+                    ? ` · loaded in ${fmtSecs(loadPerf.totalMs)}`
+                    : "";
+                const suffixSpan = `<span class="load-time-suffix">${loadSuffix}</span>`;
 
                 if (svc) {
                     // Structured metadata from browser
@@ -1830,10 +1913,10 @@
                         timeLine += `</span>`;
                         lines.push(timeLine);
                     }
-                    lines.push(`<span class="key">${statsText}</span>`);
+                    lines.push(`<span class="key">${statsText}${suffixSpan}</span>`);
                     infoEl.innerHTML = lines.map(l => `<div class="tb-meta">${l}</div>`).join('');
                 } else {
-                    infoEl.innerHTML = `<span class="filename">${esc(filename)}</span><span class="stats">${statsText}</span>`;
+                    infoEl.innerHTML = `<span class="filename">${esc(filename)}</span><span class="stats">${statsText}${suffixSpan}</span>`;
                 }
 
                 buildLanes();
@@ -2002,6 +2085,13 @@
                 if (hasCpu) {
                     btnCpu.textContent = `🔥 Flamegraph (${trace.cpuSamples.length})`;
                 }
+
+                // Parse-perf button: shown after every successful load. The
+                // breakdown (loadPerf) is filled by showParsedTrace; even before
+                // totalMs is finalized in the double-rAF, the panel falls back to
+                // a provisional total so a click always shows something useful.
+                const btnPerf = document.getElementById("btn-parse-perf");
+                if (btnPerf) btnPerf.style.display = loadPerf ? "" : "none";
 
                 showToast("shift-drag-hint", "⇧ Shift+drag to select a region", "info", 0, true);
                 showToast("option-drag-hint", "⌥ Option+drag to zoom", "info", 0, true);
@@ -4290,6 +4380,9 @@
             document.getElementById("btn-uninstrumented-info").addEventListener("click", (e) => {
                 showUninstrumentedPopup(e.target);
             });
+            document.getElementById("btn-parse-perf").addEventListener("click", (e) => {
+                showParsePerfPopup(e.currentTarget);
+            });
             document.getElementById("btn-prev-poi").addEventListener("click", () => {
                 if (currentPoiIndex > 0) jumpToPoi(currentPoiIndex - 1);
                 else if (currentPoiIndex < 0 && pointsOfInterest.length > 0) jumpToPoi(0);
@@ -4966,6 +5059,143 @@
                 }
             });
 
+            // ── Parse-performance breakdown (fetch & parse timing) ──
+
+            /** Format milliseconds as seconds to 1 decimal, e.g. 8200 → "8.2 s". */
+            function fmtSecs(ms) {
+                return (ms / 1000).toFixed(1) + " s";
+            }
+
+            /** Update (or refine) the ` · loaded in X.Xs` suffix on the inline
+             *  stats line. Resilient to both info-block layouts because the
+             *  suffix lives in a dedicated `.load-time-suffix` span that
+             *  showViewer always emits. Pass the specific perf record to write
+             *  (defaults to the current `loadPerf`); the double-rAF caller
+             *  passes its captured record so a freshly-started load can't
+             *  clobber it. No-op if the element or total is absent. */
+            function updateInlineLoadTime(perf = loadPerf) {
+                if (!perf || perf.totalMs == null) return;
+                const el = document.querySelector("#toolbar .tb-info .load-time-suffix");
+                if (el) el.textContent = ` · loaded in ${fmtSecs(perf.totalMs)}`;
+            }
+
+            /** Show the fetch & parse breakdown popup, mirroring the
+             *  uninstrumented-popup pattern (fixed div anchored under the
+             *  button, toggle-off if open, close button + click-outside). */
+            function showParsePerfPopup(anchor) {
+                const popup = document.getElementById("parse-perf-popup");
+                if (!popup) return;
+                // Toggle off if already visible.
+                if (popup.style.display !== "none") {
+                    popup.style.display = "none";
+                    return;
+                }
+                if (!loadPerf) return;
+                const p = loadPerf;
+                // totalMs is finalized in the double-rAF after showViewer. If the
+                // popup is opened before that fires, fall back to a provisional
+                // total measured now (still includes analysis+render).
+                const totalMs = p.totalMs != null
+                    ? p.totalMs
+                    : (p.startMs != null ? performance.now() - p.startMs : null);
+
+                const rows = [];
+                if (totalMs != null) rows.push(["Total", fmtSecs(totalMs)]);
+
+                if (p.mode === "stream") {
+                    // Fetch+parse are fused/overlapped in streamed mode.
+                    if (p.parseDoneMs != null && p.startMs != null) {
+                        rows.push(["Fetch + parse (streamed, overlapped)",
+                            fmtSecs(p.parseDoneMs - p.startMs)]);
+                    }
+                } else if (p.mode === "buffered") {
+                    if (p.fetchDoneMs != null && p.startMs != null) {
+                        rows.push(["Fetch", fmtSecs(p.fetchDoneMs - p.startMs)]);
+                    }
+                    if (p.parseDoneMs != null && p.fetchDoneMs != null) {
+                        rows.push(["Parse", fmtSecs(p.parseDoneMs - p.fetchDoneMs)]);
+                    }
+                } else {
+                    // 'local' (file drop / demo blob) or 'reparse': no fetch,
+                    // parse straight from an in-memory buffer.
+                    if (p.parseDoneMs != null && p.startMs != null) {
+                        rows.push(["Parse", fmtSecs(p.parseDoneMs - p.startMs)]);
+                    }
+                }
+
+                // Analysis + render = everything after parse finished. Only
+                // meaningful once the total is known (i.e. after render).
+                if (totalMs != null && p.parseDoneMs != null && p.startMs != null) {
+                    const analysisMs = totalMs - (p.parseDoneMs - p.startMs);
+                    rows.push(["Analysis + render", fmtSecs(analysisMs)]);
+                }
+
+                // Optional throughput. fetch+parse wall-clock is the most
+                // meaningful denominator (it's where the bytes/events flow).
+                let throughput = "";
+                if (p.parseDoneMs != null && p.startMs != null) {
+                    const fetchParseSec = (p.parseDoneMs - p.startMs) / 1000;
+                    if (fetchParseSec > 0) {
+                        const parts = [];
+                        if (p.events != null) {
+                            parts.push(`${Math.round(p.events / fetchParseSec).toLocaleString()} events/s`);
+                        }
+                        if (p.bytes != null) {
+                            const mbps = (p.bytes / (1024 * 1024)) / fetchParseSec;
+                            parts.push(`${mbps.toFixed(1)} MB/s`);
+                        }
+                        if (parts.length) throughput = parts.join(" · ");
+                    }
+                }
+
+                const modeLabel = {
+                    stream: "streamed (single URL)",
+                    buffered: "buffered (multi-URL)",
+                    local: "local file",
+                    reparse: "in-memory re-parse",
+                }[p.mode] || p.mode;
+
+                let html = `<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">`;
+                html += `<span style="color:#6c63ff;font-weight:600">⏱ Load breakdown</span>`;
+                html += `<span id="parse-perf-popup-close" style="cursor:pointer;color:#888;padding:0 4px">&times;</span>`;
+                html += `</div>`;
+                html += `<div style="color:#888;margin-bottom:8px">Mode: <span style="color:#d0ccff">${esc(modeLabel)}</span></div>`;
+                for (const [label, val] of rows) {
+                    html += `<div style="display:flex;justify-content:space-between;gap:16px">`;
+                    html += `<span style="color:#ccc">${esc(label)}</span>`;
+                    html += `<span style="color:#d0ccff;font-weight:600">${esc(val)}</span>`;
+                    html += `</div>`;
+                }
+                if (throughput) {
+                    html += `<div style="margin-top:8px;color:#888">${esc(throughput)}</div>`;
+                }
+                if (p.mode === "stream") {
+                    html += `<div style="margin-top:8px;color:#777;font-size:0.9em">In streamed mode the download and parse run concurrently, so the two cannot be split — the figure is the combined wall-clock time.</div>`;
+                }
+
+                popup.innerHTML = html;
+
+                // Position below the button (mirror showUninstrumentedPopup).
+                const rect = anchor.getBoundingClientRect();
+                popup.style.top = (rect.bottom + 4) + "px";
+                popup.style.right = (window.innerWidth - rect.right) + "px";
+                popup.style.left = "auto";
+                popup.style.display = "block";
+
+                document.getElementById("parse-perf-popup-close").addEventListener("click", () => {
+                    popup.style.display = "none";
+                });
+            }
+
+            // Close the parse-perf popup when clicking outside it.
+            document.addEventListener("click", (e) => {
+                const popup = document.getElementById("parse-perf-popup");
+                const btn = document.getElementById("btn-parse-perf");
+                if (popup && popup.style.display !== "none" && !popup.contains(e.target) && e.target !== btn) {
+                    popup.style.display = "none";
+                }
+            });
+
             // ── Sidebar view tabs (poll-detail | flamegraph <-> blocking calls) ──
             function showSidebarTabs(activeTab) {
                 const tabs = document.getElementById("sidebar-tabs");
@@ -5391,6 +5621,8 @@
                         clearToasts();
                         if (document.getElementById("uninstrumented-popup").style.display !== "none") {
                             document.getElementById("uninstrumented-popup").style.display = "none";
+                        } else if (document.getElementById("parse-perf-popup").style.display !== "none") {
+                            document.getElementById("parse-perf-popup").style.display = "none";
                         } else if (document.getElementById("stack-sidebar").style.display === "flex") {
                             // If flamegraph is in the sidebar, let it handle Escape first
                             if (fgActive && fgInstance.handleEscape()) {

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -47,6 +47,9 @@ node dial9-viewer/ui/test_trace_analysis.js
 echo "--- Checking multi-component trace fetch (repeatable trace=) ---"
 node dial9-viewer/ui/test_fetch_traces.js
 
+echo "--- Checking streaming trace decode (parseTraceStream) ---"
+node dial9-viewer/ui/test_stream_parse.js
+
 echo "--- Checking bring-your-own-credentials store ---"
 node dial9-viewer/ui/test_creds.js
 


### PR DESCRIPTION
## Summary

Speeds up loading traces in the viewer by (1) downloading trace files in parallel, (2) overlapping download with parse via streaming decode, and (3) streaming object bytes straight from S3 instead of buffering them server-side. For a ~50MB trace this takes loading from ~14s sequential (download then parse) toward ~max(download, parse), with the ~2s server time-to-first-byte stall removed.

### What changed

1. **Parallel per-file download, no server-side decompress** — the S3 browser now emits one `trace=/api/object?bucket=&key=` component per selected file instead of a single combined `/api/trace?keys=...` URL. New `GET /api/object` serves a single object's raw (still-gzipped) bytes; the browser downloads components in parallel and gunzips/concatenates client-side (`fetchTraces`). Far less network transfer (files stay gzipped end-to-end). `/api/trace` is kept but documented **deprecated** (the `dial9-trace-loading` skill still references it).

2. **Streaming trace decode** — `parseTraceStream` decodes chunks as they download so parse overlaps the fetch. The decoder (`decode.js`) gains transactional incomplete-frame handling (snapshot/restore of `_pos` + `_timestampBaseNs`, `needMoreBytes`) so a chunk boundary mid-frame rolls back and waits for more bytes instead of being mistaken for EOF. Output is byte-identical to the buffered path.

3. **Chunk batching** — the browser's `DecompressionStream` emits ~16KB chunks (~708 for a 10MB trace); draining per-chunk cost ~66% overhead. Coalescing to ≥256KB (`MIN_DRAIN_BYTES`) before draining brings streaming back to the whole-buffer baseline.

4. **Repaint throttle + load timing** — the parse repaint yield is throttled by wall-clock (`PAINT_INTERVAL_MS`) instead of per-chunk. Full load timing is captured (`loadPerf`, including the analysis pass via double-rAF) and surfaced inline (`loaded in X.Xs`) plus a **⏱ Parse perf** button showing the fetch/parse/analysis breakdown.

5. **Server streams from S3** — `/api/object` now streams the object body via `axum::Body::from_stream` (new `StorageBackend::get_object_stream`; S3 override drives `ByteStream::next()`, buffered default impl keeps local/test backends unchanged) instead of `body.collect()`. Removes the ~2s TTFB; `content-length` forwarded, no `content-encoding` (browser gunzips opaque bytes). Setup errors (404/401/403) still surface before any body streams.

## Diagnostic tooling

`dial9-viewer/ui/bench_parse.js` — Node benchmark (whole-buffer vs streaming across chunk sizes) used to find and fix the batching overhead. Run: `node bench_parse.js --iters 4`.

## Testing

- New `dial9-viewer/ui/test_stream_parse.js` — proves streaming output is byte-identical to buffered parse across adversarial chunk boundaries (size 1, primes, mid-event/mid-timestamp, inside every mid-stream `TRC\0` header, gzip round-trip, time-range filter). Registered in `scripts/e2e-trace-tests.sh`.
- New `/api/object` integration tests (raw gzipped passthrough, uncompressed, missing-key 400, BYO creds, local not-found, path-traversal rejection, 4MB multi-chunk streaming).
- `cargo nextest run -p dial9-viewer`: 60/60 pass; `--stress-duration 20s`: 18/18 iterations, 0 flakes. `cargo fmt --check` + `clippy --all-targets --all-features` clean. Relevant JS tests pass.
- Reviewed by an adversarial pass (no blocking issues); `ObjectStream` marked `#[non_exhaustive]` per that feedback.

No trace wire-format change, so the demo trace was not regenerated.