### PR TITLE
unify S3 boot_id with the on-disk namespace boot_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,7 +1654,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
- "uuid",
 ]
 
 [[package]]
@@ -4922,9 +4921,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -151,7 +151,6 @@ aws-sdk-s3 = { version = "1", default-features = false, features = [
 ] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 async-trait = "0.1.89"
-uuid = { version = "1", features = ["v4"] }
 iai-callgrind = "=0.16.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/dial9-tokio-telemetry/examples/s3_stress_test.rs
+++ b/dial9-tokio-telemetry/examples/s3_stress_test.rs
@@ -136,7 +136,6 @@ fn main() -> std::io::Result<()> {
                 .to_string_lossy()
                 .to_string(),
         )
-        .boot_id(uuid::Uuid::new_v4().to_string())
         .maybe_region(args.region.as_ref())
         .build();
 

--- a/dial9-tokio-telemetry/src/background_task/mod.rs
+++ b/dial9-tokio-telemetry/src/background_task/mod.rs
@@ -1575,6 +1575,15 @@ impl S3PipelineUploader {
         }
     }
 
+    /// Override the pending config's boot_id so S3 keys use the on-disk
+    /// namespace identity. The builder calls this before the worker spawns, so
+    /// the `Ready` arm is unreachable in practice; a no-op there keeps it safe.
+    pub(crate) fn set_boot_id(&mut self, boot_id: impl Into<String>) {
+        if let S3UploaderState::Pending { s3_config, .. } = &mut self.state {
+            s3_config.set_boot_id(boot_id);
+        }
+    }
+
     /// Construct an uploader directly in the `Ready` state. Test-only —
     /// production code goes through [`new`](Self::new) and lazy init.
     #[cfg(test)]
@@ -1905,7 +1914,6 @@ mod tests {
             .bucket("test-bucket")
             .service_name("test")
             .instance_path("test")
-            .boot_id("test")
             .region("us-east-1")
             .build();
 
@@ -2002,7 +2010,6 @@ mod tests {
             .bucket("test")
             .service_name("test")
             .instance_path("test")
-            .boot_id("test")
             .region("us-east-1")
             .build();
         let sdk_config = aws_sdk_s3::Config::builder()
@@ -2389,7 +2396,6 @@ mod worker_pipeline_tests {
             .bucket("test-bucket")
             .service_name("test")
             .instance_path("test")
-            .boot_id("test")
             .region("us-east-1")
             .build();
         FlakyHarness {
@@ -2426,7 +2432,6 @@ mod worker_pipeline_tests {
             .bucket("test-bucket")
             .service_name("test")
             .instance_path("test")
-            .boot_id("test")
             .region("us-east-1")
             .build();
         (s3::S3Uploader::new(tm_client, s3_config), s3_root)
@@ -4083,7 +4088,6 @@ mod finalize_dump_tests {
             .bucket("b")
             .service_name("s")
             .instance_path("i")
-            .boot_id("boot")
             .build();
         let mut uploader = S3PipelineUploader::new(config, None);
 
@@ -4195,7 +4199,6 @@ mod s3_dump_manifest_tests {
             .prefix("traces")
             .service_name("test")
             .instance_path("test")
-            .boot_id("test")
             .region("us-east-1")
             .build();
         let uploader = s3::S3Uploader::new(fake_tm_client(root), config);

--- a/dial9-tokio-telemetry/src/background_task/s3.rs
+++ b/dial9-tokio-telemetry/src/background_task/s3.rs
@@ -47,11 +47,10 @@ where
 
 /// Configuration for S3 uploads.
 ///
-/// Only `bucket` and `service_name` are required. The remaining fields have
-/// sensible defaults:
+/// Only `bucket` and `service_name` are required. The remaining builder fields
+/// have sensible defaults:
 ///
 /// - `instance_path`: system hostname
-/// - `boot_id`: `{4 alpha derived from timestamp}-{pid}` (unique per process start)
 /// - `prefix`: none (keys start at the time bucket)
 /// - `region`: auto-detected via `HeadBucket`
 /// - `key_fn`: built-in time-first layout
@@ -75,13 +74,17 @@ pub struct S3Config {
     /// Instance identifier for S3 key paths. Defaults to the system hostname.
     #[builder(into, default = InstanceIdentity::from_hostname())]
     instance_path: InstanceIdentity,
-    /// Identifies this process lifetime. Included as both S3 object
-    /// metadata and in the default key path. A new value each application
-    /// start disambiguates segments (and segment indices) from different
-    /// runs of the same service on the same host.
+    /// Identifies this process lifetime. Included as both S3 object metadata
+    /// and in the default key path so segments (and segment indices) from
+    /// different runs of the same service on the same host don't collide.
     ///
-    /// Defaults to 4 random lowercase alpha characters.
-    #[builder(default = default_boot_id())]
+    /// Not a builder field: when telemetry is configured through
+    /// [`Dial9Config`](crate::Dial9Config) the runtime injects the same
+    /// boot_id it uses for the on-disk `{boot_id}/` namespace directory (via
+    /// [`set_boot_id`](Self::set_boot_id)), so a local trace segment and its S3
+    /// key share one identity. Defaults to a fresh `{4-alpha}-{pid}` when no
+    /// namespace is in play.
+    #[builder(skip = default_boot_id())]
     boot_id: String,
     /// Optional key prefix. When `None`, keys start at the time bucket.
     prefix: Option<String>,
@@ -107,6 +110,12 @@ impl S3Config {
     /// The S3 bucket name.
     pub(crate) fn bucket(&self) -> &str {
         &self.bucket
+    }
+
+    /// Override the boot_id so S3 keys match the on-disk namespace directory.
+    /// Called by the runtime builder when the writer is namespaced.
+    pub(crate) fn set_boot_id(&mut self, boot_id: impl Into<String>) {
+        self.boot_id = boot_id.into();
     }
 
     pub(crate) fn as_metadata(&self) -> impl Iterator<Item = (&str, &str)> {
@@ -422,14 +431,22 @@ mod tests {
         encoder.finish()
     }
 
+    /// Build a config with a fixed boot_id for deterministic key assertions.
+    fn with_boot_id(mut config: S3Config, boot_id: &str) -> S3Config {
+        config.set_boot_id(boot_id);
+        config
+    }
+
     fn make_config() -> S3Config {
-        S3Config::builder()
-            .bucket("test-bucket")
-            .prefix("traces")
-            .service_name("checkout-api")
-            .instance_path("us-east-1/i-0abc123")
-            .boot_id("test-boot-id")
-            .build()
+        with_boot_id(
+            S3Config::builder()
+                .bucket("test-bucket")
+                .prefix("traces")
+                .service_name("checkout-api")
+                .instance_path("us-east-1/i-0abc123")
+                .build(),
+            "test-boot-id",
+        )
     }
 
     fn make_segment(path: impl Into<PathBuf>, index: u32) -> SegmentRef {
@@ -509,12 +526,14 @@ mod tests {
 
     #[test]
     fn object_key_empty_prefix() {
-        let config = S3Config::builder()
-            .bucket("my-traces")
-            .service_name("checkout-api")
-            .instance_path("us-east-1/i-0abc123")
-            .boot_id("test-boot-id")
-            .build();
+        let config = with_boot_id(
+            S3Config::builder()
+                .bucket("my-traces")
+                .service_name("checkout-api")
+                .instance_path("us-east-1/i-0abc123")
+                .build(),
+            "test-boot-id",
+        );
         let segment = make_segment("/tmp/trace.0.bin", 0);
         let metadata = make_metadata(1741209000);
         let key = config.object_key(&segment, &metadata);
@@ -548,7 +567,6 @@ mod tests {
             .bucket("test-bucket")
             .service_name("svc")
             .instance_path("host")
-            .boot_id("bid")
             .key_fn(|segment: &SegmentInfo| {
                 format!("custom/{}-{}.bin.gz", segment.epoch_secs, segment.index)
             })
@@ -610,7 +628,6 @@ mod tests {
             .bucket("bucket")
             .service_name("svc")
             .instance_path("path")
-            .boot_id("bid")
             .build();
         let segment = make_segment("/tmp/trace.0.bin", 0);
         let metadata = make_metadata(1741209000);
@@ -721,13 +738,15 @@ mod tests {
         let client = fake_s3_client(s3_root.path());
         let raw_s3_client = fake_raw_s3_client(s3_root.path());
 
-        let config = S3Config::builder()
-            .bucket("test-bucket")
-            .prefix("traces")
-            .service_name("checkout-api")
-            .instance_path("us-east-1/i-0abc123")
-            .boot_id("a3f7c2d1-dead-beef-1234-567890abcdef")
-            .build();
+        let config = with_boot_id(
+            S3Config::builder()
+                .bucket("test-bucket")
+                .prefix("traces")
+                .service_name("checkout-api")
+                .instance_path("us-east-1/i-0abc123")
+                .build(),
+            "a3f7c2d1-dead-beef-1234-567890abcdef",
+        );
         let uploader = S3Uploader::new(client, config);
 
         let segment_path = local_dir.path().join("trace.3.bin");
@@ -812,7 +831,6 @@ mod tests {
             .bucket("b")
             .service_name("s")
             .instance_path("i")
-            .boot_id("boot")
             .build();
         check!(no_prefix.manifest_key("01ABC") == "dumps/01ABC.json");
     }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/builder.rs
@@ -558,11 +558,28 @@ impl<M, Mode: WriterMode> TracedRuntimeBuilder<HasTracePath, M, Mode> {
         let custom_event_sources = self.custom_event_sources;
         let dump_trigger = self.dump_trigger;
 
+        // When the writer is namespaced, the S3 keys and the embedded segment
+        // metadata must use the same boot_id as the on-disk `{boot_id}/`
+        // directory, so a local segment and its upload share one identity.
+        let mut pipeline = self.pipeline;
+        let mut segment_metadata = self.segment_metadata;
+        if let Some(boot_id) = writer.boot_id() {
+            #[cfg(feature = "worker-s3")]
+            if let PipelineConfig::S3(uploader) = &mut pipeline {
+                uploader.set_boot_id(boot_id);
+            }
+            for (key, value) in &mut segment_metadata {
+                if key == "boot_id" {
+                    *value = boot_id.to_owned();
+                }
+            }
+        }
+
         let processors = assemble_processors(
             #[cfg(feature = "cpu-profiling")]
             self.cpu_profiling_config.is_some(),
             Mode::IS_DISK,
-            self.pipeline,
+            pipeline,
         );
 
         let core_builder = TelemetryCore::builder()
@@ -580,7 +597,7 @@ impl<M, Mode: WriterMode> TracedRuntimeBuilder<HasTracePath, M, Mode> {
             .maybe_worker_metrics_sink(self.worker_metrics_sink)
             .maybe_trigger(self.trigger_rx)
             .processors(processors)
-            .segment_metadata(self.segment_metadata);
+            .segment_metadata(segment_metadata);
 
         #[cfg(feature = "cpu-profiling")]
         let core_builder = core_builder

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1544,11 +1544,9 @@ mod tests {
         }
 
         fn cfg(boot_id: &str) -> S3Config {
-            S3Config::builder()
-                .bucket("b")
-                .service_name("s")
-                .boot_id(boot_id)
-                .build()
+            let mut c = S3Config::builder().bucket("b").service_name("s").build();
+            c.set_boot_id(boot_id);
+            c
         }
 
         // Order A: client set after the uploader — already worked.
@@ -1597,12 +1595,13 @@ mod tests {
 
         #[cfg(feature = "worker-s3")]
         fn s3_cfg() -> crate::background_task::s3::S3Config {
-            crate::background_task::s3::S3Config::builder()
+            let mut c = crate::background_task::s3::S3Config::builder()
                 .bucket("test-bucket")
                 .service_name("checkout-api")
                 .instance_path("us-east-1/i-0abc123")
-                .boot_id("test-boot")
-                .build()
+                .build();
+            c.set_boot_id("test-boot");
+            c
         }
 
         #[cfg(feature = "worker-s3")]
@@ -1622,11 +1621,11 @@ mod tests {
         #[cfg(feature = "worker-s3")]
         #[test]
         fn s3_preset_replace_overwrites_metadata() {
-            let cfg2 = crate::background_task::s3::S3Config::builder()
+            let mut cfg2 = crate::background_task::s3::S3Config::builder()
                 .bucket("other-bucket")
                 .service_name("other-svc")
-                .boot_id("other-boot")
                 .build();
+            cfg2.set_boot_id("other-boot");
             let builder = TracedRuntime::builder()
                 .with_s3_uploader::<Disk>(s3_cfg())
                 .with_s3_uploader(cfg2);

--- a/dial9-tokio-telemetry/tests/namespace_isolation.rs
+++ b/dial9-tokio-telemetry/tests/namespace_isolation.rs
@@ -130,3 +130,79 @@ fn gc_enabled_reclaims_dead_peer() {
         "dead peer dir must be reclaimed when gc_dead_namespaces is true"
     );
 }
+
+/// The S3 uploader's boot_id must match the on-disk namespace directory, so a
+/// local segment and its upload share one identity. We can't reach S3 from a
+/// unit test, but the same boot_id is embedded in every sealed segment's
+/// `SegmentMetadata`, so decoding it and comparing to the directory name
+/// proves the injection end to end.
+#[cfg(all(unix, feature = "worker-s3"))]
+#[test]
+fn s3_boot_id_matches_namespace_dir() {
+    use std::collections::HashMap;
+
+    use dial9_tokio_telemetry::background_task::s3::S3Config;
+    use dial9_trace_format::decoder::Decoder;
+
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = Dial9Config::builder()
+        .on_disk_buffer(dir.path().join("trace.bin"))
+        .max_total_size(4 * 1024 * 1024)
+        .with_runtime(|r| {
+            r.with_s3_uploader::<dial9_tokio_telemetry::telemetry::Disk>(
+                S3Config::builder()
+                    .bucket("test-bucket")
+                    .service_name("test-svc")
+                    .build(),
+            )
+        })
+        .build()
+        .expect("config should build");
+    let rt = TracedRuntime::try_new(cfg).expect("runtime should build");
+    rt.block_on(async {
+        tokio::task::yield_now().await;
+    });
+    drop(rt);
+
+    let boot_dir = boot_id_dirs(dir.path())
+        .into_iter()
+        .next()
+        .expect("a boot_id namespace dir");
+    let boot_id = boot_dir.file_name().unwrap().to_str().unwrap();
+
+    let sealed = std::fs::read_dir(&boot_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| p.extension().is_some_and(|e| e == "bin"))
+        .expect("a sealed .bin segment");
+
+    let data = std::fs::read(&sealed).unwrap();
+    let mut dec = Decoder::new(&data).unwrap();
+
+    #[derive(serde::Deserialize)]
+    #[serde(tag = "event")]
+    enum Event {
+        SegmentMetadataEvent {
+            entries: HashMap<String, String>,
+        },
+        #[serde(other)]
+        Other,
+    }
+
+    let mut boot_ids = Vec::new();
+    dec.for_each_event(|raw| {
+        if let Event::SegmentMetadataEvent { entries } = raw.deserialize().expect("deserialize")
+            && let Some(b) = entries.get("boot_id")
+        {
+            boot_ids.push(b.clone());
+        }
+    })
+    .unwrap();
+
+    assert!(!boot_ids.is_empty(), "expected a boot_id metadata entry");
+    assert!(
+        boot_ids.iter().all(|b| b == boot_id),
+        "segment boot_id metadata {boot_ids:?} must match namespace dir {boot_id:?}"
+    );
+}

--- a/dial9-tokio-telemetry/tests/on_trigger_dump.rs
+++ b/dial9-tokio-telemetry/tests/on_trigger_dump.rs
@@ -19,7 +19,6 @@ fn test_s3_config() -> S3Config {
         .prefix("traces")
         .service_name("test-svc")
         .instance_path("us-east-1/test-host")
-        .boot_id("test-boot-id")
         .region("us-east-1")
         .build()
 }

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -25,7 +25,6 @@ fn dummy_s3(s3_root: &std::path::Path) -> (S3Config, aws_sdk_s3::Client) {
         .bucket("dummy-bucket")
         .service_name("test")
         .instance_path("test")
-        .boot_id("test")
         .region("us-east-1")
         .build();
     (s3_config, fake_s3_client(s3_root))
@@ -117,7 +116,6 @@ fn end_to_end_trace_to_s3_roundtrip() {
         .prefix("traces")
         .service_name("test-svc")
         .instance_path("us-east-1/test-host")
-        .boot_id("test-boot-id")
         .region("us-east-1")
         .build();
 
@@ -296,7 +294,6 @@ fn region_auto_detection_corrects_wrong_client_region() {
         .prefix("traces")
         .service_name("test-svc")
         .instance_path("test-host")
-        .boot_id("test-boot-id")
         .build();
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -409,7 +406,6 @@ fn stress_test_all_segments_uploaded_and_valid() {
         .prefix("traces")
         .service_name("stress-svc")
         .instance_path("test-host")
-        .boot_id("stress-boot")
         .region("us-east-1")
         .build();
 
@@ -623,7 +619,6 @@ fn graceful_shutdown_completes_when_s3_hangs() {
         .prefix("traces")
         .service_name("test-svc")
         .instance_path("test-host")
-        .boot_id("test-boot")
         .region("us-east-1")
         .build();
 
@@ -694,7 +689,6 @@ fn stress_test_with_s3_failures() {
         .prefix("traces")
         .service_name("flaky-svc")
         .instance_path("test-host")
-        .boot_id("flaky-boot")
         .region("us-east-1")
         .build();
 
@@ -777,7 +771,6 @@ fn permanently_broken_s3_produces_failure_metrics() {
         .prefix("traces")
         .service_name("test-svc")
         .instance_path("test-host")
-        .boot_id("test-boot")
         .region("us-east-1")
         .build();
 
@@ -866,7 +859,6 @@ fn dump_trigger_uploads_segments_and_writes_manifest() {
         .prefix("traces")
         .service_name("dump-svc")
         .instance_path("test-host")
-        .boot_id("dump-boot")
         .region("us-east-1")
         .build();
 

--- a/examples/metrics-service/src/main.rs
+++ b/examples/metrics-service/src/main.rs
@@ -255,7 +255,6 @@ fn main() -> std::io::Result<()> {
                     .to_string_lossy()
                     .to_string(),
             )
-            .boot_id(uuid::Uuid::new_v4().to_string())
             .maybe_region(args.s3_region.as_ref())
             .build();
 


### PR DESCRIPTION
After #534 there were two boot_ids generated independently: the on-disk namespace dir used one (from setup_namespace) and the S3 upload key used a different one (from S3Config's default). So a segment that landed in qmxz-481/ locally got uploaded under a different bvtn-481/ prefix in S3, and you couldn't correlate a local trace file with its upload.

Now the runtime injects the namespace boot_id into the S3 config and the embedded segment metadata at build time, so the local dir and the S3 key share one identity. It falls back to the random {4-alpha}-{pid} default when S3Config is used outside the managed Dial9Config path.

Added an integration test that decodes a sealed segment and asserts its boot_id metadata matches the namespace directory name. I confirmed it actually guards the behavior: with the injection removed, the test fails (segment boot_id rojy-... vs dir lvkt-...).

NOTE: This is a breaking change because it removes the `.boot_id()` from the public S3Config builder. I am not sure if this is the best way forward. I am open to ideas - should we keep it backwards compatible by keeping the builder method and have the namespace `boot_id` override it at build time instead or just roll with this?

Closes #548