### PR TITLE
Improve event timestamps in MacOS & fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Unguarded logging in loops causes log spam that degrades observability and can i
 
 ## Formatting and linting
 
-- For Rust code changes, run `cargo fmt --check` and `cargo clippy --all-targets --all-features`. Report if you did not run them.
+- For Rust code changes, run `cargo fmt --check` and clippy. On Linux, run `cargo clippy --all-targets --all-features`. On non-Linux targets, run `cargo clippy --all-targets --features __nonlinux_all_features` instead. Report if you did not run them.
 - **Preserve doc comments and inline comments.** When reviewing your diff, verify you have not accidentally deleted documentation comments (`///`, `//!`), inline explanatory comments (`//`), or module-level docs. Refactors that move code must carry all associated comments with it.
 
 ## Demo Trace

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -96,19 +96,20 @@ pub fn clock_monotonic_ns() -> u64 {
     clock_monotonic_ns_impl()
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn clock_monotonic_ns_impl() -> u64 {
-    // Matches Rust's Unix `Instant` backend on Linux.
-    clock_gettime_ns(libc::CLOCK_MONOTONIC)
+    clock_gettime_ns(MONOTONIC_CLOCK_ID)
 }
 
-#[cfg(target_vendor = "apple")]
-fn clock_monotonic_ns_impl() -> u64 {
-    // Matches Rust's Darwin `Instant` backend on Apple platforms.
-    clock_gettime_ns(libc::CLOCK_UPTIME_RAW)
-}
+// Matches Rust's Darwin `Instant` backend on Apple platforms.
+#[cfg(all(unix, target_vendor = "apple"))]
+const MONOTONIC_CLOCK_ID: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
 
-#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+// Matches Rust's Unix `Instant` backend on non-Apple platforms.
+#[cfg(all(unix, not(target_vendor = "apple")))]
+const MONOTONIC_CLOCK_ID: libc::clockid_t = libc::CLOCK_MONOTONIC;
+
+#[cfg(unix)]
 fn clock_gettime_ns(clock_id: libc::clockid_t) -> u64 {
     let mut ts = libc::timespec {
         tv_sec: 0,
@@ -120,7 +121,7 @@ fn clock_gettime_ns(clock_id: libc::clockid_t) -> u64 {
     ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
 }
 
-#[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
+#[cfg(not(unix))]
 fn clock_monotonic_ns_impl() -> u64 {
     use std::sync::OnceLock;
     use std::time::Instant;

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -95,19 +95,31 @@ pub(crate) fn thread_cpu_time_nanos() -> u64 {
 /// all trace timestamps (poll events, CPU samples, sched events).
 #[cfg(target_os = "linux")]
 pub fn clock_monotonic_ns() -> u64 {
+    clock_gettime_ns(libc::CLOCK_MONOTONIC)
+}
+
+/// Read a monotonic clock in nanoseconds. On Apple platforms, `CLOCK_UPTIME_RAW`
+/// matches the clock Rust uses for `Instant` and kernel timeouts.
+#[cfg(target_vendor = "apple")]
+pub fn clock_monotonic_ns() -> u64 {
+    clock_gettime_ns(libc::CLOCK_UPTIME_RAW)
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn clock_gettime_ns(clock_id: libc::clockid_t) -> u64 {
     let mut ts = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
     unsafe {
-        libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
+        libc::clock_gettime(clock_id, &mut ts);
     }
     ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
 }
 
-/// `CLOCK_MONOTONIC` in nanoseconds. Non-Linux fallback: elapsed time
-/// since the first call on this process via `Instant`.
-#[cfg(not(target_os = "linux"))]
+/// Portable fallback: elapsed time since the first call on this process via
+/// `Instant`.
+#[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
 pub fn clock_monotonic_ns() -> u64 {
     use std::sync::OnceLock;
     use std::time::Instant;

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -130,19 +130,12 @@ fn clock_monotonic_ns_impl() -> u64 {
 }
 
 /// `CLOCK_REALTIME` in nanoseconds since the Unix epoch.
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 pub(crate) fn clock_realtime_ns() -> u64 {
-    let mut ts = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    unsafe {
-        libc::clock_gettime(libc::CLOCK_REALTIME, &mut ts);
-    }
-    ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
+    clock_gettime_ns(libc::CLOCK_REALTIME)
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 pub(crate) fn clock_realtime_ns() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -91,17 +91,20 @@ pub(crate) fn thread_cpu_time_nanos() -> u64 {
     0
 }
 
-/// Read `CLOCK_MONOTONIC` in nanoseconds. Used as the single time base for
-/// all trace timestamps (poll events, CPU samples, sched events).
-#[cfg(target_os = "linux")]
+/// Read monotonic time in nanoseconds for trace timestamps.
 pub fn clock_monotonic_ns() -> u64 {
+    clock_monotonic_ns_impl()
+}
+
+#[cfg(target_os = "linux")]
+fn clock_monotonic_ns_impl() -> u64 {
+    // Matches Rust's Unix `Instant` backend on Linux.
     clock_gettime_ns(libc::CLOCK_MONOTONIC)
 }
 
-/// Read a monotonic clock in nanoseconds. On Apple platforms, `CLOCK_UPTIME_RAW`
-/// matches the clock Rust uses for `Instant` and kernel timeouts.
 #[cfg(target_vendor = "apple")]
-pub fn clock_monotonic_ns() -> u64 {
+fn clock_monotonic_ns_impl() -> u64 {
+    // Matches Rust's Darwin `Instant` backend on Apple platforms.
     clock_gettime_ns(libc::CLOCK_UPTIME_RAW)
 }
 
@@ -117,10 +120,8 @@ fn clock_gettime_ns(clock_id: libc::clockid_t) -> u64 {
     ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
 }
 
-/// Portable fallback: elapsed time since the first call on this process via
-/// `Instant`.
 #[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
-pub fn clock_monotonic_ns() -> u64 {
+fn clock_monotonic_ns_impl() -> u64 {
     use std::sync::OnceLock;
     use std::time::Instant;
     static EPOCH: OnceLock<Instant> = OnceLock::new();

--- a/dial9-tokio-telemetry/src/telemetry/events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/events.rs
@@ -112,7 +112,7 @@ pub fn clock_monotonic_ns() -> u64 {
     use std::sync::OnceLock;
     use std::time::Instant;
     static EPOCH: OnceLock<Instant> = OnceLock::new();
-    EPOCH.get_or_init(Instant::now).elapsed().as_nanos() as u64
+    (EPOCH.get_or_init(Instant::now).elapsed().as_nanos() as u64).saturating_add(1)
 }
 
 /// `CLOCK_REALTIME` in nanoseconds since the Unix epoch.


### PR DESCRIPTION
# Changes
- On MacOS, for `clock_monotonic_ns`, use `CLOCK_UPTIME_RAW` instead of the fallback implementation (this is what `Instant::now()` internally uses).
- Hide conditionally-compiled implementations behind a consistently documented public function.
- Also, for consistency, on MacOS, for the sibling `clock_realtime_ns`, use the same Unix call as Linux (as it works the same).
- Make the non-Unix fallback more realistic by always reporting one extra nanosecond, ensuring `elapsed()` never gives 0.
- Proper clippy instructions in `AGENTS.md` for MacOS.