### PR TITLE
viewer: stream trace objects from S3 (parallel download, no server-side buffering)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
  "aws-smithy-types",
  "axum",
  "axum-extra",
+ "bytes",
  "clap",
  "flate2",
  "futures",

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -26,6 +26,7 @@ required-features = ["dev-server"]
 [dependencies]
 axum = "0.8"
 axum-extra = { version = "0.10", features = ["query"] }
+bytes = "1"
 clap = { version = "4", features = ["derive"] }
 flate2 = "1"
 futures = "0.3"

--- a/dial9-viewer/skills/dial9-trace-loading/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-loading/SKILL.md
@@ -163,8 +163,9 @@ Start the viewer (`dial9-viewer --bucket BUCKET`, default port 3000), then fetch
 const resp = await fetch('http://localhost:3000/api/search?bucket=BUCKET&q=2026-04-09/19');
 const objects = await resp.json(); // [{key, size, last_modified}, ...]
 
-// Single file: fetch and parse one trace
-const traceResp = await fetch(`http://localhost:3000/api/trace?bucket=BUCKET&keys=${encodeURIComponent(objects[0].key)}`);
+// Single file: fetch and parse one trace. /api/object serves the file's raw
+// (still-gzipped) bytes; parseTrace decompresses transparently.
+const traceResp = await fetch(`http://localhost:3000/api/object?bucket=BUCKET&key=${encodeURIComponent(objects[0].key)}`);
 const buf = Buffer.from(await traceResp.arrayBuffer());
 const trace = await parseTrace(buf);
 
@@ -176,7 +177,7 @@ fs.mkdirSync(dir, { recursive: true });
 const limit = 20;
 for (let i = 0; i < objects.length; i += limit) {
   await Promise.all(objects.slice(i, i + limit).map(async (obj) => {
-    const r = await fetch(`http://localhost:3000/api/trace?bucket=BUCKET&keys=${encodeURIComponent(obj.key)}`);
+    const r = await fetch(`http://localhost:3000/api/object?bucket=BUCKET&key=${encodeURIComponent(obj.key)}`);
     fs.writeFileSync(`${dir}/${obj.key.split('/').pop()}`, Buffer.from(await r.arrayBuffer()));
   }));
 }
@@ -184,6 +185,10 @@ for await (const trace of parseTrace(dir)) {
   // analyze each trace
 }
 ```
+
+> **Note:** `GET /api/trace?bucket=&keys=a&keys=b` (server-side gunzip +
+> concatenate) still exists but is **deprecated and slated for removal**. Prefer
+> `/api/object` (one file per request, raw bytes), which transfers far less data.
 
 ## Merging multiple trace files
 

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -190,6 +190,9 @@ fn api_router(state: AppState) -> Router {
         )
         .route("/prefixes", axum::routing::get(prefixes::list_prefixes))
         .route("/search", axum::routing::get(search::search))
+        .route("/object", axum::routing::get(trace::get_object))
+        // DEPRECATED (slated for removal): superseded by /object, which serves a
+        // single object's raw bytes so the browser merges/gunzips client-side.
         .route("/trace", axum::routing::get(trace::get_trace))
         .with_state(state)
 }

--- a/dial9-viewer/src/server/trace.rs
+++ b/dial9-viewer/src/server/trace.rs
@@ -4,6 +4,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum_extra::extract::Query;
 use flate2::read::GzDecoder;
+use futures::TryStreamExt;
 use futures::future::join_all;
 use serde::Deserialize;
 use std::io::Read;
@@ -28,6 +29,18 @@ pub struct ObjectParams {
 /// file in parallel and gunzips each client-side (see `fetchTraces` in
 /// `trace_parser.js`). Keeping the bytes compressed on the wire is the whole
 /// point — far less network transfer than the old server-side-merged response.
+///
+/// The body is streamed straight from the backend (see
+/// [`StorageBackend::get_object_stream`]) rather than buffered: bytes reach the
+/// browser as S3 delivers them, removing the ~2s time-to-first-byte stall the
+/// old `collect()`-then-send path imposed.
+///
+/// IMPORTANT: we deliberately do NOT set `content-encoding: gzip` even though
+/// the object is gzip-compressed. We serve the raw gzip bytes opaquely and the
+/// browser gunzips them itself via `DecompressionStream` in `fetchTraceStream`.
+/// Setting `content-encoding: gzip` would make the browser transparently
+/// decompress the body, and the client-side decoder would then double-handle
+/// (or fail on) already-decompressed bytes.
 pub async fn get_object(
     State(state): State<AppState>,
     creds: MaybeCreds,
@@ -45,14 +58,32 @@ pub async fn get_object(
         return Err((StatusCode::BAD_REQUEST, "key is required".to_string()));
     }
 
-    let data = backend
-        .get_object(&bucket, &key)
+    // Setup errors (not found / auth) surface here, before any body streams, so
+    // they still map to the right status. Mid-stream errors (below) cannot.
+    let object = backend
+        .get_object_stream(&bucket, &key)
         .await
         .map_err(storage_error_response)?;
 
-    Ok(Response::builder()
-        .header("content-type", "application/octet-stream")
-        .body(Body::from(data))
+    // Log a chunk error rather than dropping it: once streaming has begun the
+    // status line is already sent, so this is the only signal that the response
+    // was truncated. Per-request (not in a loop), so a plain warn! is fine.
+    let body_stream = object.stream.inspect_err(move |e| {
+        tracing::warn!(
+            bucket = %bucket,
+            key = %key,
+            error = %e,
+            "error mid-stream while serving /api/object; response is truncated"
+        );
+    });
+
+    let mut builder = Response::builder().header("content-type", "application/octet-stream");
+    if let Some(len) = object.content_length {
+        builder = builder.header("content-length", len);
+    }
+
+    Ok(builder
+        .body(Body::from_stream(body_stream))
         .unwrap()
         .into_response())
 }

--- a/dial9-viewer/src/server/trace.rs
+++ b/dial9-viewer/src/server/trace.rs
@@ -15,6 +15,49 @@ use crate::server::error::storage_error_response;
 const MAX_KEYS: usize = 100;
 
 #[derive(Deserialize)]
+pub struct ObjectParams {
+    /// A single S3 key (e.g. ?key=2026-04-09/.../123-0.bin.gz)
+    pub key: String,
+    pub bucket: Option<String>,
+}
+
+/// `GET /api/object?bucket=&key=` — stream a single object's bytes verbatim.
+///
+/// Unlike [`get_trace`], this does NOT decompress: a `.bin.gz` object is served
+/// still-gzipped. The viewer fetches one `trace=/api/object?…` component per
+/// file in parallel and gunzips each client-side (see `fetchTraces` in
+/// `trace_parser.js`). Keeping the bytes compressed on the wire is the whole
+/// point — far less network transfer than the old server-side-merged response.
+pub async fn get_object(
+    State(state): State<AppState>,
+    creds: MaybeCreds,
+    Query(params): Query<ObjectParams>,
+) -> Result<Response, (StatusCode, String)> {
+    let backend = state.resolve(creds)?;
+
+    let bucket = params
+        .bucket
+        .or(state.default_bucket.clone())
+        .ok_or((StatusCode::BAD_REQUEST, "bucket is required".to_string()))?;
+
+    let key = params.key;
+    if key.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "key is required".to_string()));
+    }
+
+    let data = backend
+        .get_object(&bucket, &key)
+        .await
+        .map_err(storage_error_response)?;
+
+    Ok(Response::builder()
+        .header("content-type", "application/octet-stream")
+        .body(Body::from(data))
+        .unwrap()
+        .into_response())
+}
+
+#[derive(Deserialize)]
 pub struct TraceParams {
     /// S3 keys (repeated query param: ?keys=a&keys=b)
     #[serde(default)]
@@ -22,6 +65,15 @@ pub struct TraceParams {
     pub bucket: Option<String>,
 }
 
+/// `GET /api/trace?bucket=&keys=a&keys=b` — fetch every key, gunzip each, and
+/// concatenate into one uncompressed response.
+///
+/// DEPRECATED: scheduled for removal. The viewer no longer links here; it now
+/// emits one `trace=/api/object?…` component per file and lets the browser
+/// download them in parallel and gunzip client-side ([`get_object`]). This
+/// endpoint forces the backend to decompress and buffer the whole merged trace,
+/// which transfers far more bytes. It remains only for out-of-tree callers (the
+/// `dial9-trace-loading` skill); new code should use `/api/object`.
 pub async fn get_trace(
     State(state): State<AppState>,
     creds: MaybeCreds,

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+use futures::Stream;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -9,6 +11,35 @@ pub struct ObjectInfo {
     pub key: String,
     pub size: i64,
     pub last_modified: Option<String>,
+}
+
+/// A handle to an object's bytes that can be streamed to the client as they
+/// arrive, rather than buffered in full first.
+///
+/// This exists to remove the time-to-first-byte (TTFB) stall on `/api/object`:
+/// the old buffered path called `ByteStream::collect()`, which pulled the entire
+/// object out of S3 into a `Vec<u8>` before a single byte could be written to
+/// the browser (measured ~2s TTFB on real traces). With a streamed body, bytes
+/// flow to the browser as S3 delivers them, so the server↔S3 download overlaps
+/// with the browser↔server transfer (and the browser's incremental
+/// gunzip+decode in `fetchTraceStream`).
+///
+/// The chunk error type is [`std::io::Error`] so the stream composes directly
+/// with [`axum::body::Body::from_stream`] (whose error bound is
+/// `Into<BoxError>`).
+///
+/// `#[non_exhaustive]`: adding a field later (e.g. `content_type`) must not be a
+/// breaking change for out-of-crate `StorageBackend` implementors. It is only
+/// ever constructed inside this crate, where struct-literal construction still
+/// works.
+#[non_exhaustive]
+pub struct ObjectStream {
+    /// The object's bytes, chunk by chunk, as they arrive from the backend.
+    pub stream: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>,
+    /// The object's total size, if known up front (S3 returns `Content-Length`
+    /// on `GetObject`). Forwarded as the response `content-length` header so the
+    /// browser can show real download progress.
+    pub content_length: Option<i64>,
 }
 
 /// Abstraction over trace storage (S3, local FS, etc.)
@@ -38,6 +69,39 @@ pub trait StorageBackend: Send + Sync {
         bucket: &str,
         key: &str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, StorageError>> + Send + '_>>;
+
+    /// Like [`get_object`](StorageBackend::get_object), but returns the body as a
+    /// stream so the HTTP layer can forward bytes to the client as they arrive
+    /// instead of buffering the whole object first. See [`ObjectStream`] for the
+    /// TTFB rationale.
+    ///
+    /// Setup errors (object not found, auth failure, etc.) surface from the
+    /// returned future *before* any body streams — so the HTTP layer can still
+    /// map them to a 404/401/403 status. Errors encountered mid-stream (after
+    /// the status line and headers have already been sent) arrive as
+    /// `Err(io::Error)` items on the stream and can no longer change the status.
+    ///
+    /// The default implementation buffers via `get_object` and wraps the result
+    /// in a single-chunk stream. This is correct (just not incremental) and is
+    /// the right behavior for backends with no TTFB problem — e.g. local file
+    /// reads — so [`LocalBackend`] and test backends need no override.
+    fn get_object_stream(
+        &self,
+        bucket: &str,
+        key: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<ObjectStream, StorageError>> + Send + '_>> {
+        let bucket = bucket.to_string();
+        let key = key.to_string();
+        Box::pin(async move {
+            let data = self.get_object(&bucket, &key).await?;
+            let content_length = Some(data.len() as i64);
+            let stream = futures::stream::once(async move { Ok(Bytes::from(data)) });
+            Ok(ObjectStream {
+                stream: Box::pin(stream),
+                content_length,
+            })
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -386,6 +450,63 @@ impl StorageBackend for S3Backend {
                 .map_err(|e| StorageError::Other(e.to_string()))?;
 
             Ok(bytes.to_vec())
+        })
+    }
+
+    /// Stream the object body straight from S3 instead of buffering it. The
+    /// `GetObject` request (and thus NoSuchKey / auth / not-found classification)
+    /// still completes synchronously in the returned future, so the HTTP layer
+    /// gets the right status before any body streams. The body is then handed
+    /// back as a chunk stream — we do NOT call `.collect()`.
+    fn get_object_stream(
+        &self,
+        bucket: &str,
+        key: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<ObjectStream, StorageError>> + Send + '_>> {
+        let bucket = bucket.to_string();
+        let key = key.to_string();
+        Box::pin(async move {
+            let resp = self
+                .client
+                .get_object()
+                .bucket(&bucket)
+                .key(&key)
+                .send()
+                .await
+                .map_err(|e| {
+                    use aws_sdk_s3::operation::get_object::GetObjectError;
+
+                    // Classify before unwrapping the service error so auth
+                    // failures (which arrive as the redirect/4xx service error)
+                    // collapse to Unauthorized rather than leaking the message.
+                    let classified = classify_s3_error(&e);
+                    match e.into_service_error() {
+                        GetObjectError::NoSuchKey(_) => {
+                            StorageError::NotFound(format!("{bucket}/{key}"))
+                        }
+                        _ => classified,
+                    }
+                })?;
+
+            let content_length = resp.content_length();
+
+            // Drive the body via the always-public `ByteStream::next()` (the
+            // `Stream` impl on `ByteStream` itself is feature-gated/private in
+            // this SDK). `unfold` yields one chunk per poll, mapping the SDK
+            // chunk error into `io::Error` so the stream composes with
+            // `Body::from_stream`. No `.collect()` — bytes flow as they arrive.
+            let stream = futures::stream::unfold(resp.body, |mut body| async move {
+                match body.next().await {
+                    Some(Ok(chunk)) => Some((Ok(chunk), body)),
+                    Some(Err(e)) => Some((Err(std::io::Error::other(e)), body)),
+                    None => None,
+                }
+            });
+
+            Ok(ObjectStream {
+                stream: Box::pin(stream),
+                content_length,
+            })
         })
     }
 }

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -491,6 +491,30 @@ async fn object_serves_uncompressed_bytes() {
     check!(body.as_ref() == data);
 }
 
+/// A large object must stream back byte-for-byte intact. Because the handler
+/// now uses `Body::from_stream` instead of buffering, this exercises the
+/// multi-chunk path: the s3s fake delivers the body in several `ByteStream`
+/// chunks and they must reassemble exactly. Kept to a few MB so it stays cheap.
+#[tokio::test]
+async fn object_streams_large_object_intact() {
+    let (s3, base, _dir) = setup_s3_test("obj-bucket", Some("obj-bucket".into()), None).await;
+    let client = reqwest::Client::new();
+
+    // 4MB of non-trivial bytes so a single read can't accidentally satisfy it.
+    let big: Vec<u8> = (0..4 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+    put_object(&s3, "obj-bucket", "big.bin", &big).await;
+
+    let resp = client
+        .get(format!("{base}/api/object?key=big.bin"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    check!(body.len() == big.len());
+    check!(body.as_ref() == big.as_slice());
+}
+
 #[tokio::test]
 async fn object_requires_key() {
     let state = AppState::new(Arc::new(FakeBackend), Some("test-bucket".into()), None);

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -444,6 +444,94 @@ async fn trace_handles_uncompressed_data() {
     check!(body.as_ref() == data);
 }
 
+// --- /api/object (raw single-object passthrough) tests ---
+
+/// The defining property of /api/object: it serves a `.bin.gz` object's bytes
+/// VERBATIM, still gzipped — it must NOT decompress (that's the browser's job
+/// via fetchTraces). Contrast with /api/trace, which gunzips server-side.
+#[tokio::test]
+async fn object_serves_raw_gzipped_bytes() {
+    let (s3, base, _dir) = setup_s3_test("obj-bucket", Some("obj-bucket".into()), None).await;
+    let client = reqwest::Client::new();
+
+    let plaintext = b"DECOMPRESSED_TRACE_BODY";
+    let gzipped = gzip_bytes(plaintext);
+    put_object(&s3, "obj-bucket", "seg.bin.gz", &gzipped).await;
+
+    let resp = client
+        .get(format!("{base}/api/object?key=seg.bin.gz"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    // Bytes are the raw gzip stream, NOT the decompressed plaintext.
+    check!(body.as_ref() == gzipped.as_slice());
+    check!(body.as_ref() != plaintext.as_slice());
+    // Sanity: a gzip stream starts with the 0x1f 0x8b magic.
+    check!(body.len() >= 2 && body[0] == 0x1f && body[1] == 0x8b);
+}
+
+/// An uncompressed object is returned verbatim too.
+#[tokio::test]
+async fn object_serves_uncompressed_bytes() {
+    let (s3, base, _dir) = setup_s3_test("obj-bucket", Some("obj-bucket".into()), None).await;
+    let client = reqwest::Client::new();
+
+    let data = b"raw uncompressed object";
+    put_object(&s3, "obj-bucket", "raw.bin", data).await;
+
+    let resp = client
+        .get(format!("{base}/api/object?key=raw.bin"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    check!(body.as_ref() == data);
+}
+
+#[tokio::test]
+async fn object_requires_key() {
+    let state = AppState::new(Arc::new(FakeBackend), Some("test-bucket".into()), None);
+    let base = start_server(state).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/api/object?key=&bucket=test-bucket"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 400);
+}
+
+/// BYO credentials: /api/object must be served by the header-supplied ephemeral
+/// backend (the s3s fake), not the erroring default backend.
+#[tokio::test]
+async fn byo_credentials_serve_object_from_headers() {
+    let (s3, base, _dir) = setup_byo_test("byo-bucket").await;
+    let client = reqwest::Client::new();
+
+    let data = b"BYO_OBJECT_BYTES";
+    let gzipped = gzip_bytes(data);
+    put_object(&s3, "byo-bucket", "seg.bin.gz", &gzipped).await;
+
+    let resp = client
+        .get(format!(
+            "{base}/api/object?key=seg.bin.gz&bucket=byo-bucket"
+        ))
+        .header(H_AKID, "test")
+        .header(H_SECRET, "test")
+        .header(H_REGION, "us-east-1")
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    // Served raw (still gzipped) by the ephemeral backend.
+    check!(body.as_ref() == gzipped.as_slice());
+}
+
 /// Full end-to-end smoke test: simulates the browser flow.
 /// 1. Upload gzipped trace segments to fake S3
 /// 2. Search for them via /api/search
@@ -850,6 +938,55 @@ async fn local_trace_not_found() {
         .await
         .unwrap();
     check!(resp.status().as_u16() == 404);
+}
+
+/// /api/object on the local backend serves the file's raw (gzipped) bytes
+/// without decompressing.
+#[tokio::test]
+async fn local_object_serves_raw_bytes() {
+    let dir = setup_local_dir();
+    let base = start_server(local_state(dir.path())).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!(
+            "{base}/api/object?key=2026-04-09/1910/svc/host/123-0.bin.gz"
+        ))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body = resp.bytes().await.unwrap();
+    // The on-disk file is gzip(b"trace seg 0"); served verbatim.
+    check!(body.as_ref() == gzip_bytes(b"trace seg 0").as_slice());
+}
+
+#[tokio::test]
+async fn local_object_not_found() {
+    let dir = setup_local_dir();
+    let base = start_server(local_state(dir.path())).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/api/object?key=nonexistent.bin"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 404);
+}
+
+#[tokio::test]
+async fn local_object_path_traversal_rejected() {
+    let dir = setup_local_dir();
+    let base = start_server(local_state(dir.path())).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/api/object?key=../../../etc/passwd"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() != 200);
 }
 
 #[tokio::test]

--- a/dial9-viewer/ui/README.md
+++ b/dial9-viewer/ui/README.md
@@ -6,8 +6,8 @@ the assets are served from disk by `../src/bin/dev_server.rs`.
 
 Key files:
 
-- `index.html` — landing page / S3 browser. Builds `/api/trace` URLs and opens
-  the viewer or flamegraph.
+- `index.html` — landing page / S3 browser. Emits one `trace=/api/object?…`
+  component per selected file and opens the viewer or flamegraph.
 - `viewer.html` — main trace viewer.
 - `flamegraph.html` — standalone CPU-profile flamegraph view.
 - `decode.js` — low-level binary trace-frame decoder (`TraceDecoder`).
@@ -17,12 +17,26 @@ Key files:
 ## The `trace=` query parameter
 
 `trace=` is **repeatable**. Each value is fetched independently and may be
-individually gzipped (unlike `/api/trace`, which gunzips server-side before
-returning a single response). `TraceParser.fetchTraces()` fetches every
-component, runs each through `maybeGunzip`, and concatenates the raw bytes.
-The decoder treats a concatenated stream as multiple segments — a mid-stream
+individually gzipped. `TraceParser.fetchTraces()` fetches every component (in
+parallel), runs each through `maybeGunzip`, and concatenates the raw bytes. The
+decoder treats a concatenated stream as multiple segments — a mid-stream
 `TRC\0` header resets the frame parser — so the combined buffer parses as one
 trace. Read all values with `params.getAll('trace')`, never `params.get`.
+
+For S3-backed traces, `index.html` points each `trace=` at
+`/api/object?bucket=&key=`, which serves one file's raw (still-gzipped) bytes.
+The browser thus downloads the files in parallel and decompresses them
+client-side — far less network transfer than a single merged response.
+
+### `/api/trace` (deprecated)
+
+`GET /api/trace?bucket=&keys=a&keys=b` fetches every key, gunzips each
+server-side, and returns one concatenated **uncompressed** blob. This is
+**deprecated and slated for removal**: it transfers far more bytes (the merged,
+decompressed trace) and serializes the work on the backend. The UI no longer
+links to it; it remains only for out-of-tree callers (e.g. the
+`dial9-trace-loading` skill). New code should fetch individual objects via
+`/api/object` and let `fetchTraces` merge them.
 
 ## Tests — IMPORTANT for agents
 

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -1472,24 +1472,34 @@
         return params;
     }
 
+    // Build one viewer `trace=` component per selected key, each pointing at
+    // /api/object (which serves that single file's raw, still-gzipped bytes).
+    // The viewer and flamegraph read all repeated `trace=` params, download
+    // them in parallel, and gunzip + concatenate client-side (see fetchTraces
+    // in trace_parser.js). This replaced a single /api/trace URL that forced
+    // the backend to fetch every file, gunzip them, and merge into one large
+    // uncompressed response — far more bytes over the wire and much slower.
+    function objectTraceUrls(bucket, keys) {
+        return keys.map(key => {
+            const p = new URLSearchParams();
+            p.set('bucket', bucket);
+            p.set('key', key);
+            return '/api/object?' + p.toString();
+        });
+    }
+
     // CPU Profiling button: open a flamegraph of the selected segments. The
     // flamegraph view builds from the trace's CpuSampleEvents (and resolves
     // symbols from SymbolTableEntry), ignoring all other event types, so we
-    // serve the full trace via /api/trace — no server-side event filtering is
-    // needed for a working flamegraph. The selection is already size-capped.
+    // serve each whole file — no server-side event filtering is needed for a
+    // working flamegraph. The selection is already size-capped.
     function viewCpuProfile() {
         if (!heatmapSelection || !heatmapSelection.keys.length) return;
         const bucket = bucketInput.value.trim();
         if (!bucket) { alert('Bucket is required'); return; }
         const keys = heatmapSelection.keys;
-        const params = new URLSearchParams();
-        params.set('bucket', bucket);
-        for (const key of keys) {
-            params.append('keys', key);
-        }
-        const traceUrl = '/api/trace?' + params.toString();
         const fgParams = traceTitleParams(keys);
-        fgParams.set('trace', traceUrl);
+        for (const url of objectTraceUrls(bucket, keys)) fgParams.append('trace', url);
         window.open('flamegraph.html?' + fgParams.toString(), '_blank');
     }
 
@@ -1630,12 +1640,11 @@
         if (keys.length === 0) return;
 
         const bucket = bucketInput.value.trim();
-        const keysParams = keys.map(k => `keys=${encodeURIComponent(k)}`).join('&');
-        const traceUrl = `/api/trace?bucket=${encodeURIComponent(bucket)}&${keysParams}`;
 
-        // Pass structured metadata for the viewer title.
+        // Pass structured metadata for the viewer title, plus one trace=
+        // component per file (downloaded in parallel + gunzipped client-side).
         const titleParams = traceTitleParams(keys);
-        titleParams.set('trace', traceUrl);
+        for (const url of objectTraceUrls(bucket, keys)) titleParams.append('trace', url);
 
         window.open(`viewer.html?${titleParams.toString()}`, '_blank');
     }

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -74,11 +74,12 @@
    * concatenate them into a single ArrayBuffer.
    *
    * The `trace` query parameter is repeatable: each component is fetched
-   * independently and may be gzipped on its own (unlike `/api/trace`, which
-   * gunzips server-side before serving). We therefore ungzip every component
-   * here, then concatenate the raw bytes. The trace decoder treats a
-   * concatenated stream as multiple segments — a mid-stream `TRC\0` header
-   * resets the frame parser — so the combined buffer parses as one trace.
+   * independently (in parallel) and may be gzipped on its own — the S3 browser
+   * points each at `/api/object`, which serves one file's raw, still-gzipped
+   * bytes. We therefore ungzip every component here, then concatenate the raw
+   * bytes. The trace decoder treats a concatenated stream as multiple segments
+   * — a mid-stream `TRC\0` header resets the frame parser — so the combined
+   * buffer parses as one trace.
    *
    * @param {string|string[]} urls one URL or a list of URLs (order preserved)
    * @param {{signal?: AbortSignal, headers?: Object}} [opts] `headers` is


### PR DESCRIPTION
## What

Stream trace objects from S3 instead of buffering them server-side, and download multiple files in parallel from the browser.

Two commits:

1. **download trace files in parallel, stop decompressing server-side** — Adds `GET /api/object?bucket=&key=` which serves one object's bytes verbatim (still gzipped). The S3 browser now emits one `trace=/api/object?…` param per selected file; the viewer/flamegraph download them in parallel and gunzip client-side. Far less network transfer (files stay gzipped end-to-end). The old `/api/trace` (fetch-all, gunzip, merge, ship uncompressed) is kept but documented deprecated; nothing in the UI links to it.
2. **stream /api/object from S3 instead of buffering** — `get_object` previously ran `ByteStream::collect()` into a `Vec<u8>` before writing a byte to the client (~2s TTFB on real traces). Adds `StorageBackend::get_object_stream` returning an `ObjectStream` (boxed `Stream<Item = Result<Bytes, io::Error>>` + optional `content_length`). S3 overrides it: `GetObject` is still sent synchronously so `NoSuchKey`/auth/not-found classification surfaces (correct 404/401/403) before any body streams, then the body is streamed via `futures::stream::unfold` over `ByteStream::next()`. `ObjectStream` is marked `#[non_exhaustive]` per the API rules. Default impl wraps `get_object` so `LocalBackend`/test backends are unchanged.

## Why

Old path forced the backend to fetch every file, gunzip each, concatenate, and ship one large uncompressed blob — more bytes over the wire and serialized work, with no byte reaching the browser until the whole object downloaded from S3.