### PR TITLE
feat(viewer): export flamegraph as interactive SVG or folded stacks

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,0 +1,402 @@
+THIRD-PARTY LICENSES
+====================
+
+dial9 is licensed under Apache-2.0 (see LICENSE). It additionally incorporates
+the following third-party software, which is licensed separately as noted
+below.
+
+--------------------------------------------------------------------------------
+Brendan Gregg's FlameGraph (flamegraph.pl)
+--------------------------------------------------------------------------------
+
+The embedded interactive SVG script produced by `dial9-viewer/ui/flamegraph_export.js`
+(the `embeddedScript()` function and the surrounding SVG structure) is derived
+from flamegraph.pl by Brendan Gregg.
+
+    Copyright 2016 Netflix, Inc.
+    Copyright 2011 Joyent, Inc.  All rights reserved.
+    Copyright 2011 Brendan Gregg.  All rights reserved.
+
+    https://github.com/brendangregg/FlameGraph
+
+Licensed under the Common Development and Distribution License (CDDL) Version
+1.0. The full text of the CDDL-1.0 follows.
+
+
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE Version 1.0
+
+1. Definitions.
+
+    1.1. "Contributor" means each individual or entity that creates
+         or contributes to the creation of Modifications.
+
+    1.2. "Contributor Version" means the combination of the Original
+         Software, prior Modifications used by a Contributor (if any),
+         and the Modifications made by that particular Contributor.
+
+    1.3. "Covered Software" means (a) the Original Software, or (b)
+         Modifications, or (c) the combination of files containing
+         Original Software with files containing Modifications, in
+         each case including portions thereof.
+
+    1.4. "Executable" means the Covered Software in any form other
+         than Source Code.
+
+    1.5. "Initial Developer" means the individual or entity that first
+         makes Original Software available under this License.
+
+    1.6. "Larger Work" means a work which combines Covered Software or
+         portions thereof with code not governed by the terms of this
+         License.
+
+    1.7. "License" means this document.
+
+    1.8. "Licensable" means having the right to grant, to the maximum
+         extent possible, whether at the time of the initial grant or
+         subsequently acquired, any and all of the rights conveyed
+         herein.
+
+    1.9. "Modifications" means the Source Code and Executable form of
+         any of the following:
+
+        A. Any file that results from an addition to, deletion from or
+           modification of the contents of a file containing Original
+           Software or previous Modifications;
+
+        B. Any new file that contains any part of the Original
+           Software or previous Modifications; or
+
+        C. Any new file that is contributed or otherwise made
+           available under the terms of this License.
+
+    1.10. "Original Software" means the Source Code and Executable
+          form of computer software code that is originally released
+          under this License.
+
+    1.11. "Patent Claims" means any patent claim(s), now owned or
+          hereafter acquired, including without limitation, method,
+          process, and apparatus claims, in any patent Licensable by
+          grantor.
+
+    1.12. "Source Code" means (a) the common form of computer software
+          code in which modifications are made and (b) associated
+          documentation included in or with such code.
+
+    1.13. "You" (or "Your") means an individual or a legal entity
+          exercising rights under, and complying with all of the terms
+          of, this License.  For legal entities, "You" includes any
+          entity which controls, is controlled by, or is under common
+          control with You.  For purposes of this definition,
+          "control" means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by
+          contract or otherwise, or (b) ownership of more than fifty
+          percent (50%) of the outstanding shares or beneficial
+          ownership of such entity.
+
+2. License Grants.
+
+    2.1. The Initial Developer Grant.
+
+    Conditioned upon Your compliance with Section 3.1 below and
+    subject to third party intellectual property claims, the Initial
+    Developer hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+        (a) under intellectual property rights (other than patent or
+            trademark) Licensable by Initial Developer, to use,
+            reproduce, modify, display, perform, sublicense and
+            distribute the Original Software (or portions thereof),
+            with or without Modifications, and/or as part of a Larger
+            Work; and
+
+        (b) under Patent Claims infringed by the making, using or
+            selling of Original Software, to make, have made, use,
+            practice, sell, and offer for sale, and/or otherwise
+            dispose of the Original Software (or portions thereof).
+
+        (c) The licenses granted in Sections 2.1(a) and (b) are
+            effective on the date Initial Developer first distributes
+            or otherwise makes the Original Software available to a
+            third party under the terms of this License.
+
+        (d) Notwithstanding Section 2.1(b) above, no patent license is
+            granted: (1) for code that You delete from the Original
+            Software, or (2) for infringements caused by: (i) the
+            modification of the Original Software, or (ii) the
+            combination of the Original Software with other software
+            or devices.
+
+    2.2. Contributor Grant.
+
+    Conditioned upon Your compliance with Section 3.1 below and
+    subject to third party intellectual property claims, each
+    Contributor hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+        (a) under intellectual property rights (other than patent or
+            trademark) Licensable by Contributor to use, reproduce,
+            modify, display, perform, sublicense and distribute the
+            Modifications created by such Contributor (or portions
+            thereof), either on an unmodified basis, with other
+            Modifications, as Covered Software and/or as part of a
+            Larger Work; and
+
+        (b) under Patent Claims infringed by the making, using, or
+            selling of Modifications made by that Contributor either
+            alone and/or in combination with its Contributor Version
+            (or portions of such combination), to make, use, sell,
+            offer for sale, have made, and/or otherwise dispose of:
+            (1) Modifications made by that Contributor (or portions
+            thereof); and (2) the combination of Modifications made by
+            that Contributor with its Contributor Version (or portions
+            of such combination).
+
+        (c) The licenses granted in Sections 2.2(a) and 2.2(b) are
+            effective on the date Contributor first distributes or
+            otherwise makes the Modifications available to a third
+            party.
+
+        (d) Notwithstanding Section 2.2(b) above, no patent license is
+            granted: (1) for any code that Contributor has deleted
+            from the Contributor Version; (2) for infringements caused
+            by: (i) third party modifications of Contributor Version,
+            or (ii) the combination of Modifications made by that
+            Contributor with other software (except as part of the
+            Contributor Version) or other devices; or (3) under Patent
+            Claims infringed by Covered Software in the absence of
+            Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+    3.1. Availability of Source Code.
+
+    Any Covered Software that You distribute or otherwise make
+    available in Executable form must also be made available in Source
+    Code form and that Source Code form must be distributed only under
+    the terms of this License.  You must include a copy of this
+    License with every copy of the Source Code form of the Covered
+    Software You distribute or otherwise make available.  You must
+    inform recipients of any such Covered Software in Executable form
+    as to how they can obtain such Covered Software in Source Code
+    form in a reasonable manner on or through a medium customarily
+    used for software exchange.
+
+    3.2. Modifications.
+
+    The Modifications that You create or to which You contribute are
+    governed by the terms of this License.  You represent that You
+    believe Your Modifications are Your original creation(s) and/or
+    You have sufficient rights to grant the rights conveyed by this
+    License.
+
+    3.3. Required Notices.
+
+    You must include a notice in each of Your Modifications that
+    identifies You as the Contributor of the Modification.  You may
+    not remove or alter any copyright, patent or trademark notices
+    contained within the Covered Software, or any notices of licensing
+    or any descriptive text giving attribution to any Contributor or
+    the Initial Developer.
+
+    3.4. Application of Additional Terms.
+
+    You may not offer or impose any terms on any Covered Software in
+    Source Code form that alters or restricts the applicable version
+    of this License or the recipients' rights hereunder.  You may
+    choose to offer, and to charge a fee for, warranty, support,
+    indemnity or liability obligations to one or more recipients of
+    Covered Software.  However, you may do so only on Your own behalf,
+    and not on behalf of the Initial Developer or any Contributor.
+    You must make it absolutely clear that any such warranty, support,
+    indemnity or liability obligation is offered by You alone, and You
+    hereby agree to indemnify the Initial Developer and every
+    Contributor for any liability incurred by the Initial Developer or
+    such Contributor as a result of warranty, support, indemnity or
+    liability terms You offer.
+
+    3.5. Distribution of Executable Versions.
+
+    You may distribute the Executable form of the Covered Software
+    under the terms of this License or under the terms of a license of
+    Your choice, which may contain terms different from this License,
+    provided that You are in compliance with the terms of this License
+    and that the license for the Executable form does not attempt to
+    limit or alter the recipient's rights in the Source Code form from
+    the rights set forth in this License.  If You distribute the
+    Covered Software in Executable form under a different license, You
+    must make it absolutely clear that any terms which differ from
+    this License are offered by You alone, not by the Initial
+    Developer or Contributor.  You hereby agree to indemnify the
+    Initial Developer and every Contributor for any liability incurred
+    by the Initial Developer or such Contributor as a result of any
+    such terms You offer.
+
+    3.6. Larger Works.
+
+    You may create a Larger Work by combining Covered Software with
+    other code not governed by the terms of this License and
+    distribute the Larger Work as a single product.  In such a case,
+    You must make sure the requirements of this License are fulfilled
+    for the Covered Software.
+
+4. Versions of the License.
+
+    4.1. New Versions.
+
+    Sun Microsystems, Inc. is the initial license steward and may
+    publish revised and/or new versions of this License from time to
+    time.  Each version will be given a distinguishing version number.
+    Except as provided in Section 4.3, no one other than the license
+    steward has the right to modify this License.
+
+    4.2. Effect of New Versions.
+
+    You may always continue to use, distribute or otherwise make the
+    Covered Software available under the terms of the version of the
+    License under which You originally received the Covered Software.
+    If the Initial Developer includes a notice in the Original
+    Software prohibiting it from being distributed or otherwise made
+    available under any subsequent version of the License, You must
+    distribute and make the Covered Software available under the terms
+    of the version of the License under which You originally received
+    the Covered Software.  Otherwise, You may also choose to use,
+    distribute or otherwise make the Covered Software available under
+    the terms of any subsequent version of the License published by
+    the license steward.
+
+    4.3. Modified Versions.
+
+    When You are an Initial Developer and You want to create a new
+    license for Your Original Software, You may create and use a
+    modified version of this License if You: (a) rename the license
+    and remove any references to the name of the license steward
+    (except to note that the license differs from this License); and
+    (b) otherwise make it clear that the license contains terms which
+    differ from this License.
+
+5. DISCLAIMER OF WARRANTY.
+
+    COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS"
+    BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED
+    SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR
+    PURPOSE OR NON-INFRINGING.  THE ENTIRE RISK AS TO THE QUALITY AND
+    PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU.  SHOULD ANY
+    COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE
+    INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY
+    NECESSARY SERVICING, REPAIR OR CORRECTION.  THIS DISCLAIMER OF
+    WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE.  NO USE OF
+    ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS
+    DISCLAIMER.
+
+6. TERMINATION.
+
+    6.1. This License and the rights granted hereunder will terminate
+    automatically if You fail to comply with terms herein and fail to
+    cure such breach within 30 days of becoming aware of the breach.
+    Provisions which, by their nature, must remain in effect beyond
+    the termination of this License shall survive.
+
+    6.2. If You assert a patent infringement claim (excluding
+    declaratory judgment actions) against Initial Developer or a
+    Contributor (the Initial Developer or Contributor against whom You
+    assert such claim is referred to as "Participant") alleging that
+    the Participant Software (meaning the Contributor Version where
+    the Participant is a Contributor or the Original Software where
+    the Participant is the Initial Developer) directly or indirectly
+    infringes any patent, then any and all rights granted directly or
+    indirectly to You by such Participant, the Initial Developer (if
+    the Initial Developer is not the Participant) and all Contributors
+    under Sections 2.1 and/or 2.2 of this License shall, upon 60 days
+    notice from Participant terminate prospectively and automatically
+    at the expiration of such 60 day notice period, unless if within
+    such 60 day period You withdraw Your claim with respect to the
+    Participant Software against such Participant either unilaterally
+    or pursuant to a written agreement with Participant.
+
+    6.3. In the event of termination under Sections 6.1 or 6.2 above,
+    all end user licenses that have been validly granted by You or any
+    distributor hereunder prior to termination (excluding licenses
+    granted to You by any distributor) shall survive termination.
+
+7. LIMITATION OF LIABILITY.
+
+    UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+    (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE
+    INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF
+    COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE
+    LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR
+    CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+    LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK
+    STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+    COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+    INFORMED OF THE POSSIBILITY OF SUCH DAMAGES.  THIS LIMITATION OF
+    LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL
+    INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT
+    APPLICABLE LAW PROHIBITS SUCH LIMITATION.  SOME JURISDICTIONS DO
+    NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR
+    CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT
+    APPLY TO YOU.
+
+8. U.S. GOVERNMENT END USERS.
+
+    The Covered Software is a "commercial item," as that term is
+    defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial
+    computer software" (as that term is defined at 48
+    C.F.R. 252.227-7014(a)(1)) and "commercial computer software
+    documentation" as such terms are used in 48 C.F.R. 12.212
+    (Sept. 1995).  Consistent with 48 C.F.R. 12.212 and 48
+    C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all
+    U.S. Government End Users acquire Covered Software with only those
+    rights set forth herein.  This U.S. Government Rights clause is in
+    lieu of, and supersedes, any other FAR, DFAR, or other clause or
+    provision that addresses Government rights in computer software
+    under this License.
+
+9. MISCELLANEOUS.
+
+    This License represents the complete agreement concerning subject
+    matter hereof.  If any provision of this License is held to be
+    unenforceable, such provision shall be reformed only to the extent
+    necessary to make it enforceable.  This License shall be governed
+    by the law of the jurisdiction specified in a notice contained
+    within the Original Software (except to the extent applicable law,
+    if any, provides otherwise), excluding such jurisdiction's
+    conflict-of-law provisions.  Any litigation relating to this
+    License shall be subject to the jurisdiction of the courts located
+    in the jurisdiction and venue specified in a notice contained
+    within the Original Software, with the losing party responsible
+    for costs, including, without limitation, court costs and
+    reasonable attorneys' fees and expenses.  The application of the
+    United Nations Convention on Contracts for the International Sale
+    of Goods is expressly excluded.  Any law or regulation which
+    provides that the language of a contract shall be construed
+    against the drafter shall not apply to this License.  You agree
+    that You alone are responsible for compliance with the United
+    States export administration regulations (and the export control
+    laws and regulation of any other countries) when You use,
+    distribute or otherwise make available any Covered Software.
+
+10. RESPONSIBILITY FOR CLAIMS.
+
+    As between Initial Developer and the Contributors, each party is
+    responsible for claims and damages arising, directly or
+    indirectly, out of its utilization of rights under this License
+    and You agree to work with Initial Developer and Contributors to
+    distribute such responsibility on an equitable basis.  Nothing
+    herein is intended or shall be deemed to constitute any admission
+    of liability.
+
+--------------------------------------------------------------------
+
+NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND
+DISTRIBUTION LICENSE (CDDL)
+
+For Covered Software in this distribution, this License shall
+be governed by the laws of the State of California (excluding
+conflict-of-law provisions).
+
+Any litigation relating to this License shall be subject to the
+jurisdiction of the Federal Courts of the Northern District of
+California and the state courts of the State of California, with
+venue lying in Santa Clara County, California.

--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -50,6 +50,46 @@
 }
 .fg-help-btn:hover { color: #fff; border-color: #888; }
 
+.fg-export-wrap { position: relative; display: inline-flex; }
+.fg-export-btn {
+    background: #2a2a4a;
+    border: 1px solid #555;
+    color: #ccc;
+    cursor: pointer;
+    font-size: 0.9em;
+    padding: 3px 8px;
+    border-radius: 4px;
+    line-height: 1.2;
+}
+.fg-export-btn:hover:not(:disabled) { color: #fff; border-color: #6c63ff; }
+.fg-export-btn:disabled { opacity: 0.4; cursor: default; }
+.fg-export-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    background: #16213e;
+    border: 1px solid #444;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    z-index: 20;
+    min-width: 170px;
+    padding: 4px;
+}
+.fg-export-menu button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    color: #ccc;
+    cursor: pointer;
+    font-size: 0.9em;
+    padding: 6px 8px;
+    border-radius: 3px;
+}
+.fg-export-menu button:hover { background: #2a2a4a; color: #fff; }
+
 .fg-breadcrumb {
     display: none;
     align-items: center;

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -75,6 +75,7 @@
         <script src="trace_parser.js"></script>
         <script src="creds.js"></script>
         <script src="trace_analysis.js"></script>
+        <script src="flamegraph_export.js"></script>
         <script src="flamegraph.js"></script>
         <script>
             (async function () {
@@ -206,7 +207,7 @@
                 }
 
                 const fg = FlamegraphRenderer.createFlamegraph(containerEl, updateUrlZoom);
-                fg.setData(allSamples, trace.callframeSymbols);
+                fg.setData(allSamples, trace.callframeSymbols, { exportTitle: `Flamegraph — ${label}` });
 
                 // Restore zoom from URL (only if time range filter succeeded, otherwise tree differs)
                 if (timeRangeMatched) {

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -11,16 +11,30 @@
     );
   }
 
+  function getExport() {
+    if (typeof require !== "undefined") return require("./flamegraph_export.js");
+    if (typeof FlamegraphExport !== "undefined") return FlamegraphExport;
+    return null; // export is optional; UI degrades gracefully if not loaded
+  }
+
   const buildFlamegraphTree = getAnalysis().buildFlamegraphTree;
+  // Shared with the SVG export (flamegraph_export.js) via trace_analysis.js so
+  // the exported graph's colors match the on-screen canvas.
+  const flamegraphColor = getAnalysis().flamegraphColor;
   const FG_ROW_H = 18;
 
-  function flamegraphColor(name) {
-    let h = 0;
-    for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
-    const hue = 10 + (Math.abs(h) % 40);
-    const sat = 60 + (Math.abs(h >> 8) % 30);
-    const lit = 40 + (Math.abs(h >> 16) % 15);
-    return `hsl(${hue},${sat}%,${lit}%)`;
+  // Trigger a browser download of `content` (string) as `filename`.
+  function downloadFile(filename, content, mime) {
+    const blob = new Blob([content], { type: mime || "application/octet-stream" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    // Revoke on the next tick so the click has been dispatched.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
   // Like flattenFlamegraph in trace_analysis.js but attaches treeNode refs
@@ -135,6 +149,14 @@
       '<span class="fg-search-clear" title="Clear search">\u00d7</span>' +
       '<span class="fg-search-stats"></span>' +
       '<select class="fg-spawn-filter"></select>' +
+      '<span class="fg-export-wrap">' +
+      '<button type="button" class="fg-export-btn" title="Export this flamegraph" ' +
+      'aria-haspopup="menu" aria-expanded="false" disabled>\u2b07 Export</button>' +
+      '<div class="fg-export-menu" role="menu" style="display:none">' +
+      '<button type="button" role="menuitem" class="fg-export-svg">Interactive SVG (.svg)</button>' +
+      '<button type="button" role="menuitem" class="fg-export-folded">Folded stacks (.txt)</button>' +
+      '</div>' +
+      '</span>' +
       '<span class="fg-help-btn" tabindex="0" role="button" title="Keyboard shortcuts">\u2139\ufe0f</span>';
     container.appendChild(searchBar);
 
@@ -142,6 +164,10 @@
     const searchClear = searchBar.querySelector(".fg-search-clear");
     const searchStats = searchBar.querySelector(".fg-search-stats");
     const spawnFilter = searchBar.querySelector(".fg-spawn-filter");
+    const exportBtn = searchBar.querySelector(".fg-export-btn");
+    const exportMenu = searchBar.querySelector(".fg-export-menu");
+    const exportSvgBtn = searchBar.querySelector(".fg-export-svg");
+    const exportFoldedBtn = searchBar.querySelector(".fg-export-folded");
     const helpBtn = searchBar.querySelector(".fg-help-btn");
 
     const helpOverlay = document.createElement("div");
@@ -163,11 +189,88 @@
     container.appendChild(helpOverlay);
 
     helpBtn.addEventListener("click", function () {
+      closeExportMenu(); // don't leave two popups open at once
       helpOverlay.style.display = helpOverlay.style.display === "none" ? "flex" : "none";
     });
     helpOverlay.addEventListener("click", function (e) {
       if (e.target === helpOverlay) helpOverlay.style.display = "none";
     });
+
+    // ── Export: turn the rendered tree into a downloadable artifact ──
+    // The export reflects the CURRENT view — the active spawn-location filter
+    // (workerTree/offworkerTree are rebuilt by applySpawnFilter) — but always
+    // the full (un-zoomed) trees, since an exported file should stand alone.
+    let exportTitle = "dial9 flamegraph";
+    // Formats a node's weight for SVG hover text. Defaults to CPU samples; the
+    // heap views override it via setData so bytes/allocs render correctly.
+    let exportFormatValue = null;
+
+    // Resolve the (optional) export module once. It is statically loaded by
+    // every page that uses the flamegraph, so absence means a build/wiring bug;
+    // we warn once and disable the control rather than failing silently.
+    const FE = getExport();
+    if (!FE) {
+      console.warn("flamegraph: export module (flamegraph_export.js) not loaded; export disabled");
+      const wrap = searchBar.querySelector(".fg-export-wrap");
+      if (wrap) wrap.style.display = "none";
+    }
+
+    function exportPanels() {
+      const panels = [];
+      if (workerTree) panels.push({ label: workerLabelPrefix, tree: workerTree });
+      if (offworkerTree) panels.push({ label: offworkerLabelPrefix, tree: offworkerTree });
+      return panels;
+    }
+
+    function hasExportableData() {
+      return (workerTree && workerTree.count > 0) || (offworkerTree && offworkerTree.count > 0);
+    }
+
+    function closeExportMenu() {
+      if (!exportMenu) return;
+      exportMenu.style.display = "none";
+      exportBtn.setAttribute("aria-expanded", "false");
+    }
+
+    if (FE) {
+      exportBtn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        if (!hasExportableData()) return;
+        const open = exportMenu.style.display !== "none";
+        exportMenu.style.display = open ? "none" : "block";
+        exportBtn.setAttribute("aria-expanded", open ? "false" : "true");
+      });
+
+      exportSvgBtn.addEventListener("click", function () {
+        const svg = FE.treeToInteractiveSvg(exportPanels(), {
+          title: exportTitle,
+          formatValue: exportFormatValue,
+        });
+        downloadFile(FE.filenameStem(exportTitle) + ".svg", svg, "image/svg+xml");
+        closeExportMenu();
+      });
+
+      exportFoldedBtn.addEventListener("click", function () {
+        // One folded file per panel section is awkward to consume; concatenate
+        // with a comment header per section so a single file round-trips. Skip
+        // panels whose folded output is empty so we never emit a dangling
+        // header (and so the join doesn't insert a blank section).
+        const folded = exportPanels()
+          .map((p) => ({ label: p.label, body: FE.treeToFolded(p.tree) }))
+          .filter((s) => s.body.length > 0)
+          .map((s) => "# " + s.label + "\n" + s.body)
+          .join("\n");
+        downloadFile(FE.filenameStem(exportTitle) + ".folded.txt", folded, "text/plain");
+        closeExportMenu();
+      });
+
+      // Close the menu on any outside click. Named so destroy() can detach it.
+      document.addEventListener("click", onExportOutsideClick);
+    }
+
+    function onExportOutsideClick(e) {
+      if (!searchBar.contains(e.target)) closeExportMenu();
+    }
 
     searchClear.style.display = "none";
     searchClear.addEventListener("click", function () {
@@ -644,6 +747,10 @@
         unpinTooltip();
         return true;
       }
+      if (exportMenu && exportMenu.style.display !== "none") {
+        closeExportMenu();
+        return true;
+      }
       if (helpOverlay.style.display !== "none") {
         helpOverlay.style.display = "none";
         return true;
@@ -686,6 +793,14 @@
       offworkerLabel.textContent =
         `${offworkerLabelPrefix} \u2014 ${offworkerSamples.length} samples`;
 
+      // Export is only meaningful when there is something rendered. Always
+      // close the menu: the trees were just rebuilt, so a menu left open would
+      // refer to the previous (filtered) dataset.
+      const canExport = hasExportableData();
+      exportBtn.disabled = !canExport;
+      exportBtn.title = canExport ? "Export this flamegraph" : "No samples to export";
+      closeExportMenu();
+
       renderAll();
     }
 
@@ -701,6 +816,8 @@
       formatCount = (opts && opts.formatCount) || null;
       workerLabelPrefix = (opts && opts.workerLabel) || "Worker threads";
       offworkerLabelPrefix = (opts && opts.offworkerLabel) || "Off-worker (sampler thread)";
+      exportTitle = (opts && opts.exportTitle) || "dial9 flamegraph";
+      exportFormatValue = (opts && opts.exportFormatValue) || null;
 
       // Build spawn location dropdown
       const locCounts = new Map();
@@ -730,6 +847,7 @@
     function destroy() {
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("click", onDocClick);
+      document.removeEventListener("click", onExportOutsideClick);
       workerCanvas.removeEventListener("mousemove", onWorkerMove);
       offworkerCanvas.removeEventListener("mousemove", onOffworkerMove);
       workerCanvas.removeEventListener("mouseleave", canvasMouseLeave);

--- a/dial9-viewer/ui/flamegraph_export.js
+++ b/dial9-viewer/ui/flamegraph_export.js
@@ -17,6 +17,15 @@
 //     (no visual filtering) so no data is lost for downstream tools.
 //
 // Pure functions only — no DOM, no globals — so they run under node for tests.
+//
+// The embedded interactive script (embeddedScript function) and the surrounding
+// SVG structure are derived from flamegraph.pl by Brendan Gregg, licensed under
+// the CDDL 1.0:
+//   Copyright 2016 Netflix, Inc.
+//   Copyright 2011 Joyent, Inc. All rights reserved.
+//   Copyright 2011 Brendan Gregg. All rights reserved.
+//   https://github.com/brendangregg/FlameGraph
+//   License: CDDL-1.0 (see THIRD_PARTY_LICENSES)
 
 (function (exports) {
   "use strict";
@@ -145,6 +154,9 @@
   // with the literals above (xpad=10, fontsize=12, fontwidth=0.59, inverted=0).
   // Behavior is intentionally identical: click=zoom, mouseover=details,
   // Ctrl-F=search, Ctrl-I=ignorecase, Reset Zoom, and URL state restore.
+  //
+  // Derived from flamegraph.pl, © Netflix/Joyent/Brendan Gregg, licensed under
+  // CDDL-1.0. See the file header and THIRD_PARTY_LICENSES for the full notice.
   function embeddedScript() {
     return [
       '"use strict";',
@@ -457,8 +469,11 @@
       `<svg version="1.1" width="${W}" height="${H}" onload="init(evt)" viewBox="0 0 ${W} ${H}" ` +
         'xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">'
     );
-    out.push("<!-- Flame graph stack visualization. Exported by dial9. " +
-      "Structure & script ported from https://github.com/brendangregg/FlameGraph -->");
+    out.push("<!-- Flame graph stack visualization. Exported by dial9. -->");
+    out.push("<!-- Structure & embedded script derived from flamegraph.pl, " +
+      "https://github.com/brendangregg/FlameGraph -->");
+    out.push("<!-- Copyright 2016 Netflix, Inc.; Copyright 2011 Joyent, Inc.; " +
+      "Copyright 2011 Brendan Gregg. Licensed under CDDL-1.0. -->");
     out.push("<defs>");
     out.push('<linearGradient id="background" y1="0" y2="1" x1="0" x2="0">');
     out.push(`<stop stop-color="${BG1}" offset="5%"/>`);

--- a/dial9-viewer/ui/flamegraph_export.js
+++ b/dial9-viewer/ui/flamegraph_export.js
@@ -1,0 +1,576 @@
+// flamegraph_export.js - Export a rendered flamegraph tree to portable formats.
+//
+// The viewer renders flamegraphs onto a <canvas>, which cannot be saved or
+// shared. This module turns the same tree the canvas is painted from (the
+// `{name, fullName, location, count, self, children}` shape produced by
+// trace_analysis.js `buildFlamegraphTree`) into two portable artifacts:
+//
+//   - Interactive SVG: a standalone, self-contained flame graph that behaves
+//     like Brendan Gregg's flamegraph.pl / the flamegraph-rs (inferno) output:
+//     hover a frame for details, click to zoom, Ctrl-F to regex-search with a
+//     "Matched: N%" readout, Reset Zoom, Ctrl-I to toggle case sensitivity, and
+//     URL state (?x=&y=&s=). The embedded SVG structure and the embedded
+//     <script> are ported, near-verbatim, from flamegraph.pl so the behavior is
+//     identical to the canonical tool. No external assets, no network.
+//   - Folded stacks: the universal `frame1;frame2;frame3 <count>` text format
+//     consumed by inferno, flamegraph.pl, and speedscope. Carries the FULL tree
+//     (no visual filtering) so no data is lost for downstream tools.
+//
+// Pure functions only — no DOM, no globals — so they run under node for tests.
+
+(function (exports) {
+  "use strict";
+
+  // ── geometry, ported from flamegraph.pl tunables ──
+  const FONT_SIZE = 12;
+  const FONT_WIDTH = 0.59; // avg glyph width relative to font size
+  const FRAME_HEIGHT = 16;
+  const FRAME_PAD = 1; // vertical gap between frames
+  const XPAD = 10; // left/right pad
+  const YPAD1 = FONT_SIZE * 3; // top pad (title)
+  const YPAD2 = FONT_SIZE * 2 + 10; // bottom pad (labels)
+  const DEFAULT_WIDTH = 1200;
+  const MINWIDTH_PX = 0.1; // omit frames narrower than this many pixels
+  const FONT_TYPE = "Verdana";
+  const SEARCH_COLOR = "rgb(230,0,230)";
+  const BG1 = "#eeeeee";
+  const BG2 = "#eeeeb0";
+
+  // The frame color is the SAME hash-to-warm-color mapping the on-screen canvas
+  // uses (hue range 10–50, red/orange — flamegraph.pl's "hot" palette family),
+  // sourced from trace_analysis.js so the export and the canvas can never drift.
+  function getAnalysis() {
+    if (typeof require !== "undefined") return require("./trace_analysis.js");
+    if (typeof TraceAnalysis !== "undefined") return TraceAnalysis;
+    throw new Error(
+      "TraceAnalysis not found. Load trace_analysis.js before flamegraph_export.js"
+    );
+  }
+  const flamegraphColor = getAnalysis().flamegraphColor;
+
+  function escapeXml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;");
+  }
+
+  // 1234567 -> "1,234,567"
+  function withCommas(n) {
+    const s = String(n);
+    return s.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+
+  // ── Folded stacks ──────────────────────────────────────────────────────
+  // Walk a tree into the universal folded-stacks format. Each frame contributes
+  // its own self-weight under the full path from root to that frame. The
+  // synthetic "(all)" root is not emitted as a path component. Counts are
+  // rounded to integers because the folded format and its consumers (inferno,
+  // flamegraph.pl) expect integer sample counts; the SVG keeps exact weights.
+  function treeToFolded(root) {
+    if (!root) return "";
+    const lines = [];
+    function walk(node, stack) {
+      const label = node === root ? null : (node.fullName || node.name);
+      const path = label == null ? stack : stack.concat(label);
+      const self = Math.round(node.self || 0);
+      if (self > 0 && path.length > 0) {
+        lines.push(path.join(";") + " " + self);
+      }
+      const kids = [...node.children.values()].sort((a, b) => b.count - a.count);
+      for (const child of kids) walk(child, path);
+    }
+    walk(root, []);
+    return lines.join("\n") + (lines.length ? "\n" : "");
+  }
+
+  // ── Interactive SVG ────────────────────────────────────────────────────
+
+  // Merge the (worker / off-worker) panels into ONE single-rooted tree, which
+  // is what a normal flame graph is. flamegraph.pl's embedded JS assumes a
+  // single full-width root frame (its search percentage relies on it), so:
+  //   - one panel with data  → use that panel's tree directly as the root.
+  //   - several panels        → synthesize a root whose children are the panels,
+  //     each wrapped in a labeled frame, preserving the worker/off-worker split
+  //     while keeping a single zoomable, searchable graph.
+  // Returns null when there is nothing to draw. Read-only: never mutates inputs.
+  function buildExportRoot(panels) {
+    const usable = (panels || []).filter((p) => p && p.tree && p.tree.count > 0);
+    if (usable.length === 0) return null;
+    if (usable.length === 1) return usable[0].tree;
+    let total = 0;
+    const children = new Map();
+    for (const p of usable) {
+      total += p.tree.count;
+      children.set("[" + p.label + "]", {
+        name: "[" + p.label + "]",
+        fullName: "[" + p.label + "]",
+        location: null,
+        count: p.tree.count,
+        self: 0,
+        children: p.tree.children,
+      });
+    }
+    return { name: "", fullName: "", location: null, count: total, self: 0, children };
+  }
+
+  // Lay a tree out into flat positioned frames using flamegraph.pl's geometry:
+  // x is cumulative count-space, children packed left-to-right within their
+  // parent's span, sorted by descending count (matching the on-screen view).
+  // Frames (and their subtrees) narrower than `minTime` count-units are pruned,
+  // exactly like flamegraph.pl's narrow-block removal.
+  function layoutTree(root, minTime) {
+    const frames = [];
+    let maxDepth = 0;
+    function walk(node, depth, sTime) {
+      const eTime = sTime + node.count;
+      if (eTime - sTime < minTime && depth > 0) return; // keep the root always
+      if (depth > maxDepth) maxDepth = depth;
+      frames.push({ node, depth, sTime, eTime });
+      let cx = sTime;
+      const kids = [...node.children.values()].sort((a, b) => b.count - a.count);
+      for (const child of kids) {
+        walk(child, depth + 1, cx);
+        cx += child.count;
+      }
+    }
+    walk(root, 0, 0);
+    return { frames, maxDepth };
+  }
+
+  // The embedded interactive script, ported from flamegraph.pl's CDATA block
+  // (https://github.com/brendangregg/FlameGraph). Perl tunables are substituted
+  // with the literals above (xpad=10, fontsize=12, fontwidth=0.59, inverted=0).
+  // Behavior is intentionally identical: click=zoom, mouseover=details,
+  // Ctrl-F=search, Ctrl-I=ignorecase, Reset Zoom, and URL state restore.
+  function embeddedScript() {
+    return [
+      '"use strict";',
+      "var details, searchbtn, unzoombtn, matchedtxt, svg, searching, currentSearchTerm, ignorecase, ignorecaseBtn;",
+      "function init(evt) {",
+      '  details = document.getElementById("details").firstChild;',
+      '  searchbtn = document.getElementById("search");',
+      '  ignorecaseBtn = document.getElementById("ignorecase");',
+      '  unzoombtn = document.getElementById("unzoom");',
+      '  matchedtxt = document.getElementById("matched");',
+      '  svg = document.getElementsByTagName("svg")[0];',
+      "  searching = 0;",
+      "  currentSearchTerm = null;",
+      "  var params = get_params();",
+      "  if (params.x && params.y)",
+      "    zoom(find_group(document.querySelector('[x=\"' + params.x + '\"][y=\"' + params.y + '\"]')));",
+      "  if (params.s) search(params.s);",
+      "}",
+      'window.addEventListener("click", function(e) {',
+      "  var target = find_group(e.target);",
+      "  if (target) {",
+      '    if (target.nodeName == "a") { if (e.ctrlKey === false) return; e.preventDefault(); }',
+      '    if (target.classList.contains("parent")) unzoom(true);',
+      "    zoom(target);",
+      "    if (!document.querySelector('.parent')) {",
+      "      var params = get_params();",
+      "      if (params.x) delete params.x;",
+      "      if (params.y) delete params.y;",
+      "      history.replaceState(null, null, parse_params(params));",
+      '      unzoombtn.classList.add("hide");',
+      "      return;",
+      "    }",
+      '    var el = target.querySelector("rect");',
+      "    if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {",
+      "      var params = get_params();",
+      "      params.x = el.attributes._orig_x.value;",
+      "      params.y = el.attributes.y.value;",
+      "      history.replaceState(null, null, parse_params(params));",
+      "    }",
+      "  }",
+      '  else if (e.target.id == "unzoom") clearzoom();',
+      '  else if (e.target.id == "search") search_prompt();',
+      '  else if (e.target.id == "ignorecase") toggle_ignorecase();',
+      "}, false)",
+      'window.addEventListener("mouseover", function(e) {',
+      "  var target = find_group(e.target);",
+      '  if (target) details.nodeValue = "Function: " + g_to_text(target);',
+      "}, false)",
+      'window.addEventListener("mouseout", function(e) {',
+      "  var target = find_group(e.target);",
+      "  if (target) details.nodeValue = ' ';",
+      "}, false)",
+      'window.addEventListener("keydown",function (e) {',
+      "  if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) { e.preventDefault(); search_prompt(); }",
+      "  else if (e.ctrlKey && e.keyCode === 73) { e.preventDefault(); toggle_ignorecase(); }",
+      "}, false)",
+      "function get_params() {",
+      "  var params = {};",
+      "  var paramsarr = window.location.search.substr(1).split('&');",
+      "  for (var i = 0; i < paramsarr.length; ++i) {",
+      '    var tmp = paramsarr[i].split("=");',
+      "    if (!tmp[0] || !tmp[1]) continue;",
+      "    params[tmp[0]]  = decodeURIComponent(tmp[1]);",
+      "  }",
+      "  return params;",
+      "}",
+      "function parse_params(params) {",
+      '  var uri = "?";',
+      "  for (var key in params) { uri += key + '=' + encodeURIComponent(params[key]) + '&'; }",
+      '  if (uri.slice(-1) == "&") uri = uri.substring(0, uri.length - 1);',
+      "  if (uri == '?') uri = window.location.href.split('?')[0];",
+      "  return uri;",
+      "}",
+      "function find_child(node, selector) {",
+      "  var children = node.querySelectorAll(selector);",
+      "  if (children.length) return children[0];",
+      "}",
+      "function find_group(node) {",
+      "  var parent = node.parentElement;",
+      "  if (!parent) return;",
+      '  if (parent.id == "frames") return node;',
+      "  return find_group(parent);",
+      "}",
+      "function orig_save(e, attr, val) {",
+      '  if (e.attributes["_orig_" + attr] != undefined) return;',
+      "  if (e.attributes[attr] == undefined) return;",
+      "  if (val == undefined) val = e.attributes[attr].value;",
+      '  e.setAttribute("_orig_" + attr, val);',
+      "}",
+      "function orig_load(e, attr) {",
+      '  if (e.attributes["_orig_"+attr] == undefined) return;',
+      '  e.attributes[attr].value = e.attributes["_orig_" + attr].value;',
+      '  e.removeAttribute("_orig_"+attr);',
+      "}",
+      "function g_to_text(e) {",
+      '  var text = find_child(e, "title").firstChild.nodeValue;',
+      "  return (text)",
+      "}",
+      "function g_to_func(e) {",
+      "  var func = g_to_text(e);",
+      "  return (func);",
+      "}",
+      "function update_text(e) {",
+      '  var r = find_child(e, "rect");',
+      '  var t = find_child(e, "text");',
+      "  var w = parseFloat(r.attributes.width.value) -3;",
+      '  var txt = find_child(e, "title").textContent.replace(/\\([^(]*\\)$/,"");',
+      "  t.attributes.x.value = parseFloat(r.attributes.x.value) + 3;",
+      "  if (w < 2 * " + FONT_SIZE + " * " + FONT_WIDTH + ") { t.textContent = \"\"; return; }",
+      "  t.textContent = txt;",
+      "  var sl = t.getSubStringLength(0, txt.length);",
+      "  if (/^ *$/.test(txt) || sl < w) return;",
+      "  var start = Math.floor((w/sl) * txt.length);",
+      "  for (var x = start; x > 0; x = x-2) {",
+      "    if (t.getSubStringLength(0, x + 2) <= w) { t.textContent = txt.substring(0, x) + '..'; return; }",
+      "  }",
+      '  t.textContent = "";',
+      "}",
+      "function zoom_reset(e) {",
+      "  if (e.attributes != undefined) { orig_load(e, 'x'); orig_load(e, 'width'); }",
+      "  if (e.childNodes == undefined) return;",
+      "  for (var i = 0, c = e.childNodes; i < c.length; i++) { zoom_reset(c[i]); }",
+      "}",
+      "function zoom_child(e, x, ratio) {",
+      "  if (e.attributes != undefined) {",
+      "    if (e.attributes.x != undefined) {",
+      "      orig_save(e, 'x');",
+      "      e.attributes.x.value = (parseFloat(e.attributes.x.value) - x - " + XPAD + ") * ratio + " + XPAD + ";",
+      "      if (e.tagName == 'text') e.attributes.x.value = find_child(e.parentNode, 'rect[x]').attributes.x.value + 3;",
+      "    }",
+      "    if (e.attributes.width != undefined) {",
+      "      orig_save(e, 'width');",
+      "      e.attributes.width.value = parseFloat(e.attributes.width.value) * ratio;",
+      "    }",
+      "  }",
+      "  if (e.childNodes == undefined) return;",
+      "  for (var i = 0, c = e.childNodes; i < c.length; i++) { zoom_child(c[i], x - " + XPAD + ", ratio); }",
+      "}",
+      "function zoom_parent(e) {",
+      "  if (e.attributes) {",
+      "    if (e.attributes.x != undefined) { orig_save(e, 'x'); e.attributes.x.value = " + XPAD + "; }",
+      "    if (e.attributes.width != undefined) { orig_save(e, 'width'); e.attributes.width.value = parseInt(svg.width.baseVal.value) - (" + XPAD + " * 2); }",
+      "  }",
+      "  if (e.childNodes == undefined) return;",
+      "  for (var i = 0, c = e.childNodes; i < c.length; i++) { zoom_parent(c[i]); }",
+      "}",
+      "function zoom(node) {",
+      "  var attr = find_child(node, 'rect').attributes;",
+      "  var width = parseFloat(attr.width.value);",
+      "  var xmin = parseFloat(attr.x.value);",
+      "  var xmax = parseFloat(xmin + width);",
+      "  var ymin = parseFloat(attr.y.value);",
+      "  var ratio = (svg.width.baseVal.value - 2 * " + XPAD + ") / width;",
+      "  var fudge = 0.0001;",
+      "  unzoombtn.classList.remove('hide');",
+      "  var el = document.getElementById('frames').children;",
+      "  for (var i = 0; i < el.length; i++) {",
+      "    var e = el[i];",
+      "    var a = find_child(e, 'rect').attributes;",
+      "    var ex = parseFloat(a.x.value);",
+      "    var ew = parseFloat(a.width.value);",
+      "    var upstack;",
+      "    upstack = parseFloat(a.y.value) > ymin;",
+      "    if (upstack) {",
+      "      if (ex <= xmin && (ex+ew+fudge) >= xmax) { e.classList.add('parent'); zoom_parent(e); update_text(e); }",
+      "      else e.classList.add('hide');",
+      "    } else {",
+      "      if (ex < xmin || ex + fudge >= xmax) { e.classList.add('hide'); }",
+      "      else { zoom_child(e, xmin, ratio); update_text(e); }",
+      "    }",
+      "  }",
+      "  search();",
+      "}",
+      "function unzoom(dont_update_text) {",
+      "  unzoombtn.classList.add('hide');",
+      "  var el = document.getElementById('frames').children;",
+      "  for(var i = 0; i < el.length; i++) {",
+      "    el[i].classList.remove('parent');",
+      "    el[i].classList.remove('hide');",
+      "    zoom_reset(el[i]);",
+      "    if(!dont_update_text) update_text(el[i]);",
+      "  }",
+      "  search();",
+      "}",
+      "function clearzoom() {",
+      "  unzoom();",
+      "  var params = get_params();",
+      "  if (params.x) delete params.x;",
+      "  if (params.y) delete params.y;",
+      "  history.replaceState(null, null, parse_params(params));",
+      "}",
+      "function toggle_ignorecase() {",
+      "  ignorecase = !ignorecase;",
+      "  if (ignorecase) { ignorecaseBtn.classList.add('show'); } else { ignorecaseBtn.classList.remove('show'); }",
+      "  reset_search();",
+      "  search();",
+      "}",
+      "function reset_search() {",
+      "  var el = document.querySelectorAll('#frames rect');",
+      "  for (var i = 0; i < el.length; i++) { orig_load(el[i], 'fill') }",
+      "  var params = get_params();",
+      "  delete params.s;",
+      "  history.replaceState(null, null, parse_params(params));",
+      "}",
+      "function search_prompt() {",
+      "  if (!searching) {",
+      "    var term = prompt('Enter a search term (regexp allowed, eg: ^ext4_)' + (ignorecase ? ', ignoring case' : '') + '\\nPress Ctrl-i to toggle case sensitivity', '');",
+      "    if (term != null) search(term);",
+      "  } else {",
+      "    reset_search();",
+      "    searching = 0;",
+      "    currentSearchTerm = null;",
+      "    searchbtn.classList.remove('show');",
+      "    searchbtn.firstChild.nodeValue = 'Search';",
+      "    matchedtxt.classList.add('hide');",
+      "    matchedtxt.firstChild.nodeValue = '';",
+      "  }",
+      "}",
+      "function search(term) {",
+      "  if (term) currentSearchTerm = term;",
+      "  var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');",
+      "  var el = document.getElementById('frames').children;",
+      "  var matches = new Object();",
+      "  var maxwidth = 0;",
+      "  for (var i = 0; i < el.length; i++) {",
+      "    var e = el[i];",
+      "    var func = g_to_func(e);",
+      "    var rect = find_child(e, 'rect');",
+      "    if (func == null || rect == null) continue;",
+      "    var w = parseFloat(rect.attributes.width.value);",
+      "    if (w > maxwidth) maxwidth = w;",
+      "    if (func.match(re)) {",
+      "      var x = parseFloat(rect.attributes.x.value);",
+      "      orig_save(rect, 'fill');",
+      "      rect.attributes.fill.value = '" + SEARCH_COLOR + "';",
+      "      if (matches[x] == undefined) { matches[x] = w; } else { if (w > matches[x]) { matches[x] = w; } }",
+      "      searching = 1;",
+      "    }",
+      "  }",
+      "  if (!searching) return;",
+      "  var params = get_params();",
+      "  params.s = currentSearchTerm;",
+      "  history.replaceState(null, null, parse_params(params));",
+      "  searchbtn.classList.add('show');",
+      "  searchbtn.firstChild.nodeValue = 'Reset Search';",
+      "  var count = 0;",
+      "  var lastx = -1;",
+      "  var lastw = 0;",
+      "  var keys = Array();",
+      "  for (k in matches) { if (matches.hasOwnProperty(k)) keys.push(k); }",
+      "  keys.sort(function(a, b){ return a - b; });",
+      "  var fudge = 0.0001;",
+      "  for (var k in keys) {",
+      "    var x = parseFloat(keys[k]);",
+      "    var w = matches[keys[k]];",
+      "    if (x >= lastx + lastw - fudge) { count += w; lastx = x; lastw = w; }",
+      "  }",
+      "  matchedtxt.classList.remove('hide');",
+      "  var pct = 100 * count / maxwidth;",
+      "  if (pct != 100) pct = pct.toFixed(1)",
+      "  matchedtxt.firstChild.nodeValue = 'Matched: ' + pct + '%';",
+      "}",
+    ].join("\n");
+  }
+
+  // Render `panels` into a single standalone, interactive flame graph SVG.
+  // panels: Array<{ label: string, tree: object }>
+  // opts:   { title?: string, width?: number, formatValue?: (count) => string }
+  //   formatValue turns a node's weight into the human-readable quantity shown
+  //   in each frame's hover text. It defaults to CPU samples ("1,234 samples");
+  //   heap exports pass a formatter that renders bytes ("5.2 MB") or allocation
+  //   counts ("1,234 allocs") so the SVG matches the on-screen graph.
+  function treeToInteractiveSvg(panels, opts) {
+    opts = opts || {};
+    const W = opts.width || DEFAULT_WIDTH;
+    const title = opts.title || "Flame Graph";
+    const formatValue =
+      typeof opts.formatValue === "function"
+        ? opts.formatValue
+        : (count) => withCommas(Math.round(count)) + " samples";
+    const root = buildExportRoot(panels);
+
+    // Empty graph: still a valid, well-formed SVG with a message.
+    if (!root) {
+      const h = YPAD1 + YPAD2 + FRAME_HEIGHT;
+      return (
+        '<?xml version="1.0" standalone="no"?>\n' +
+        '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
+        `<svg version="1.1" width="${W}" height="${h}" viewBox="0 0 ${W} ${h}" ` +
+        'xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' +
+        `<rect width="${W}" height="${h}" fill="${BG1}"/>\n` +
+        `<text x="${W / 2}" y="${FONT_SIZE * 2}" text-anchor="middle" ` +
+        `font-family="${FONT_TYPE}" font-size="${FONT_SIZE + 5}">${escapeXml(title)}</text>\n` +
+        `<text x="${XPAD}" y="${FONT_SIZE * 4}" font-family="${FONT_TYPE}" ` +
+        `font-size="${FONT_SIZE}">No data to export.</text>\n</svg>\n`
+      );
+    }
+
+    const timemax = root.count;
+    const widthPerTime = (W - 2 * XPAD) / timemax;
+    const minTime = MINWIDTH_PX / widthPerTime;
+    const { frames, maxDepth } = layoutTree(root, minTime);
+
+    const H = (maxDepth + 1) * FRAME_HEIGHT + YPAD1 + YPAD2;
+
+    const out = [];
+    out.push('<?xml version="1.0" standalone="no"?>');
+    out.push('<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">');
+    out.push(
+      `<svg version="1.1" width="${W}" height="${H}" onload="init(evt)" viewBox="0 0 ${W} ${H}" ` +
+        'xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">'
+    );
+    out.push("<!-- Flame graph stack visualization. Exported by dial9. " +
+      "Structure & script ported from https://github.com/brendangregg/FlameGraph -->");
+    out.push("<defs>");
+    out.push('<linearGradient id="background" y1="0" y2="1" x1="0" x2="0">');
+    out.push(`<stop stop-color="${BG1}" offset="5%"/>`);
+    out.push(`<stop stop-color="${BG2}" offset="95%"/>`);
+    out.push("</linearGradient>");
+    out.push("</defs>");
+    out.push('<style type="text/css">');
+    out.push(`  text { font-family:${FONT_TYPE}; font-size:${FONT_SIZE}px; fill:rgb(0,0,0); }`);
+    out.push("  #search, #ignorecase { opacity:0.1; cursor:pointer; }");
+    out.push("  #search:hover, #search.show, #ignorecase:hover, #ignorecase.show { opacity:1; }");
+    out.push("  #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }");
+    out.push(`  #title { text-anchor:middle; font-size:${FONT_SIZE + 5}px}`);
+    out.push("  #unzoom { cursor:pointer; }");
+    out.push("  #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }");
+    out.push("  .hide { display:none; }");
+    out.push("  .parent { opacity:0.5; }");
+    out.push("</style>");
+    out.push('<script type="text/ecmascript">');
+    out.push("<![CDATA[");
+    out.push(embeddedScript());
+    out.push("]]>");
+    out.push("</script>");
+
+    // Background + chrome.
+    out.push(`<rect x="0" y="0" width="${W}" height="${H}" fill="url(#background)"/>`);
+    out.push(`<text id="title" x="${(W / 2).toFixed(2)}" y="${FONT_SIZE * 2}">${escapeXml(title)}</text>`);
+    out.push(`<text id="details" x="${XPAD}" y="${H - YPAD2 / 2}"> </text>`);
+    out.push(`<text id="unzoom" x="${XPAD}" y="${FONT_SIZE * 2}" class="hide">Reset Zoom</text>`);
+    out.push(`<text id="search" x="${W - XPAD - 100}" y="${FONT_SIZE * 2}">Search</text>`);
+    out.push(`<text id="ignorecase" x="${W - XPAD - 16}" y="${FONT_SIZE * 2}">ic</text>`);
+    out.push(`<text id="matched" x="${W - XPAD - 100}" y="${H - YPAD2 / 2}"> </text>`);
+
+    // Frames.
+    out.push('<g id="frames">');
+    for (const f of frames) {
+      const node = f.node;
+      // Round x1/x2 to 0.1px FIRST, then derive width from the rounded edges —
+      // exactly like flamegraph.pl's filledRectangle. Computing width from the
+      // unrounded delta and rounding it independently lets a frame's emitted
+      // right edge (x + width) drift from round(x2) by up to 0.1px. The embedded
+      // zoom's ancestor test `ex <= xmin && (ex+ew+fudge) >= xmax` uses
+      // fudge=0.0001, so a last child sharing its parent's right edge could,
+      // after independent double-rounding, push past it and fail the test —
+      // leaving the ancestor's context row blank on zoom.
+      const rx1 = Number((XPAD + f.sTime * widthPerTime).toFixed(1));
+      const rx2 = Number((XPAD + f.eTime * widthPerTime).toFixed(1));
+      const x1 = rx1;
+      const w = rx2 - rx1;
+      const y1 = H - YPAD2 - (f.depth + 1) * FRAME_HEIGHT + FRAME_PAD;
+      const y2 = H - YPAD2 - f.depth * FRAME_HEIGHT;
+      const h = y2 - y1;
+
+      const isRoot = f.depth === 0;
+      const pct = ((100 * node.count) / timemax).toFixed(2);
+      const fullName = node.fullName || node.name || "";
+      const value = formatValue(node.count);
+      const info = isRoot
+        ? `all (${value}, 100%)`
+        : `${fullName} (${value}, ${pct}%)`;
+
+      // Label text: truncated function name that fits the rect width.
+      let label = "";
+      if (!isRoot) {
+        const chars = Math.floor(w / (FONT_SIZE * FONT_WIDTH));
+        if (chars >= 3) {
+          const nm = node.name || "";
+          label = nm.slice(0, chars);
+          if (chars < nm.length) label = label.slice(0, -2) + "..";
+        }
+      }
+
+      const fill = isRoot ? flamegraphColor("root") : flamegraphColor(node.name || "");
+      out.push("<g>");
+      out.push(`<title>${escapeXml(info)}</title>`);
+      out.push(
+        `<rect x="${x1.toFixed(1)}" y="${y1.toFixed(1)}" width="${w.toFixed(1)}" ` +
+          `height="${h.toFixed(1)}" fill="${fill}" rx="2" ry="2"/>`
+      );
+      out.push(
+        `<text x="${(x1 + 3).toFixed(2)}" y="${(3 + (y1 + y2) / 2).toFixed(1)}">${escapeXml(label)}</text>`
+      );
+      out.push("</g>");
+    }
+    out.push("</g>");
+    out.push("</svg>");
+    out.push("");
+    return out.join("\n");
+  }
+
+  // Sanitize an arbitrary label into a safe filename stem. Trims leading/
+  // trailing underscores AND dots so we never emit a dotfile (".cache") or a
+  // name that is only punctuation (".."); falls back to "flamegraph".
+  function filenameStem(label) {
+    const base = (label || "flamegraph")
+      .replace(/^Flamegraph\s*—\s*/i, "")
+      .replace(/[^A-Za-z0-9._-]+/g, "_")
+      .replace(/^[._]+|[._]+$/g, "");
+    return base || "flamegraph";
+  }
+
+  const api = {
+    treeToFolded,
+    treeToInteractiveSvg,
+    buildExportRoot,
+    layoutTree,
+    filenameStem,
+    flamegraphColor,
+    escapeXml,
+  };
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  } else {
+    exports.FlamegraphExport = api;
+  }
+})(typeof exports === "undefined" ? this : exports);

--- a/dial9-viewer/ui/test_flamegraph_export.js
+++ b/dial9-viewer/ui/test_flamegraph_export.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+"use strict";
+
+// Tests for flamegraph_export.js — the folded-stacks serializer and the
+// interactive-SVG generator. These run against both a hand-built tree (for
+// exact-output assertions) and a tree built from demo-trace.bin via
+// buildFlamegraphTree (for the real node shape), so the export stays in
+// lockstep with the analysis layer.
+
+const fs = require("fs");
+const path = require("path");
+const { assert, test, testAsync, summarize } = require("./test_harness.js");
+const FE = require("./flamegraph_export.js");
+const { parseTrace } = require("./trace_parser.js");
+const TraceAnalysis = require("./trace_analysis.js");
+
+// Build a small tree matching the buildFlamegraphTree output shape.
+function node(name, count, self, children) {
+  const m = new Map();
+  for (const c of children || []) m.set(c.fullName || c.name, c);
+  return { name, fullName: name, location: null, count, self: self, children: m };
+}
+
+function makeTree() {
+  // (all) 100
+  //  └─ main 100 (self 0)
+  //      ├─ work 60 (self 40)
+  //      │   └─ inner 20 (self 20)
+  //      └─ idle 40 (self 40)
+  const inner = node("inner", 20, 20, []);
+  const work = node("work", 60, 40, [inner]);
+  const idle = node("idle", 40, 40, []);
+  const main = node("main", 100, 0, [work, idle]);
+  return node("(all)", 100, 0, [main]);
+}
+
+// ── Folded stacks ──────────────────────────────────────────────────────
+test("treeToFolded emits one line per self-bearing leaf path", () => {
+  const folded = FE.treeToFolded(makeTree());
+  const lines = folded.trim().split("\n").sort();
+  assert.deepStrictEqual(lines, [
+    "main;idle 40",
+    "main;work 40",
+    "main;work;inner 20",
+  ]);
+});
+
+test("treeToFolded omits the synthetic (all) root from paths", () => {
+  assert.ok(!FE.treeToFolded(makeTree()).includes("(all)"));
+});
+
+test("treeToFolded self-weights sum to the root count", () => {
+  const sum = FE.treeToFolded(makeTree())
+    .trim()
+    .split("\n")
+    .reduce((acc, l) => acc + Number(l.slice(l.lastIndexOf(" ") + 1)), 0);
+  assert.strictEqual(sum, 100);
+});
+
+test("treeToFolded on empty/null tree is a safe empty string", () => {
+  assert.strictEqual(FE.treeToFolded(null), "");
+  assert.strictEqual(FE.treeToFolded(node("(all)", 0, 0, [])), "");
+});
+
+test("treeToFolded on an all-internal tree (no self weight) is empty", () => {
+  // The folded-export concat in flamegraph.js skips panels whose treeToFolded
+  // is "" so it never emits a dangling "# label" header; this is that precondition.
+  const internal = node("(all)", 50, 0, [node("a", 50, 0, [node("b", 0, 0, [])])]);
+  assert.strictEqual(FE.treeToFolded(internal), "");
+});
+
+// ── buildExportRoot (panel merge) ────────────────────────────────────────
+test("buildExportRoot returns the single panel's tree unchanged", () => {
+  const t = makeTree();
+  const root = FE.buildExportRoot([{ label: "Worker threads", tree: t }]);
+  assert.strictEqual(root, t, "single panel should pass through by identity");
+});
+
+test("buildExportRoot synthesizes a combined root for multiple panels", () => {
+  const a = makeTree();
+  const b = node("(all)", 50, 0, [node("other", 50, 50, [])]);
+  const root = FE.buildExportRoot([
+    { label: "Worker threads", tree: a },
+    { label: "Off-worker", tree: b },
+  ]);
+  assert.strictEqual(root.count, 150, "root count = sum of panels");
+  assert.strictEqual(root.children.size, 2, "one child frame per panel");
+  assert.ok(root.children.has("[Worker threads]"));
+  assert.ok(root.children.has("[Off-worker]"));
+  // Must NOT mutate inputs.
+  assert.strictEqual(a.count, 100);
+});
+
+test("buildExportRoot returns null when there is no data", () => {
+  assert.strictEqual(FE.buildExportRoot([]), null);
+  assert.strictEqual(FE.buildExportRoot([{ label: "x", tree: node("(all)", 0, 0, []) }]), null);
+});
+
+// ── layout ──────────────────────────────────────────────────────────────
+test("layoutTree packs children left-to-right by descending count", () => {
+  const { frames, maxDepth } = FE.layoutTree(makeTree(), 0);
+  assert.strictEqual(maxDepth, 3, "(all)=0, main=1, work/idle=2, inner=3");
+  // The root frame must exist at depth 0 spanning the full count range.
+  const root = frames.find((f) => f.depth === 0);
+  assert.strictEqual(root.sTime, 0);
+  assert.strictEqual(root.eTime, 100);
+  // 'work' (60) is wider so it must be placed before 'idle' (40): work starts at 0.
+  const depth2 = frames.filter((f) => f.depth === 2).sort((a, b) => a.sTime - b.sTime);
+  assert.strictEqual(depth2[0].node.name, "work");
+});
+
+// ── Interactive SVG ──────────────────────────────────────────────────────
+function svgOf(panels, opts) {
+  return FE.treeToInteractiveSvg(panels, opts);
+}
+
+test("treeToInteractiveSvg produces a well-formed standalone svg", () => {
+  const svg = svgOf([{ label: "Worker threads", tree: makeTree() }], { title: "T" });
+  assert.ok(svg.includes("<svg "), "has <svg>");
+  assert.ok(svg.trim().endsWith("</svg>"), "ends with </svg>");
+  assert.ok(svg.includes('xmlns="http://www.w3.org/2000/svg"'), "svg namespace");
+  assert.ok(svg.includes('onload="init(evt)"'), "wires the init() entrypoint");
+});
+
+test("treeToInteractiveSvg embeds the interactive script + chrome", () => {
+  const svg = svgOf([{ label: "W", tree: makeTree() }], {});
+  // The interactive behaviors must all be present in the embedded script.
+  for (const fn of ["function zoom(", "function search(", "function unzoom(",
+    "function toggle_ignorecase(", "function init(", "function update_text("]) {
+    assert.ok(svg.includes(fn), `embedded script defines ${fn}`);
+  }
+  // Clickable chrome elements the script binds to by id.
+  for (const id of ['id="unzoom"', 'id="search"', 'id="ignorecase"', 'id="details"', 'id="matched"', 'id="frames"']) {
+    assert.ok(svg.includes(id), `has element ${id}`);
+  }
+  // CDATA wrapping so the JS survives XML parsing.
+  assert.ok(svg.includes("<![CDATA[") && svg.includes("]]>"), "script is CDATA-wrapped");
+});
+
+test("treeToInteractiveSvg frames carry title+rect+text in a <g> (zoom contract)", () => {
+  const svg = svgOf([{ label: "W", tree: makeTree() }], {});
+  // The embedded JS relies on each frame being <g><title/><rect/><text/></g>.
+  assert.ok(/<g>\s*<title>[^<]*<\/title>\s*<rect /.test(svg), "g>title>rect order");
+  assert.ok(svg.includes("work ("), "frame title shows func + samples");
+  assert.ok(svg.includes("all (100 samples, 100%)"), "root frame labeled 'all ... 100%'");
+});
+
+test("treeToInteractiveSvg escapes XML metacharacters in frame names", () => {
+  const t = node("(all)", 10, 0, [node('a<b>&"x', 10, 10, [])]);
+  const svg = svgOf([{ label: "L", tree: t }], {});
+  assert.ok(!svg.includes("a<b>"), "raw < must be escaped");
+  assert.ok(svg.includes("&lt;") && svg.includes("&amp;"), "uses entities");
+});
+
+test("treeToInteractiveSvg defaults frame weights to 'samples'", () => {
+  // Frame weight is the node's total count (work=60), not its self weight.
+  const svg = svgOf([{ label: "W", tree: makeTree() }], { title: "T" });
+  assert.ok(svg.includes("work (60 samples,"), "leaf labeled in samples");
+  assert.ok(svg.includes("all (100 samples, 100%)"), "root labeled in samples");
+});
+
+test("treeToInteractiveSvg uses formatValue for frame weights (heap units)", () => {
+  // Heap exports pass a formatter that renders bytes/allocs instead of samples.
+  const fmt = (count) => `~${count} B`;
+  const svg = svgOf([{ label: "W", tree: makeTree() }], { title: "T", formatValue: fmt });
+  assert.ok(svg.includes("all (~100 B, 100%)"), "root uses formatValue");
+  assert.ok(svg.includes("work (~60 B,"), "leaf uses formatValue");
+  assert.ok(!/\d samples/.test(svg), "no hardcoded 'samples' when formatValue is supplied");
+});
+
+test("treeToInteractiveSvg with no usable panels renders a placeholder, not a crash", () => {
+  const svg = svgOf([{ label: "L", tree: node("(all)", 0, 0, []) }], {});
+  assert.ok(svg.includes("<svg ") && svg.includes("No data to export"));
+});
+
+test("treeToInteractiveSvg merges multiple panels into one searchable graph", () => {
+  const a = makeTree();
+  const b = node("(all)", 50, 0, [node("other", 50, 50, [])]);
+  const svg = svgOf([
+    { label: "Worker threads", tree: a },
+    { label: "Off-worker", tree: b },
+  ], { title: "combined" });
+  assert.ok(svg.includes("[Worker threads]"), "worker panel frame present");
+  assert.ok(svg.includes("[Off-worker]"), "off-worker panel frame present");
+  assert.ok(svg.includes("all (150 samples, 100%)"), "combined root = 150 samples");
+});
+
+// Regression: a last child that exactly covers its parent's right edge must
+// emit an identical right edge (x+width) after rounding, or the embedded zoom's
+// ancestor test (fudge=0.0001) fails and the ancestor row blanks out on zoom.
+// We use sample counts that force fractional pixel positions.
+test("coinciding parent/child right edges round identically", () => {
+  // parent=37 split into first=20, last=17 (last covers parent's right edge).
+  // 37 over a 1200px-wide graph yields non-grid pixel positions.
+  const last = node("last", 17, 17, []);
+  const first = node("first", 20, 20, []);
+  const parent = node("parent", 37, 0, [first, last]);
+  const root = node("(all)", 37, 0, [parent]);
+  const svg = svgOf([{ label: "W", tree: root }], {});
+  // Pull every FRAME rect's x and width (frame rects carry rx="2"; the
+  // background rect does not, so this excludes it).
+  const rects = [...svg.matchAll(/<rect x="([\d.]+)" y="[\d.]+" width="([\d.]+)"[^/]*rx="2"/g)]
+    .map((m) => ({ x: Number(m[1]), w: Number(m[2]), right: Number(m[1]) + Number(m[2]) }));
+  assert.ok(rects.length >= 4, `expected >=4 rects, got ${rects.length}`);
+  // The widest rects (root, parent) and the last child should share a right edge.
+  const maxRight = Math.max(...rects.map((r) => r.right));
+  const sharing = rects.filter((r) => Math.abs(r.right - maxRight) < 1e-9);
+  // root + parent + last child = at least 3 frames share the max right edge.
+  assert.ok(sharing.length >= 3,
+    `expected >=3 frames to share the right edge exactly, got ${sharing.length} (rights: ${rects.map((r) => r.right.toFixed(1)).join(",")})`);
+});
+
+// ── filename ──────────────────────────────────────────────────────────────
+test("filenameStem sanitizes labels into safe stems", () => {
+  assert.strictEqual(FE.filenameStem("Flamegraph — Magnus @ host-1"), "Magnus_host-1");
+  assert.strictEqual(FE.filenameStem(""), "flamegraph");
+  assert.strictEqual(FE.filenameStem("a/b\\c d"), "a_b_c_d");
+});
+
+test("filenameStem never produces a dotfile or punctuation-only name", () => {
+  // Leading/trailing dots must be trimmed so the download is not a hidden file
+  // and dot-only inputs fall back to the default stem.
+  assert.strictEqual(FE.filenameStem(".."), "flamegraph");
+  assert.strictEqual(FE.filenameStem("..."), "flamegraph");
+  assert.strictEqual(FE.filenameStem(".cache"), "cache");
+  assert.strictEqual(FE.filenameStem("a..."), "a");
+  assert.strictEqual(FE.filenameStem("Flamegraph — .."), "flamegraph");
+});
+
+async function main() {
+  const tracePath = path.join(__dirname, "demo-trace.bin");
+  if (fs.existsSync(tracePath)) {
+    await testAsync("exports a real tree built from demo-trace.bin", async () => {
+      const trace = await parseTrace(fs.readFileSync(tracePath));
+      const samples = trace.cpuSamples.filter((s) => s.callchain.length > 0 && s.source !== 1);
+      assert.ok(samples.length > 0, "demo trace has CPU samples");
+      const tree = TraceAnalysis.buildFlamegraphTree(samples, trace.callframeSymbols);
+
+      const folded = FE.treeToFolded(tree);
+      assert.ok(folded.length > 0, "folded output is non-empty");
+      for (const line of folded.trim().split("\n")) {
+        assert.ok(/ \d+$/.test(line), `folded line well-formed: ${line}`);
+      }
+
+      const svg = FE.treeToInteractiveSvg([{ label: "Worker threads", tree }], { title: "demo" });
+      assert.ok(svg.includes("<svg ") && svg.trim().endsWith("</svg>"));
+      assert.ok(svg.includes('onload="init(evt)"') && svg.includes("function zoom("));
+      // Sanity: many frames rendered from a real trace.
+      const frameCount = (svg.match(/<g>\s*<title>/g) || []).length;
+      assert.ok(frameCount > 10, `expected many frames, got ${frameCount}`);
+    });
+  } else {
+    console.log("(skipping demo-trace.bin test — file not present)");
+  }
+  summarize();
+}
+
+main();

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -616,6 +616,22 @@
   }
 
   /**
+   * Deterministic warm (red/orange) color for a frame, hashed from its name.
+   * Shared by the on-screen canvas (flamegraph.js) and the SVG export
+   * (flamegraph_export.js) so an exported graph matches what the user sees.
+   * @param {string} name frame name
+   * @returns {string} an `hsl(...)` color string
+   */
+  function flamegraphColor(name) {
+    let h = 0;
+    for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
+    const hue = 10 + (Math.abs(h) % 40);
+    const sat = 60 + (Math.abs(h >> 8) % 30);
+    const lit = 40 + (Math.abs(h >> 16) % 15);
+    return `hsl(${hue},${sat}%,${lit}%)`;
+  }
+
+  /**
    * Build a flamegraph tree from CPU samples with reversed callchains.
    * @param {import('./trace_parser.js').CpuSample[]} samples
    * @param {Map} callframeSymbols
@@ -1174,6 +1190,7 @@
     buildActiveTaskTimeline,
     computeSchedulingDelays,
     filterPointsOfInterest,
+    flamegraphColor,
     buildFlamegraphTree,
     flattenFlamegraph,
     buildFgData,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -915,6 +915,7 @@
         <script src="creds.js"></script>
         <script src="trace_analysis.js"></script>
         <script src="format.js"></script>
+        <script src="flamegraph_export.js"></script>
         <script src="flamegraph.js"></script>
         <script src="panel_layout.js"></script>
         <script>
@@ -5737,7 +5738,11 @@
                 if (wasHidden) widenSidebarForFlamegraph();
                 if (wasHidden && trace) requestAnimationFrame(renderAll);
                 requestAnimationFrame(() => {
-                    fgInstance.setData(samples, trace.callframeSymbols, fgOpts);
+                    // fgOpts may carry its own exportTitle/exportFormatValue (e.g. heap
+                    // views); fall back to the sidebar `title` only when it doesn't.
+                    const exportOpts = Object.assign({}, fgOpts);
+                    if (exportOpts.exportTitle == null) exportOpts.exportTitle = title;
+                    fgInstance.setData(samples, trace.callframeSymbols, exportOpts);
                     fgInstance.resize();
                 });
             }
@@ -5887,6 +5892,12 @@
                     return {
                         workerLabel: mode === "bytes" ? "Worker thread allocations (by bytes)" : "Worker thread allocations (by count)",
                         offworkerLabel: mode === "bytes" ? "Non-worker thread allocations (by bytes)" : "Non-worker thread allocations (by count)",
+                        exportTitle: `Heap flamegraph (${mode === "bytes" ? "by bytes" : "by count"})${durStr}`,
+                        // Heap weights are bytes (or alloc counts), not CPU samples, so
+                        // the exported SVG must label them the same way the canvas does.
+                        exportFormatValue: mode === "bytes"
+                            ? (count) => `~${fmtB(count)}`
+                            : (count) => `~${Math.round(count).toLocaleString()} allocs`,
                         formatCount(count, total, self, treeNode) {
                             const pct = ((count / total) * 100).toFixed(1);
                             if (mode === "bytes") {
@@ -6022,7 +6033,9 @@
 
                 // Give the container a frame to get its layout, then render
                 requestAnimationFrame(() => {
-                    fgInstance.setData(samples, trace.callframeSymbols);
+                    fgInstance.setData(samples, trace.callframeSymbols, {
+                        exportTitle: `CPU flamegraph — ${durMs}ms selected`,
+                    });
                     fgInstance.resize();
                 });
 

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -59,4 +59,7 @@ node dial9-viewer/ui/test_prefix_detection.js
 echo "--- Checking enclosing spans (per-worker) ---"
 node dial9-viewer/ui/test_enclosing_spans.js
 
+echo "--- Checking flamegraph export (folded + SVG) ---"
+node dial9-viewer/ui/test_flamegraph_export.js
+
 echo "All E2E trace checks passed."


### PR DESCRIPTION
Adds an "Export" control to the flamegraph toolbar that turns the rendered tree into two portable artifacts:

- Interactive SVG: a standalone, self-contained flame graph (hover, click-to- zoom, Ctrl-F regex search, URL state) ported from brendangregg/FlameGraph.
- Folded stacks (.txt): the universal `frame1;frame2 <count>` format consumed by inferno, flamegraph.pl, and speedscope.

The export module (flamegraph_export.js) is pure (no DOM/globals) so it runs under node for tests, and is embedded into the binary via rust-embed so the control is available without --dev.

Cleanups applied during review:
- Heap exports label weights as bytes/allocs (via a formatValue option), matching the on-screen graph, instead of hardcoding "samples".
- CPU-region and heap views thread descriptive export titles + filenames.
- filenameStem trims leading/trailing dots so exports can't become dotfiles.
- Folded export skips empty panel sections (no dangling "# header").
- flamegraphColor deduped into trace_analysis.js (single source shared by the canvas and the SVG export, so colors can't drift).
- Export menu: Esc closes it, closes on filter change / help open, aria attributes, initial disabled state; outside-click listener cleaned up in destroy(); export module resolved once and warns instead of failing silently.

Tests: test_flamegraph_export.js (registered in scripts/e2e-trace-tests.sh) covers folded serialization, SVG generation, panel merge, formatValue units, and filenameStem edge cases.