### PR TITLE
viewer: overlap trace download and parse (streaming decode + load-timing UX)

### DIFF
--- a/dial9-trace-format/js/decode.js
+++ b/dial9-trace-format/js/decode.js
@@ -130,6 +130,68 @@ class TraceDecoder {
     this.stackPool = new Map();
     this.version = 0;
     this._timestampBaseNs = 0n;
+    // Streaming mode. When false (default, whole-buffer decode), a frame that
+    // runs off the end of the buffer is a truncated tail: `nextFrame()` stops
+    // gracefully at EOF. When true, the same condition means "the buffer holds
+    // only a partial frame; more bytes are coming" — `nextFrame()` returns null
+    // WITHOUT consuming the partial frame and sets `needMoreBytes`, so the
+    // streaming caller can roll back, append more bytes, and retry.
+    this._streaming = false;
+    // Set by `nextFrame()` (streaming mode only) when it returned null because
+    // the trailing bytes are an incomplete frame rather than a real EOF.
+    this.needMoreBytes = false;
+  }
+
+  /**
+   * Enable streaming mode (see the `_streaming` field). In this mode a frame
+   * that runs past the end of the accumulated buffer is treated as incomplete
+   * (more bytes coming) rather than as a truncated EOF tail.
+   */
+  enableStreaming() {
+    this._streaming = true;
+  }
+
+  /**
+   * Replace the underlying buffer with a (typically longer) one that shares the
+   * same already-decoded prefix, preserving decode position and accumulated
+   * decoder state (schemas, pools, timestamp base, version). Used by the
+   * streaming parser to grow the readable window as chunks arrive without
+   * re-decoding what was already produced.
+   */
+  setBuffer(buffer) {
+    const ab = buffer instanceof ArrayBuffer ? buffer : buffer.buffer;
+    const off = buffer.byteOffset || 0;
+    const len = buffer.byteLength;
+    this._view = new DataView(ab, off, len);
+  }
+
+  /**
+   * Snapshot the positional decode state so the streaming caller can roll back
+   * after an incomplete frame. Only `_pos` and `_timestampBaseNs` are mutated
+   * mid-frame: schema/pool maps are updated with idempotent `.set()` calls
+   * (re-decoding the same frame overwrites with identical values), but the
+   * timestamp base is ADDITIVE — re-decoding a delta-encoded event without a
+   * rollback would double-apply the delta. See `_decodeEvent`.
+   */
+  snapshot() {
+    return { pos: this._pos, timestampBaseNs: this._timestampBaseNs };
+  }
+
+  /** Restore a snapshot produced by `snapshot()`. */
+  restore(snap) {
+    this._pos = snap.pos;
+    this._timestampBaseNs = snap.timestampBaseNs;
+  }
+
+  /**
+   * Reset the read position to the start of the current buffer WITHOUT
+   * touching accumulated decoder state (schemas, pools, timestamp base,
+   * version). Used by the streaming parser after it drops the consumed prefix
+   * and re-wraps the decoder over the unconsumed tail (which now starts at
+   * offset 0). See `setBuffer`.
+   */
+  rewindToStart() {
+    this._pos = 0;
   }
 
   decodeHeader() {
@@ -142,11 +204,21 @@ class TraceDecoder {
   }
 
   nextFrame() {
+    this.needMoreBytes = false;
     if (this._pos >= this._view.byteLength) return null;
     try {
       const tag = this._view.getUint8(this._pos);
       // Mid-stream header = reset frame (concatenated thread-local batch)
-      if (tag === MAGIC[0] && this._pos + 5 <= this._view.byteLength) {
+      if (tag === MAGIC[0]) {
+        if (this._pos + 5 > this._view.byteLength) {
+          // A would-be header straddles the end of the buffer. We can't tell
+          // yet whether it's a real header or a coincidental 0x54 frame tag
+          // until more bytes arrive. In streaming mode, ask for them; in
+          // whole-buffer mode this is a truncated tail.
+          if (this._streaming) { this.needMoreBytes = true; return null; }
+          this._pos = this._view.byteLength;
+          return null;
+        }
         let isHeader = true;
         for (let i = 1; i < 4; i++) {
           if (this._view.getUint8(this._pos + i) !== MAGIC[i]) { isHeader = false; break; }
@@ -178,6 +250,13 @@ class TraceDecoder {
       }
     } catch (e) {
       if (e instanceof RangeError) {
+        if (this._streaming) {
+          // The buffer holds only part of this frame; more bytes are coming.
+          // Leave `_pos` untouched — the streaming caller rolls back via the
+          // snapshot it took before this call — and ask for more data.
+          this.needMoreBytes = true;
+          return null;
+        }
         // Truncated frame at end of segment; stop gracefully.
         this._pos = this._view.byteLength;
         return null;

--- a/dial9-viewer/ui/bench_parse.js
+++ b/dial9-viewer/ui/bench_parse.js
@@ -1,0 +1,149 @@
+// bench_parse.js — diagnostic parse-speed benchmark for the trace decoder.
+//
+// Measures whole-buffer parse vs. streaming parse (parseTraceStream) at a range
+// of chunk sizes, with and without the per-chunk progress yield, so we can see
+// where streaming overhead comes from and iterate on it with real data.
+//
+// Usage:
+//   node bench_parse.js [trace.bin|trace.bin.gz] [--iters N] [--quick]
+//
+// Defaults to demo-trace.bin in this directory. Prints a table of
+// milliseconds + events/sec; the streaming rows show overhead vs the
+// whole-buffer baseline.
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+const { parseTrace, parseTraceStream } = require("./trace_parser.js");
+
+function parseArgs(argv) {
+  const args = { file: null, iters: 3, quick: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--iters") args.iters = Number(argv[++i]);
+    else if (a === "--quick") args.quick = true;
+    else if (!a.startsWith("--")) args.file = a;
+  }
+  return args;
+}
+
+/** Decompress if gzipped, returning raw trace bytes as a Uint8Array. */
+function loadRaw(file) {
+  const buf = fs.readFileSync(file);
+  if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
+    return new Uint8Array(zlib.gunzipSync(buf));
+  }
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+/** Async iterable that yields `raw` in fixed-size chunks. Models the network /
+ *  DecompressionStream feeding the decoder chunk-by-chunk. `delayMs` optionally
+ *  simulates per-chunk arrival latency (0 = arrive as fast as the CPU drains). */
+function chunkedSource(raw, chunkSize, delayMs = 0) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (let off = 0; off < raw.length; off += chunkSize) {
+        const end = Math.min(off + chunkSize, raw.length);
+        // Copy so each chunk is its own exactly-sized buffer (like a real
+        // stream chunk), not a view into `raw`.
+        const chunk = raw.slice(off, end);
+        if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+        yield chunk;
+      }
+    },
+  };
+}
+
+function fmtMs(ms) {
+  return ms.toFixed(0).padStart(7) + " ms";
+}
+function fmtRate(events, ms) {
+  const perSec = events / (ms / 1000);
+  return (perSec / 1e6).toFixed(2).padStart(6) + " M ev/s";
+}
+
+async function timeIt(fn, iters) {
+  const samples = [];
+  let result = null;
+  for (let i = 0; i < iters; i++) {
+    const t0 = process.hrtime.bigint();
+    result = await fn();
+    const t1 = process.hrtime.bigint();
+    samples.push(Number(t1 - t0) / 1e6);
+  }
+  samples.sort((a, b) => a - b);
+  return { ms: samples[Math.floor(samples.length / 2)], result }; // median
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const file = args.file || path.join(__dirname, "demo-trace.bin");
+  const raw = loadRaw(file);
+
+  console.log(`\nTrace: ${file}`);
+  console.log(`Raw size: ${(raw.length / 1048576).toFixed(2)} MB · iters: ${args.iters} (median reported)\n`);
+
+  // Baseline: whole-buffer parse.
+  const base = await timeIt(() => parseTrace(raw.slice()), args.iters);
+  const events = base.result.events.length;
+  console.log(`Events: ${events.toLocaleString()} · CPU samples: ${base.result.cpuSamples.length.toLocaleString()}\n`);
+
+  const baseMs = base.ms;
+  console.log("mode                              time         rate        overhead");
+  console.log("─".repeat(72));
+  console.log(
+    `whole-buffer (baseline)        ${fmtMs(baseMs)}   ${fmtRate(events, baseMs)}        —`
+  );
+
+  const KB = 1024, MB = 1024 * 1024;
+  const chunkSizes = args.quick
+    ? [64 * KB, 1 * MB]
+    : [16 * KB, 64 * KB, 256 * KB, 1 * MB, 4 * MB];
+
+  for (const yield_ of [false, true]) {
+    console.log(
+      `\n  streaming · progress-yield ${yield_ ? "ON " : "OFF"} (onParseProgress set):`
+    );
+    for (const cs of chunkSizes) {
+      // onParseProgress presence is what triggers the progress yield in
+      // parseTraceStream, so toggle it to isolate the yield cost.
+      const opts = yield_ ? { onParseProgress: () => {} } : {};
+      const { ms, result } = await timeIt(
+        () => parseTraceStream(chunkedSource(raw, cs), opts),
+        args.iters
+      );
+      const ok = result.events.length === events;
+      const label = `chunk ${(cs / KB).toString().padStart(5)}KB`;
+      const ovh = `${(((ms - baseMs) / baseMs) * 100).toFixed(0)}%`.padStart(6);
+      console.log(
+        `    ${label}                ${fmtMs(ms)}   ${fmtRate(events, ms)}     ${ovh}${ok ? "" : "  ✗ EVENT COUNT MISMATCH"}`
+      );
+    }
+  }
+
+  // The browser's DecompressionStream("gzip") feeds ~16KB chunks with
+  // onParseProgress set (the viewer always sets it). This is the real-world
+  // case parseTraceStream must handle well: it feeds 16KB chunks through the
+  // SAME parseTraceStream the viewer uses. With the internal MIN_DRAIN_BYTES
+  // batching it should sit near the whole-buffer baseline, not ~1.7x it.
+  console.log(
+    "\n  ⮑ browser path: 16KB source (DecompressionStream-like) + progress-yield ON:"
+  );
+  {
+    const { ms, result } = await timeIt(
+      () => parseTraceStream(chunkedSource(raw, 16 * KB), { onParseProgress: () => {} }),
+      args.iters
+    );
+    const ok = result.events.length === events;
+    const ovh = `${(((ms - baseMs) / baseMs) * 100).toFixed(0)}%`.padStart(6);
+    console.log(
+      `    16KB chunks (batched)      ${fmtMs(ms)}   ${fmtRate(events, ms)}     ${ovh}${ok ? "" : "  ✗ EVENT COUNT MISMATCH"}`
+    );
+  }
+  console.log("");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -102,16 +102,26 @@
                     return;
                 }
 
-                // Fetch trace(s): each component is fetched and gunzipped
-                // independently, then concatenated into one buffer.
-                let buffer;
+                // Load the trace. For a single URL we STREAM: download and
+                // decode overlap, hiding most of the parse time behind the
+                // download. For multiple repeated `trace=` components we fall
+                // back to the buffered fetch+concatenate path (each component is
+                // fetched and gunzipped independently, then concatenated).
+                const credHeaders = window.Dial9Creds ? Dial9Creds.headers() : {};
+                let trace;
                 try {
-                    loadingEl.textContent = traceUrls.length > 1
-                        ? `Fetching ${traceUrls.length} traces\u2026`
-                        : "Fetching trace\u2026";
-                    // Attach bring-your-own-credentials headers if present.
-                    const credHeaders = window.Dial9Creds ? Dial9Creds.headers() : {};
-                    buffer = await TraceParser.fetchTraces(traceUrls, { headers: credHeaders });
+                    if (traceUrls.length === 1 && TraceParser.canStreamDecode()) {
+                        loadingEl.textContent = "Loading trace\u2026";
+                        const stream = await TraceParser.fetchTraceStream(traceUrls[0], { headers: credHeaders });
+                        trace = await TraceParser.parseTraceStream(stream);
+                    } else {
+                        loadingEl.textContent = traceUrls.length > 1
+                            ? `Fetching ${traceUrls.length} traces\u2026`
+                            : "Fetching trace\u2026";
+                        const buffer = await TraceParser.fetchTraces(traceUrls, { headers: credHeaders });
+                        loadingEl.textContent = "Parsing trace\u2026";
+                        trace = await TraceParser.parseTrace(buffer);
+                    }
                 } catch (err) {
                     if (/HTTP 401/.test(err.message) && window.Dial9Creds && !Dial9Creds.has()) {
                         showError(
@@ -119,18 +129,8 @@
                             "home page after applying your credentials."
                         );
                     } else {
-                        showError("Failed to fetch trace: " + err.message);
+                        showError("Failed to load trace: " + err.message);
                     }
-                    return;
-                }
-
-                // Parse trace
-                let trace;
-                try {
-                    loadingEl.textContent = "Parsing trace\u2026";
-                    trace = await TraceParser.parseTrace(buffer);
-                } catch (err) {
-                    showError("Failed to parse trace: " + err.message);
                     return;
                 }
 

--- a/dial9-viewer/ui/test_stream_parse.js
+++ b/dial9-viewer/ui/test_stream_parse.js
@@ -18,7 +18,7 @@ const fs = require("fs");
 const path = require("path");
 const zlib = require("zlib");
 const { assert, testAsync, summarize } = require("./test_harness.js");
-const { parseTrace, parseTraceStream } = require("./trace_parser.js");
+const { parseTrace, parseTraceStream, fetchTraceStream } = require("./trace_parser.js");
 
 // Yield an async iterable of fixed-size Uint8Array chunks over `bytes`.
 function chunked(bytes, size) {
@@ -251,6 +251,33 @@ async function main() {
     const streamFiltered = canonical(await parseTraceStream(chunked(raw, 333), opts));
     assert.deepStrictEqual(streamFiltered, refFiltered);
   });
+
+  // ── Test: fetchTraceStream falls back gracefully when the ok response has
+  //    no streamable `body` (e.g. cached/synthesized responses). It must still
+  //    gunzip + decode to the same ParsedTrace instead of throwing on
+  //    `null.getReader()`. We mock fetch to return a body-less response that
+  //    only exposes arrayBuffer(), for both gzipped and raw bodies. ──
+  for (const [label, body] of [["gzipped", zlib.gzipSync(Buffer.from(raw))], ["raw", raw]]) {
+    await testAsync(`fetchTraceStream falls back when response has no body (${label})`, async () => {
+      const u8 = Uint8Array.from(body);
+      const original = global.fetch;
+      global.fetch = async () => ({
+        ok: true,
+        status: 200,
+        body: null, // no streamable body → exercise the arrayBuffer() fallback
+        async arrayBuffer() {
+          return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+        },
+      });
+      try {
+        const stream = await fetchTraceStream("/no-body");
+        const got = canonical(await parseTraceStream(stream));
+        assert.deepStrictEqual(got, refCanon);
+      } finally {
+        global.fetch = original;
+      }
+    });
+  }
 
   summarize();
 }

--- a/dial9-viewer/ui/test_stream_parse.js
+++ b/dial9-viewer/ui/test_stream_parse.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+"use strict";
+
+// Tests for the streaming trace decoder (parseTraceStream).
+//
+// The streaming parser must produce a ParsedTrace byte-for-byte identical to
+// parseTrace() on the same concatenated bytes, no matter how the bytes are
+// chunked. The risky part is the transactional frame decode in
+// TraceDecoder.nextFrame(): a chunk boundary that falls mid-event (or mid
+// TRC\0 header) must be detected as "need more bytes", rolled back, and
+// re-attempted once the next chunk arrives — never silently dropped.
+//
+// We exercise adversarial chunk boundaries: size 1 (every byte boundary), a
+// few fixed small sizes, prime sizes, and boundaries deliberately placed
+// inside event timestamps and inside a mid-stream TRC\0 header.
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+const { assert, testAsync, summarize } = require("./test_harness.js");
+const { parseTrace, parseTraceStream } = require("./trace_parser.js");
+
+// Yield an async iterable of fixed-size Uint8Array chunks over `bytes`.
+function chunked(bytes, size) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (let i = 0; i < bytes.length; i += size) {
+        yield bytes.subarray(i, Math.min(i + size, bytes.length));
+      }
+    },
+  };
+}
+
+// Yield an async iterable using an explicit list of boundary offsets. The
+// boundaries are sorted and de-duplicated so the emitted chunks always cover
+// `bytes` contiguously in order (a buggy unsorted list would silently reorder
+// or drop bytes and mask real failures).
+function chunkedAt(bytes, boundaries) {
+  const inner = [...new Set(boundaries.filter((b) => b > 0 && b < bytes.length))]
+    .sort((a, b) => a - b);
+  const offs = [0, ...inner, bytes.length];
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (let i = 1; i < offs.length; i++) {
+        if (offs[i] > offs[i - 1]) yield bytes.subarray(offs[i - 1], offs[i]);
+      }
+    },
+  };
+}
+
+// Serialize a ParsedTrace into a stable, comparable plain object. Maps are
+// turned into sorted entry arrays so deepStrictEqual doesn't depend on Map
+// insertion order (it shouldn't differ, but this makes failures legible and
+// robust). BigInts are stringified.
+function canonical(trace) {
+  const mapEntries = (m) => [...m.entries()].sort((a, b) => {
+    const ka = String(a[0]), kb = String(b[0]);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
+  return JSON.parse(JSON.stringify({
+    magic: trace.magic,
+    version: trace.version,
+    events: trace.events,
+    minTs: trace.minTs,
+    maxTs: trace.maxTs,
+    recordMinTs: trace.recordMinTs,
+    recordMaxTs: trace.recordMaxTs,
+    truncated: trace.truncated,
+    timeFiltered: trace.timeFiltered,
+    filterStartTime: trace.filterStartTime,
+    filterEndTime: trace.filterEndTime,
+    cpuSamples: trace.cpuSamples,
+    allocEvents: trace.allocEvents,
+    freeEvents: trace.freeEvents,
+    memoryOverflows: trace.memoryOverflows,
+    customEvents: trace.customEvents,
+    clockSyncAnchors: trace.clockSyncAnchors,
+    clockOffsetNs: trace.clockOffsetNs,
+    blockInPlaceGaps: trace.blockInPlaceGaps,
+    spawnLocations: mapEntries(trace.spawnLocations),
+    taskSpawnLocs: mapEntries(trace.taskSpawnLocs),
+    taskSpawnTimes: mapEntries(trace.taskSpawnTimes),
+    taskTerminateTimes: mapEntries(trace.taskTerminateTimes),
+    taskInstrumented: mapEntries(trace.taskInstrumented),
+    callframeSymbols: mapEntries(trace.callframeSymbols),
+    threadNames: mapEntries(trace.threadNames),
+    tidToWorker: mapEntries(trace.tidToWorker),
+    runtimeWorkers: mapEntries(trace.runtimeWorkers),
+    taskDumps: mapEntries(trace.taskDumps),
+  }, (_, v) => (typeof v === "bigint" ? v.toString() : v)));
+}
+
+async function main() {
+  const tracePath = path.join(__dirname, "demo-trace.bin");
+  if (!fs.existsSync(tracePath)) {
+    console.error(`Trace file not found: ${tracePath}`);
+    process.exit(1);
+  }
+
+  const fileBytes = fs.readFileSync(tracePath);
+  const rawTrace =
+    fileBytes[0] === 0x1f && fileBytes[1] === 0x8b
+      ? zlib.gunzipSync(fileBytes)
+      : Buffer.from(fileBytes);
+  const raw = Uint8Array.from(rawTrace); // plain Uint8Array (subarray-safe)
+
+  // Reference parse of the whole (gunzipped) buffer.
+  const reference = await parseTrace(raw);
+  const refCanon = canonical(reference);
+  console.log(
+    `Reference: ${reference.events.length} events, ` +
+      `${reference.cpuSamples.length} cpu samples, ` +
+      `${raw.length} raw bytes`
+  );
+  assert.ok(reference.events.length > 0, "reference has events");
+
+  // Find offsets of every TRC\0 mid-stream header. Skip the leading header at
+  // 0. (These byte patterns can also appear inside frame payloads; that's
+  // fine — splitting there still exercises the rollback path.)
+  function headerOffsetsIn(bytes) {
+    const offs = [];
+    for (let i = 1; i + 4 <= bytes.length; i++) {
+      if (bytes[i] === 0x54 && bytes[i + 1] === 0x52 && bytes[i + 2] === 0x43 && bytes[i + 3] === 0x00) {
+        offs.push(i);
+      }
+    }
+    return offs;
+  }
+  const headerOffsets = headerOffsetsIn(raw);
+  console.log(`Found ${headerOffsets.length} mid-stream TRC\\0 header pattern(s)`);
+
+  async function streamCanon(iterable) {
+    const t = await parseTraceStream(iterable);
+    return canonical(t);
+  }
+
+  // Assert that streaming `bytes` (any prefix of the trace) with the given
+  // chunking yields the same ParsedTrace as parsing the whole `bytes` buffer.
+  // The buffered parser and the stream parser must handle a truncated tail
+  // identically, so this works for arbitrary byte slices.
+  async function assertStreamMatches(bytes, iterable) {
+    const ref = canonical(await parseTrace(bytes));
+    const got = await streamCanon(iterable);
+    assert.deepStrictEqual(got, ref);
+  }
+
+  // A prefix big enough to span several segments (TRC\0 resets), every event
+  // type, pools, and symbols — but small enough that byte-by-byte chunking is
+  // fast. We pick a prefix that ends just before a mid-stream header so the
+  // truncation is clean, falling back to ~1MB.
+  let prefixEnd = Math.min(1_000_000, raw.length);
+  for (const h of headerOffsets) {
+    if (h >= 200_000 && h <= 1_200_000) { prefixEnd = h; break; }
+  }
+  const prefix = raw.subarray(0, prefixEnd);
+  const prefixHeaders = headerOffsetsIn(prefix);
+  console.log(
+    `Adversarial prefix: ${prefix.length} bytes, ${prefixHeaders.length} segment header(s)`
+  );
+
+  // ── Test: chunk size 1 (every single-byte boundary, maximally adversarial)
+  //    over the prefix — exercises rollback at every byte offset. ──
+  await testAsync("chunk size 1 (byte-by-byte) over prefix matches", async () => {
+    await assertStreamMatches(prefix, chunked(prefix, 1));
+  });
+
+  // ── Test: tiny prime chunk sizes over the prefix ──
+  for (const size of [2, 3, 5, 7, 13]) {
+    await testAsync(`chunk size ${size} over prefix matches`, async () => {
+      await assertStreamMatches(prefix, chunked(prefix, size));
+    });
+  }
+
+  // ── Test: a spread of fixed chunk sizes over the FULL buffer ──
+  for (const size of [64, 256, 1024, 4096, 65536, 1 << 20]) {
+    await testAsync(`chunk size ${size} (full trace) matches reference`, async () => {
+      const got = await streamCanon(chunked(raw, size));
+      assert.deepStrictEqual(got, refCanon);
+    });
+  }
+
+  // ── Test: one giant chunk (whole buffer in a single read) ──
+  await testAsync("single whole-buffer chunk matches reference", async () => {
+    const got = await streamCanon(chunked(raw, raw.length));
+    assert.deepStrictEqual(got, refCanon);
+  });
+
+  // ── Test: boundary placed inside a mid-stream TRC\0 header (partial header
+  //    straddling the chunk boundary) on the full buffer. ──
+  if (headerOffsets.length > 0) {
+    const h = headerOffsets[0];
+    for (const off of [h, h + 1, h + 2, h + 3, h + 4]) {
+      await testAsync(`boundary inside/at TRC\\0 header at +${off - h}`, async () => {
+        const got = await streamCanon(chunkedAt(raw, [off]));
+        assert.deepStrictEqual(got, refCanon);
+      });
+    }
+    // Boundaries inside EVERY mid-stream header at once.
+    await testAsync("boundary inside every TRC\\0 header at once", async () => {
+      const got = await streamCanon(chunkedAt(raw, headerOffsets.flatMap((x) => [x + 1, x + 2, x + 3])));
+      assert.deepStrictEqual(got, refCanon);
+    });
+  }
+
+  // ── Test: boundaries placed mid-event over the prefix. Event frames are
+  //    TAG_EVENT(0x02) followed by a 2-byte type_id and (for timestamped
+  //    events) a 3-byte delta. Split 1..4 bytes after each 0x02 byte to land
+  //    inside the type_id / timestamp delta. Many of these land mid-event;
+  //    any that land between frames are still valid splits. ──
+  await testAsync("boundaries mid-event (after 0x02 tags) over prefix match", async () => {
+    const boundaries = [];
+    for (let i = 5; i < prefix.length; i++) {
+      if (prefix[i] === 0x02) {
+        for (const d of [1, 2, 3, 4]) {
+          if (i + d < prefix.length) boundaries.push(i + d);
+        }
+      }
+    }
+    await assertStreamMatches(prefix, chunkedAt(prefix, boundaries));
+  });
+
+  // ── Test: gzipped input, decoded after gunzip, fed chunked into the stream
+  //    parser. (fetchTraceStream does the gunzip; here we gunzip then chunk the
+  //    post-gunzip bytes, which is exactly what the stream parser consumes.) ──
+  await testAsync("gzip round-trip: gunzip then chunked stream matches reference", async () => {
+    const gz = zlib.gzipSync(Buffer.from(raw));
+    const regunzipped = Uint8Array.from(zlib.gunzipSync(gz));
+    const got = await streamCanon(chunked(regunzipped, 1000));
+    assert.deepStrictEqual(got, refCanon);
+  });
+
+  // ── Test: empty / header-only streams error like the buffered parser ──
+  await testAsync("empty stream throws Invalid trace header", async () => {
+    let threw = false;
+    try {
+      await parseTraceStream(chunked(new Uint8Array(0), 1));
+    } catch (e) {
+      threw = /Invalid trace header/.test(e.message);
+    }
+    assert.ok(threw, "expected Invalid trace header");
+  });
+
+  // ── Test: time-range filtering is honored identically when streaming ──
+  await testAsync("time-range filtered stream matches filtered reference", async () => {
+    const mid = reference.recordMinTs != null && reference.recordMaxTs != null
+      ? Math.floor((reference.recordMinTs + reference.recordMaxTs) / 2)
+      : null;
+    if (mid == null) return; // no time bounds; skip
+    const opts = { startTime: reference.recordMinTs, endTime: mid };
+    const refFiltered = canonical(await parseTrace(raw, opts));
+    const streamFiltered = canonical(await parseTraceStream(chunked(raw, 333), opts));
+    assert.deepStrictEqual(streamFiltered, refFiltered);
+  });
+
+  summarize();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -128,6 +128,24 @@
   }
 
   /**
+   * Wrap an already-buffered `Uint8Array` in the minimal subset of the
+   * `ReadableStreamDefaultReader` interface that {@link fetchTraceStream} uses
+   * (`read()` / `cancel()`). Yields the whole buffer in one chunk, then EOF.
+   * Used only as a fallback when a `fetch` response has no streamable `body`.
+   */
+  function oneShotReader(bytes) {
+    let done = false;
+    return {
+      async read() {
+        if (done) return { value: undefined, done: true };
+        done = true;
+        return { value: bytes, done: false };
+      },
+      async cancel() { done = true; },
+    };
+  }
+
+  /**
    * Fetch a single trace URL and return an async iterable of raw (gunzipped, if
    * the body was gzipped) `Uint8Array` chunks. Pair with
    * {@link parseTraceStream} so download and decode overlap.
@@ -147,7 +165,15 @@
     const resp = await fetch(url, { signal: opts.signal, headers });
     if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${url}`);
 
-    const reader = resp.body.getReader();
+    // Some runtimes hand back an ok response with no readable `body` stream
+    // even though canStreamDecode() reported support (e.g. certain cached or
+    // synthesized responses). Rather than throwing a bare TypeError on
+    // `null.getReader()`, buffer the whole body and adapt it to the same
+    // reader interface so the gzip-sniff + DecompressionStream path below is
+    // identical — we just lose the download/parse overlap for this response.
+    const reader = resp.body
+      ? resp.body.getReader()
+      : oneShotReader(new Uint8Array(await resp.arrayBuffer()));
     // Read the first non-empty chunk to sniff the gzip magic.
     let first = null;
     for (;;) {

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -964,6 +964,22 @@
     const TD = getTraceDecoder();
     const state = createParseState(options);
 
+    // Coalesce incoming chunks before draining. The browser's
+    // DecompressionStream("gzip") emits tiny ~16KB chunks (measured: ~708
+    // chunks of median/max 16384 bytes for the 10.27MB demo trace). Draining
+    // on every chunk pays a full-tail grow() copy + decode setup ~708 times,
+    // which dominates parse time (~66-78% overhead vs the whole-buffer
+    // baseline). Waiting until ≥256KB of undrained bytes have accumulated
+    // collapses those ~708 grow+drain cycles into ~40 and brings streaming back
+    // to/below the whole-buffer baseline. The 5-byte header is still decoded as
+    // soon as it arrives so a tiny trace (well under 256KB) still parses.
+    const MIN_DRAIN_BYTES = 256 * 1024;
+    // Yield a macrotask (setTimeout(0)) to the browser on this byte cadence
+    // rather than once per chunk, mirroring parseTraceBuffer's YIELD_BYTES.
+    // onProgress still fires on every batch drain so the spinner counter stays
+    // current; only the (relatively expensive) repaint yield is throttled.
+    const YIELD_BYTES = 100 * 1024; // yield to browser every ~100KB decoded
+
     // Unconsumed-tail accumulator. The decoder reads pooled strings/stacks via
     // its `stringPool`/`stackPool` maps (resolved values are copied into the
     // maps), and event field reads only touch the current frame's bytes — never
@@ -1019,17 +1035,13 @@
       }
     }
 
-    for await (const rawChunk of chunks) {
-      const chunk = rawChunk instanceof Uint8Array
-        ? rawChunk
-        : new Uint8Array(rawChunk);
-      if (chunk.length === 0) continue;
-      sawAnyBytes = true;
-      grow(chunk);
-
+    // Decode the header (once ≥5 bytes are buffered) and then drain every
+    // complete frame currently in `acc`. Shared by the batched in-loop path and
+    // the final end-of-stream flush so both go through identical logic.
+    function drainBatch() {
       if (!headerDecoded) {
         // Need at least the 5-byte header before any frames. Wait for more.
-        if (acc.length < 5) continue;
+        if (acc.length < 5) return;
         dec = new TD(acc);
         dec.enableStreaming();
         if (!dec.decodeHeader()) throw new Error("Invalid trace header");
@@ -1041,8 +1053,27 @@
         dec.setBuffer(acc);
         dec.rewindToStart();
       }
-
       drainComplete();
+    }
+
+    let lastYieldPos = 0; // consumedBytes at the last macrotask yield
+    for await (const rawChunk of chunks) {
+      const chunk = rawChunk instanceof Uint8Array
+        ? rawChunk
+        : new Uint8Array(rawChunk);
+      if (chunk.length === 0) continue;
+      sawAnyBytes = true;
+      grow(chunk);
+
+      // Batch tiny chunks: keep accumulating until the undrained tail reaches
+      // MIN_DRAIN_BYTES, then drain once. `acc` only ever holds bytes that have
+      // NOT yet been consumed (drainComplete drops the consumed prefix), so its
+      // length is exactly the pending-but-undrained count. The header is the
+      // one exception — decode it as soon as ≥5 bytes exist so small traces
+      // don't stall waiting for a 256KB batch.
+      if (acc.length < MIN_DRAIN_BYTES && headerDecoded) continue;
+
+      drainBatch();
 
       if (onProgress) {
         onProgress({
@@ -1050,8 +1081,26 @@
           totalBytes: consumedBytes + acc.length,
           eventCount: state.events.length,
         });
-        // Yield so the browser can paint the spinner between chunks.
-        await new Promise((r) => setTimeout(r, 0));
+        // Yield so the browser can paint the spinner, but only on the coarse
+        // YIELD_BYTES cadence — not once per (tiny) chunk, whose macrotask
+        // round-trips were a large part of the streaming overhead.
+        if (consumedBytes - lastYieldPos >= YIELD_BYTES) {
+          lastYieldPos = consumedBytes;
+          await new Promise((r) => setTimeout(r, 0));
+        }
+      }
+    }
+
+    // Drain the final partial batch: bytes that arrived after the last
+    // MIN_DRAIN_BYTES drain (or, for a sub-256KB trace, the only batch).
+    if (acc.length > 0 || (sawAnyBytes && !headerDecoded)) {
+      drainBatch();
+      if (onProgress) {
+        onProgress({
+          bytesRead: consumedBytes,
+          totalBytes: consumedBytes + acc.length,
+          eventCount: state.events.length,
+        });
       }
     }
 

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -955,8 +955,9 @@
    *
    * @param {AsyncIterable<Uint8Array>} chunks raw trace bytes (post-gunzip)
    * @param {Object} [options] same options as {@link parseTrace}, plus
-   *   `onParseProgress({bytesRead, totalBytes, eventCount})` (totalBytes is the
-   *   bytes received so far — unknown until the stream ends).
+   *   `onParseProgress({bytesRead, totalBytes, eventCount})`. `totalBytes` is
+   *   `null` here — when streaming we don't know the trace's full size until the
+   *   stream ends, so callers must not compute a percentage from it.
    * @returns {Promise<ParsedTrace>}
    */
   async function parseTraceStream(chunks, options) {
@@ -974,11 +975,21 @@
     // to/below the whole-buffer baseline. The 5-byte header is still decoded as
     // soon as it arrives so a tiny trace (well under 256KB) still parses.
     const MIN_DRAIN_BYTES = 256 * 1024;
-    // Yield a macrotask (setTimeout(0)) to the browser on this byte cadence
-    // rather than once per chunk, mirroring parseTraceBuffer's YIELD_BYTES.
-    // onProgress still fires on every batch drain so the spinner counter stays
-    // current; only the (relatively expensive) repaint yield is throttled.
-    const YIELD_BYTES = 100 * 1024; // yield to browser every ~100KB decoded
+    // Yield a macrotask (setTimeout(0)) to the browser on a wall-clock cadence
+    // rather than per-chunk or per-byte. KEY FACT: the `for await` over `chunks`
+    // already awaits each decompressed chunk, so the network read +
+    // DecompressionStream pump make progress on their own — the macrotask yield
+    // does NOT drive download/parse overlap. Its ONLY purpose is to hand the
+    // main thread back to the browser so it can repaint the spinner. Each yield
+    // therefore permits (roughly) one repaint, and a byte cadence fired ~100
+    // times for a 10MB trace — ~100 paints during an ~8s parse. Throttling by
+    // elapsed wall-clock time instead caps paints to a few per second
+    // regardless of trace size, with zero effect on overlap or decode output.
+    // We don't drop the yield entirely: the spinner must still tick a few
+    // times/sec so the user sees progress. onProgress still fires on EVERY
+    // batch drain (cheap) so the event/byte counters stay current; only the
+    // (relatively expensive) repaint yield is rate-limited.
+    const PAINT_INTERVAL_MS = 200; // at most ~5 repaint yields per second
 
     // Unconsumed-tail accumulator. The decoder reads pooled strings/stacks via
     // its `stringPool`/`stackPool` maps (resolved values are copied into the
@@ -1056,7 +1067,12 @@
       drainComplete();
     }
 
-    let lastYieldPos = 0; // consumedBytes at the last macrotask yield
+    // Wall-clock source that works in browser and Node. Node 16+ exposes a
+    // global `performance`, but guard anyway in case it's absent.
+    const nowMs = (typeof performance !== "undefined" && performance.now)
+      ? () => performance.now()
+      : () => Date.now();
+    let lastYieldMs = nowMs(); // wall-clock time of the last macrotask yield
     for await (const rawChunk of chunks) {
       const chunk = rawChunk instanceof Uint8Array
         ? rawChunk
@@ -1078,14 +1094,21 @@
       if (onProgress) {
         onProgress({
           bytesRead: consumedBytes,
-          totalBytes: consumedBytes + acc.length,
+          // Total is unknown while streaming (we haven't seen the whole trace),
+          // so report null rather than `consumedBytes + acc.length` — `acc` is
+          // just the small undrained tail, which would peg any percentage at
+          // ~99% the entire time.
+          totalBytes: null,
           eventCount: state.events.length,
         });
-        // Yield so the browser can paint the spinner, but only on the coarse
-        // YIELD_BYTES cadence — not once per (tiny) chunk, whose macrotask
-        // round-trips were a large part of the streaming overhead.
-        if (consumedBytes - lastYieldPos >= YIELD_BYTES) {
-          lastYieldPos = consumedBytes;
+        // Yield so the browser can paint the spinner, but only once at least
+        // PAINT_INTERVAL_MS of wall-clock time has elapsed since the last
+        // yield — not once per (tiny) chunk and not on a byte cadence. Because
+        // the `for await` above already pumps the network/decompression, this
+        // throttle reduces repaints without slowing download/parse overlap.
+        const t = nowMs();
+        if (t - lastYieldMs >= PAINT_INTERVAL_MS) {
+          lastYieldMs = t;
           await new Promise((r) => setTimeout(r, 0));
         }
       }
@@ -1098,7 +1121,7 @@
       if (onProgress) {
         onProgress({
           bytesRead: consumedBytes,
-          totalBytes: consumedBytes + acc.length,
+          totalBytes: null, // unknown while streaming — see note above
           eventCount: state.events.length,
         });
       }

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -117,6 +117,86 @@
   }
 
   /**
+   * Whether the current runtime can stream a `fetch` response body and gunzip
+   * it incrementally. Node test runtimes (and older browsers) lack a real
+   * streaming `response.body` or `DecompressionStream`; callers fall back to
+   * the buffered `fetchTraces` + `parseTraceBuffer` path there.
+   */
+  function canStreamDecode() {
+    return typeof ReadableStream !== "undefined" &&
+      typeof DecompressionStream !== "undefined";
+  }
+
+  /**
+   * Fetch a single trace URL and return an async iterable of raw (gunzipped, if
+   * the body was gzipped) `Uint8Array` chunks. Pair with
+   * {@link parseTraceStream} so download and decode overlap.
+   *
+   * We peek the first chunk's first two bytes for the gzip magic (1f 8b). If
+   * present, the remaining body is piped through `DecompressionStream("gzip")`
+   * after re-feeding the peeked chunk; otherwise chunks pass through raw.
+   * `headers` follow the same same-origin credential-withholding rule as
+   * {@link fetchTraces}.
+   *
+   * @param {string} url single trace URL
+   * @param {{signal?: AbortSignal, headers?: Object}} [opts]
+   * @returns {Promise<AsyncIterable<Uint8Array>>}
+   */
+  async function fetchTraceStream(url, opts = {}) {
+    const headers = isSameOrigin(url) ? opts.headers : undefined;
+    const resp = await fetch(url, { signal: opts.signal, headers });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${url}`);
+
+    const reader = resp.body.getReader();
+    // Read the first non-empty chunk to sniff the gzip magic.
+    let first = null;
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value && value.byteLength > 0) {
+        first = value instanceof Uint8Array ? value : new Uint8Array(value);
+        break;
+      }
+    }
+
+    const isGzip = first != null && first.length >= 2 &&
+      first[0] === 0x1f && first[1] === 0x8b;
+
+    // A ReadableStream that re-emits the peeked first chunk then drains the
+    // rest of the body reader.
+    const rawStream = new ReadableStream({
+      start(controller) {
+        if (first != null) controller.enqueue(first);
+      },
+      async pull(controller) {
+        const { value, done } = await reader.read();
+        if (done) { controller.close(); return; }
+        if (value && value.byteLength > 0) controller.enqueue(value);
+      },
+      cancel(reason) { return reader.cancel(reason); },
+    });
+
+    const byteStream = isGzip
+      ? rawStream.pipeThrough(new DecompressionStream("gzip"))
+      : rawStream;
+
+    return {
+      [Symbol.asyncIterator]() {
+        const r = byteStream.getReader();
+        return {
+          async next() {
+            const { value, done } = await r.read();
+            if (done) return { done: true, value: undefined };
+            const u8 = value instanceof Uint8Array ? value : new Uint8Array(value);
+            return { done: false, value: u8 };
+          },
+          async return() { await r.cancel(); return { done: true, value: undefined }; },
+        };
+      },
+    };
+  }
+
+  /**
    * @typedef {{
    *   eventType: number,
    *   timestamp: number,
@@ -374,105 +454,120 @@
     return iterable;
   }
 
-  /** @private Parse a binary trace buffer. */
-  async function parseTraceBuffer(buffer, options) {
-    buffer = await maybeGunzip(buffer);
+  const UNCAPPED_FRAMES = new Set([
+    "TaskSpawnEvent",
+    "TaskTerminateEvent",
+    "CpuSampleEvent",
+    "TaskDumpEvent",
+    "SymbolTableEntry",
+    "SegmentMetadataEvent",
+    "ClockSyncEvent",
+  ]);
+  const TRACE_BOUND_EXCLUDED_FRAMES = new Set([
+    "SymbolTableEntry",
+    "SegmentMetadataEvent",
+    "ClockSyncEvent",
+  ]);
+  // Legacy classifier: epoch ns are ~1e18, monotonic ns are much smaller.
+  // 2020 is a practical floor that separates those ranges.
+  const LEGACY_EPOCH_FLOOR_MS = 1_577_836_800_000; // 2020-01-01
+
+  /**
+   * @private Build the mutable accumulator that {@link processFrame} fills and
+   * {@link finalizeParse} drains. Shared by the whole-buffer
+   * ({@link parseTraceBuffer}) and streaming ({@link parseTraceStream}) paths
+   * so there is exactly one copy of the frame-handling and post-processing
+   * logic. Returns the same `ParsedTrace` for the same concatenated bytes
+   * regardless of how those bytes were chunked.
+   */
+  function createParseState(options) {
     const maxEvents = (options && options.maxEvents != null) ? options.maxEvents : MAX_EVENTS;
     const startTime = (options && options.startTime != null) ? options.startTime : 0;
     const endTime = (options && options.endTime != null) ? options.endTime : Infinity;
     const hasTimeFilter = startTime > 0 || endTime < Infinity;
-    const onProgress = (options && options.onParseProgress) || null;
-    const YIELD_BYTES = 100 * 1024; // yield to browser every 100KB
-    const TD = getTraceDecoder();
-    const dec = new TD(
-      buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer
-    );
-    if (!dec.decodeHeader()) throw new Error("Invalid trace header");
-    const totalBytes = dec.byteLength;
+    return {
+      maxEvents, startTime, endTime, hasTimeFilter,
+      events: [],
+      spawnLocations: new Map(),
+      taskSpawnLocs: new Map(),
+      taskSpawnTimes: new Map(),
+      taskTerminateTimes: new Map(),
+      taskInstrumented: new Map(), // taskId -> bool (true if spawned via TelemetryHandle::spawn)
+      callframeSymbols: new Map(),
+      cpuSamples: [],
+      allocEvents: [],
+      freeEvents: [],
+      memoryOverflows: [],
+      threadNames: new Map(),
+      tidToWorker: new Map(), // tid → workerId (stable mapping from park/unpark events)
+      runtimeWorkers: new Map(), // runtime name → [workerId, ...]
+      taskDumps: new Map(), // taskId → [{timestamp, callchain}] sorted by timestamp
+      customEvents: [], // unrecognized event types: {name, timestamp, fields}
+      // { monotonicNs, realtimeNs } anchors used to recover wall clock.
+      clockSyncAnchors: [],
+      legacySegmentMetaWallNs: null,
+      // Smallest monotonic ts seen across all event frames.
+      // Used as the monotonic timestamp for the legacy synthesized anchor.
+      minMonoTs: null,
+      recordMinTs: Infinity,
+      recordMaxTs: -Infinity,
+    };
+  }
 
-    const events = [];
-    const spawnLocations = new Map();
-    const taskSpawnLocs = new Map();
-    const taskSpawnTimes = new Map();
-    const taskTerminateTimes = new Map();
-    const taskInstrumented = new Map(); // taskId -> bool (true if spawned via TelemetryHandle::spawn)
-    const callframeSymbols = new Map();
-    const cpuSamples = [];
-    const allocEvents = [];
-    const freeEvents = [];
-    const memoryOverflows = [];
-    const threadNames = new Map();
-    const tidToWorker = new Map(); // tid → workerId (stable mapping from park/unpark events)
-    const runtimeWorkers = new Map(); // runtime name → [workerId, ...]
-    const taskDumps = new Map(); // taskId → [{timestamp, callchain}] sorted by timestamp
-    const customEvents = []; // unrecognized event types: {name, timestamp, fields}
-    // { monotonicNs, realtimeNs } anchors used to recover wall clock.
-    const clockSyncAnchors = [];
-    // Legacy classifier: epoch ns are ~1e18, monotonic ns are much smaller.
-    // 2020 is a practical floor that separates those ranges.
-    const LEGACY_EPOCH_FLOOR_MS = 1_577_836_800_000; // 2020-01-01
-    let legacySegmentMetaWallNs = null;
-    // Smallest monotonic ts seen across all event frames.
-    // Used as the monotonic timestamp for the legacy synthesized anchor.
-    let minMonoTs = null;
-
-    const capped = () => events.length >= maxEvents;
-    const UNCAPPED_FRAMES = new Set([
-      "TaskSpawnEvent",
-      "TaskTerminateEvent",
-      "CpuSampleEvent",
-      "TaskDumpEvent",
-      "SymbolTableEntry",
-      "SegmentMetadataEvent",
-      "ClockSyncEvent",
-    ]);
-    const TRACE_BOUND_EXCLUDED_FRAMES = new Set([
-      "SymbolTableEntry",
-      "SegmentMetadataEvent",
-      "ClockSyncEvent",
-    ]);
-    let recordMinTs = Infinity, recordMaxTs = -Infinity;
-    function includeRecordTimestamp(t) {
-      if (t == null) return;
-      if (t < recordMinTs) recordMinTs = t;
-      if (t > recordMaxTs) recordMaxTs = t;
+  /**
+   * @private Handle a single decoded frame, mutating `state`. `dec` is the
+   * decoder the frame came from (used only to read a custom event's schema
+   * units). This is the single shared switch body — do not duplicate it.
+   */
+  function processFrame(frame, state, dec) {
+    const { startTime, endTime } = state;
+    if (frame.type !== "event") return;
+    const v = frame.values;
+    const ts = num(frame.timestamp_ns);
+    // Track smallest monotonic ts for legacy anchor synthesis.
+    // Skip SegmentMetadata (legacy wall clock) and SymbolTableEntry.
+    if (
+      ts != null &&
+      frame.name !== "SegmentMetadataEvent" &&
+      frame.name !== "SymbolTableEntry" &&
+      (state.minMonoTs == null || ts < state.minMonoTs)
+    ) {
+      state.minMonoTs = ts;
     }
 
-    let lastYieldPos = 0;
-    let frame;
-    while ((frame = dec.nextFrame()) !== null) {
-      // Yield to browser periodically so spinner can update
-      if (onProgress && dec.position - lastYieldPos >= YIELD_BYTES) {
-        lastYieldPos = dec.position;
-        onProgress({ bytesRead: dec.position, totalBytes, eventCount: events.length });
-        await new Promise((r) => setTimeout(r, 0));
+    const capped = state.events.length >= state.maxEvents;
+    if (capped && !UNCAPPED_FRAMES.has(frame.name)) return;
+
+    // Time range filtering: skip events outside the requested range
+    // (uncapped frames like symbols/metadata are always processed)
+    const inTimeRange = ts >= startTime && ts <= endTime;
+    if (!inTimeRange && !UNCAPPED_FRAMES.has(frame.name)) return;
+    if (inTimeRange && !TRACE_BOUND_EXCLUDED_FRAMES.has(frame.name)) {
+      if (ts != null) {
+        if (ts < state.recordMinTs) state.recordMinTs = ts;
+        if (ts > state.recordMaxTs) state.recordMaxTs = ts;
       }
+    }
 
-      if (frame.type !== "event") continue;
-      const v = frame.values;
-      const ts = num(frame.timestamp_ns);
-      // Track smallest monotonic ts for legacy anchor synthesis.
-      // Skip SegmentMetadata (legacy wall clock) and SymbolTableEntry.
-      if (
-        ts != null &&
-        frame.name !== "SegmentMetadataEvent" &&
-        frame.name !== "SymbolTableEntry" &&
-        (minMonoTs == null || ts < minMonoTs)
-      ) {
-        minMonoTs = ts;
-      }
+    const events = state.events;
+    const spawnLocations = state.spawnLocations;
+    const taskSpawnLocs = state.taskSpawnLocs;
+    const taskSpawnTimes = state.taskSpawnTimes;
+    const taskTerminateTimes = state.taskTerminateTimes;
+    const taskInstrumented = state.taskInstrumented;
+    const callframeSymbols = state.callframeSymbols;
+    const cpuSamples = state.cpuSamples;
+    const allocEvents = state.allocEvents;
+    const freeEvents = state.freeEvents;
+    const memoryOverflows = state.memoryOverflows;
+    const threadNames = state.threadNames;
+    const tidToWorker = state.tidToWorker;
+    const runtimeWorkers = state.runtimeWorkers;
+    const taskDumps = state.taskDumps;
+    const customEvents = state.customEvents;
+    const clockSyncAnchors = state.clockSyncAnchors;
 
-      if (capped() && !UNCAPPED_FRAMES.has(frame.name)) continue;
-
-      // Time range filtering: skip events outside the requested range
-      // (uncapped frames like symbols/metadata are always processed)
-      const inTimeRange = ts >= startTime && ts <= endTime;
-      if (!inTimeRange && !UNCAPPED_FRAMES.has(frame.name)) continue;
-      if (inTimeRange && !TRACE_BOUND_EXCLUDED_FRAMES.has(frame.name)) {
-        includeRecordTimestamp(ts);
-      }
-
-      switch (frame.name) {
+    switch (frame.name) {
         case "PollStartEvent": {
           const spawnLoc = v.spawn_loc || null;
           if (spawnLoc) spawnLocations.set(spawnLoc, spawnLoc);
@@ -660,11 +755,11 @@
         case "SegmentMetadataEvent": {
           // If this looks epoch-scale, treat it as legacy wall clock.
           if (
-            legacySegmentMetaWallNs == null &&
+            state.legacySegmentMetaWallNs == null &&
             ts != null &&
             ts / 1e6 >= LEGACY_EPOCH_FLOOR_MS
           ) {
-            legacySegmentMetaWallNs = ts;
+            state.legacySegmentMetaWallNs = ts;
           }
           const entries = v.entries || {};
           for (const [key, val] of Object.entries(entries)) {
@@ -717,19 +812,33 @@
           }
           break;
         }
-      }
     }
+  }
+
+  /**
+   * @private Run the post-frame-loop passes (clock anchors, tid→worker
+   * resolution, block-in-place gaps) and assemble the final `ParsedTrace`.
+   * Identical for the whole-buffer and streaming paths. `version` is read from
+   * the decoder after the last frame.
+   */
+  function finalizeParse(state, version) {
+    const {
+      events, spawnLocations, taskSpawnLocs, taskSpawnTimes, taskTerminateTimes,
+      taskInstrumented, callframeSymbols, cpuSamples, allocEvents, freeEvents,
+      memoryOverflows, threadNames, tidToWorker, runtimeWorkers, taskDumps,
+      customEvents, clockSyncAnchors, maxEvents, startTime, endTime, hasTimeFilter,
+    } = state;
 
     // Legacy fallback: synthesize an anchor from legacy SegmentMetadata wall
     // time + earliest monotonic event timestamp. This is best-effort only.
     if (
       clockSyncAnchors.length === 0 &&
-      legacySegmentMetaWallNs != null &&
-      minMonoTs != null
+      state.legacySegmentMetaWallNs != null &&
+      state.minMonoTs != null
     ) {
       clockSyncAnchors.push({
-        monotonicNs: minMonoTs,
-        realtimeNs: legacySegmentMetaWallNs,
+        monotonicNs: state.minMonoTs,
+        realtimeNs: state.legacySegmentMetaWallNs,
       });
     }
 
@@ -773,12 +882,12 @@
 
     return {
       magic: "D9TF",
-      version: dec.version,
+      version,
       events,
       minTs: events.length > 0 ? evMinTs : null,
       maxTs: events.length > 0 ? evMaxTs : null,
-      recordMinTs: recordMinTs < Infinity ? recordMinTs : null,
-      recordMaxTs: recordMaxTs > -Infinity ? recordMaxTs : null,
+      recordMinTs: state.recordMinTs < Infinity ? state.recordMinTs : null,
+      recordMaxTs: state.recordMaxTs > -Infinity ? state.recordMaxTs : null,
       truncated: events.length >= maxEvents,
       timeFiltered: hasTimeFilter,
       filterStartTime: hasTimeFilter ? startTime : null,
@@ -805,6 +914,155 @@
       clockOffsetNs,
       blockInPlaceGaps,
     };
+  }
+
+  /** @private Parse a binary trace buffer. */
+  async function parseTraceBuffer(buffer, options) {
+    buffer = await maybeGunzip(buffer);
+    const onProgress = (options && options.onParseProgress) || null;
+    const YIELD_BYTES = 100 * 1024; // yield to browser every 100KB
+    const TD = getTraceDecoder();
+    const dec = new TD(
+      buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer
+    );
+    if (!dec.decodeHeader()) throw new Error("Invalid trace header");
+    const totalBytes = dec.byteLength;
+    const state = createParseState(options);
+
+    let lastYieldPos = 0;
+    let frame;
+    while ((frame = dec.nextFrame()) !== null) {
+      // Yield to browser periodically so spinner can update
+      if (onProgress && dec.position - lastYieldPos >= YIELD_BYTES) {
+        lastYieldPos = dec.position;
+        onProgress({ bytesRead: dec.position, totalBytes, eventCount: state.events.length });
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      processFrame(frame, state, dec);
+    }
+
+    return finalizeParse(state, dec.version);
+  }
+
+  /**
+   * Parse a trace from an async stream of raw (already-gunzipped) byte chunks.
+   * Decoding overlaps with the network download: each chunk is appended to a
+   * growable buffer, and all *complete* frames it newly exposes are drained
+   * immediately; an incomplete trailing frame is rolled back and re-attempted
+   * once the next chunk arrives. The same {@link processFrame} /
+   * {@link finalizeParse} logic runs as for {@link parseTraceBuffer}, so the
+   * result is byte-for-byte identical to parsing the concatenated buffer.
+   *
+   * @param {AsyncIterable<Uint8Array>} chunks raw trace bytes (post-gunzip)
+   * @param {Object} [options] same options as {@link parseTrace}, plus
+   *   `onParseProgress({bytesRead, totalBytes, eventCount})` (totalBytes is the
+   *   bytes received so far — unknown until the stream ends).
+   * @returns {Promise<ParsedTrace>}
+   */
+  async function parseTraceStream(chunks, options) {
+    const onProgress = (options && options.onParseProgress) || null;
+    const TD = getTraceDecoder();
+    const state = createParseState(options);
+
+    // Unconsumed-tail accumulator. The decoder reads pooled strings/stacks via
+    // its `stringPool`/`stackPool` maps (resolved values are copied into the
+    // maps), and event field reads only touch the current frame's bytes — never
+    // earlier offsets. So once a frame is fully decoded its bytes are dead, and
+    // we can drop the consumed prefix after each drain. That keeps `acc`
+    // bounded by (largest single frame + one chunk) and makes appends O(tail)
+    // instead of O(total) — avoiding O(n²) blow-up on many small chunks.
+    let acc = new Uint8Array(0);
+    let dec = null;
+    let headerDecoded = false;
+    let sawAnyBytes = false;
+    let consumedBytes = 0; // total bytes already decoded (for progress only)
+
+    function grow(chunk) {
+      if (chunk.length === 0) return;
+      // Always copy into a buffer sized EXACTLY to the accumulated bytes.
+      // Aliasing an incoming chunk (which may be a `subarray` view into a
+      // larger underlying ArrayBuffer) is unsafe: the field decoders build
+      // `new Uint8Array(view.buffer, …, len)` directly on the underlying
+      // buffer, bypassing the DataView's length bound, and would happily read
+      // bytes that lie past the logical end of the stream-so-far. Keeping
+      // `acc.buffer.byteLength === acc.length` makes such over-reads throw
+      // RangeError (→ needMoreBytes), which is exactly the incomplete-frame
+      // signal the streaming loop relies on.
+      const next = new Uint8Array(acc.length + chunk.length);
+      next.set(acc, 0);
+      next.set(chunk, acc.length);
+      acc = next;
+    }
+
+    // Drain every complete frame currently in `acc`, then drop the consumed
+    // prefix so the accumulator holds only the (incomplete) trailing frame.
+    function drainComplete() {
+      for (;;) {
+        const snap = dec.snapshot();
+        const frame = dec.nextFrame();
+        if (frame === null) {
+          if (dec.needMoreBytes) {
+            // Partial frame at the tail: undo any positional advance so the
+            // re-wrapped decoder re-attempts this frame from the same offset.
+            dec.restore(snap);
+          }
+          break;
+        }
+        processFrame(frame, state, dec);
+      }
+      // Drop everything the decoder has already consumed. `dec.position` points
+      // at the start of the incomplete trailing frame (or end-of-buffer).
+      const keepFrom = dec.position;
+      if (keepFrom > 0) {
+        consumedBytes += keepFrom;
+        acc = acc.slice(keepFrom);
+      }
+    }
+
+    for await (const rawChunk of chunks) {
+      const chunk = rawChunk instanceof Uint8Array
+        ? rawChunk
+        : new Uint8Array(rawChunk);
+      if (chunk.length === 0) continue;
+      sawAnyBytes = true;
+      grow(chunk);
+
+      if (!headerDecoded) {
+        // Need at least the 5-byte header before any frames. Wait for more.
+        if (acc.length < 5) continue;
+        dec = new TD(acc);
+        dec.enableStreaming();
+        if (!dec.decodeHeader()) throw new Error("Invalid trace header");
+        headerDecoded = true;
+      } else {
+        // Re-wrap the decoder over the grown tail, rebasing its position to 0
+        // (the consumed prefix was dropped by the previous drainComplete()).
+        // Accumulated state (schemas, pools, timestamp base) is preserved.
+        dec.setBuffer(acc);
+        dec.rewindToStart();
+      }
+
+      drainComplete();
+
+      if (onProgress) {
+        onProgress({
+          bytesRead: consumedBytes,
+          totalBytes: consumedBytes + acc.length,
+          eventCount: state.events.length,
+        });
+        // Yield so the browser can paint the spinner between chunks.
+        await new Promise((r) => setTimeout(r, 0));
+      }
+    }
+
+    if (!sawAnyBytes || !headerDecoded) {
+      throw new Error("Invalid trace header");
+    }
+
+    // Stream ended. Any bytes still pending are a genuinely truncated tail
+    // (the file ended mid-frame) — finalize with whatever we decoded, matching
+    // the whole-buffer decoder's graceful EOF behavior.
+    return finalizeParse(state, dec.version);
   }
 
   // ── Directory parsing (Node-only) ──
@@ -1170,8 +1428,11 @@
       EVENT_TYPES,
       OFF_WORKER_WORKER_ID,
       parseTrace,
+      parseTraceStream,
       parseOne,
       fetchTraces,
+      fetchTraceStream,
+      canStreamDecode,
       formatFrame,
       symbolizeChain,
       deduplicateSamples,
@@ -1182,7 +1443,10 @@
       EVENT_TYPES,
       OFF_WORKER_WORKER_ID,
       parseTrace,
+      parseTraceStream,
       fetchTraces,
+      fetchTraceStream,
+      canStreamDecode,
       formatFrame,
       symbolizeChain,
       deduplicateSamples,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1393,6 +1393,13 @@
                     resetDropZone();
                     return;
                 }
+                // Trace is rendering: freeze the wall-clock timer. Log the final
+                // elapsed time for easy copy/paste measurement.
+                if (loadStartTime != null) {
+                    const secs = ((performance.now() - loadStartTime) / 1000).toFixed(1);
+                    console.log(`loaded in ${secs}s (events=${trace.events.length})`);
+                }
+                stopLoadTimer();
                 currentTraceBuffer = buffer;
                 currentTraceName = name;
                 showViewer(name);
@@ -1467,12 +1474,46 @@
 
             let loadAbortController = null;
 
+            // Live wall-clock "time to load" timer. Starts the instant a load
+            // begins (showLoadingState, the single earliest point common to
+            // every spinner-showing path: URL stream, multi-URL buffered, file
+            // drop, demo, and re-parse) and ticks up visibly until the trace
+            // renders, so the user can watch elapsed time alongside the event
+            // counter during the download+parse stall. It won't tick during a
+            // long synchronous drain (the main thread is busy) — that's
+            // acceptable and actually informative.
+            let loadStartTime = null;
+            let loadTimerInterval = null;
+
+            /** Render the elapsed-time span; safe to call repeatedly. */
+            function renderLoadElapsed() {
+                const el = document.getElementById("load-elapsed");
+                if (el && loadStartTime != null) {
+                    const secs = (performance.now() - loadStartTime) / 1000;
+                    el.textContent = ` · ${secs.toFixed(1)}s`;
+                }
+            }
+
+            /** Begin the wall-clock timer for the current load (idempotent). */
+            function startLoadTimer() {
+                loadStartTime = performance.now();
+                if (loadTimerInterval) clearInterval(loadTimerInterval);
+                loadTimerInterval = setInterval(renderLoadElapsed, 100);
+            }
+
+            /** Stop and clear the timer so it never leaks or keeps ticking. */
+            function stopLoadTimer() {
+                if (loadTimerInterval) { clearInterval(loadTimerInterval); loadTimerInterval = null; }
+                loadStartTime = null;
+            }
+
             function showLoadingState(label) {
                 loadAbortController = new AbortController();
+                startLoadTimer();
                 dropZone.innerHTML = '';
                 const wrap = document.createElement("div");
                 wrap.style.textAlign = "center";
-                wrap.innerHTML = `<div class="loading-spinner"></div><div style="margin-bottom:8px">${esc(label)}</div><div class="loading-progress" id="load-progress"></div>`;
+                wrap.innerHTML = `<div class="loading-spinner"></div><div style="margin-bottom:8px">${esc(label)}</div><div class="loading-progress"><span id="load-progress"></span><span id="load-elapsed"></span></div>`;
                 const btn = document.createElement("button");
                 btn.textContent = "← Back";
                 btn.style.cssText = "background:#2a2a4a;border:1px solid #444;color:#ccc;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:0.9em;margin-top:12px";
@@ -1480,6 +1521,7 @@
                 wrap.appendChild(btn);
                 wrap.insertAdjacentHTML("beforeend", '<div style="margin-top:8px;font-size:0.8em;color:#666">or press Escape</div>');
                 dropZone.appendChild(wrap);
+                renderLoadElapsed();
             }
 
             function updateLoadProgress(text) {
@@ -1488,11 +1530,18 @@
             }
 
             function cancelLoad() {
+                stopLoadTimer();
                 if (loadAbortController) { loadAbortController.abort(); loadAbortController = null; }
                 resetDropZone();
             }
 
             function resetDropZone() {
+                // Single chokepoint for every load-end-without-render path:
+                // cancelLoad, the catch blocks in parseAndShowTrace /
+                // loadTraceFromUrl, the processTrace-failed early return, and
+                // the Back/reset button. Stop the timer here so it never leaks
+                // or keeps ticking after a load ends. Idempotent.
+                stopLoadTimer();
                 dropZone.innerHTML = `
                     <div>
                         <div style="font-size: 2em; margin-bottom: 12px">📊</div>

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1376,34 +1376,83 @@
                 showLoadingState(label);
             }
 
+            /** Build the standard onParseProgress callback for the spinner. */
+            function makeParseProgress() {
+                return ({ bytesRead, totalBytes, eventCount }) => {
+                    const pct = totalBytes ? (((bytesRead / totalBytes) * 100) | 0) : 0;
+                    updateLoadProgress(`Parsing: ${pct}% · ${(eventCount / 1000) | 0}k events`);
+                };
+            }
+
+            /** Finish loading: analyze the parsed trace, retain the buffer for
+             *  in-memory re-parse (Set/Clear Range), and show the viewer. */
+            function showParsedTrace(parsed, buffer, name) {
+                trace = parsed;
+                updateLoadProgress(`Analyzing ${trace.events.length.toLocaleString()} events…`);
+                if (!processTrace()) {
+                    resetDropZone();
+                    return;
+                }
+                currentTraceBuffer = buffer;
+                currentTraceName = name;
+                showViewer(name);
+                if (trace.events.length === 0 && hasCpuProfileSamples(trace.cpuSamples)) {
+                    requestAnimationFrame(() => showFlamegraph(minTs, maxTs));
+                }
+            }
+
             /** Parse an already-fetched buffer and show the viewer. */
             async function parseAndShowTrace(buffer, name, opts = {}) {
                 try {
-                    const fullOpts = {
-                        ...opts,
-                        onParseProgress: ({ bytesRead, totalBytes, eventCount }) => {
-                            const pct = ((bytesRead / totalBytes) * 100) | 0;
-                            updateLoadProgress(`Parsing: ${pct}% · ${(eventCount / 1000) | 0}k events`);
-                        },
-                    };
+                    const fullOpts = { ...opts, onParseProgress: makeParseProgress() };
                     updateLoadProgress("Decompressing…");
-                    trace = await parseTrace(buffer, fullOpts);
-                    updateLoadProgress(`Analyzing ${trace.events.length.toLocaleString()} events…`);
+                    const parsed = await parseTrace(buffer, fullOpts);
                     await new Promise((r) => setTimeout(r, 0));
-                    if (!processTrace()) {
-                        resetDropZone();
-                        return;
-                    }
-                    currentTraceBuffer = buffer;
-                    currentTraceName = name;
-                    showViewer(name);
-                    if (trace.events.length === 0 && hasCpuProfileSamples(trace.cpuSamples)) {
-                        requestAnimationFrame(() => showFlamegraph(minTs, maxTs));
-                    }
+                    showParsedTrace(parsed, buffer, name);
                 } catch (err) {
                     if (err.name === "AbortError") return;
                     alert("Error: " + err.message);
                     resetDropZone();
+                }
+            }
+
+            /**
+             * Stream a single trace URL: decode chunks as they download so parse
+             * time overlaps the download (~max(download, parse) instead of their
+             * sum). We capture the gunzipped chunks while parsing so the full
+             * buffer is still available afterwards for in-memory Set/Clear-Range
+             * re-parsing (which never re-fetches).
+             */
+            async function streamAndShowTrace(url, name, opts = {}) {
+                try {
+                    const credHeaders = window.Dial9Creds ? Dial9Creds.headers() : {};
+                    const stream = await TraceParser.fetchTraceStream(url, {
+                        signal: loadAbortController?.signal,
+                        headers: credHeaders,
+                    });
+                    const captured = [];
+                    const capturing = {
+                        async *[Symbol.asyncIterator]() {
+                            for await (const chunk of stream) {
+                                captured.push(chunk);
+                                yield chunk;
+                            }
+                        },
+                    };
+                    const fullOpts = { ...opts, onParseProgress: makeParseProgress() };
+                    const parsed = await TraceParser.parseTraceStream(capturing, fullOpts);
+                    loadAbortController = null;
+                    // Reassemble the full buffer from the captured chunks.
+                    let total = 0;
+                    for (const c of captured) total += c.length;
+                    const buffer = new Uint8Array(total);
+                    let off = 0;
+                    for (const c of captured) { buffer.set(c, off); off += c.length; }
+                    await new Promise((r) => setTimeout(r, 0));
+                    showParsedTrace(parsed, buffer.buffer, name);
+                } catch (err) {
+                    if (err.name === "AbortError") return;
+                    throw err;
                 }
             }
 
@@ -1458,11 +1507,23 @@
             }
 
             // `urls` may be a single URL or a list (one per repeated `trace=`).
-            // Each component is fetched and gunzipped independently, then the raw
-            // buffers are concatenated into one trace (see fetchTraces).
+            // For a single URL we STREAM: download and decode overlap, so the
+            // spinner advances during the download and total load time is about
+            // max(download, parse) rather than their sum. For multiple repeated
+            // `trace=` components we fall back to the buffered fetch+concatenate
+            // path (each component is fetched and gunzipped independently, then
+            // the raw buffers are concatenated into one trace; see fetchTraces).
             async function loadTraceFromUrl(urls) {
                 const list = Array.isArray(urls) ? urls : [urls];
                 try {
+                    const name = urlParams.get('svc')
+                        || list[0].split('/').pop()?.split('?')[0]
+                        || 'trace.bin';
+                    if (list.length === 1 && TraceParser.canStreamDecode()) {
+                        updateLoadProgress("Loading…");
+                        await streamAndShowTrace(list[0], name, getParseOptions());
+                        return;
+                    }
                     updateLoadProgress(list.length > 1 ? `Fetching ${list.length} traces…` : "Fetching…");
                     // Attach bring-your-own-credentials headers if present. A
                     // tab opened directly (not from the browser page) has no
@@ -1473,9 +1534,6 @@
                         headers: credHeaders,
                     });
                     loadAbortController = null;
-                    const name = urlParams.get('svc')
-                        || list[0].split('/').pop()?.split('?')[0]
-                        || 'trace.bin';
                     await parseAndShowTrace(arrayBuffer, name, getParseOptions());
                 } catch (err) {
                     if (err.name === 'AbortError') return;

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -780,6 +780,7 @@
                     <button id="btn-cpu-flamegraph" style="display:none;background:#2a1a2a;border-color:#b388ff;color:#d0bcff;white-space:nowrap" title="Show a CPU flamegraph for the whole trace">🔥 Flamegraph</button>
                     <button id="btn-heap-flamegraph" style="display:none;background:#1a2a1a;border-color:#4caf50;color:#81c784;white-space:nowrap" title="Show heap allocation flamegraph">🔥 Heap</button>
                     <button id="btn-uninstrumented-info" style="display:none;background:#1e2050;border-color:#6c63ff;color:#d0ccff;white-space:nowrap" title="Some tasks lack wake tracking — click for details">ⓘ Blind spawns</button>
+                    <button id="btn-parse-perf" style="display:none;background:#1e2050;border-color:#6c63ff;color:#d0ccff;white-space:nowrap" title="Show the dial9 fetch &amp; parse time breakdown for this load">⏱ Parse perf</button>
                     <button id="btn-set-range" title="Set time range filter (reloads with only events in range)">Set Range</button>
                     <button id="btn-clear-range" title="Clear time range filter" style="display:none">Clear Range</button>
                     <button id="btn-reset">New File</button>
@@ -862,6 +863,7 @@
                     <div id="fg-container" style="flex:1;display:flex;flex-direction:column;overflow:hidden"></div>
                 </div>
                 <div id="uninstrumented-popup" style="display:none;position:fixed;background:#1a1a2e;border:1px solid #6c63ff;border-radius:8px;padding:12px 16px;z-index:200;max-width:700px;max-height:400px;overflow-y:auto;font-size:0.82em;line-height:1.6;box-shadow:0 4px 20px rgba(0,0,0,0.5);font-family:monospace"></div>
+                <div id="parse-perf-popup" style="display:none;position:fixed;background:#1a1a2e;border:1px solid #6c63ff;border-radius:8px;padding:12px 16px;z-index:200;max-width:420px;max-height:400px;overflow-y:auto;font-size:0.82em;line-height:1.7;box-shadow:0 4px 20px rgba(0,0,0,0.5);font-family:monospace"></div>
             </div>
             <div id="stack-sidebar">
                 <div class="sidebar-resize" id="sidebar-resize-handle"></div>
@@ -1379,16 +1381,32 @@
             /** Build the standard onParseProgress callback for the spinner. */
             function makeParseProgress() {
                 return ({ bytesRead, totalBytes, eventCount }) => {
-                    const pct = totalBytes ? (((bytesRead / totalBytes) * 100) | 0) : 0;
-                    updateLoadProgress(`Parsing: ${pct}% · ${(eventCount / 1000) | 0}k events`);
+                    const events = `${(eventCount / 1000) | 0}k events`;
+                    // Streaming reports totalBytes=null (the full size isn't known
+                    // until the stream ends), so show MB decoded instead of a
+                    // bogus percentage. The buffered path knows the total.
+                    if (totalBytes) {
+                        const pct = ((bytesRead / totalBytes) * 100) | 0;
+                        updateLoadProgress(`Parsing: ${pct}% · ${events}`);
+                    } else {
+                        const mb = (bytesRead / (1024 * 1024)).toFixed(1);
+                        updateLoadProgress(`Parsing: ${mb} MB · ${events}`);
+                    }
                 };
             }
 
             /** Finish loading: analyze the parsed trace, retain the buffer for
              *  in-memory re-parse (Set/Clear Range), and show the viewer. */
-            function showParsedTrace(parsed, buffer, name) {
+            async function showParsedTrace(parsed, buffer, name) {
                 trace = parsed;
                 updateLoadProgress(`Analyzing ${trace.events.length.toLocaleString()} events…`);
+                // processTrace() runs synchronously and hogs the main thread for
+                // a couple of seconds on a large trace. Yield for a paint frame
+                // first (double rAF: the callback after the next paint) so the
+                // browser actually renders the "Analyzing…" label before the
+                // blocking work starts — otherwise the label is set but never
+                // shown, and the spinner appears stuck on the last parse line.
+                await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
                 if (!processTrace()) {
                     resetDropZone();
                     return;
@@ -1403,6 +1421,32 @@
                 currentTraceBuffer = buffer;
                 currentTraceName = name;
                 showViewer(name);
+                // Record the TOTAL load time including the analysis+render phase
+                // that just ran in showViewer. The live `loadStartTime` timer was
+                // already frozen above (before analysis), so we measure here from
+                // the recorded loadPerf.startMs. A double requestAnimationFrame
+                // defers until after the browser has laid out and painted the
+                // first frame, so totalMs reflects "once the render completes"
+                // rather than just "JS returned". Then refine the inline stats
+                // suffix (showViewer wrote it provisionally / without a total).
+                if (loadPerf) {
+                    loadPerf.events = trace.events.length;
+                    // Best-effort decompressed size. The streaming path passes the
+                    // reassembled gunzipped buffer (exact). The buffered/local/
+                    // reparse paths pass the input buffer fed to the parser.
+                    const buf = buffer;
+                    if (buf != null) {
+                        loadPerf.bytes = buf.byteLength != null
+                            ? buf.byteLength
+                            : (buf.length != null ? buf.length : null);
+                    }
+                    const perf = loadPerf; // capture in case a new load starts
+                    requestAnimationFrame(() => requestAnimationFrame(() => {
+                        if (perf.startMs == null) return;
+                        perf.totalMs = performance.now() - perf.startMs;
+                        updateInlineLoadTime(perf);
+                    }));
+                }
                 if (trace.events.length === 0 && hasCpuProfileSamples(trace.cpuSamples)) {
                     requestAnimationFrame(() => showFlamegraph(minTs, maxTs));
                 }
@@ -1414,8 +1458,8 @@
                     const fullOpts = { ...opts, onParseProgress: makeParseProgress() };
                     updateLoadProgress("Decompressing…");
                     const parsed = await parseTrace(buffer, fullOpts);
-                    await new Promise((r) => setTimeout(r, 0));
-                    showParsedTrace(parsed, buffer, name);
+                    if (loadPerf) loadPerf.parseDoneMs = performance.now();
+                    await showParsedTrace(parsed, buffer, name);
                 } catch (err) {
                     if (err.name === "AbortError") return;
                     alert("Error: " + err.message);
@@ -1447,7 +1491,11 @@
                         },
                     };
                     const fullOpts = { ...opts, onParseProgress: makeParseProgress() };
+                    if (loadPerf) loadPerf.mode = "stream";
                     const parsed = await TraceParser.parseTraceStream(capturing, fullOpts);
+                    // Streaming fuses fetch+parse, so there is no separate fetch
+                    // mark — parseDoneMs covers the combined fetch+parse phase.
+                    if (loadPerf) loadPerf.parseDoneMs = performance.now();
                     loadAbortController = null;
                     // Reassemble the full buffer from the captured chunks.
                     let total = 0;
@@ -1455,8 +1503,7 @@
                     const buffer = new Uint8Array(total);
                     let off = 0;
                     for (const c of captured) { buffer.set(c, off); off += c.length; }
-                    await new Promise((r) => setTimeout(r, 0));
-                    showParsedTrace(parsed, buffer.buffer, name);
+                    await showParsedTrace(parsed, buffer.buffer, name);
                 } catch (err) {
                     if (err.name === "AbortError") return;
                     throw err;
@@ -1485,6 +1532,22 @@
             let loadStartTime = null;
             let loadTimerInterval = null;
 
+            // Phase-timing record for the current/last load, captured across
+            // ALL load paths (single-URL stream, multi-URL buffered, local file
+            // drop, demo, and in-memory re-parse). All marks use
+            // performance.now() (ms). Unlike the live `loadStartTime` (which is
+            // frozen when the spinner is replaced, BEFORE analysis+render),
+            // `totalMs` here is recorded after showViewer via a double rAF so
+            // it INCLUDES the analysis+render phase. Fields:
+            //   startMs     - load began (showLoadingState)
+            //   fetchDoneMs - buffered fetch returned (buffered mode only)
+            //   parseDoneMs - parsing finished (all modes)
+            //   totalMs     - start → render-complete (set in double-rAF)
+            //   mode        - 'stream' | 'buffered' | 'local' | 'reparse'
+            //   events      - decoded event count
+            //   bytes       - decompressed buffer length (if known)
+            let loadPerf = null;
+
             /** Render the elapsed-time span; safe to call repeatedly. */
             function renderLoadElapsed() {
                 const el = document.getElementById("load-elapsed");
@@ -1498,7 +1561,10 @@
             function startLoadTimer() {
                 loadStartTime = performance.now();
                 if (loadTimerInterval) clearInterval(loadTimerInterval);
-                loadTimerInterval = setInterval(renderLoadElapsed, 100);
+                // 250ms (4x/sec) keeps the elapsed display readable while
+                // repainting less often than the previous 100ms (10x/sec),
+                // matching the coarser paint cadence in parseTraceStream.
+                loadTimerInterval = setInterval(renderLoadElapsed, 250);
             }
 
             /** Stop and clear the timer so it never leaks or keeps ticking. */
@@ -1510,6 +1576,20 @@
             function showLoadingState(label) {
                 loadAbortController = new AbortController();
                 startLoadTimer();
+                // Reset the phase-timing record at the single earliest point
+                // common to every load path. `mode` defaults to 'local' (file
+                // drop / demo-from-blob have no network fetch); the URL paths
+                // overwrite it with 'stream'/'buffered', and reparseWithRange
+                // with 'reparse'.
+                loadPerf = {
+                    startMs: performance.now(),
+                    fetchDoneMs: null,
+                    parseDoneMs: null,
+                    totalMs: null,
+                    mode: "local",
+                    events: null,
+                    bytes: null,
+                };
                 dropZone.innerHTML = '';
                 const wrap = document.createElement("div");
                 wrap.style.textAlign = "center";
@@ -1582,6 +1662,9 @@
                         signal: loadAbortController?.signal,
                         headers: credHeaders,
                     });
+                    // Buffered mode fetches the whole trace before parsing, so
+                    // fetch and parse are separate phases (unlike streaming).
+                    if (loadPerf) { loadPerf.mode = "buffered"; loadPerf.fetchDoneMs = performance.now(); }
                     loadAbortController = null;
                     await parseAndShowTrace(arrayBuffer, name, getParseOptions());
                 } catch (err) {
@@ -1605,6 +1688,10 @@
                 updateUrlTimeRange(startNs, endNs);
                 resetTraceState({ clearUrlRange: false });
                 enterLoadingView(`Loading ${currentTraceName}…`);
+                // In-memory re-parse: no network fetch, parse straight from the
+                // retained buffer. enterLoadingView reset loadPerf to 'local';
+                // tag it 'reparse' so the perf panel reflects what happened.
+                if (loadPerf) loadPerf.mode = "reparse";
 
                 const opts = {};
                 if (startNs != null) opts.startTime = startNs;
@@ -1818,6 +1905,16 @@
                 const truncNote = trace.truncated ? " (truncated)" : "";
                 const filterNote = trace.timeFiltered ? " (time-filtered)" : "";
                 const statsText = `${trace.events.length.toLocaleString()} events · ${workerIds.length} workers · ${durStr}${truncNote}${filterNote}`;
+                // The total load time is finalized after this function returns
+                // (double-rAF in showParsedTrace), so we emit an empty suffix
+                // span here and updateInlineLoadTime() fills it in once known.
+                // If a prior load already recorded a total (e.g. a fast cached
+                // re-show), seed it immediately. Two layouts: svc-metadata
+                // (inside a .tb-meta/.key) and filename (inside .stats).
+                const loadSuffix = (loadPerf && loadPerf.totalMs != null)
+                    ? ` · loaded in ${fmtSecs(loadPerf.totalMs)}`
+                    : "";
+                const suffixSpan = `<span class="load-time-suffix">${loadSuffix}</span>`;
 
                 if (svc) {
                     // Structured metadata from browser
@@ -1830,10 +1927,10 @@
                         timeLine += `</span>`;
                         lines.push(timeLine);
                     }
-                    lines.push(`<span class="key">${statsText}</span>`);
+                    lines.push(`<span class="key">${statsText}${suffixSpan}</span>`);
                     infoEl.innerHTML = lines.map(l => `<div class="tb-meta">${l}</div>`).join('');
                 } else {
-                    infoEl.innerHTML = `<span class="filename">${esc(filename)}</span><span class="stats">${statsText}</span>`;
+                    infoEl.innerHTML = `<span class="filename">${esc(filename)}</span><span class="stats">${statsText}${suffixSpan}</span>`;
                 }
 
                 buildLanes();
@@ -2002,6 +2099,13 @@
                 if (hasCpu) {
                     btnCpu.textContent = `🔥 Flamegraph (${trace.cpuSamples.length})`;
                 }
+
+                // Parse-perf button: shown after every successful load. The
+                // breakdown (loadPerf) is filled by showParsedTrace; even before
+                // totalMs is finalized in the double-rAF, the panel falls back to
+                // a provisional total so a click always shows something useful.
+                const btnPerf = document.getElementById("btn-parse-perf");
+                if (btnPerf) btnPerf.style.display = loadPerf ? "" : "none";
 
                 showToast("shift-drag-hint", "⇧ Shift+drag to select a region", "info", 0, true);
                 showToast("option-drag-hint", "⌥ Option+drag to zoom", "info", 0, true);
@@ -4290,6 +4394,9 @@
             document.getElementById("btn-uninstrumented-info").addEventListener("click", (e) => {
                 showUninstrumentedPopup(e.target);
             });
+            document.getElementById("btn-parse-perf").addEventListener("click", (e) => {
+                showParsePerfPopup(e.currentTarget);
+            });
             document.getElementById("btn-prev-poi").addEventListener("click", () => {
                 if (currentPoiIndex > 0) jumpToPoi(currentPoiIndex - 1);
                 else if (currentPoiIndex < 0 && pointsOfInterest.length > 0) jumpToPoi(0);
@@ -4966,6 +5073,143 @@
                 }
             });
 
+            // ── Parse-performance breakdown (fetch & parse timing) ──
+
+            /** Format milliseconds as seconds to 1 decimal, e.g. 8200 → "8.2 s". */
+            function fmtSecs(ms) {
+                return (ms / 1000).toFixed(1) + " s";
+            }
+
+            /** Update (or refine) the ` · loaded in X.Xs` suffix on the inline
+             *  stats line. Resilient to both info-block layouts because the
+             *  suffix lives in a dedicated `.load-time-suffix` span that
+             *  showViewer always emits. Pass the specific perf record to write
+             *  (defaults to the current `loadPerf`); the double-rAF caller
+             *  passes its captured record so a freshly-started load can't
+             *  clobber it. No-op if the element or total is absent. */
+            function updateInlineLoadTime(perf = loadPerf) {
+                if (!perf || perf.totalMs == null) return;
+                const el = document.querySelector("#toolbar .tb-info .load-time-suffix");
+                if (el) el.textContent = ` · loaded in ${fmtSecs(perf.totalMs)}`;
+            }
+
+            /** Show the fetch & parse breakdown popup, mirroring the
+             *  uninstrumented-popup pattern (fixed div anchored under the
+             *  button, toggle-off if open, close button + click-outside). */
+            function showParsePerfPopup(anchor) {
+                const popup = document.getElementById("parse-perf-popup");
+                if (!popup) return;
+                // Toggle off if already visible.
+                if (popup.style.display !== "none") {
+                    popup.style.display = "none";
+                    return;
+                }
+                if (!loadPerf) return;
+                const p = loadPerf;
+                // totalMs is finalized in the double-rAF after showViewer. If the
+                // popup is opened before that fires, fall back to a provisional
+                // total measured now (still includes analysis+render).
+                const totalMs = p.totalMs != null
+                    ? p.totalMs
+                    : (p.startMs != null ? performance.now() - p.startMs : null);
+
+                const rows = [];
+                if (totalMs != null) rows.push(["Total", fmtSecs(totalMs)]);
+
+                if (p.mode === "stream") {
+                    // Fetch+parse are fused/overlapped in streamed mode.
+                    if (p.parseDoneMs != null && p.startMs != null) {
+                        rows.push(["Fetch + parse (streamed, overlapped)",
+                            fmtSecs(p.parseDoneMs - p.startMs)]);
+                    }
+                } else if (p.mode === "buffered") {
+                    if (p.fetchDoneMs != null && p.startMs != null) {
+                        rows.push(["Fetch", fmtSecs(p.fetchDoneMs - p.startMs)]);
+                    }
+                    if (p.parseDoneMs != null && p.fetchDoneMs != null) {
+                        rows.push(["Parse", fmtSecs(p.parseDoneMs - p.fetchDoneMs)]);
+                    }
+                } else {
+                    // 'local' (file drop / demo blob) or 'reparse': no fetch,
+                    // parse straight from an in-memory buffer.
+                    if (p.parseDoneMs != null && p.startMs != null) {
+                        rows.push(["Parse", fmtSecs(p.parseDoneMs - p.startMs)]);
+                    }
+                }
+
+                // Analysis + render = everything after parse finished. Only
+                // meaningful once the total is known (i.e. after render).
+                if (totalMs != null && p.parseDoneMs != null && p.startMs != null) {
+                    const analysisMs = totalMs - (p.parseDoneMs - p.startMs);
+                    rows.push(["Analysis + render", fmtSecs(analysisMs)]);
+                }
+
+                // Optional throughput. fetch+parse wall-clock is the most
+                // meaningful denominator (it's where the bytes/events flow).
+                let throughput = "";
+                if (p.parseDoneMs != null && p.startMs != null) {
+                    const fetchParseSec = (p.parseDoneMs - p.startMs) / 1000;
+                    if (fetchParseSec > 0) {
+                        const parts = [];
+                        if (p.events != null) {
+                            parts.push(`${Math.round(p.events / fetchParseSec).toLocaleString()} events/s`);
+                        }
+                        if (p.bytes != null) {
+                            const mbps = (p.bytes / (1024 * 1024)) / fetchParseSec;
+                            parts.push(`${mbps.toFixed(1)} MB/s`);
+                        }
+                        if (parts.length) throughput = parts.join(" · ");
+                    }
+                }
+
+                const modeLabel = {
+                    stream: "streamed (single URL)",
+                    buffered: "buffered (multi-URL)",
+                    local: "local file",
+                    reparse: "in-memory re-parse",
+                }[p.mode] || p.mode;
+
+                let html = `<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">`;
+                html += `<span style="color:#6c63ff;font-weight:600">⏱ Load breakdown</span>`;
+                html += `<span id="parse-perf-popup-close" style="cursor:pointer;color:#888;padding:0 4px">&times;</span>`;
+                html += `</div>`;
+                html += `<div style="color:#888;margin-bottom:8px">Mode: <span style="color:#d0ccff">${esc(modeLabel)}</span></div>`;
+                for (const [label, val] of rows) {
+                    html += `<div style="display:flex;justify-content:space-between;gap:16px">`;
+                    html += `<span style="color:#ccc">${esc(label)}</span>`;
+                    html += `<span style="color:#d0ccff;font-weight:600">${esc(val)}</span>`;
+                    html += `</div>`;
+                }
+                if (throughput) {
+                    html += `<div style="margin-top:8px;color:#888">${esc(throughput)}</div>`;
+                }
+                if (p.mode === "stream") {
+                    html += `<div style="margin-top:8px;color:#777;font-size:0.9em">In streamed mode the download and parse run concurrently, so the two cannot be split — the figure is the combined wall-clock time.</div>`;
+                }
+
+                popup.innerHTML = html;
+
+                // Position below the button (mirror showUninstrumentedPopup).
+                const rect = anchor.getBoundingClientRect();
+                popup.style.top = (rect.bottom + 4) + "px";
+                popup.style.right = (window.innerWidth - rect.right) + "px";
+                popup.style.left = "auto";
+                popup.style.display = "block";
+
+                document.getElementById("parse-perf-popup-close").addEventListener("click", () => {
+                    popup.style.display = "none";
+                });
+            }
+
+            // Close the parse-perf popup when clicking outside it.
+            document.addEventListener("click", (e) => {
+                const popup = document.getElementById("parse-perf-popup");
+                const btn = document.getElementById("btn-parse-perf");
+                if (popup && popup.style.display !== "none" && !popup.contains(e.target) && e.target !== btn) {
+                    popup.style.display = "none";
+                }
+            });
+
             // ── Sidebar view tabs (poll-detail | flamegraph <-> blocking calls) ──
             function showSidebarTabs(activeTab) {
                 const tabs = document.getElementById("sidebar-tabs");
@@ -5391,6 +5635,8 @@
                         clearToasts();
                         if (document.getElementById("uninstrumented-popup").style.display !== "none") {
                             document.getElementById("uninstrumented-popup").style.display = "none";
+                        } else if (document.getElementById("parse-perf-popup").style.display !== "none") {
+                            document.getElementById("parse-perf-popup").style.display = "none";
                         } else if (document.getElementById("stack-sidebar").style.display === "flex") {
                             // If flamegraph is in the sidebar, let it handle Escape first
                             if (fgActive && fgInstance.handleEscape()) {

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -47,6 +47,9 @@ node dial9-viewer/ui/test_trace_analysis.js
 echo "--- Checking multi-component trace fetch (repeatable trace=) ---"
 node dial9-viewer/ui/test_fetch_traces.js
 
+echo "--- Checking streaming trace decode (parseTraceStream) ---"
+node dial9-viewer/ui/test_stream_parse.js
+
 echo "--- Checking bring-your-own-credentials store ---"
 node dial9-viewer/ui/test_creds.js
 


### PR DESCRIPTION
## What

Make the viewer decode a trace **as it downloads**, so parse time overlaps the network fetch (total load ≈ `max(download, parse)` instead of their sum), plus chunk batching and honest load-progress/timing UX.

Three commits:

1. **stream trace decode so download and parse overlap** — Adds `fetchTraceStream` (sniffs the gzip magic, pipes through `DecompressionStream`) + `parseTraceStream` (incremental frame decode with transactional snapshot/restore for incomplete frames) to `trace_parser.js`. `streamAndShowTrace` captures gunzipped chunks while parsing so the full buffer is still available for in-memory Set/Clear-Range re-parse. Gated by `canStreamDecode()` + single-URL; multi-URL and runtimes lacking `DecompressionStream` fall back to the buffered path. `flamegraph.html` gets the same streaming path.
2. **batch streamed chunks + live load timer** — `DecompressionStream("gzip")` emits tiny ~16KB chunks (~708 for the 10MB demo); per-chunk grow+drain cost ~66–78% overhead. Coalesce until the undrained tail reaches `MIN_DRAIN_BYTES` (256KB) before draining (~708 → ~40 cycles); the 5-byte header still decodes immediately and the final partial batch always drains. Adds a live elapsed timer and `bench_parse.js`.
3. **loading progress & timing UX for streamed traces** — Time-based paint throttle (`PAINT_INTERVAL_MS`), a `loadPerf` record across all load paths, an inline "loaded in X.Xs" + "⏱ Parse perf" popup. Folds in two follow-up fixes: report `totalBytes=null` while streaming (the size is genuinely unknown, so show MB decoded instead of a bogus ~99%), and make `showParsedTrace` async + double-rAF so the "Analyzing…" label actually paints before the synchronous analysis crunch.

## Why

Streaming overlaps download with decode and lets the spinner advance honestly during load.

## Verification

- `node dial9-viewer/ui/test_stream_parse.js` → **all pass**. The test proves the streamed decode is **byte-identical** to the buffered path: byte-by-byte chunking forces a restore at every offset, explicit boundaries inside every `TRC\0` header and mid-event, full-buffer at 64B–1MB, gzip round-trip, and time-range filtering — all `deepStrictEqual` against the buffered reference.
- `node dial9-viewer/ui/test_trace_analysis.js` → all pass.
- `cargo build -p dial9-viewer` clean (rust-embed picks up the JS).
- `test_stream_parse.js` is registered in `scripts/e2e-trace-tests.sh` (the `trace-integrity` CI job).

JS/HTML-only; no `.rs` and no trace-format change. Composes with #PR1 but doesn't require it.

