### PR TITLE
refactor(tracing-layer)!: rename Dial9TokioLayer to Dial9TracingLayer

### DIFF
--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -391,15 +391,15 @@ Without liveset tracking, the profiler adds negligible overhead. With liveset tr
 dial9-tokio-telemetry = { version = "0.3", features = ["tracing-layer"] }
 ```
 
-**Use tracing_subscriber to connect the `Dial9TokioLayer`:**
+**Use tracing_subscriber to connect the `Dial9TracingLayer`:**
 ```rust
-use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 use tracing_subscriber::prelude::*;
 
 tracing_subscriber::registry()
     .with(tracing_subscriber::fmt::layer())
     .with(
-        Dial9TokioLayer::new().with_filter(
+        Dial9TracingLayer::new().with_filter(
             tracing_subscriber::filter::Targets::new()
                 .with_target("my_app", tracing::Level::TRACE)
                 .with_default(tracing::Level::ERROR),

--- a/dial9-tokio-telemetry/benches/tracing_layer_bench.rs
+++ b/dial9-tokio-telemetry/benches/tracing_layer_bench.rs
@@ -1,7 +1,7 @@
 //! Multi-thread bench for the tracing layer.
 //!
 //! Measures span emission throughput as N threads share one
-//! `Dial9TokioLayer` (and therefore one schemas Mutex). Each thread
+//! `Dial9TracingLayer` (and therefore one schemas Mutex). Each thread
 //! emits 100 spans after a barrier sync; the iteration is timed end to
 //! end across N ∈ {1, 2, 4, 8, 16, 32}.
 //!
@@ -9,7 +9,7 @@
 //!   cargo bench --bench tracing_layer_bench --features tracing-layer
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 use std::sync::{Arc, Barrier};
 use tracing::Dispatch;
 use tracing_subscriber::prelude::*;
@@ -18,9 +18,9 @@ fn bench_multi_thread(c: &mut Criterion) {
     let mut group = c.benchmark_group("multi_thread");
     group.measurement_time(std::time::Duration::from_secs(8));
 
-    // One shared subscriber (one Dial9TokioLayer, one schemas Mutex).
+    // One shared subscriber (one Dial9TracingLayer, one schemas Mutex).
     // All threads dispatch through this single layer, contending on the mutex.
-    let dispatch = Dispatch::new(tracing_subscriber::registry().with(Dial9TokioLayer::new()));
+    let dispatch = Dispatch::new(tracing_subscriber::registry().with(Dial9TracingLayer::new()));
 
     let spans_per_thread = 100;
 

--- a/dial9-tokio-telemetry/benches/tracing_layer_iai.rs
+++ b/dial9-tokio-telemetry/benches/tracing_layer_iai.rs
@@ -2,7 +2,7 @@
 //!
 //! Two groups, each with baseline / depth 1·3·5 / with_fields:
 //! - `tracing_only`: spans with registry subscriber (no dial9 encoding)
-//! - `with_dial9`: spans with `Dial9TokioLayer` (full encoding path)
+//! - `with_dial9`: spans with `Dial9TracingLayer` (full encoding path)
 //!
 //! Multi-thread contention scaling is in `tracing_layer_bench.rs`.
 //!
@@ -19,7 +19,7 @@
 fn main() {}
 
 use dial9_tokio_telemetry::telemetry::{InMemoryWriter, TelemetryGuard, TracedRuntime};
-use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 use tokio::runtime::Runtime;
@@ -53,7 +53,7 @@ fn setup_with_dial9() -> Harness {
         .build_and_start(builder, InMemoryWriter::new(16 * 1024 * 1024).unwrap())
         .unwrap();
     let _sub_guard = tracing::subscriber::set_default(
-        tracing_subscriber::registry().with(Dial9TokioLayer::new()),
+        tracing_subscriber::registry().with(Dial9TracingLayer::new()),
     );
     Harness {
         runtime,

--- a/dial9-tokio-telemetry/examples/production_use.rs
+++ b/dial9-tokio-telemetry/examples/production_use.rs
@@ -110,7 +110,7 @@
 //! To get the most use out of dial9, you need application-specific events in your traces to make sense of your data. The best way to do this is to emit some sort
 //! of request id into your dial9 traces. There are a couple of ways to do this:
 //!
-//! 1. Use the `Dial9TokioLayer`, which is a tracing layer that allows dial9 to capture your tracing spans directly. Typically, you will
+//! 1. Use the `Dial9TracingLayer`, which is a tracing layer that allows dial9 to capture your tracing spans directly. Typically, you will
 //!    select a narrow set of top-level spans to track.
 //! 2. Emit an event when your request starts and when your request stops. Because these should _normally_ always be on the same Tokio Task, we can
 //!    correlate post-hoc to figure exactly which polls belonged to which requests.

--- a/dial9-tokio-telemetry/examples/tracing_sleep.rs
+++ b/dial9-tokio-telemetry/examples/tracing_sleep.rs
@@ -1,7 +1,7 @@
 //! Demonstrates tracing spans across async sleep boundaries.
 //! Each span is polled multiple times (producing multiple segments in the viewer).
 use dial9_tokio_telemetry::telemetry::{DiskWriter, TracedRuntime};
-use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 use std::time::Duration;
 use tracing_subscriber::prelude::*;
 
@@ -28,7 +28,7 @@ fn main() {
         .build_and_start(builder, writer)
         .unwrap();
 
-    let subscriber = tracing_subscriber::registry().with(Dial9TokioLayer::new());
+    let subscriber = tracing_subscriber::registry().with(Dial9TracingLayer::new());
     tracing::subscriber::set_global_default(subscriber).expect("failed to set subscriber");
 
     runtime.block_on(async {

--- a/dial9-tokio-telemetry/src/tracing_layer.rs
+++ b/dial9-tokio-telemetry/src/tracing_layer.rs
@@ -5,11 +5,11 @@
 //! # Usage
 //!
 //! ```ignore
-//! use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+//! use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 //! use tracing_subscriber::prelude::*;
 //!
 //! tracing_subscriber::registry()
-//!     .with(Dial9TokioLayer::new())
+//!     .with(Dial9TracingLayer::new())
 //!     .init();
 //! ```
 //!
@@ -29,13 +29,13 @@
 //! unaffected while controlling trace volume:
 //!
 //! ```ignore
-//! use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+//! use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 //! use tracing_subscriber::prelude::*;
 //!
 //! tracing_subscriber::registry()
 //!     .with(tracing_subscriber::fmt::layer())
 //!     .with(
-//!         Dial9TokioLayer::new().with_filter(
+//!         Dial9TracingLayer::new().with_filter(
 //!             tracing_subscriber::filter::Targets::new()
 //!                 .with_target("my_app", tracing::Level::DEBUG)
 //!                 .with_default(tracing::Level::WARN),
@@ -190,24 +190,24 @@ impl FieldVisitor<'_> {
 /// # Setup
 ///
 /// ```ignore
-/// use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+/// use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 /// use tracing_subscriber::prelude::*;
 ///
 /// tracing_subscriber::registry()
-///     .with(Dial9TokioLayer::new())
+///     .with(Dial9TracingLayer::new())
 ///     .init();
 /// ```
-pub struct Dial9TokioLayer {
+pub struct Dial9TracingLayer {
     schemas: Mutex<HashMap<Identifier, CallsiteSchemas>>,
 }
 
-impl fmt::Debug for Dial9TokioLayer {
+impl fmt::Debug for Dial9TracingLayer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Dial9TokioLayer").finish_non_exhaustive()
+        f.debug_struct("Dial9TracingLayer").finish_non_exhaustive()
     }
 }
 
-impl Dial9TokioLayer {
+impl Dial9TracingLayer {
     /// Create a new layer.
     pub fn new() -> Self {
         Self {
@@ -225,7 +225,7 @@ impl Dial9TokioLayer {
     }
 }
 
-impl Default for Dial9TokioLayer {
+impl Default for Dial9TracingLayer {
     fn default() -> Self {
         Self::new()
     }
@@ -239,7 +239,7 @@ fn field_value<'a>(fields: &'a [(&str, String)], name: &str) -> Option<&'a str> 
         .map(|(_, v)| v.as_str())
 }
 
-impl<S> Layer<S> for Dial9TokioLayer
+impl<S> Layer<S> for Dial9TracingLayer
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {

--- a/dial9-tokio-telemetry/tests/tracing_layer.rs
+++ b/dial9-tokio-telemetry/tests/tracing_layer.rs
@@ -4,7 +4,7 @@
 // (thread-local) instead.
 
 use dial9_tokio_telemetry::telemetry::{DiskWriter, TracedRuntime};
-use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 use dial9_trace_format::types::FieldValueRef;
 use std::collections::HashSet;
 use std::sync::{Arc, Barrier};
@@ -131,7 +131,7 @@ fn span_events_appear_in_trace() {
     let writer = DiskWriter::single_file(&trace_path).unwrap();
     let (runtime, guard) = TracedRuntime::build_and_start(builder, writer).unwrap();
 
-    let subscriber = tracing_subscriber::registry().with(Dial9TokioLayer::new());
+    let subscriber = tracing_subscriber::registry().with(Dial9TracingLayer::new());
     tracing::subscriber::set_global_default(subscriber).expect("failed to set global subscriber");
 
     runtime.block_on(async {
@@ -321,7 +321,7 @@ fn span_events_appear_in_trace() {
 /// Verify the layer silently skips when no Dial9Handle is present.
 #[test]
 fn no_telemetry_handle_does_not_panic() {
-    let subscriber = tracing_subscriber::registry().with(Dial9TokioLayer::new());
+    let subscriber = tracing_subscriber::registry().with(Dial9TracingLayer::new());
     let _guard = tracing::subscriber::set_default(subscriber);
 
     // This runs on a plain thread with no dial9 runtime, so no Dial9Handle.
@@ -345,7 +345,7 @@ fn span_events_on_current_thread_runtime() {
     let writer = DiskWriter::single_file(&trace_path).unwrap();
     let (runtime, guard) = TracedRuntime::build_and_start(builder, writer).unwrap();
 
-    let subscriber = tracing_subscriber::registry().with(Dial9TokioLayer::new());
+    let subscriber = tracing_subscriber::registry().with(Dial9TracingLayer::new());
     let _sub_guard = tracing::subscriber::set_default(subscriber);
 
     runtime.block_on(async {

--- a/dial9-viewer/skills/dial9-trace-analysis/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-analysis/SKILL.md
@@ -220,7 +220,7 @@ const fgData = buildFgData(workerSamples, trace.callframeSymbols);
 
 ## buildSpanData(customEvents)
 
-Pairs `SpanEnter`/`SpanExit` custom events into complete span objects. Requires the `tracing-layer` feature on `dial9-tokio-telemetry` and `Dial9TokioLayer` in the subscriber.
+Pairs `SpanEnter`/`SpanExit` custom events into complete span objects. Requires the `tracing-layer` feature on `dial9-tokio-telemetry` and `Dial9TracingLayer` in the subscriber.
 
 ```javascript
 const { allSpans, spanMeta, maxDepth, childrenByParent } = buildSpanData(trace.customEvents);

--- a/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-recipes/SKILL.md
@@ -218,7 +218,7 @@ traceWakeChain(taskId, spans.wakesByTask, trace.taskSpawnLocs);
 
 ## Span duration percentiles by name
 
-Requires `Dial9TokioLayer` in the subscriber.
+Requires `Dial9TracingLayer` in the subscriber.
 
 ```javascript
 const { analyzeTraces } = require('./analyze.js');

--- a/dial9-viewer/skills/dial9-zoom-window/SKILL.md
+++ b/dial9-viewer/skills/dial9-zoom-window/SKILL.md
@@ -107,7 +107,7 @@ poll (or a busy runtime) was actually delaying other tasks.
 
 ### 5. Inner spans of the dominant poll
 
-If the app installed the tracing layer (`Dial9TokioLayer`), the `tracing` spans
+If the app installed the tracing layer (`Dial9TracingLayer`), the `tracing` spans
 that executed inside the longest poll, by name. Tells you *what code* ran inside a
 long poll even without reading CPU stacks.
 

--- a/examples/metrics-service/src/main.rs
+++ b/examples/metrics-service/src/main.rs
@@ -18,7 +18,7 @@ use dial9_tokio_telemetry::telemetry::cpu_profile::{CpuProfilingConfig, SchedEve
 use dial9_tokio_telemetry::telemetry::{
     Dial9TokioHandle, DiskWriter, ProcessResourceUsageConfig, TaskDumpConfig, TracedRuntime,
 };
-use dial9_tokio_telemetry::tracing_layer::Dial9TokioLayer;
+use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 use tokio::runtime::Builder;
 use tokio_util::sync::CancellationToken;
 
@@ -166,7 +166,7 @@ fn main() -> std::io::Result<()> {
                 ),
         )
         .with(
-            Dial9TokioLayer::new().with_filter(
+            Dial9TracingLayer::new().with_filter(
                 tracing_subscriber::filter::Targets::new()
                     .with_target("metrics_service", tracing::Level::TRACE)
                     .with_default(tracing::Level::ERROR),


### PR DESCRIPTION
closes #481 

## Summary
The public type Dial9TokioLayer is now Dial9TracingLayer. Callers must update imports and constructors.

This is a BREAKING CHANGE.