### PR TITLE
Sync landing-page state to the URL

### DIFF
--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -371,6 +371,7 @@
 
     <script src="creds.js"></script>
     <script src="prefix_detect.js"></script>
+    <script src="url_state.js"></script>
     <script src="heatmap.js"></script>
     <script>
     // ── ?trace= passthrough: redirect to viewer (preserving all params,
@@ -414,6 +415,8 @@
     let rawObjects = [];       // raw search results
     let currentTab = 'browse';
     let aggregationEnabled = false; // server runs demand-driven aggregation
+    let currentQuickRange = null;   // hours, when a "Last Nhr" quick range is active
+                                    // (null once the user edits the range manually)
 
     const ROW_H = 26;          // px height of each host row in the heatmap
 
@@ -547,6 +550,7 @@
             [...bucketsBox.children].forEach(c => c.classList.remove('selected'));
             if (el) el.classList.add('selected');
             bucketInput.value = name;
+            syncUrl();
             setStatus(`Detecting region for ${name}…`, null);
             const result = await Dial9Creds.check(name);
             if (result.ok) {
@@ -576,6 +580,7 @@
             // default bucket) belong to a different identity than these
             // credentials. The user re-picks from their own buckets below.
             bucketInput.value = '';
+            syncUrl();
             // Store the credentials (no region detection yet — we don't have a
             // bucket). Then list the buckets these credentials can see; this both
             // validates the credentials and powers the picker.
@@ -610,6 +615,7 @@
             // so a later search can't query a foreign bucket as the server's
             // ambient identity (which would 500/leak).
             bucketInput.value = '';
+            syncUrl();
             bucketsBox.innerHTML = '';
             bucketsRow.style.display = 'none';
             // The heatmap was built from the now-removed identity's bucket; wipe
@@ -650,18 +656,82 @@
         }
     }
 
-    // ── Init: load config ──
-    const params = new URLSearchParams(window.location.search);
-    if (params.get('bucket')) bucketInput.value = params.get('bucket');
-
+    // ── Init: restore state from the URL ──
+    //
+    // Every state-changing action mirrors the page state into the query string
+    // via syncUrl(), so a link reproduces the same bucket, prefix, tab, time
+    // window, timezone, and raw query. Restore that saved state here on load.
     const prefixInput = document.getElementById('prefix-input');
+    const rawSearchInput = document.getElementById('raw-search-input');
     let serverHasPrefix = false;
 
     function updateSearchReady() {
         const waitingForPrefix = serverHasPrefix && prefixInput.value.trim() === '';
         document.getElementById('search-btn').disabled = waitingForPrefix;
     }
-    prefixInput.addEventListener('input', updateSearchReady);
+    prefixInput.addEventListener('input', () => { updateSearchReady(); syncUrl(); });
+    rawSearchInput.addEventListener('input', syncUrl);
+
+    // While restoring state from the URL on load, syncUrl() is suppressed: the
+    // intermediate restore steps (tab switch, range set) would otherwise each
+    // rewrite the URL and could drop fields not yet restored. We sync once at
+    // the end of restore instead.
+    let restoring = false;
+
+    // Mirror the current DOM state into the URL, replacing the history entry so
+    // a stream of actions doesn't stack up Back-button steps. A quick range is
+    // stored relative (`last=N`) so the link keeps meaning "the last N hours
+    // from now"; a manually-edited range is stored as precise epoch-second
+    // `from`/`to` so it reproduces exactly regardless of the viewer's TZ toggle.
+    function syncUrl() {
+        if (restoring) return;
+        const state = {
+            bucket: bucketInput.value.trim(),
+            prefix: prefixInput.value.trim(),
+            tab: currentTab,
+            tz: useLocalTz ? 'local' : 'utc',
+            q: rawSearchInput.value.trim(),
+        };
+        if (currentQuickRange) {
+            state.last = currentQuickRange;
+        } else {
+            const fromDate = pickerToDate(document.getElementById('range-from').value);
+            const toDate = pickerToDate(document.getElementById('range-to').value);
+            if (fromDate) state.from = Math.floor(fromDate.getTime() / 1000);
+            if (toDate) state.to = Math.floor(toDate.getTime() / 1000);
+        }
+        const qs = Dial9UrlState.serialize(state);
+        history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
+    }
+
+    // Restore saved state. Timezone first: the range pickers format in the
+    // active TZ, so it must be set before any date is written below.
+    const urlState = Dial9UrlState.parse(window.location.search);
+    restoring = true;
+    if (urlState.tz === 'local') {
+        useLocalTz = true;
+        document.getElementById('tz-btn').textContent = 'TZ: Local';
+    }
+    if (urlState.bucket) bucketInput.value = urlState.bucket;
+    if (urlState.prefix) prefixInput.value = urlState.prefix;
+    if (urlState.q) rawSearchInput.value = urlState.q;
+    if (urlState.tab === 'raw') switchTab('raw');
+
+    // Restore the time range. A relative `last=N` re-anchors to now (so a shared
+    // link always shows the last N hours); a precise `from`/`to` is restored
+    // verbatim; otherwise fall back to the last-1hr default.
+    if (urlState.last) {
+        setQuickRange(urlState.last);
+    } else if (urlState.from != null && urlState.to != null) {
+        document.getElementById('range-from').value = dateToPickerStr(new Date(urlState.from * 1000));
+        document.getElementById('range-to').value = dateToPickerStr(new Date(urlState.to * 1000));
+    } else {
+        setQuickRange(1);
+    }
+    restoring = false;
+    // Normalize the URL once: collapses any malformed/duplicate params from the
+    // incoming link into the canonical serialization.
+    syncUrl();
 
     fetch('/api/config').then(async r => {
         if (!r.ok) {
@@ -678,7 +748,7 @@
             bucketInput.value = config.default_bucket;
         }
         if (config.default_prefix) {
-            prefixInput.value = config.default_prefix;
+            if (!prefixInput.value) prefixInput.value = config.default_prefix;
             serverHasPrefix = true;
             updateSearchReady();
         }
@@ -686,11 +756,14 @@
         // drives the sampled server-side loop instead of decoding raw traces.
         aggregationEnabled = !!config.aggregation_enabled;
         if (config.supports_byo_credentials) initCredsUi();
+        // Server defaults (bucket/prefix) were filled programmatically above;
+        // reflect them in the URL so the link is complete.
+        syncUrl();
         discoverPrefixes().then(autoSearch);
     }).catch(() => { discoverPrefixes().then(autoSearch); });
 
-    // Default to last 1 hour
-    setQuickRange(1);
+    // The initial time range is restored from the URL (or defaulted to last
+    // 1hr) in the state-restore block above, before /api/config resolves.
 
     // On page load, automatically run the last-1hr search so the heatmap is
     // populated without an extra click.
@@ -733,11 +806,13 @@
                 prefixInput.placeholder = '(no prefix — dates at root)';
                 serverHasPrefix = false;
                 updateSearchReady();
+                syncUrl();
                 return;
             }
             // If there's exactly one prefix and the input is empty, auto-select it
             if (prefixes.length === 1 && !prefixInput.value) {
                 prefixInput.value = prefixes[0].replace(/\/$/, '');
+                syncUrl();
             }
             prefixInput.placeholder = 'e.g. traces';
             for (const p of prefixes) {
@@ -750,6 +825,7 @@
                     suggestions.querySelectorAll('button').forEach(b => b.classList.remove('active'));
                     btn.classList.add('active');
                     updateSearchReady();
+                    syncUrl();
                 });
                 if (prefixInput.value === label) btn.classList.add('active');
                 suggestions.appendChild(btn);
@@ -761,8 +837,11 @@
         }
     }
 
-    // Re-discover when bucket changes
-    bucketInput.addEventListener('change', discoverPrefixes);
+    // Re-discover when bucket changes (on commit), and keep the URL in sync as
+    // the user types. Prefix discovery hits the server, so only run it on the
+    // less-frequent `change`; mirror to the URL on every keystroke.
+    bucketInput.addEventListener('change', () => { discoverPrefixes(); syncUrl(); });
+    bucketInput.addEventListener('input', syncUrl);
 
     // ── Timezone toggle ──
     document.getElementById('tz-btn').addEventListener('click', () => {
@@ -783,6 +862,7 @@
         } else {
             renderRawTable(rawObjects);
         }
+        syncUrl();
     });
 
     // ── Helpers ──
@@ -915,21 +995,28 @@
         const from = new Date(now.getTime() - hours * 3600 * 1000);
         document.getElementById('range-from').value = dateToPickerStr(from);
         document.getElementById('range-to').value = dateToPickerStr(now);
+        // Remember the relative window so the URL stays relative ("last N hours
+        // from now") rather than freezing these computed timestamps.
+        currentQuickRange = hours;
         // Highlight the selected quick button
         document.querySelectorAll('.quick-btns button').forEach(b => b.classList.remove('selected'));
         const labels = {'1': 'Last 1hr', '3': 'Last 3hr', '24': 'Last 24hr'};
         document.querySelectorAll('.quick-btns button').forEach(b => {
             if (b.textContent === labels[hours]) b.classList.add('selected');
         });
+        syncUrl();
     }
 
-    // Clear quick-button highlight when user manually edits the range
-    document.getElementById('range-from').addEventListener('input', () => {
+    // A manual edit turns the range into a precise/custom window: clear the
+    // quick-button highlight and the relative marker so the URL records exact
+    // timestamps instead.
+    function clearQuickRange() {
+        currentQuickRange = null;
         document.querySelectorAll('.quick-btns button').forEach(b => b.classList.remove('selected'));
-    });
-    document.getElementById('range-to').addEventListener('input', () => {
-        document.querySelectorAll('.quick-btns button').forEach(b => b.classList.remove('selected'));
-    });
+        syncUrl();
+    }
+    document.getElementById('range-from').addEventListener('input', clearQuickRange);
+    document.getElementById('range-to').addEventListener('input', clearQuickRange);
 
     // ── Tab switching ──
     function switchTab(tab) {
@@ -943,6 +1030,7 @@
         document.getElementById('cpu-btn').style.display = tab === 'browse' ? '' : 'none';
         document.getElementById('health-btn').style.display = tab === 'browse' ? '' : 'none';
         updateSelectionCount();
+        syncUrl();
     }
 
     // ── Time-range search (Browse mode) ──

--- a/dial9-viewer/ui/test_url_state.js
+++ b/dial9-viewer/ui/test_url_state.js
@@ -1,0 +1,157 @@
+"use strict";
+
+// Tests for url_state.js — the landing-page URL state serializer/parser.
+// Run with: node dial9-viewer/ui/test_url_state.js
+
+const { test, assert, summarize } = require("./test_harness.js");
+const UrlState = require("./url_state.js");
+
+// ── parse ──
+
+test("parse: empty query yields empty state", () => {
+  assert.deepStrictEqual(UrlState.parse(""), {});
+  assert.deepStrictEqual(UrlState.parse("?"), {});
+});
+
+test("parse: leading '?' is optional", () => {
+  assert.deepStrictEqual(UrlState.parse("?bucket=b"), { bucket: "b" });
+  assert.deepStrictEqual(UrlState.parse("bucket=b"), { bucket: "b" });
+});
+
+test("parse: reads bucket/prefix/q strings", () => {
+  const s = UrlState.parse("?bucket=my-bucket&prefix=traces&q=2026-04-09");
+  assert.strictEqual(s.bucket, "my-bucket");
+  assert.strictEqual(s.prefix, "traces");
+  assert.strictEqual(s.q, "2026-04-09");
+});
+
+test("parse: decodes percent-encoded values", () => {
+  const s = UrlState.parse("?prefix=" + encodeURIComponent("a/b c"));
+  assert.strictEqual(s.prefix, "a/b c");
+});
+
+test("parse: tab only accepts known values", () => {
+  assert.strictEqual(UrlState.parse("?tab=raw").tab, "raw");
+  assert.strictEqual(UrlState.parse("?tab=browse").tab, "browse");
+  assert.strictEqual(UrlState.parse("?tab=bogus").tab, undefined);
+});
+
+test("parse: tz only accepts known values", () => {
+  assert.strictEqual(UrlState.parse("?tz=local").tz, "local");
+  assert.strictEqual(UrlState.parse("?tz=utc").tz, "utc");
+  assert.strictEqual(UrlState.parse("?tz=pst").tz, undefined);
+});
+
+test("parse: relative 'last' is read as a number", () => {
+  const s = UrlState.parse("?last=24");
+  assert.strictEqual(s.last, 24);
+  assert.strictEqual(s.from, undefined);
+  assert.strictEqual(s.to, undefined);
+});
+
+test("parse: 'last' takes precedence over from/to", () => {
+  // A relative window and a precise window should never both be honored; the
+  // relative one wins so the link keeps meaning "the last N hours".
+  const s = UrlState.parse("?last=3&from=1000&to=2000");
+  assert.strictEqual(s.last, 3);
+  assert.strictEqual(s.from, undefined);
+  assert.strictEqual(s.to, undefined);
+});
+
+test("parse: non-positive or invalid 'last' is ignored, from/to honored", () => {
+  const s = UrlState.parse("?last=0&from=1000&to=2000");
+  assert.strictEqual(s.last, undefined);
+  assert.strictEqual(s.from, 1000);
+  assert.strictEqual(s.to, 2000);
+
+  const s2 = UrlState.parse("?last=abc&from=1000&to=2000");
+  assert.strictEqual(s2.last, undefined);
+  assert.strictEqual(s2.from, 1000);
+});
+
+test("parse: from/to parsed as integer epoch seconds", () => {
+  const s = UrlState.parse("?from=1700000000&to=1700003600");
+  assert.strictEqual(s.from, 1700000000);
+  assert.strictEqual(s.to, 1700003600);
+});
+
+test("parse: invalid from/to are dropped", () => {
+  const s = UrlState.parse("?from=nope&to=");
+  assert.strictEqual(s.from, undefined);
+  assert.strictEqual(s.to, undefined);
+});
+
+// ── serialize ──
+
+test("serialize: empty state yields empty string", () => {
+  assert.strictEqual(UrlState.serialize({}), "");
+  assert.strictEqual(UrlState.serialize(undefined), "");
+});
+
+test("serialize: omits default tab and tz", () => {
+  assert.strictEqual(UrlState.serialize({ tab: "browse", tz: "utc" }), "");
+  assert.strictEqual(UrlState.serialize({ tab: "raw" }), "tab=raw");
+  assert.strictEqual(UrlState.serialize({ tz: "local" }), "tz=local");
+});
+
+test("serialize: omits empty strings", () => {
+  assert.strictEqual(UrlState.serialize({ bucket: "", prefix: "", q: "" }), "");
+});
+
+test("serialize: relative 'last' wins over precise from/to", () => {
+  const qs = UrlState.serialize({ last: 24, from: 1000, to: 2000 });
+  assert.strictEqual(qs, "last=24");
+});
+
+test("serialize: precise from/to when no quick range", () => {
+  const qs = UrlState.serialize({ from: 1700000000, to: 1700003600 });
+  assert.strictEqual(qs, "from=1700000000&to=1700003600");
+});
+
+test("serialize: ignores non-positive 'last'", () => {
+  const qs = UrlState.serialize({ last: 0, from: 1000, to: 2000 });
+  assert.strictEqual(qs, "from=1000&to=2000");
+});
+
+test("serialize: stable key order", () => {
+  const qs = UrlState.serialize({
+    q: "x",
+    to: 2000,
+    from: 1000,
+    tz: "local",
+    tab: "raw",
+    prefix: "p",
+    bucket: "b",
+  });
+  assert.strictEqual(qs, "bucket=b&prefix=p&tab=raw&tz=local&from=1000&to=2000&q=x");
+});
+
+test("serialize: percent-encodes values", () => {
+  const qs = UrlState.serialize({ prefix: "a/b c" });
+  assert.strictEqual(qs, "prefix=a%2Fb+c");
+});
+
+// ── round-trips ──
+
+test("round-trip: relative quick range", () => {
+  const state = { bucket: "b", prefix: "traces", tab: "browse", tz: "utc", last: 3 };
+  const back = UrlState.parse("?" + UrlState.serialize(state));
+  // Defaults (browse/utc) are omitted on serialize, so they won't reappear.
+  assert.deepStrictEqual(back, { bucket: "b", prefix: "traces", last: 3 });
+});
+
+test("round-trip: precise window in raw tab, local tz", () => {
+  const state = {
+    bucket: "b",
+    prefix: "traces",
+    tab: "raw",
+    tz: "local",
+    from: 1700000000,
+    to: 1700003600,
+    q: "2026-04-09/1910",
+  };
+  const back = UrlState.parse("?" + UrlState.serialize(state));
+  assert.deepStrictEqual(back, state);
+});
+
+summarize();

--- a/dial9-viewer/ui/url_state.js
+++ b/dial9-viewer/ui/url_state.js
@@ -1,0 +1,114 @@
+"use strict";
+
+// url_state.js — serialize/restore the trace-browser landing page state to and
+// from the URL query string, so a search is shareable and survives reload.
+//
+// Shared between index.html (loaded via <script src>) and the unit tests
+// (loaded via require). Keep this dependency-free so both contexts can use it.
+//
+// State shape (all fields optional):
+//   { bucket, prefix, tab, tz, last, from, to, q }
+//     bucket : S3 bucket name (string)
+//     prefix : user-entered key prefix (string)
+//     tab    : 'browse' | 'raw'   (default 'browse' — omitted from URL)
+//     tz     : 'utc' | 'local'    (default 'utc'    — omitted from URL)
+//     last   : relative window in hours (number) — a quick range like "Last
+//              24hr". Stored relative so a shared link always means "the last N
+//              hours from now", not a frozen window.
+//     from   : range start, epoch seconds (integer) — a precise/custom window
+//     to     : range end,   epoch seconds (integer) — a precise/custom window
+//     q      : raw-search prefix query (string)
+//
+// `last` and `from`/`to` are mutually exclusive: a quick range serializes as
+// `last`, a manually-edited range as precise `from`/`to`. Defaults are omitted
+// from the query string so a pristine page produces a clean URL.
+
+(function (exports) {
+  // Parse a query string (with or without leading "?") into a state object.
+  // Only well-formed values are kept; anything missing/invalid is left unset
+  // so callers can fall back to their own defaults.
+  function parse(search) {
+    const p = new URLSearchParams(search || "");
+    const out = {};
+
+    const bucket = p.get("bucket");
+    if (bucket) out.bucket = bucket;
+
+    const prefix = p.get("prefix");
+    if (prefix) out.prefix = prefix;
+
+    const q = p.get("q");
+    if (q) out.q = q;
+
+    const tab = p.get("tab");
+    if (tab === "browse" || tab === "raw") out.tab = tab;
+
+    const tz = p.get("tz");
+    if (tz === "utc" || tz === "local") out.tz = tz;
+
+    // A relative quick range ("last N hours") takes precedence over a precise
+    // window: it's the more shareable intent, and the two are mutually
+    // exclusive on write, so a well-formed `last` means there is no from/to.
+    const last = toPositiveNumber(p.get("last"));
+    if (last != null) {
+      out.last = last;
+    } else {
+      const from = toEpoch(p.get("from"));
+      if (from != null) out.from = from;
+
+      const to = toEpoch(p.get("to"));
+      if (to != null) out.to = to;
+    }
+
+    return out;
+  }
+
+  // Serialize a state object into a query string (no leading "?"). Empty and
+  // default-valued fields are omitted, and keys are emitted in a stable order
+  // so the same state always yields the same string.
+  function serialize(state) {
+    const s = state || {};
+    const p = new URLSearchParams();
+
+    if (s.bucket) p.set("bucket", s.bucket);
+    if (s.prefix) p.set("prefix", s.prefix);
+    // 'browse' is the default tab, so only the non-default 'raw' is recorded.
+    if (s.tab === "raw") p.set("tab", s.tab);
+    // 'utc' is the default timezone, so only 'local' is recorded.
+    if (s.tz === "local") p.set("tz", s.tz);
+    // A relative quick range wins over a precise window so the link keeps
+    // meaning "the last N hours from now" instead of freezing the timestamps.
+    if (Number.isFinite(s.last) && s.last > 0) {
+      p.set("last", String(s.last));
+    } else {
+      if (Number.isFinite(s.from)) p.set("from", String(s.from));
+      if (Number.isFinite(s.to)) p.set("to", String(s.to));
+    }
+    if (s.q) p.set("q", s.q);
+
+    return p.toString();
+  }
+
+  // Parse an epoch-seconds string into an integer, or null if absent/invalid.
+  function toEpoch(v) {
+    if (v == null || v === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? Math.trunc(n) : null;
+  }
+
+  // Parse a strictly-positive number (used for the relative `last` window), or
+  // null if absent/invalid/non-positive.
+  function toPositiveNumber(v) {
+    if (v == null || v === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }
+
+  exports.parse = parse;
+  exports.serialize = serialize;
+
+  // Browser: expose on window as the stable scripting contract.
+  if (typeof window !== "undefined") {
+    window.Dial9UrlState = exports;
+  }
+})(typeof exports === "undefined" ? {} : exports);

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -56,6 +56,9 @@ node dial9-viewer/ui/test_stream_parse.js
 echo "--- Checking bring-your-own-credentials store ---"
 node dial9-viewer/ui/test_creds.js
 
+echo "--- Checking landing-page URL state (serialize/parse) ---"
+node dial9-viewer/ui/test_url_state.js
+
 echo "--- Checking skills snippets ---"
 node dial9-viewer/ui/test_all_skills_snippets.js
 


### PR DESCRIPTION
The trace-browser landing page now mirrors its full state into the query string so a search is shareable and survives reload. State is restored on load and re-synced on every state-changing action via history.replaceState.

Tracked params: bucket, prefix, tab (browse/raw), tz (utc/local), the raw-search query (q), and the time range. Defaults (tab=browse, tz=utc) are omitted so a pristine page keeps a clean URL.

Relative quick ranges stay relative: "Last 1/3/24hr" serialize as last=N and re-anchor to now on load, rather than freezing into precise timestamps. Only a manually-edited range serializes as precise from/to epoch seconds; the two are mutually exclusive and last wins.

Serialize/parse logic lives in a dependency-free url_state.js module (mirrors prefix_detect.js/creds.js), unit-tested in test_url_state.js and registered in scripts/e2e-trace-tests.sh.