### PR TITLE
Group by runtime in the UI

### DIFF
--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -29,7 +29,8 @@
 }
 .fg-search-clear:hover { color: #fff; }
 .fg-search-stats { color: #888; font-size: 0.82em; }
-.fg-spawn-filter {
+.fg-spawn-filter,
+.fg-runtime-filter {
     background: #2a2a4a;
     border: 1px solid #444;
     color: #ccc;

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -609,7 +609,10 @@
                 }
 
                 const fg = FlamegraphRenderer.createFlamegraph(containerEl, updateUrlZoom);
-                fg.setData(allSamples, trace.callframeSymbols, { exportTitle: `Flamegraph — ${label}` });
+                fg.setData(allSamples, trace.callframeSymbols, {
+                    exportTitle: `Flamegraph — ${label}`,
+                    runtimeWorkers: trace.runtimeWorkers,
+                });
 
                 // Restore zoom from URL (only if time range filter succeeded, otherwise tree differs)
                 if (timeRangeMatched) {

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -18,6 +18,7 @@
   }
 
   const buildFlamegraphTree = getAnalysis().buildFlamegraphTree;
+  const buildRuntimeFilterData = getAnalysis().buildRuntimeFilterData;
   // Shared with the SVG export (flamegraph_export.js) via trace_analysis.js so
   // the exported graph's colors match the on-screen canvas.
   const flamegraphColor = getAnalysis().flamegraphColor;
@@ -137,6 +138,10 @@
     let repaintQueued = false;
     let allSamples = [];
     let currentSymbols = null;
+    // Map of workerId -> runtime name, derived from the trace's runtime.<name>
+    // segment metadata. Empty when the trace has a single runtime (or none),
+    // in which case the runtime filter stays hidden.
+    let workerRuntime = new Map();
     const hitRegions = { worker: [], offworker: [] };
 
     // DOM
@@ -148,6 +153,7 @@
       (isMac ? '\u2318' : 'Ctrl') + ' + F or /)" />' +
       '<span class="fg-search-clear" title="Clear search">\u00d7</span>' +
       '<span class="fg-search-stats"></span>' +
+      '<select class="fg-runtime-filter" style="display:none"></select>' +
       '<select class="fg-spawn-filter"></select>' +
       '<span class="fg-export-wrap">' +
       '<button type="button" class="fg-export-btn" title="Export this flamegraph" ' +
@@ -164,6 +170,7 @@
     const searchClear = searchBar.querySelector(".fg-search-clear");
     const searchStats = searchBar.querySelector(".fg-search-stats");
     const spawnFilter = searchBar.querySelector(".fg-spawn-filter");
+    const runtimeFilter = searchBar.querySelector(".fg-runtime-filter");
     const exportBtn = searchBar.querySelector(".fg-export-btn");
     const exportMenu = searchBar.querySelector(".fg-export-menu");
     const exportSvgBtn = searchBar.querySelector(".fg-export-svg");
@@ -197,8 +204,8 @@
     });
 
     // ── Export: turn the rendered tree into a downloadable artifact ──
-    // The export reflects the CURRENT view — the active spawn-location filter
-    // (workerTree/offworkerTree are rebuilt by applySpawnFilter) — but always
+    // The export reflects the CURRENT view — the active spawn-location/runtime
+    // filters (workerTree/offworkerTree are rebuilt by applyFilters) — but always
     // the full (un-zoomed) trees, since an exported file should stand alone.
     let exportTitle = "dial9 flamegraph";
     // Formats a node's weight for SVG hover text. Defaults to CPU samples; the
@@ -769,11 +776,19 @@
       return false;
     }
 
-    function applySpawnFilter() {
+    function applyFilters() {
       const filterVal = spawnFilter.value;
-      const samples = filterVal
-        ? allSamples.filter((s) => (s.spawnLoc || "(unknown)") === filterVal)
-        : allSamples;
+      const runtimeVal = runtimeFilter.value;
+      let samples = allSamples;
+      if (filterVal) {
+        samples = samples.filter((s) => (s.spawnLoc || "(unknown)") === filterVal);
+      }
+      if (runtimeVal) {
+        // Off-worker samples (workerId 255) have no runtime; a runtime filter
+        // excludes them. Worker samples are kept when their worker belongs to
+        // the selected runtime.
+        samples = samples.filter((s) => workerRuntime.get(s.workerId) === runtimeVal);
+      }
 
       const workerSamples = samples.filter((s) => s.workerId !== 255);
       const offworkerSamples = samples.filter((s) => s.workerId === 255);
@@ -804,7 +819,8 @@
       renderAll();
     }
 
-    spawnFilter.addEventListener("change", applySpawnFilter);
+    spawnFilter.addEventListener("change", applyFilters);
+    runtimeFilter.addEventListener("change", applyFilters);
 
     let workerLabelPrefix = "Worker threads";
     let offworkerLabelPrefix = "Off-worker (sampler thread)";
@@ -836,7 +852,35 @@
         spawnFilter.appendChild(opt);
       }
 
-      applySpawnFilter();
+      buildRuntimeFilter(samples, opts && opts.runtimeWorkers);
+
+      applyFilters();
+    }
+
+    // Build the runtime-filter dropdown from the trace's runtime.<name>
+    // segment metadata. Only shown when the trace actually has more than one
+    // runtime; otherwise the control stays hidden (single-runtime traces look
+    // exactly as before). Mirrors the multi-runtime lane grouping in the
+    // timeline view so the two stay consistent.
+    function buildRuntimeFilter(samples, runtimeWorkers) {
+      runtimeFilter.style.display = "none";
+      runtimeFilter.value = "";
+      const data = buildRuntimeFilterData
+        ? buildRuntimeFilterData(samples, runtimeWorkers)
+        : { workerRuntime: new Map(), options: [] };
+      workerRuntime = data.workerRuntime;
+      if (data.options.length === 0) return; // single runtime: nothing to filter
+
+      runtimeFilter.innerHTML = '<option value="">All runtimes</option>';
+      for (const o of data.options) {
+        const opt = document.createElement("option");
+        opt.value = o.name;
+        const label = o.inferred ? `${o.name} runtime` : `runtime: ${o.name}`;
+        opt.textContent = `${label} (${o.sampleCount})`;
+        opt.title = label;
+        runtimeFilter.appendChild(opt);
+      }
+      runtimeFilter.style.display = "";
     }
 
     function resize() {
@@ -955,6 +999,7 @@
       offworkerCanvas.style.display = "none";
       offworkerLabel.style.display = "none";
       spawnFilter.style.display = "none";
+      runtimeFilter.style.display = "none";
       renderAll();
     }
 

--- a/dial9-viewer/ui/test_runtime_groups.js
+++ b/dial9-viewer/ui/test_runtime_groups.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+"use strict";
+
+// Tests for computeRuntimeGroups: grouping worker lanes by Tokio runtime.
+//
+// The default ("main") runtime is not named on the wire — its workers carry
+// no runtime.<name> segment metadata — so it is inferred as the block of
+// present workers that no named runtime claims.
+
+const assert = require("assert");
+const { computeRuntimeGroups, buildRuntimeFilterData } = require("./trace_analysis.js");
+
+function names(groups) {
+  return groups.map((g) => g.name);
+}
+
+// 1. No runtime metadata at all → single inferred "main" group with everyone.
+{
+  const groups = computeRuntimeGroups([0, 1, 2, 3], new Map());
+  assert.strictEqual(groups.length, 1, "one group when no metadata");
+  assert.strictEqual(groups[0].name, "main");
+  assert.strictEqual(groups[0].inferred, true);
+  assert.deepStrictEqual(groups[0].workerIds, [0, 1, 2, 3]);
+}
+
+// 2. The reported bug: a named "journal" runtime (64..71) plus an unnamed
+//    main block (0..7). Main must be inferred and lead the ordering.
+{
+  const wids = [0, 1, 2, 3, 4, 5, 6, 7, 64, 65, 66, 67, 68, 69, 70, 71];
+  const rt = new Map([["journal", [64, 65, 66, 67, 68, 69, 70, 71]]]);
+  const groups = computeRuntimeGroups(wids, rt);
+  assert.deepStrictEqual(names(groups), ["main", "journal"], "main leads journal");
+  assert.deepStrictEqual(groups[0].workerIds, [0, 1, 2, 3, 4, 5, 6, 7]);
+  assert.strictEqual(groups[0].inferred, true);
+  assert.deepStrictEqual(groups[1].workerIds, [64, 65, 66, 67, 68, 69, 70, 71]);
+  assert.strictEqual(groups[1].inferred, false);
+}
+
+// 3. Multiple named runtimes, no inferred main (every worker is claimed).
+{
+  const rt = new Map([
+    ["io", [2, 3]],
+    ["main", [0, 1]],
+  ]);
+  const groups = computeRuntimeGroups([0, 1, 2, 3], rt);
+  // Ordered by lowest worker id, so explicitly-named "main" (0,1) leads "io".
+  assert.deepStrictEqual(names(groups), ["main", "io"]);
+  assert.strictEqual(groups.find((g) => g.name === "main").inferred, false,
+    "explicitly named main is not inferred");
+}
+
+// 4. Named runtime "main" coexisting with an unnamed block → the inferred
+//    group must not collide with the real "main".
+{
+  const rt = new Map([["main", [10, 11]]]);
+  const groups = computeRuntimeGroups([0, 1, 10, 11], rt);
+  const inferred = groups.find((g) => g.inferred);
+  assert.strictEqual(inferred.name, "main (untracked)");
+  assert.deepStrictEqual(inferred.workerIds, [0, 1]);
+  assert.deepStrictEqual(
+    groups.find((g) => g.name === "main").workerIds, [10, 11]);
+}
+
+// 5. Metadata references workers not present in the trace → only present
+//    workers are grouped (lanes always match rendered workers).
+{
+  const rt = new Map([["journal", [64, 65, 66, 67]]]);
+  // Only 64 and 65 actually appear in the trace.
+  const groups = computeRuntimeGroups([0, 1, 64, 65], rt);
+  assert.deepStrictEqual(groups.find((g) => g.name === "journal").workerIds, [64, 65]);
+  assert.deepStrictEqual(groups.find((g) => g.inferred).workerIds, [0, 1]);
+}
+
+// 6. Empty trace → no groups.
+{
+  assert.deepStrictEqual(computeRuntimeGroups([], new Map()), []);
+}
+
+// 7. runtimeWorkers undefined (older parser / legacy ParsedTrace) → all main.
+{
+  const groups = computeRuntimeGroups([5, 6], undefined);
+  assert.strictEqual(groups.length, 1);
+  assert.strictEqual(groups[0].name, "main");
+  assert.deepStrictEqual(groups[0].workerIds, [5, 6]);
+}
+
+// ── buildRuntimeFilterData (flamegraph runtime filter) ──
+
+const sample = (workerId) => ({ workerId, callchain: [1], timestamp: 0 });
+
+// 8. Multi-runtime CPU samples → options with per-runtime sample counts and a
+//    workerId → runtime map. Off-worker samples (255) are excluded.
+{
+  const rt = new Map([["journal", [64, 65]]]);
+  const samples = [
+    sample(0), sample(0), sample(1), // main: 3
+    sample(64), sample(65),          // journal: 2
+    sample(255),                     // off-worker: excluded
+  ];
+  const { workerRuntime, options } = buildRuntimeFilterData(samples, rt);
+  assert.strictEqual(workerRuntime.get(0), "main");
+  assert.strictEqual(workerRuntime.get(64), "journal");
+  assert.strictEqual(workerRuntime.has(255), false, "off-worker not mapped");
+  assert.deepStrictEqual(options.map((o) => o.name), ["main", "journal"]);
+  const main = options.find((o) => o.name === "main");
+  const journal = options.find((o) => o.name === "journal");
+  assert.strictEqual(main.sampleCount, 3);
+  assert.strictEqual(main.inferred, true);
+  assert.strictEqual(journal.sampleCount, 2);
+  assert.strictEqual(journal.inferred, false);
+}
+
+// 9. Single runtime (only the inferred main block present) → no options, so
+//    the caller hides the filter. Empty workerRuntime map.
+{
+  const samples = [sample(0), sample(1), sample(255)];
+  const { workerRuntime, options } = buildRuntimeFilterData(samples, new Map());
+  assert.strictEqual(options.length, 0);
+  assert.strictEqual(workerRuntime.size, 0);
+}
+
+// 10. A named runtime exists in metadata but produced no samples in this
+//     window → only one runtime is actually present → filter hidden.
+{
+  const rt = new Map([["journal", [64, 65]]]);
+  const samples = [sample(0), sample(1)]; // no journal samples here
+  const { options } = buildRuntimeFilterData(samples, rt);
+  assert.strictEqual(options.length, 0, "absent runtime does not appear");
+}
+
+// 11. runtimeWorkers undefined (e.g. heap view passes nothing) → hidden.
+{
+  const { options } = buildRuntimeFilterData([sample(0)], undefined);
+  assert.strictEqual(options.length, 0);
+}
+
+// 12. Custom off-worker id is honored.
+{
+  const rt = new Map([["io", [10, 11]]]);
+  const samples = [sample(0), sample(10), sample(99)];
+  const { workerRuntime, options } = buildRuntimeFilterData(samples, rt, 99);
+  assert.strictEqual(workerRuntime.has(99), false, "custom off-worker excluded");
+  assert.deepStrictEqual(options.map((o) => o.name).sort(), ["io", "main"]);
+}
+
+console.log("test_runtime_groups: all assertions passed");

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -1537,9 +1537,102 @@
     };
   }
 
+  // ───────────────────────────────────────────────────────────────────
+  // Runtime grouping
+  //
+  // A trace may contain workers from several Tokio runtimes. Named runtimes
+  // are described on the wire by `runtime.<name>` segment-metadata entries
+  // (parsed into `runtimeWorkers: Map<name, [workerId, ...]>`). The default
+  // ("main") runtime is NOT named — its workers carry no metadata — so we
+  // infer it as the block of present workers that no named runtime claims.
+  //
+  // Returns an ordered list of groups: [{ name, workerIds, inferred }],
+  // sorted by lowest worker id (so the inferred main block, which is
+  // allocated first, naturally leads). Only workers that actually appear in
+  // `workerIds` are placed into groups, so the grouping always matches the
+  // lanes the viewer renders.
+  function computeRuntimeGroups(workerIds, runtimeWorkers) {
+    const present = new Set(workerIds);
+    // worker id -> named runtime that claims it (first claim wins; runtimes
+    // own disjoint, contiguous id blocks so collisions shouldn't occur).
+    const claimedBy = new Map();
+    const namedNames = new Set();
+    if (runtimeWorkers) {
+      for (const [name, ids] of runtimeWorkers) {
+        namedNames.add(name);
+        for (const id of ids) {
+          if (present.has(id) && !claimedBy.has(id)) claimedBy.set(id, name);
+        }
+      }
+    }
+
+    // The inferred default runtime. Avoid colliding with an explicit
+    // runtime that happens to be named "main".
+    let mainName = "main";
+    if (namedNames.has(mainName)) mainName = "main (untracked)";
+
+    const byName = new Map(); // name -> [workerId, ...]
+    for (const w of workerIds) {
+      const name = claimedBy.get(w) ?? mainName;
+      if (!byName.has(name)) byName.set(name, []);
+      byName.get(name).push(w);
+    }
+
+    const groups = [];
+    for (const [name, ids] of byName) {
+      ids.sort((a, b) => a - b);
+      // `mainName` is chosen to avoid `namedNames`, so the inferred default
+      // runtime is exactly the bucket whose name equals `mainName`.
+      groups.push({ name, workerIds: ids, inferred: name === mainName });
+    }
+    // Order groups by their lowest worker id for a stable, intuitive layout.
+    groups.sort((a, b) => a.workerIds[0] - b.workerIds[0]);
+    return groups;
+  }
+
+  // Build the data backing the flamegraph's runtime filter from CPU samples
+  // and the trace's runtime.<name> metadata. Returns:
+  //   { workerRuntime: Map<workerId, runtimeName>,
+  //     options: [{ name, inferred, sampleCount }] }   // one per runtime
+  // `options` is empty when the trace has a single runtime (or no runtime
+  // metadata), signalling the caller to hide the filter. Off-worker samples
+  // (workerId === offWorkerId, default 255) carry no runtime and are excluded
+  // from both the worker set and the per-runtime counts.
+  function buildRuntimeFilterData(samples, runtimeWorkers, offWorkerId) {
+    const off = offWorkerId == null ? 255 : offWorkerId;
+    const empty = { workerRuntime: new Map(), options: [] };
+    if (!runtimeWorkers) return empty;
+
+    const presentWorkers = new Set();
+    for (const s of samples) {
+      if (s.workerId !== off) presentWorkers.add(s.workerId);
+    }
+    const groups = computeRuntimeGroups([...presentWorkers], runtimeWorkers);
+    if (groups.length <= 1) return empty; // single runtime: nothing to filter
+
+    const workerRuntime = new Map();
+    const counts = new Map();
+    for (const g of groups) {
+      for (const w of g.workerIds) workerRuntime.set(w, g.name);
+      counts.set(g.name, 0);
+    }
+    for (const s of samples) {
+      const rt = workerRuntime.get(s.workerId);
+      if (rt != null) counts.set(rt, counts.get(rt) + 1);
+    }
+    const options = groups.map((g) => ({
+      name: g.name,
+      inferred: g.inferred,
+      sampleCount: counts.get(g.name),
+    }));
+    return { workerRuntime, options };
+  }
+
   // Export for both browser and Node.js
   const analysisExports = {
     buildWorkerSpans,
+    computeRuntimeGroups,
+    buildRuntimeFilterData,
     attachCpuSamples,
     buildActiveTaskTimeline,
     computeSchedulingDelays,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -672,6 +672,37 @@
                 position: relative;
                 display: flex;
             }
+            /* Per-runtime header above the runtime's worker lanes. Only shown
+               when a trace has more than one runtime. Click to collapse. */
+            .runtime-header {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                height: 24px;
+                padding-left: 8px;
+                background: #0f1830;
+                border-top: 1px solid #2a3a5e;
+                border-bottom: 1px solid #2a3a5e;
+                color: #cdd8f0;
+                font-size: 0.78em;
+                font-weight: 600;
+                cursor: pointer;
+                user-select: none;
+                position: sticky;
+                top: 0;
+                z-index: 3;
+            }
+            .runtime-header:hover { background: #16213e; }
+            .runtime-header .rt-toggle {
+                display: inline-block;
+                width: 1em;
+                text-align: center;
+                color: #8aa0c8;
+            }
+            .runtime-header .rt-count {
+                color: #7587a8;
+                font-weight: 400;
+            }
             .lane-label {
                 width: 100px;
                 flex-shrink: 0;
@@ -983,7 +1014,7 @@
         <script src="panel_layout.js"></script>
         <script>
             const { EVENT_TYPES: ET, parseTrace, formatFrame, symbolizeChain, deduplicateSamples } = TraceParser;
-            const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline, computeSchedulingDelays, filterPointsOfInterest, buildSpanData, collectDescendants, selectSpanRenderSet, enclosingSpans, computeSpanLayout, getTraceTimeRange, hasCpuProfileSamples, buildProcessCpuUsageSeries } = TraceAnalysis;
+            const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline, computeSchedulingDelays, filterPointsOfInterest, buildSpanData, collectDescendants, selectSpanRenderSet, enclosingSpans, computeSpanLayout, getTraceTimeRange, hasCpuProfileSamples, buildProcessCpuUsageSeries, computeRuntimeGroups } = TraceAnalysis;
 
             function esc(s) {
                 return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -1149,6 +1180,12 @@
             // ── State ──
             let trace = null;
             let workerIds = [];
+            // Runtime grouping: ordered [{name, workerIds, inferred}] computed
+            // from runtime.<name> segment metadata (the inferred "main" block
+            // covers workers no named runtime claims). `collapsedRuntimes`
+            // holds the names of runtimes whose lanes are currently hidden.
+            let runtimeGroups = [];
+            let collapsedRuntimes = new Set();
             let minTs = 0,
                 maxTs = 0,
                 durationNs = 0;
@@ -1928,6 +1965,20 @@
                 });
                 workerIds = [...wSet].sort((a, b) => a - b);
 
+                // Group workers by runtime (named runtimes from segment
+                // metadata; the rest fall into the inferred "main" runtime).
+                // Order the flat lane list to match the group order so the
+                // group headers sit directly above their lanes.
+                runtimeGroups = computeRuntimeGroups(workerIds, trace.runtimeWorkers);
+                workerIds = runtimeGroups.flatMap((g) => g.workerIds);
+                // Drop collapse state for runtimes that no longer exist so it
+                // doesn't leak across trace loads. Names that survive (e.g. a
+                // same-trace time-range reparse) keep their collapsed state.
+                const liveRuntimes = new Set(runtimeGroups.map((g) => g.name));
+                for (const name of collapsedRuntimes) {
+                    if (!liveRuntimes.has(name)) collapsedRuntimes.delete(name);
+                }
+
                 minTs = timeRange.minTs;
                 maxTs = timeRange.maxTs;
                 durationNs = timeRange.durationNs;
@@ -2247,8 +2298,7 @@
                             const viewDur = Math.max(spanDur * 10, 1e6);
                             viewStart = Math.max(minTs, s.start - viewDur * 0.3);
                             viewEnd = Math.min(maxTs, viewStart + viewDur);
-                            const laneIdx = workerIds.indexOf(s.workerId);
-                            if (laneIdx >= 0) lanesContainer.scrollTop = laneIdx * LANE_H;
+                            scrollToWorkerLane(s.workerId);
                             // Highlight the navigated span
                             selectedSpanId = s.spanId;
                             selectedSpanIds = new Set([s.spanId]);
@@ -2386,36 +2436,112 @@
                 }
 
                 // Scroll to worker lane
-                const laneIdx = workerIds.indexOf(poi.worker);
-                if (laneIdx >= 0) {
-                    const scrollTop = laneIdx * LANE_H;
-                    lanesContainer.scrollTop = scrollTop;
-                }
+                scrollToWorkerLane(poi.worker);
 
                 updatePoiCounter();
                 renderAll();
             }
 
             // ── Lane DOM ──
+            //
+            // Builds one lane per worker, grouped under a collapsible header
+            // per runtime. With a single runtime we skip the headers entirely
+            // so the common case looks unchanged. Each lane carries its
+            // worker id in `data-worker` so hit-testing resolves the worker
+            // from DOM geometry rather than assuming uniform row heights
+            // (collapsed runtimes and headers break the index×LANE_H mapping).
             function buildLanes() {
                 lanesContainer.innerHTML = "";
                 laneCanvases = {};
-                for (const w of workerIds) {
-                    const lane = document.createElement("div");
-                    lane.className = "lane";
-                    const label = document.createElement("div");
-                    label.className = "lane-label";
-                    label.textContent = `Worker ${w}`;
-                    const content = document.createElement("div");
-                    content.className = "lane-content";
-                    const canvas = document.createElement("canvas");
-                    canvas.id = `worker-${w}-canvas`;
-                    content.appendChild(canvas);
-                    lane.appendChild(label);
-                    lane.appendChild(content);
-                    lanesContainer.appendChild(lane);
-                    laneCanvases[w] = canvas;
+                const showHeaders = runtimeGroups.length > 1;
+                for (const group of runtimeGroups) {
+                    const collapsed = collapsedRuntimes.has(group.name);
+                    if (showHeaders) {
+                        const header = document.createElement("div");
+                        header.className = "runtime-header";
+                        header.dataset.runtime = group.name;
+                        const n = group.workerIds.length;
+                        header.innerHTML =
+                            `<span class="rt-toggle">${collapsed ? "▸" : "▾"}</span>` +
+                            `<span class="rt-name"></span>` +
+                            `<span class="rt-count">${n} worker${n === 1 ? "" : "s"}</span>`;
+                        // Set the runtime name as text (avoid HTML injection).
+                        header.querySelector(".rt-name").textContent =
+                            group.inferred ? `${group.name} runtime` : `runtime: ${group.name}`;
+                        lanesContainer.appendChild(header);
+                    }
+                    if (collapsed) continue;
+                    for (const w of group.workerIds) {
+                        const lane = document.createElement("div");
+                        lane.className = "lane";
+                        lane.dataset.worker = w;
+                        const label = document.createElement("div");
+                        label.className = "lane-label";
+                        label.textContent = `Worker ${w}`;
+                        const content = document.createElement("div");
+                        content.className = "lane-content";
+                        const canvas = document.createElement("canvas");
+                        canvas.id = `worker-${w}-canvas`;
+                        content.appendChild(canvas);
+                        lane.appendChild(label);
+                        lane.appendChild(content);
+                        lanesContainer.appendChild(lane);
+                        laneCanvases[w] = canvas;
+                    }
                 }
+            }
+
+            // Toggle a runtime's collapsed state, rebuild lanes, and re-render.
+            function toggleRuntimeCollapsed(name) {
+                if (collapsedRuntimes.has(name)) collapsedRuntimes.delete(name);
+                else collapsedRuntimes.add(name);
+                buildLanes();
+                renderAll();
+            }
+
+            // Resolve the worker id under a vertical mouse position inside the
+            // lanes container, using DOM geometry (robust to runtime headers
+            // and collapsed runtimes). Returns null if the point is not over a
+            // worker lane (e.g. over a header or empty space).
+            function workerAtClientY(clientY) {
+                // Fast path: with a single runtime there are no headers and
+                // nothing can be collapsed, so lanes are uniform LANE_H rows in
+                // workerIds order — resolve by arithmetic. This keeps the
+                // high-frequency hover path O(1) (one rect read, no per-lane DOM
+                // scan) for the common single-runtime case.
+                if (runtimeGroups.length <= 1) {
+                    const top = lanesContainer.getBoundingClientRect().top;
+                    const idx = Math.floor(
+                        (clientY - top + lanesContainer.scrollTop) / LANE_H,
+                    );
+                    if (idx < 0 || idx >= workerIds.length) return null;
+                    return workerIds[idx];
+                }
+                // Grouped layout: runtime headers and collapsed runtimes break
+                // the uniform-row assumption, so resolve from DOM geometry.
+                const lanes = lanesContainer.querySelectorAll(".lane");
+                for (const lane of lanes) {
+                    const r = lane.getBoundingClientRect();
+                    if (clientY >= r.top && clientY < r.bottom) {
+                        const w = Number(lane.dataset.worker);
+                        return Number.isNaN(w) ? null : w;
+                    }
+                }
+                return null;
+            }
+
+            // Scroll the lanes container so the given worker's lane is at the
+            // top of the viewport. If the worker's runtime is collapsed, expand
+            // it first so a navigation target (POI, span jump, sched jump) is
+            // actually revealed rather than silently scrolling to nothing.
+            function scrollToWorkerLane(workerId) {
+                const group = runtimeGroups.find((g) => g.workerIds.includes(workerId));
+                if (group && collapsedRuntimes.has(group.name)) {
+                    collapsedRuntimes.delete(group.name);
+                    buildLanes();
+                }
+                const lane = lanesContainer.querySelector(`.lane[data-worker="${workerId}"]`);
+                if (lane) lanesContainer.scrollTop = lane.offsetTop;
             }
 
             // ── Rendering ──
@@ -2627,8 +2753,11 @@
                 syncFoldablePanels();
                 renderTimeline(drawW - scrollbarW);
                 if (prof) _t = _profMark(prof, "timeline", _t);
-                for (const w of workerIds) renderLane(w, drawW);
-                if (prof) _t = _profMark(prof, `lanes(${workerIds.length})`, _t);
+                // Only render lanes that have a canvas: workers in a collapsed
+                // runtime have no lane DOM, so skip them.
+                const visibleWorkers = workerIds.filter((w) => laneCanvases[w]);
+                for (const w of visibleWorkers) renderLane(w, drawW);
+                if (prof) _t = _profMark(prof, `lanes(${visibleWorkers.length})`, _t);
                 renderSpanPanel(scrollbarW);
                 if (prof) _t = _profMark(prof, `spanPanel(allSpans=${allSpans.length})`, _t);
                 renderCustomEventsPanel(scrollbarW);
@@ -5210,18 +5339,22 @@
                 const lanesRect = lanesContainer.getBoundingClientRect();
                 if (e.clientY < lanesRect.top || e.clientY > lanesRect.bottom ||
                     e.clientX < lanesRect.left || e.clientX > lanesRect.right) return;
+                // Click on a runtime header toggles that runtime's lanes
+                // (handled before clearing selection so the toggle is
+                // non-destructive to the current task/event selection).
+                const header = e.target.closest(".runtime-header");
+                if (header) { toggleRuntimeCollapsed(header.dataset.runtime); return; }
+
                 // Any click in the lanes clears the selected-event marker.
                 selectedEvent = null;
                 const mouseX = e.clientX - lanesRect.left - LABEL_W;
-                const mouseY = e.clientY - lanesRect.top;
                 const drawW = lanesRect.width - LABEL_W;
                 if (mouseX < 0 || mouseX > drawW) { selectedTaskId = null; renderAll(); return; }
 
                 const ns = viewStart + (mouseX / drawW) * (viewEnd - viewStart);
-                const laneIdx = Math.floor((mouseY + lanesContainer.scrollTop) / LANE_H);
-                if (laneIdx < 0 || laneIdx >= workerIds.length) { selectedTaskId = null; renderAll(); return; }
+                const w = workerAtClientY(e.clientY);
+                if (w == null) { selectedTaskId = null; renderAll(); return; }
 
-                const w = workerIds[laneIdx];
                 const spans = workerSpans[w];
                 let found = null;
                 let foundSpan = null;
@@ -6051,8 +6184,7 @@
                         viewEnd = Math.min(maxTs, viewStart + pad);
                         hideStackPopup();
                         // Scroll to worker lane
-                        const laneIdx = workerIds.indexOf(w);
-                        if (laneIdx >= 0) lanesContainer.scrollTop = laneIdx * LANE_H;
+                        scrollToWorkerLane(w);
                         renderAll();
                     });
                 });
@@ -6246,7 +6378,6 @@
                     }
                     const rect = lanesContainer.getBoundingClientRect();
                     const mouseX = e.clientX - rect.left - LABEL_W;
-                    const mouseY = e.clientY - rect.top;
                     const drawW = rect.width - LABEL_W;
                     if (mouseX < 0 || mouseX > drawW) {
                         tooltip.style.display = "none";
@@ -6262,16 +6393,13 @@
                     // Throttle crosshair redraw with RAF
                     scheduleCrosshairRedraw();
 
-                    const laneIdx = Math.floor(
-                        (mouseY + lanesContainer.scrollTop) / LANE_H,
-                    );
-                    if (laneIdx < 0 || laneIdx >= workerIds.length) {
+                    const w = workerAtClientY(e.clientY);
+                    if (w == null) {
                         tooltip.style.display = "none";
                         lanesContainer.style.cursor = "";
                         return;
                     }
 
-                    const w = workerIds[laneIdx];
                     const spans = workerSpans[w];
 
                     // Determine worker state at this point in time
@@ -6899,6 +7027,7 @@
                 requestAnimationFrame(() => {
                     fgInstance.setData(samples, trace.callframeSymbols, {
                         exportTitle: `CPU flamegraph — ${durMs}ms selected`,
+                        runtimeWorkers: trace.runtimeWorkers,
                     });
                     fgInstance.resize();
                 });

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -74,4 +74,7 @@ node dial9-viewer/ui/test_enclosing_spans.js
 echo "--- Checking flamegraph export (folded + SVG) ---"
 node dial9-viewer/ui/test_flamegraph_export.js
 
+echo "--- Checking runtime grouping (multi-runtime lanes) ---"
+node dial9-viewer/ui/test_runtime_groups.js
+
 echo "All E2E trace checks passed."


### PR DESCRIPTION
Runtime groups exist in the trace file, but the viewer wasn't capturing them. This surfaces them in the viewer.