### PR TITLE
fix(viewer): pipeline multi-trace loads and unify parse paint throttling

### DIFF
--- a/dial9-viewer/ui/README.md
+++ b/dial9-viewer/ui/README.md
@@ -17,11 +17,24 @@ Key files:
 ## The `trace=` query parameter
 
 `trace=` is **repeatable**. Each value is fetched independently and may be
-individually gzipped. `TraceParser.fetchTraces()` fetches every component (in
-parallel), runs each through `maybeGunzip`, and concatenates the raw bytes. The
-decoder treats a concatenated stream as multiple segments — a mid-stream
-`TRC\0` header resets the frame parser — so the combined buffer parses as one
-trace. Read all values with `params.getAll('trace')`, never `params.get`.
+individually gzipped. The decoder treats a concatenated stream as multiple
+segments — a mid-stream `TRC\0` header resets the frame parser — so N components
+parse as one trace. Read all values with `params.getAll('trace')`, never
+`params.get`.
+
+The viewer and flamegraph **stream** the components whenever the runtime
+supports it (`DecompressionStream` + a readable `fetch` body):
+`TraceParser.fetchTracesStream()` dispatches every component's `fetch()` up
+front (so downloads run concurrently) and yields their gunzipped chunks
+back-to-back, in order, into a single `parseTraceStream`. Parsing the first
+segment then overlaps the in-flight downloads of the rest, so total load time is
+~`max(download, parse)` instead of `download_all + parse` — the same win the
+single-URL path already had, now for N components too (issue #595).
+
+`TraceParser.fetchTraces()` is the non-streaming fallback (no
+`DecompressionStream`, e.g. some Node test runtimes): it awaits every component
+in parallel, runs each through `maybeGunzip`, concatenates the raw bytes, and
+hands the whole buffer to `parseTrace`. Same bytes, but no fetch/parse overlap.
 
 For S3-backed traces, `index.html` points each `trace=` at
 `/api/object?bucket=&key=`, which serves one file's raw (still-gzipped) bytes.

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -505,17 +505,25 @@
                     return;
                 }
 
-                // Load the trace. For a single URL we STREAM: download and
-                // decode overlap, hiding most of the parse time behind the
-                // download. For multiple repeated `trace=` components we fall
-                // back to the buffered fetch+concatenate path (each component is
-                // fetched and gunzipped independently, then concatenated).
+                // Load the trace. We STREAM whenever the runtime supports it
+                // (single OR multiple URLs): download and decode overlap, hiding
+                // most of the parse time behind the download. For multiple
+                // components the fetches run concurrently and stream in
+                // back-to-back as one trace, so parsing the first overlaps the
+                // others' downloads (issue #595). Only when streaming is
+                // unavailable do we fall back to the buffered fetch+concatenate
+                // path (each component fetched and gunzipped independently, then
+                // concatenated).
                 const credHeaders = window.Dial9Creds ? Dial9Creds.headers() : {};
                 let trace;
                 try {
-                    if (traceUrls.length === 1 && TraceParser.canStreamDecode()) {
-                        loadingEl.textContent = "Loading trace\u2026";
-                        const stream = await TraceParser.fetchTraceStream(traceUrls[0], { headers: credHeaders });
+                    if (TraceParser.canStreamDecode()) {
+                        loadingEl.textContent = traceUrls.length > 1
+                            ? `Loading ${traceUrls.length} traces\u2026`
+                            : "Loading trace\u2026";
+                        const stream = traceUrls.length === 1
+                            ? await TraceParser.fetchTraceStream(traceUrls[0], { headers: credHeaders })
+                            : TraceParser.fetchTracesStream(traceUrls, { headers: credHeaders });
                         trace = await TraceParser.parseTraceStream(stream);
                     } else {
                         loadingEl.textContent = traceUrls.length > 1

--- a/dial9-viewer/ui/heatmap.js
+++ b/dial9-viewer/ui/heatmap.js
@@ -24,7 +24,7 @@
 // Maximum total bytes we allow opening in the trace viewer at once. Opening a
 // very wide time range would download hundreds of MB and overwhelm the viewer,
 // so we cap it and nudge the user toward narrow (1–2 minute) selections.
-const MAX_OPEN_BYTES = 100 * 1024 * 1024;
+const MAX_OPEN_BYTES = 200 * 1024 * 1024;
 
 // Minimum duration (seconds) attributed to a segment whose end time is unknown
 // or not strictly after its start, so a zero-width segment still renders as a

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -1599,9 +1599,11 @@
     // Build one viewer `trace=` component per selected key, each pointing at
     // /api/object (which serves that single file's raw, still-gzipped bytes).
     // The viewer and flamegraph read all repeated `trace=` params, download
-    // them in parallel, and gunzip + concatenate client-side (see fetchTraces
-    // in trace_parser.js). This replaced a single /api/trace URL that forced
-    // the backend to fetch every file, gunzip them, and merge into one large
+    // them in parallel, and gunzip + decode client-side — streaming the
+    // components back-to-back into one parse when supported (fetchTracesStream),
+    // or buffering+concatenating as a fallback (fetchTraces); both in
+    // trace_parser.js. This replaced a single /api/trace URL that forced the
+    // backend to fetch every file, gunzip them, and merge into one large
     // uncompressed response — far more bytes over the wire and much slower.
     function objectTraceUrls(bucket, keys) {
         return keys.map(key => {
@@ -1799,7 +1801,7 @@
             cpuBtn.disabled = over && !aggregationEnabled;
             healthBtn.disabled = !aggregationEnabled;
             warn.textContent = over && !aggregationEnabled
-                ? `Too large to open (${formatSize(sel.bytes)} > 100 MB) — narrow your selection.`
+                ? `Too large to open (${formatSize(sel.bytes)} > ${formatSize(MAX_OPEN_BYTES)}) — narrow your selection.`
                 : '';
             const win = sel.t0 && sel.t1 ? ` · ${fmtTick(sel.t0)}–${fmtTick(sel.t1)}` : '';
             count.textContent = `${sel.keys.length} segment${sel.keys.length !== 1 ? 's' : ''} · ${formatSize(sel.bytes)}${win}`;

--- a/dial9-viewer/ui/test_fetch_traces.js
+++ b/dial9-viewer/ui/test_fetch_traces.js
@@ -8,7 +8,22 @@ const fs = require("fs");
 const path = require("path");
 const zlib = require("zlib");
 const { assert, testAsync, summarize } = require("./test_harness.js");
-const { fetchTraces, parseTrace } = require("./trace_parser.js");
+const { fetchTraces, fetchTracesStream, parseTrace, parseTraceStream } = require("./trace_parser.js");
+
+// Drain an async iterable of Uint8Array chunks into one contiguous Uint8Array.
+async function collectChunks(iterable) {
+  const chunks = [];
+  let total = 0;
+  for await (const c of iterable) {
+    const u8 = c instanceof Uint8Array ? c : new Uint8Array(c);
+    chunks.push(u8);
+    total += u8.length;
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) { out.set(c, off); off += c.length; }
+  return out;
+}
 
 // Minimal fetch() mock: maps a URL → bytes (Buffer/Uint8Array) and returns a
 // Response-like object exposing arrayBuffer(). Supports an error URL too.
@@ -154,6 +169,135 @@ async function main() {
     } finally {
       restore();
       global.location = originalLocation;
+    }
+  });
+
+  // ── fetchTracesStream: streams components back-to-back as one trace ──
+
+  // Concatenated stream is byte-identical to the buffered fetchTraces output,
+  // and parses (via parseTraceStream) to the same event count.
+  await testAsync("fetchTracesStream concatenation matches fetchTraces", async () => {
+    const restore = installFetchMock({ "/gz": gzTrace, "/raw": rawTrace });
+    try {
+      const streamed = await collectChunks(fetchTracesStream(["/gz", "/raw"]));
+      const buffered = bytesOf(await fetchTraces(["/gz", "/raw"]));
+      assert.deepStrictEqual(streamed, buffered, "streamed bytes == buffered bytes");
+
+      const parsed = await parseTraceStream(fetchTracesStream(["/gz", "/raw"]));
+      assert.strictEqual(parsed.events.length, singleEvents * 2,
+        `expected ${singleEvents * 2} events, got ${parsed.events.length}`);
+    } finally { restore(); }
+  });
+
+  // Components are emitted strictly in `urls` order even though the fetches run
+  // concurrently (a later, faster component must not jump the queue).
+  await testAsync("fetchTracesStream preserves order", async () => {
+    const a = new Uint8Array([1, 2, 3]);
+    const b = new Uint8Array([4, 5]);
+    const c = new Uint8Array([6]);
+    const restore = installFetchMock({ "/a": a, "/b": b, "/c": c });
+    try {
+      const out = await collectChunks(fetchTracesStream(["/a", "/b", "/c"]));
+      assert.deepStrictEqual(out, new Uint8Array([1, 2, 3, 4, 5, 6]));
+    } finally { restore(); }
+  });
+
+  // The whole point of #595: all component fetches are dispatched up front (so
+  // downloads run concurrently and overlap the parse), NOT one-after-another as
+  // each stream is drained. Calling fetchTracesStream must issue every fetch()
+  // synchronously, before any chunk is consumed.
+  await testAsync("fetchTracesStream dispatches all fetches concurrently", async () => {
+    const restore = installFetchMock({ "/a": rawTrace, "/b": rawTrace, "/c": rawTrace });
+    try {
+      const iterable = fetchTracesStream(["/a", "/b", "/c"]);
+      // No chunk has been consumed yet, but all three fetches should already
+      // be in flight (fetchTraceStream calls fetch() synchronously before its
+      // first await, and fetchTracesStream maps over all URLs eagerly).
+      assert.strictEqual(restore.calls.length, 3,
+        `expected 3 concurrent fetches before consuming, got ${restore.calls.length}`);
+      // Draining still works after the fact.
+      const out = await collectChunks(iterable);
+      assert.strictEqual(out.length, rawTrace.length * 3, "all three components drained");
+    } finally { restore(); }
+  });
+
+  // Credential headers follow the same same-origin rule as fetchTraces.
+  await testAsync("fetchTracesStream withholds credentials cross-origin", async () => {
+    const restore = installFetchMock({
+      "/api/object?key=seg": rawTrace,
+      "https://attacker.example/x": rawTrace,
+    });
+    const originalLocation = global.location;
+    global.location = { origin: "https://dial9.example", href: "https://dial9.example/viewer.html" };
+    try {
+      const headers = { "x-dial9-aws-access-key-id": "AKIA", "x-dial9-aws-secret-access-key": "shh" };
+      await collectChunks(fetchTracesStream(["/api/object?key=seg", "https://attacker.example/x"], { headers }));
+      const sameOrigin = restore.calls.find((c) => c.url === "/api/object?key=seg");
+      const crossOrigin = restore.calls.find((c) => c.url === "https://attacker.example/x");
+      assert.deepStrictEqual(sameOrigin.opts.headers, headers, "same-origin keeps credentials");
+      assert.strictEqual(crossOrigin.opts.headers, undefined, "cross-origin withholds credentials");
+    } finally {
+      restore();
+      global.location = originalLocation;
+    }
+  });
+
+  // A later component that fails (e.g. 404) while an earlier one is still
+  // resolving must (a) reject the iterator when emission reaches it, and (b) NOT
+  // leave a transient unhandled rejection (which fires the browser's
+  // `unhandledrejection` event / Node's unhandledRejection). The eager-dispatch
+  // design attaches a no-op catch to each fetch promise to prevent (b).
+  //
+  // The window only opens across a REAL macrotask gap: component 0 must take a
+  // timer to resolve so that, while we await it, the microtask queue drains and
+  // Node runs its unhandled-rejection check with component 1 still un-awaited.
+  // A synchronous one-shot reader would award component 1 within microtasks and
+  // mask the bug, so this uses a body whose first read resolves via setTimeout.
+  await testAsync("fetchTracesStream: late failure rejects without unhandled rejection", async () => {
+    // /slow: streams rawTrace, but its first read lands on a real timer.
+    // /late: 404s after one microtask. /slow is index 0, /late is index 1.
+    const originalFetch = global.fetch;
+    global.fetch = async (url) => {
+      if (url === "/late") {
+        return { ok: false, status: 404, async arrayBuffer() { return new ArrayBuffer(0); } };
+      }
+      let sent = false;
+      return {
+        ok: true,
+        status: 200,
+        body: {
+          getReader() {
+            return {
+              async read() {
+                if (sent) return { done: true, value: undefined };
+                sent = true;
+                await new Promise((r) => setTimeout(r, 20)); // macrotask gap
+                return { done: false, value: rawTrace };
+              },
+              async cancel() {},
+            };
+          },
+        },
+      };
+    };
+    let unhandled = 0;
+    const onUnhandled = () => { unhandled++; };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      let threw = false;
+      try {
+        await collectChunks(fetchTracesStream(["/slow", "/late"]));
+      } catch (e) {
+        threw = true;
+        assert.ok(/404/.test(e.message), `error mentions status: ${e.message}`);
+      }
+      assert.ok(threw, "expected the iterator to reject");
+      // Let any stray microtask/macrotask-deferred rejection settle.
+      await new Promise((r) => setTimeout(r, 10));
+      assert.strictEqual(unhandled, 0, `expected 0 unhandled rejections, got ${unhandled}`);
+    } finally {
+      global.fetch = originalFetch;
+      process.removeListener("unhandledRejection", onUnhandled);
     }
   });
 

--- a/dial9-viewer/ui/test_heatmap.js
+++ b/dial9-viewer/ui/test_heatmap.js
@@ -204,7 +204,7 @@ function seg(o) {
 }
 
 // ── constants ──
-ok(MAX_OPEN_BYTES === 100 * 1024 * 1024, "MAX_OPEN_BYTES is 100 MiB");
+ok(MAX_OPEN_BYTES === 200 * 1024 * 1024, "MAX_OPEN_BYTES is 200 MiB");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed === 0 ? 0 : 1);

--- a/dial9-viewer/ui/test_parse_yield_throttle.js
+++ b/dial9-viewer/ui/test_parse_yield_throttle.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+"use strict";
+
+// Regression test for issue #595: the buffered trace parser (parseTraceBuffer,
+// used for multi-trace `trace=` loads — a single trace streams instead) must
+// throttle its expensive macrotask yield by WALL-CLOCK time, not by bytes.
+//
+// The bug: parseTraceBuffer used to `await setTimeout(0)` once per 100KB of
+// decoded bytes. Each setTimeout(0) is clamped to ~4ms in browsers and forces a
+// repaint, so a 10MB trace fired ~108 yields/repaints and parsed far slower
+// than the single-trace streaming path (which already throttled by wall-clock).
+//
+// parseTraceStream already moved off the byte cadence; this asserts the buffered
+// path matches that behavior. We mock the clock so the test is fully
+// deterministic (no dependence on how fast the host actually parses):
+//   • frozen clock  → ZERO macrotask yields, even though onProgress fires on
+//     every 100KB milestone. (The old byte-cadence code yielded on each.)
+//   • fast clock    → the parser still yields, so the spinner can repaint.
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+const { assert, testAsync, summarize } = require("./test_harness.js");
+const { parseTrace } = require("./trace_parser.js");
+
+// Run `fn` with global setTimeout counted (delay-0 macrotask yields only) and
+// performance.now driven by `clock()`. Restores both afterward.
+async function withInstrumentedClock(clock, fn) {
+  const realSetTimeout = global.setTimeout;
+  const realPerformance = global.performance;
+  let yields = 0;
+  global.setTimeout = function (cb, delay, ...rest) {
+    if (delay === 0 || delay == null) yields++;
+    return realSetTimeout(cb, delay, ...rest);
+  };
+  // parseTraceBuffer's nowMs closure reads `performance.now()` at call time, so
+  // swapping the whole global picks up our clock. (performance.now itself is a
+  // read-only property, so we can't reassign just the method.)
+  global.performance = { now: clock };
+  try {
+    await fn();
+  } finally {
+    global.setTimeout = realSetTimeout;
+    global.performance = realPerformance;
+  }
+  return yields;
+}
+
+async function main() {
+  const tracePath = path.join(__dirname, "demo-trace.bin");
+  if (!fs.existsSync(tracePath)) {
+    console.error(`Trace file not found: ${tracePath}`);
+    process.exit(1);
+  }
+  const fileBytes = fs.readFileSync(tracePath);
+  const raw = Uint8Array.from(
+    fileBytes[0] === 0x1f && fileBytes[1] === 0x8b
+      ? zlib.gunzipSync(fileBytes)
+      : Buffer.from(fileBytes),
+  );
+
+  // Sanity: the demo is big enough to cross many 100KB progress milestones, so
+  // a byte-cadence yield would fire many times. Otherwise the test is vacuous.
+  const milestones = Math.floor(raw.length / (100 * 1024));
+  assert.ok(
+    milestones >= 20,
+    `demo trace spans ${milestones} progress milestones (need >= 20 for a meaningful test)`,
+  );
+
+  // Reference: events from an un-instrumented parse, to prove the yield change
+  // doesn't alter decode output.
+  const reference = await parseTrace(raw);
+  assert.ok(reference.events.length > 0, "reference has events");
+
+  // ── Frozen clock: the wall-clock throttle must suppress ALL macrotask yields
+  //    while onProgress still fires on every 100KB milestone. The pre-#595
+  //    byte-cadence code yielded once per milestone here. ──
+  await testAsync("frozen clock: progress fires but zero macrotask yields", async () => {
+    let progressFires = 0;
+    const yields = await withInstrumentedClock(
+      () => 1000, // never advances
+      async () => {
+        const t = await parseTrace(raw, {
+          onParseProgress: () => {
+            progressFires++;
+          },
+        });
+        assert.strictEqual(
+          t.events.length,
+          reference.events.length,
+          "throttling must not change decoded event count",
+        );
+      },
+    );
+    assert.ok(
+      progressFires >= 20,
+      `onProgress should fire on each 100KB milestone (got ${progressFires})`,
+    );
+    assert.strictEqual(
+      yields,
+      0,
+      `frozen clock must yield 0 times, got ${yields} (byte-cadence regression: would be ~${progressFires})`,
+    );
+  });
+
+  // ── Fast clock: every milestone is >= PAINT_INTERVAL_MS apart, so the parser
+  //    still hands the thread back so the spinner can repaint. ──
+  await testAsync("fast clock: parser still yields so the spinner repaints", async () => {
+    let progressFires = 0;
+    let t = 0;
+    const yields = await withInstrumentedClock(
+      () => (t += 1000), // +1s per read >> 200ms paint interval
+      async () => {
+        await parseTrace(raw, {
+          onParseProgress: () => {
+            progressFires++;
+          },
+        });
+      },
+    );
+    assert.ok(yields >= 1, `fast clock should still yield at least once (got ${yields})`);
+    // Yields are clamped to the paint cadence: never more than one per progress
+    // milestone (and with a real clock, far fewer).
+    assert.ok(
+      yields <= progressFires,
+      `yields (${yields}) must not exceed progress milestones (${progressFires})`,
+    );
+  });
+
+  // ── No progress callback: no yields at all (used by Node directory parsing
+  //    and tests, where there is no spinner to tick). ──
+  await testAsync("no onParseProgress: parser never yields", async () => {
+    const yields = await withInstrumentedClock(
+      () => 1000,
+      async () => {
+        await parseTrace(raw); // no onParseProgress
+      },
+    );
+    assert.strictEqual(yields, 0, `parse without onParseProgress must not yield (got ${yields})`);
+  });
+
+  summarize();
+}
+
+main();

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -246,6 +246,88 @@
     }
 
     /**
+     * Stream MULTIPLE trace URLs as one logical trace: yield every component's
+     * raw (gunzipped) chunks back-to-back, in `urls` order. Pair with
+     * {@link parseTraceStream} — the decoder treats the concatenation as multiple
+     * segments (a mid-stream `TRC\0` header resets schemas/pools/timestamp base),
+     * so N components stream in as one trace, exactly as if they'd been
+     * downloaded, gunzipped, and concatenated by {@link fetchTraces}.
+     *
+     * Why this beats `fetchTraces` for N > 1: `fetchTraces` awaits ALL downloads,
+     * concatenates into one big buffer, THEN parses — zero fetch/parse overlap.
+     * Here every component's `fetch()` is dispatched up front (so the requests
+     * run concurrently, same as `Promise.all`), but we hand chunks to the parser
+     * as soon as the FIRST component starts arriving. Parsing segment 0 then
+     * overlaps the in-flight downloads of segments 1..N — the same
+     * ~max(download, parse) win the single-URL path already gets, now for the
+     * multi-trace case (issue #595). Components are emitted strictly in order so
+     * the result is byte-identical to the buffered concat.
+     *
+     * @param {string[]} urls one or more trace URLs (order preserved)
+     * @param {{signal?: AbortSignal, headers?: Object}} [opts]
+     * @returns {AsyncIterable<Uint8Array>}
+     */
+    function fetchTracesStream(urls, opts = {}) {
+        const list = Array.isArray(urls) ? urls : [urls];
+        // Dispatch every component's fetch up front so the network requests run
+        // concurrently (the `fetch()` inside fetchTraceStream starts on call).
+        // We hold the per-URL stream PROMISES and await them in order below, so a
+        // later component that finishes its headers first still can't jump the
+        // queue — emission stays strictly ordered.
+        //
+        // A later component can reject (e.g. HTTP 404) BEFORE we await it while
+        // an earlier one is still draining. Without a handler attached at
+        // creation time that rejection is "unhandled" until the loop reaches it,
+        // which fires Node's unhandledRejection / the browser's
+        // `unhandledrejection` event (noisy; trips error reporters). So we attach
+        // a no-op catch to each promise immediately to mark it handled; the loop
+        // below still awaits the ORIGINAL promise, so the real error surfaces
+        // (and rejects the iterator) when emission reaches that component.
+        const streamPromises = list.map((url) => {
+            const p = fetchTraceStream(url, opts);
+            p.catch(() => {});
+            return p;
+        });
+        // Cancel a not-yet-consumed component's stream so its open response body
+        // / connection closes promptly instead of lingering until GC. Fire and
+        // forget: if the fetch already failed there is nothing to cancel, and any
+        // error from cancel() itself is irrelevant to the caller.
+        function cancelUnconsumed(sp) {
+            Promise.resolve(sp)
+                .then((stream) => {
+                    const it =
+                        stream && typeof stream[Symbol.asyncIterator] === "function"
+                            ? stream[Symbol.asyncIterator]()
+                            : null;
+                    return it && typeof it.return === "function"
+                        ? it.return()
+                        : undefined;
+                })
+                .catch(() => {});
+        }
+        return {
+            async *[Symbol.asyncIterator]() {
+                let i = 0;
+                try {
+                    for (; i < streamPromises.length; i++) {
+                        const stream = await streamPromises[i];
+                        for await (const chunk of stream) yield chunk;
+                    }
+                } finally {
+                    // Early exit (a component threw, or the consumer stopped
+                    // iterating): the components AFTER the current one already had
+                    // their fetch() dispatched and may hold an open body. The
+                    // current one (i) is handled by for-await-of's own
+                    // iterator-return on break/throw; cancel the rest.
+                    for (let j = i + 1; j < streamPromises.length; j++) {
+                        cancelUnconsumed(streamPromises[j]);
+                    }
+                }
+            },
+        };
+    }
+
+    /**
      * @typedef {{
      *   eventType: number,
      *   timestamp: number,
@@ -1027,11 +1109,53 @@
         };
     }
 
+    // Both parse loops (whole-buffer and streaming) must periodically hand the
+    // main thread back to the browser so the loading spinner can repaint. A
+    // `setTimeout(0)` is clamped to ~4ms in browsers AND forces a repaint, so
+    // yielding too often — once per 100KB (whole-buffer) or once per chunk
+    // (streaming) — produces a paint storm that dominates parse time. Issue #595:
+    // the whole-buffer path (used by multi-trace `trace=` loads) yielded on a
+    // byte cadence and so painted ~100+ times and parsed much slower than the
+    // single-trace streaming path, which had already moved to this wall-clock
+    // throttle. Both paths now share ONE policy so it can't drift again.
+    const PAINT_INTERVAL_MS = 200; // at most ~5 repaint yields per second
+
+    /**
+     * @private Wall-clock throttle for the parse loops' spinner-repaint yields.
+     * `await throttle.yieldIfDue()` is a no-op until `PAINT_INTERVAL_MS` of
+     * wall-clock has elapsed since the last yield, then it yields a macrotask.
+     * Independent of trace size and chunking. Used by both {@link parseTraceBuffer}
+     * and {@link parseTraceStream}.
+     */
+    function makePaintThrottle() {
+        // Wall-clock source that works in browser and Node. Node 16+ exposes a
+        // global `performance`, but guard anyway in case it's absent.
+        const nowMs =
+            typeof performance !== "undefined" && performance.now
+                ? () => performance.now()
+                : () => Date.now();
+        let lastYieldMs = nowMs();
+        return {
+            async yieldIfDue() {
+                const t = nowMs();
+                if (t - lastYieldMs >= PAINT_INTERVAL_MS) {
+                    lastYieldMs = t;
+                    await new Promise((r) => setTimeout(r, 0));
+                }
+            },
+        };
+    }
+
     /** @private Parse a binary trace buffer. */
     async function parseTraceBuffer(buffer, options) {
         buffer = await maybeGunzip(buffer);
         const onProgress = (options && options.onParseProgress) || null;
-        const YIELD_BYTES = 100 * 1024; // yield to browser every 100KB
+        // Cheap per-frame gate. Every PROGRESS_BYTES of decoded bytes we refresh
+        // the progress counter (a cheap textContent write) and check the paint
+        // throttle. Bytes (not a clock read) are the gate so we don't touch the
+        // throttle on all ~300k frames of a large trace.
+        const PROGRESS_BYTES = 100 * 1024;
+        const paint = makePaintThrottle();
         const TD = getTraceDecoder();
         const dec = new TD(
             buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer,
@@ -1040,18 +1164,19 @@
         const totalBytes = dec.byteLength;
         const state = createParseState(options);
 
-        let lastYieldPos = 0;
+        let lastProgressPos = 0;
         let frame;
         while ((frame = dec.nextFrame()) !== null) {
-            // Yield to browser periodically so spinner can update
-            if (onProgress && dec.position - lastYieldPos >= YIELD_BYTES) {
-                lastYieldPos = dec.position;
+            if (onProgress && dec.position - lastProgressPos >= PROGRESS_BYTES) {
+                lastProgressPos = dec.position;
                 onProgress({
                     bytesRead: dec.position,
                     totalBytes,
                     eventCount: state.events.length,
                 });
-                await new Promise((r) => setTimeout(r, 0));
+                // Hand the main thread back so the spinner can paint, throttled
+                // to PAINT_INTERVAL_MS — not on every byte milestone.
+                await paint.yieldIfDue();
             }
             processFrame(frame, state, dec);
         }
@@ -1103,8 +1228,10 @@
         // We don't drop the yield entirely: the spinner must still tick a few
         // times/sec so the user sees progress. onProgress still fires on EVERY
         // batch drain (cheap) so the event/byte counters stay current; only the
-        // (relatively expensive) repaint yield is rate-limited.
-        const PAINT_INTERVAL_MS = 200; // at most ~5 repaint yields per second
+        // (relatively expensive) repaint yield is rate-limited. The throttle is
+        // shared with parseTraceBuffer (see makePaintThrottle) so the policy can't
+        // drift between the two paths (issue #595).
+        const paint = makePaintThrottle();
 
         // Unconsumed-tail accumulator. The decoder reads pooled strings/stacks via
         // its `stringPool`/`stackPool` maps (resolved values are copied into the
@@ -1183,13 +1310,6 @@
             drainComplete();
         }
 
-        // Wall-clock source that works in browser and Node. Node 16+ exposes a
-        // global `performance`, but guard anyway in case it's absent.
-        const nowMs =
-            typeof performance !== "undefined" && performance.now
-                ? () => performance.now()
-                : () => Date.now();
-        let lastYieldMs = nowMs(); // wall-clock time of the last macrotask yield
         for await (const rawChunk of chunks) {
             const chunk =
                 rawChunk instanceof Uint8Array
@@ -1219,16 +1339,12 @@
                     totalBytes: null,
                     eventCount: state.events.length,
                 });
-                // Yield so the browser can paint the spinner, but only once at least
-                // PAINT_INTERVAL_MS of wall-clock time has elapsed since the last
-                // yield — not once per (tiny) chunk and not on a byte cadence. Because
-                // the `for await` above already pumps the network/decompression, this
-                // throttle reduces repaints without slowing download/parse overlap.
-                const t = nowMs();
-                if (t - lastYieldMs >= PAINT_INTERVAL_MS) {
-                    lastYieldMs = t;
-                    await new Promise((r) => setTimeout(r, 0));
-                }
+                // Yield so the browser can paint the spinner, throttled to
+                // PAINT_INTERVAL_MS — not once per (tiny) chunk and not on a byte
+                // cadence. Because the `for await` above already pumps the
+                // network/decompression, this throttle reduces repaints without
+                // slowing download/parse overlap.
+                await paint.yieldIfDue();
             }
         }
 
@@ -1705,6 +1821,7 @@
             parseOne,
             fetchTraces,
             fetchTraceStream,
+            fetchTracesStream,
             canStreamDecode,
             formatFrame,
             symbolizeChain,
@@ -1719,6 +1836,7 @@
             parseTraceStream,
             fetchTraces,
             fetchTraceStream,
+            fetchTracesStream,
             canStreamDecode,
             formatFrame,
             symbolizeChain,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1639,19 +1639,28 @@
             }
 
             /**
-             * Stream a single trace URL: decode chunks as they download so parse
-             * time overlaps the download (~max(download, parse) instead of their
-             * sum). We capture the gunzipped chunks while parsing so the full
-             * buffer is still available afterwards for in-memory Set/Clear-Range
-             * re-parsing (which never re-fetches).
+             * Stream one OR MORE trace URLs: decode chunks as they download so
+             * parse time overlaps the download (~max(download, parse) instead of
+             * their sum). For multiple URLs the fetches run concurrently and the
+             * components stream in back-to-back, in order, as one logical trace —
+             * so parsing the first segment overlaps the in-flight downloads of the
+             * rest (issue #595). We capture the gunzipped chunks while parsing so
+             * the full buffer is still available afterwards for in-memory
+             * Set/Clear-Range re-parsing (which never re-fetches).
              */
-            async function streamAndShowTrace(url, name, opts = {}) {
+            async function streamAndShowTrace(urls, name, opts = {}) {
+                const list = Array.isArray(urls) ? urls : [urls];
                 try {
                     const credHeaders = window.Dial9Creds ? Dial9Creds.headers() : {};
-                    const stream = await TraceParser.fetchTraceStream(url, {
-                        signal: loadAbortController?.signal,
-                        headers: credHeaders,
-                    });
+                    const stream = list.length === 1
+                        ? await TraceParser.fetchTraceStream(list[0], {
+                            signal: loadAbortController?.signal,
+                            headers: credHeaders,
+                        })
+                        : TraceParser.fetchTracesStream(list, {
+                            signal: loadAbortController?.signal,
+                            headers: credHeaders,
+                        });
                     const captured = [];
                     const capturing = {
                         async *[Symbol.asyncIterator]() {
@@ -1807,21 +1816,25 @@
             }
 
             // `urls` may be a single URL or a list (one per repeated `trace=`).
-            // For a single URL we STREAM: download and decode overlap, so the
-            // spinner advances during the download and total load time is about
-            // max(download, parse) rather than their sum. For multiple repeated
-            // `trace=` components we fall back to the buffered fetch+concatenate
-            // path (each component is fetched and gunzipped independently, then
-            // the raw buffers are concatenated into one trace; see fetchTraces).
+            // We STREAM whenever the runtime supports it (single OR multiple
+            // URLs): download and decode overlap, so the spinner advances during
+            // the download and total load time is about max(download, parse)
+            // rather than their sum. For multiple components the fetches run
+            // concurrently and stream in back-to-back as one trace, so parsing
+            // the first segment overlaps the others' downloads (issue #595). Only
+            // when streaming is unavailable (no DecompressionStream, e.g. some
+            // Node test runtimes) do we fall back to the buffered fetch+
+            // concatenate path (each component fetched and gunzipped
+            // independently, then concatenated into one trace; see fetchTraces).
             async function loadTraceFromUrl(urls) {
                 const list = Array.isArray(urls) ? urls : [urls];
                 try {
                     const name = urlParams.get('svc')
                         || list[0].split('/').pop()?.split('?')[0]
                         || 'trace.bin';
-                    if (list.length === 1 && TraceParser.canStreamDecode()) {
-                        updateLoadProgress("Loading…");
-                        await streamAndShowTrace(list[0], name, getParseOptions());
+                    if (TraceParser.canStreamDecode()) {
+                        updateLoadProgress(list.length > 1 ? `Loading ${list.length} traces…` : "Loading…");
+                        await streamAndShowTrace(list, name, getParseOptions());
                         return;
                     }
                     updateLoadProgress(list.length > 1 ? `Fetching ${list.length} traces…` : "Fetching…");

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -53,6 +53,9 @@ node dial9-viewer/ui/test_fetch_traces.js
 echo "--- Checking streaming trace decode (parseTraceStream) ---"
 node dial9-viewer/ui/test_stream_parse.js
 
+echo "--- Checking buffered parser paint-yield throttle (#595) ---"
+node dial9-viewer/ui/test_parse_yield_throttle.js
+
 echo "--- Checking bring-your-own-credentials store ---"
 node dial9-viewer/ui/test_creds.js
 


### PR DESCRIPTION
Loading multiple traces concurrently rendered much slower than one contiguous trace, with doubled UI paints. Two causes:

1. The whole-buffer parser (parseTraceBuffer, used by the multi-trace concat path) yielded a macrotask — clamped to ~4ms AND forcing a repaint — every 100KB of decoded bytes, ~100+ paints on a 10MB trace. The streaming parser had already moved to a 200ms wall-clock throttle. Extract a shared makePaintThrottle() so both loops use one policy and it can't drift again. The per-100KB onProgress counter still fires; only the expensive yield is throttled.

2. The multi-trace path (fetchTraces) awaited all downloads, concatenated into one buffer, THEN parsed — zero fetch/parse overlap. Add fetchTracesStream(): dispatch every component's fetch up front (concurrent downloads) and yield their gunzipped chunks back-to-back, in order, into ONE parseTraceStream, so parsing segment 0 overlaps the in-flight downloads of the rest. viewer.html and flamegraph.html now stream whenever canStreamDecode(); fetchTraces remains the no-DecompressionStream fallback. Output is byte-identical (the decoder resets on a mid-stream TRC\0 header). Each fetch promise gets a no-op catch so a later component failing before it's awaited doesn't fire a transient unhandledrejection, and unconsumed sibling streams are cancelled on early exit.

Also raise the heatmap open-size cap MAX_OPEN_BYTES 100MB -> 200MB and derive the warning string from the constant.

Tests: new test_parse_yield_throttle.js (registered in e2e-trace-tests.sh); fetchTracesStream concat-parity / order / concurrent-dispatch / late-failure-no-unhandled-rejection cases in test_fetch_traces.js; test_heatmap.js assertion updated.