### PR TITLE
Extract ad-hoc span instrumentation into dial9-util crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dial9-util"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "dial9-tokio-telemetry",
+ "dial9-trace-format",
+ "pin-project-lite",
+ "tempfile",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "dial9-viewer"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "dial9-core",
     "dial9-tokio-telemetry",
+    "dial9-util",
     "dial9-trace-format",
     "dial9-trace-format-derive",
     "dial9-macro",
@@ -24,6 +25,7 @@ repository = "https://github.com/dial9-rs/dial9-tokio-telemetry"
 [workspace.dependencies]
 libc = "0.2"
 dial9-core = { version = "0.4.0-alpha.1", path = "dial9-core" }
+dial9-tokio-telemetry = { version = "0.4.0-alpha.1", path = "dial9-tokio-telemetry" }
 dial9-perf-self-profile = { version = "0.4.4", path = "perf-self-profile" }
 dial9-trace-format = { version = "0.4.1", path = "dial9-trace-format" }
 dial9-trace-format-derive = { version = "0.4.1", path = "dial9-trace-format-derive" }

--- a/dial9-tokio-telemetry/src/telemetry/buffer.rs
+++ b/dial9-tokio-telemetry/src/telemetry/buffer.rs
@@ -83,6 +83,10 @@ impl ThreadLocalEncoder<'_> {
     /// ]);
     /// ```
     // TODO(GH-XXX): replace with a version that takes timestamp as a separate parameter
+    // Currently only the `tracing-layer` feature's subscriber writes dynamic
+    // schemas through this primitive; without it the method has no in-crate
+    // caller.
+    #[cfg_attr(not(feature = "tracing-layer"), allow(dead_code))]
     pub(crate) fn write_event(
         &mut self,
         schema: &dial9_trace_format::encoder::Schema,

--- a/dial9-trace-format-derive/src/lib.rs
+++ b/dial9-trace-format-derive/src/lib.rs
@@ -13,7 +13,6 @@ const SUPPORTED_UNITS: &[&str] = &["ns", "us", "ms", "s", "bytes"];
 
 fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
     let name = &input.ident;
-    let name_str = name.to_string();
 
     let fields = match &input.data {
         Data::Struct(data) => match &data.fields {
@@ -23,20 +22,38 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
         _ => panic!("TraceEvent can only be derived for structs"),
     };
 
-    // Parse struct-level #[traceevent(wire_slot)]: opt this type into the
-    // encoder's inline fast path (a global slot doubling as wire id). Off by
-    // default.
+    // Parse struct-level attributes:
+    // - `wire_slot`: opt this type into the encoder's inline fast path (a global
+    //   slot doubling as wire id). Off by default.
+    // - `name = <expr>`: override the wire event name (defaults to the struct
+    //   name). Accepts any `&'static str` expression, not just a string literal,
+    //   so callers can build a per-call-site-unique name, e.g.
+    //   `concat!("SpanEnter:", file!(), ":", line!())`. Used to give generated
+    //   structs a name the viewer recognizes (e.g. `"SpanEnter:..."`).
     let mut wire_slot = false;
+    let mut name_override: Option<syn::Expr> = None;
     for attr in &input.attrs {
         if attr.path().is_ident("traceevent") {
             let _ = attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("wire_slot") {
                     wire_slot = true;
+                } else if meta.path.is_ident("name") {
+                    name_override = Some(meta.value()?.parse::<syn::Expr>()?);
                 }
                 Ok(())
             });
         }
     }
+    // The wire event name expression returned by `event_name()`: either the
+    // `name = ...` override (evaluated at the override's call site, so builtins
+    // like `file!()`/`line!()` resolve there) or the struct name as a literal.
+    let event_name_expr = match &name_override {
+        Some(expr) => quote! { #expr },
+        None => {
+            let name_str = name.to_string();
+            quote! { #name_str }
+        }
+    };
 
     // Find the field marked with #[traceevent(timestamp)]
     let mut timestamp_field_name = None;
@@ -172,7 +189,7 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
 
     Ok(quote! {
         impl ::dial9_trace_format::TraceEvent for #name {
-            fn event_name() -> &'static str { #name_str }
+            fn event_name() -> &'static str { #event_name_expr }
             #type_slot_impl
             fn field_defs() -> Vec<::dial9_trace_format::schema::FieldDef> {
                 vec![#(#field_def_tokens),*]
@@ -196,6 +213,12 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
 ///   header, not as a regular field.
 /// - `#[traceevent(wire_slot)]` (struct): opts the type into the encoder's
 ///   inline fast path by claiming a static wire-ID slot.
+/// - `#[traceevent(name = <expr>)]` (struct): overrides the wire event name
+///   (defaults to the struct name). Accepts any `&'static str` expression, not
+///   just a string literal, so callers can build a per-call-site-unique name —
+///   e.g. `concat!("SpanEnter:", file!(), ":", line!())`. Useful for generated
+///   structs that need a name the viewer recognizes (e.g. `"SpanEnter:..."`),
+///   which cannot be a valid Rust identifier.
 /// - `#[traceevent(unit = "...")]` (field): attaches a `unit` schema
 ///   annotation so viewers render the field in that unit. Supported values:
 ///   `"ns"`, `"us"`, `"ms"`, `"s"`, `"bytes"`. Any other value is a compile

--- a/dial9-util/Cargo.toml
+++ b/dial9-util/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "dial9-util"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = true
+description = "Ad-hoc span instrumentation (futures, guards, tower middleware) for dial9-tokio-telemetry"
+keywords = ["tokio", "telemetry", "tracing", "spans"]
+categories = ["asynchronous", "development-tools::profiling"]
+
+[dependencies]
+dial9-tokio-telemetry = { workspace = true }
+dial9-trace-format = { workspace = true }
+pin-project-lite = "0.2"
+tower-layer = { version = "0.3", optional = true }
+tower-service = { version = "0.3", optional = true }
+
+[features]
+## Tower middleware (`span::Dial9SpanLayer`) that instruments each request
+## future as a span.
+tower-layer = ["dep:tower-layer", "dep:tower-service"]
+
+[dev-dependencies]
+# The round-trip tests build a traced runtime and read the trace back, which
+# needs the `analysis` feature. Enabling it only here keeps it out of the
+# production build of the library.
+dial9-tokio-telemetry = { workspace = true, features = ["analysis"] }
+dial9-trace-format = { workspace = true, features = ["serde-deserialize"] }
+tokio = { version = "1.52.0", features = [
+    "rt",
+    "rt-multi-thread",
+    "macros",
+    "time",
+    "test-util",
+] }
+tempfile = "3"
+criterion = "0.5"
+
+[[bench]]
+name = "span_encode_bench"
+harness = false
+
+[[example]]
+name = "instrument_future"

--- a/dial9-util/benches/span_encode_bench.rs
+++ b/dial9-util/benches/span_encode_bench.rs
@@ -1,0 +1,115 @@
+//! Wall-clock encoding cost of a span event for the `dial9_span!` macro path,
+//! against the cost of the field set itself.
+//!
+//! - `macro_span_event`: what the `dial9_span!` macro generates — a per-call-site
+//!   `#[derive(TraceEvent)]` struct written via `Encoder::write`. This is the
+//!   recommended, fast path and is identical to a hand-written ("raw") event.
+//! - `macro_span_event_inline`: the same with the user field written inline
+//!   (owned `String`, no string-pool lookup) — what `dial9_span!(..., id = ~v)`
+//!   generates.
+//!
+//! Usage:
+//!   cargo bench --bench span_encode_bench
+//!
+//! The schema registration / first-string-interning cost is amortized by
+//! writing a batch of events per measured iteration (steady state is what the
+//! hot path actually pays).
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use dial9_trace_format::encoder::Encoder;
+use dial9_trace_format::{InternedString, TraceEvent};
+use std::hint::black_box;
+
+const BATCH: u64 = 512;
+
+/// The fields shared by both encoders: worker id, span id, the span name, and
+/// one user-defined field.
+const SPAN_NAME: &str = "handle_request";
+const FIELD_VALUE: &str = "req-0123456789";
+
+/// Hand-written event a user would derive to emit spans "manually" — the field
+/// set the macro generates, with the user field interned.
+#[derive(TraceEvent)]
+struct RawSpanEvent {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    worker_id: u64,
+    span_id: u64,
+    span_name: InternedString,
+    request_id: InternedString,
+}
+
+/// Hand-written event with the user field written **inline** (not interned) —
+/// what `dial9_span!(..., id = ~value)` generates.
+#[derive(TraceEvent)]
+struct RawInlineSpanEvent {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    worker_id: u64,
+    span_id: u64,
+    span_name: InternedString,
+    request_id: String,
+}
+
+/// Encode one event through the fast derived path (interned user field).
+#[inline]
+fn write_raw(enc: &mut Encoder<Vec<u8>>, ts: u64) {
+    let name = enc.intern_string_infallible(SPAN_NAME);
+    let value = enc.intern_string_infallible(FIELD_VALUE);
+    enc.write_infallible(&RawSpanEvent {
+        timestamp_ns: ts,
+        worker_id: 7,
+        span_id: 0x8000_0000_0000_0001,
+        span_name: name,
+        request_id: value,
+    });
+}
+
+/// Encode one event with the user field inline (owned `String`, no pool lookup).
+#[inline]
+fn write_raw_inline(enc: &mut Encoder<Vec<u8>>, ts: u64) {
+    let name = enc.intern_string_infallible(SPAN_NAME);
+    enc.write_infallible(&RawInlineSpanEvent {
+        timestamp_ns: ts,
+        worker_id: 7,
+        span_id: 0x8000_0000_0000_0001,
+        span_name: name,
+        request_id: FIELD_VALUE.to_string(),
+    });
+}
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("span_encode");
+    group.throughput(Throughput::Elements(BATCH));
+
+    group.bench_function("macro_span_event", |b| {
+        b.iter_batched_ref(
+            Encoder::new,
+            |enc| {
+                for i in 0..BATCH {
+                    write_raw(enc, 1_000 + i * 10);
+                }
+                black_box(&*enc);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("macro_span_event_inline", |b| {
+        b.iter_batched_ref(
+            Encoder::new,
+            |enc| {
+                for i in 0..BATCH {
+                    write_raw_inline(enc, 1_000 + i * 10);
+                }
+                black_box(&*enc);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/dial9-util/examples/instrument_future.rs
+++ b/dial9-util/examples/instrument_future.rs
@@ -1,0 +1,64 @@
+//! Ad-hoc span instrumentation without a `tracing` subscriber.
+//!
+//! Demonstrates the [`span`](dial9_util::span) module: attaching spans to
+//! futures with [`Instrument`], the [`dial9_span!`] macro for fields, and a
+//! synchronous [`enter`] guard. Each instrumented future is polled across
+//! several sleeps, producing multiple segments in the viewer.
+//!
+//! Run with: `cargo run --example instrument_future`
+//!
+//! [`enter`]: dial9_util::span::Dial9Span::enter
+//! [`dial9_span!`]: dial9_util::dial9_span
+//! [`Instrument`]: dial9_util::span::Instrument
+
+use dial9_tokio_telemetry::telemetry::{DiskWriter, TracedRuntime};
+use dial9_util::dial9_span;
+use dial9_util::span::Instrument;
+use std::time::Duration;
+
+async fn handle_request(id: u32) {
+    // A span attached to a future: one segment per poll, with gaps where the
+    // future is suspended at an `.await`. `request_id` is high-cardinality, so
+    // `~` stores it inline rather than interning it into the string pool.
+    inner_work(id)
+        .instrument(dial9_span!("inner_work", task = "inner", request_id = ~id))
+        .await;
+}
+
+async fn inner_work(id: u32) {
+    for _ in 0..3 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // A synchronous span over a CPU-bound scope.
+    let span = dial9_span!("post_process", request_id = id);
+    let _entered = span.enter();
+    std::hint::black_box((0..10_000).sum::<u64>());
+}
+
+fn main() {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.worker_threads(2).enable_all();
+
+    let writer = DiskWriter::single_file("instrument_future_trace.bin").unwrap();
+    let (runtime, _guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    runtime.block_on(async {
+        let tasks: Vec<_> = (0..10)
+            .map(|i| {
+                // Top-level span per request, attached to the spawned task.
+                tokio::spawn(
+                    handle_request(i).instrument(dial9_span!("handle_request", request_id = i)),
+                )
+            })
+            .collect();
+        for t in tasks {
+            let _ = t.await;
+        }
+    });
+
+    println!("Trace written to instrument_future_trace.bin");
+}

--- a/dial9-util/src/lib.rs
+++ b/dial9-util/src/lib.rs
@@ -1,0 +1,14 @@
+//! Utilities built on top of [`dial9-tokio-telemetry`](dial9_tokio_telemetry).
+//!
+//! Currently this crate provides ad-hoc [`span`] instrumentation: future
+//! combinators, a synchronous span guard, the [`dial9_span!`] macro, and (with
+//! the `tower-layer` feature) tower middleware. Spans produced here use the
+//! exact same wire format as the telemetry crate's `tracing` layer, so the
+//! viewer renders them on the same span timeline.
+//!
+//! Everything here is built on the *public* API of `dial9-tokio-telemetry`, so
+//! this crate stays decoupled from the runtime internals.
+
+/// Ad-hoc span instrumentation: future combinators, a span guard, the
+/// [`dial9_span!`] macro, and (with the `tower-layer` feature) tower middleware.
+pub mod span;

--- a/dial9-util/src/span/future.rs
+++ b/dial9-util/src/span/future.rs
@@ -1,0 +1,68 @@
+//! Future combinator for attaching a [`Dial9Span`] to a future.
+
+use super::Dial9Span;
+use pin_project_lite::pin_project;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pin_project! {
+    /// A future that records span enter/exit timing around each poll of the
+    /// inner future, produced by [`Instrument::instrument`].
+    ///
+    /// Each poll records one span segment, so a future that is polled, suspends
+    /// at an `.await`, and is later polled again shows up as multiple segments
+    /// with a gap between them — matching how the `tracing` layer records
+    /// instrumented futures. When the future (and thus the span) is dropped, the
+    /// span is closed.
+    pub struct Instrumented<F> {
+        #[pin]
+        inner: F,
+        span: Dial9Span,
+    }
+}
+
+impl<F> fmt::Debug for Instrumented<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Instrumented")
+            .field("span", &self.span)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<F: Future> Future for Instrumented<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        // Records an enter now and an exit when `_entered` drops at the end of
+        // this poll, capturing exactly the span of time spent in `inner.poll`.
+        let _entered = this.span.enter();
+        this.inner.poll(cx)
+    }
+}
+
+/// Extension trait that attaches a [`Dial9Span`] to a future.
+///
+/// ```no_run
+/// use dial9_util::dial9_span;
+/// use dial9_util::span::Instrument;
+///
+/// # async fn demo() {
+/// async {
+///     // ... work ...
+/// }
+/// .instrument(dial9_span!("background_job"))
+/// .await;
+/// # }
+/// ```
+pub trait Instrument: Future + Sized {
+    /// Attach `span` to this future. The span records timing around every poll
+    /// and is closed when the future is dropped.
+    fn instrument(self, span: Dial9Span) -> Instrumented<Self> {
+        Instrumented { inner: self, span }
+    }
+}
+
+impl<F: Future> Instrument for F {}

--- a/dial9-util/src/span/mod.rs
+++ b/dial9-util/src/span/mod.rs
@@ -1,0 +1,578 @@
+//! Ad-hoc span instrumentation that does not require a `tracing` subscriber.
+//!
+//! The telemetry crate's `tracing` layer is the right tool when your code is
+//! already instrumented with `tracing` and you have a subscriber wired up. This
+//! module is for everything else: emitting span-like timing information into a
+//! dial9 trace directly, with nothing but a dial9 runtime installed.
+//!
+//! Spans produced here use the exact same wire format as the tracing layer, so
+//! the viewer renders them on the same span timeline.
+//!
+//! # Instrumenting a future
+//!
+//! The common case is to attach a span to a future so the viewer shows when it
+//! was being polled (one segment per poll, gaps where it was suspended):
+//!
+//! ```no_run
+//! use dial9_util::dial9_span;
+//! use dial9_util::span::Instrument;
+//!
+//! # async fn handle(req: u32) {
+//! async {
+//!     // ... do work ...
+//! }
+//! .instrument(dial9_span!("handle_request", request_id = req))
+//! .await
+//! # }
+//! ```
+//!
+//! # Fields
+//!
+//! The [`dial9_span!`](crate::dial9_span) macro captures arbitrary key/value
+//! fields with `tracing`-style syntax — bare and `%` format with [`Display`],
+//! `?` with [`Debug`]:
+//!
+//! ```no_run
+//! # use dial9_util::dial9_span;
+//! # let path = "/x"; let retries = 1u32;
+//! # #[derive(Debug)] struct Cfg; let cfg = Cfg;
+//! let span = dial9_span!("load", path = %path, retries = retries, config = ?cfg);
+//! ```
+//!
+//! Fields added through the macro are encoded through a per-call-site
+//! [`TraceEvent`](dial9_trace_format::TraceEvent) struct generated on your
+//! behalf, so a span with fields costs no more to emit than a hand-written
+//! event. Spans built with [`Dial9Span::new`] (e.g. by
+//! [`Dial9SpanLayer`](crate::span::Dial9SpanLayer)) carry only their name; to
+//! attach fields, use the macro.
+//!
+//! Values are **interned** (pooled) by default — the right choice for
+//! low-cardinality fields, since a span re-emits its fields on every poll.
+//! Prefix a macro value with `~` to store a high-cardinality value **inline**
+//! instead, avoiding string-pool growth.
+//!
+//! # Instrumenting a synchronous scope
+//!
+//! For synchronous code, hold the guard returned by [`Dial9Span::enter`]; the
+//! span is open until the guard drops:
+//!
+//! ```no_run
+//! use dial9_util::dial9_span;
+//!
+//! let span = dial9_span!("expensive_computation");
+//! let _entered = span.enter();
+//! // ... work attributed to the span ...
+//! ```
+//!
+//! Do **not** hold an [`Entered`] guard across an `.await` point — it records a
+//! single contiguous segment and cannot represent suspension. Use
+//! [`Instrument::instrument`] for futures instead.
+//!
+//! # Tower middleware
+//!
+//! With the `tower-layer` feature, [`Dial9SpanLayer`] wraps a
+//! [`tower`](https://docs.rs/tower) service so each request future is
+//! instrumented automatically.
+
+mod future;
+#[cfg(feature = "tower-layer")]
+mod tower;
+pub(crate) mod wire;
+
+pub use future::{Instrument, Instrumented};
+#[cfg(feature = "tower-layer")]
+pub use tower::{Dial9SpanLayer, Dial9SpanService};
+
+use dial9_tokio_telemetry::telemetry::{
+    Dial9Handle, ThreadLocalEncoder, clock_monotonic_ns, current_worker_id,
+};
+use dial9_trace_format::{InternedString, TraceEvent};
+use std::fmt;
+
+/// Re-exports used by the [`dial9_span!`](crate::dial9_span) macro expansion.
+/// Not a stable API.
+#[doc(hidden)]
+pub mod __rt {
+    pub use super::{SpanEmit, SpanWire};
+    pub use dial9_tokio_telemetry::telemetry::ThreadLocalEncoder;
+    pub use dial9_trace_format::{InternedString, TraceEvent};
+}
+
+/// A span: a named, optionally-parented region of work that is recorded into
+/// the trace with timing information.
+///
+/// A span carries an identity (a process-unique id), a name, optional parent,
+/// and a set of fields. It does nothing on its own — timing is recorded when
+/// you either:
+///
+/// - attach it to a future with [`Instrument::instrument`], or
+/// - open it over a synchronous scope with [`enter`](Self::enter).
+///
+/// Construct one with the [`dial9_span!`](crate::dial9_span) macro (which
+/// captures the call site and fields for you), or with [`Dial9Span::new`] for a
+/// name-only span assembled at runtime.
+///
+/// When the span is dropped, a close event is recorded, telling the viewer the
+/// span is complete. `Dial9Span` is intentionally **not** `Clone`: it owns a
+/// single span identity with a single close.
+pub struct Dial9Span {
+    span_id: u64,
+    name: String,
+    parent_span_id: Option<u64>,
+    /// Field values in field order, lining up with the generated [`SpanWire`]'s
+    /// fields. Empty for spans built with [`Dial9Span::new`].
+    field_values: Vec<String>,
+    /// The per-call-site (or, for [`Dial9Span::new`], the shared name-only)
+    /// generated enter/exit writers this span emits through.
+    wire: &'static SpanWire,
+}
+
+/// Whether we are recording the start or the end of a span segment.
+#[derive(Clone, Copy)]
+enum Phase {
+    Enter,
+    Exit,
+}
+
+// ── Name-only runtime span (used by `Dial9Span::new`) ────────────────────────
+//
+// Spans built with `Dial9Span::new` carry no user fields, so they all share one
+// generated schema rather than one per call site. The framework field set is
+// fixed, so this is sound: every name-only span has the same wire shape.
+
+#[derive(TraceEvent)]
+#[traceevent(name = "SpanEnter:dial9-util::runtime")]
+struct RuntimeSpanEnter {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    worker_id: u64,
+    span_id: u64,
+    parent_span_id: Option<u64>,
+    span_name: InternedString,
+}
+
+#[derive(TraceEvent)]
+#[traceevent(name = "SpanExit:dial9-util::runtime")]
+struct RuntimeSpanExit {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    worker_id: u64,
+    span_id: u64,
+    span_name: InternedString,
+}
+
+fn runtime_enter(enc: &mut ThreadLocalEncoder<'_>, e: SpanEmit<'_>) {
+    let span_name = enc.intern_string(e.name);
+    enc.encode(&RuntimeSpanEnter {
+        timestamp_ns: e.timestamp_ns,
+        worker_id: e.worker_id,
+        span_id: e.span_id,
+        parent_span_id: e.parent_span_id,
+        span_name,
+    });
+}
+
+fn runtime_exit(enc: &mut ThreadLocalEncoder<'_>, e: SpanEmit<'_>) {
+    let span_name = enc.intern_string(e.name);
+    enc.encode(&RuntimeSpanExit {
+        timestamp_ns: e.timestamp_ns,
+        worker_id: e.worker_id,
+        span_id: e.span_id,
+        span_name,
+    });
+}
+
+static RUNTIME_SPAN_WIRE: SpanWire = SpanWire {
+    enter: runtime_enter,
+    exit: runtime_exit,
+};
+
+// ── Generated-path plumbing (used by the macro) ──────────────────────────────
+
+/// The per-call-site values an event-writer function needs. Borrowed from the
+/// [`Dial9Span`] for the duration of one emit.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug)]
+pub struct SpanEmit<'a> {
+    pub timestamp_ns: u64,
+    pub worker_id: u64,
+    pub span_id: u64,
+    pub parent_span_id: Option<u64>,
+    pub name: &'a str,
+    pub field_values: &'a [String],
+}
+
+/// `&'static` function pointers to a call site's generated enter/exit writers.
+/// Produced by the [`dial9_span!`](crate::dial9_span) macro.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct SpanWire {
+    pub enter: fn(&mut ThreadLocalEncoder<'_>, SpanEmit<'_>),
+    pub exit: fn(&mut ThreadLocalEncoder<'_>, SpanEmit<'_>),
+}
+
+/// Bridges a generated writer fn into the [`Encodable`](dial9_tokio_telemetry::telemetry::Encodable)
+/// path so it goes through `record_event` (enabled-check, flush accounting).
+struct GeneratedEvent<'a> {
+    write: fn(&mut ThreadLocalEncoder<'_>, SpanEmit<'_>),
+    emit: SpanEmit<'a>,
+}
+
+impl dial9_tokio_telemetry::telemetry::Encodable for GeneratedEvent<'_> {
+    fn encode(&self, enc: &mut ThreadLocalEncoder<'_>) {
+        (self.write)(enc, self.emit);
+    }
+}
+
+impl fmt::Debug for Dial9Span {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dial9Span")
+            .field("span_id", &self.span_id)
+            .field("name", &self.name)
+            .field("parent_span_id", &self.parent_span_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Dial9Span {
+    /// Create a name-only span.
+    ///
+    /// The span carries no user fields. When the fields are known at the call
+    /// site, prefer the [`dial9_span!`](crate::dial9_span) macro, which captures
+    /// them for you. This constructor is for spans whose name is chosen at
+    /// runtime (for example by
+    /// [`Dial9SpanLayer::named`](crate::span::Dial9SpanLayer::named)).
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            span_id: wire::next_span_id(),
+            name: name.into(),
+            parent_span_id: None,
+            field_values: Vec::new(),
+            wire: &RUNTIME_SPAN_WIRE,
+        }
+    }
+
+    /// Set this span's parent. The viewer nests the child under the parent in
+    /// the span tree.
+    ///
+    /// If no parent is set, the viewer infers nesting from timestamp
+    /// containment instead.
+    #[must_use]
+    pub fn with_parent(mut self, parent: &Dial9Span) -> Self {
+        self.parent_span_id = Some(parent.span_id);
+        self
+    }
+
+    /// Set this span's parent by id (see [`Dial9Span::id`]).
+    #[must_use]
+    pub fn with_parent_id(mut self, parent_span_id: u64) -> Self {
+        self.parent_span_id = Some(parent_span_id);
+        self
+    }
+
+    /// This span's process-unique id, for use with
+    /// [`with_parent_id`](Self::with_parent_id).
+    pub fn id(&self) -> u64 {
+        self.span_id
+    }
+
+    /// Open the span over the current scope, recording a single enter/exit
+    /// segment that runs until the returned guard is dropped.
+    ///
+    /// For synchronous code only — see the [module docs](self) for why this must
+    /// not be held across `.await`.
+    pub fn enter(&self) -> Entered<'_> {
+        self.emit(Phase::Enter);
+        Entered { span: self }
+    }
+
+    fn emit(&self, phase: Phase) {
+        let handle = Dial9Handle::current();
+        if !handle.is_enabled() {
+            return;
+        }
+        let timestamp_ns = clock_monotonic_ns();
+        let worker_id = current_worker_id().as_u64();
+
+        let write = match phase {
+            Phase::Enter => self.wire.enter,
+            Phase::Exit => self.wire.exit,
+        };
+        handle.record_event(GeneratedEvent {
+            write,
+            emit: SpanEmit {
+                timestamp_ns,
+                worker_id,
+                span_id: self.span_id,
+                parent_span_id: self.parent_span_id,
+                name: &self.name,
+                field_values: &self.field_values,
+            },
+        });
+    }
+
+    /// Implementation detail of the [`dial9_span!`](crate::dial9_span) macro.
+    /// Not part of the stable API.
+    #[doc(hidden)]
+    pub fn __from_generated(
+        wire: &'static SpanWire,
+        name: impl Into<String>,
+        field_values: Vec<String>,
+    ) -> Self {
+        Self {
+            span_id: wire::next_span_id(),
+            name: name.into(),
+            parent_span_id: None,
+            field_values,
+            wire,
+        }
+    }
+}
+
+impl Drop for Dial9Span {
+    fn drop(&mut self) {
+        let Some(handle) = Dial9Handle::try_current() else {
+            return;
+        };
+        handle.record_event(wire::SpanCloseEvent {
+            timestamp_ns: clock_monotonic_ns(),
+            span_id: self.span_id,
+        });
+    }
+}
+
+/// A guard representing an open span scope, returned by [`Dial9Span::enter`].
+///
+/// The span's exit segment is recorded when this guard is dropped.
+#[must_use = "the span is exited as soon as the guard is dropped; bind it to a variable"]
+#[derive(Debug)]
+pub struct Entered<'a> {
+    span: &'a Dial9Span,
+}
+
+impl Drop for Entered<'_> {
+    fn drop(&mut self) {
+        self.span.emit(Phase::Exit);
+    }
+}
+
+/// Construct a [`Dial9Span`], capturing the call site and (optionally) fields.
+///
+/// This is the ergonomic, lowest-overhead way to create a span: it generates a
+/// typed [`TraceEvent`](dial9_trace_format::TraceEvent) per call site so emitting
+/// is as cheap as a hand-written event.
+///
+/// Field syntax mirrors `tracing` — bare and `%` format with [`Display`], `?`
+/// with [`Debug`]:
+///
+/// ```
+/// use dial9_util::dial9_span;
+///
+/// // Just a name:
+/// let span = dial9_span!("load_config");
+///
+/// // With fields:
+/// # let path = "/etc/app.toml";
+/// # let retries = 3u32;
+/// let span = dial9_span!("load_config", path = %path, retries = retries);
+/// # #[derive(Debug)] struct Cfg;
+/// # let cfg = Cfg;
+/// let span = dial9_span!("validate", config = ?cfg);
+/// ```
+///
+/// # Interning
+///
+/// By default field values are **interned** (pooled) on the wire, which dedups
+/// repeated values — a span re-emits its fields on every poll, so this is the
+/// right default for low-cardinality fields. Prefix a value with `~` to store
+/// it **inline** instead, avoiding string-pool growth for high-cardinality
+/// values such as request ids:
+///
+/// ```
+/// # use dial9_util::dial9_span;
+/// # let request_id = "req-abc123";
+/// # let route = "/users";
+/// let span = dial9_span!("request", route = route, id = ~request_id);
+/// ```
+///
+/// The `~` marker combines with the format sigils: `~%expr` (inline Display),
+/// `~?expr` (inline Debug).
+///
+/// Field values are formatted to strings eagerly at construction.
+#[macro_export]
+macro_rules! dial9_span {
+    ($name:expr $(,)?) => {
+        $crate::__dial9_span_build!($name; [])
+    };
+    ($name:expr, $($fields:tt)+) => {
+        $crate::__dial9_span_munch!($name; [] ; $($fields)+)
+    };
+}
+
+/// Token-muncher that formats each field value (handling the `%`/`?`/bare format
+/// sigils and the optional `~` inline marker) and accumulates
+/// `(key @ kind : value_expr)` triples for the build step. `kind` is `intern` or
+/// `inline`.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __dial9_span_munch {
+    ($name:expr; [$($acc:tt)*] ; ) => {
+        $crate::__dial9_span_build!($name; [$($acc)*])
+    };
+    // ── Inline (not interned): `~`, `~%`, `~?` ──
+    ($name:expr; [$($acc:tt)*] ; $key:ident = ~ ?$val:expr $(, $($rest:tt)*)?) => {
+        $crate::__dial9_span_munch!(
+            $name; [$($acc)* ($key @ inline : ::std::format!("{:?}", $val))] ; $($($rest)*)?
+        )
+    };
+    ($name:expr; [$($acc:tt)*] ; $key:ident = ~ %$val:expr $(, $($rest:tt)*)?) => {
+        $crate::__dial9_span_munch!(
+            $name; [$($acc)* ($key @ inline : ::std::format!("{}", $val))] ; $($($rest)*)?
+        )
+    };
+    ($name:expr; [$($acc:tt)*] ; $key:ident = ~ $val:expr $(, $($rest:tt)*)?) => {
+        $crate::__dial9_span_munch!(
+            $name; [$($acc)* ($key @ inline : ::std::format!("{}", $val))] ; $($($rest)*)?
+        )
+    };
+    // ── Interned (default): `%`, `?`, bare ──
+    ($name:expr; [$($acc:tt)*] ; $key:ident = %$val:expr $(, $($rest:tt)*)?) => {
+        $crate::__dial9_span_munch!(
+            $name; [$($acc)* ($key @ intern : ::std::format!("{}", $val))] ; $($($rest)*)?
+        )
+    };
+    ($name:expr; [$($acc:tt)*] ; $key:ident = ?$val:expr $(, $($rest:tt)*)?) => {
+        $crate::__dial9_span_munch!(
+            $name; [$($acc)* ($key @ intern : ::std::format!("{:?}", $val))] ; $($($rest)*)?
+        )
+    };
+    ($name:expr; [$($acc:tt)*] ; $key:ident = $val:expr $(, $($rest:tt)*)?) => {
+        $crate::__dial9_span_munch!(
+            $name; [$($acc)* ($key @ intern : ::std::format!("{}", $val))] ; $($($rest)*)?
+        )
+    };
+}
+
+/// Maps a field `kind` token to its generated struct field type.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __dial9_field_ty {
+    (intern) => {
+        $crate::span::__rt::InternedString
+    };
+    (inline) => {
+        ::std::string::String
+    };
+}
+
+/// Maps a field `kind` token to the expression that encodes one value: interned
+/// values are pooled, inline values are written as owned strings.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __dial9_field_enc {
+    (intern, $enc:expr, $val:expr) => {
+        $enc.intern_string($val)
+    };
+    (inline, $enc:expr, $val:expr) => {
+        ::std::clone::Clone::clone($val)
+    };
+}
+
+/// Build step: define the per-call-site enter/exit [`TraceEvent`] structs, the
+/// writer functions, the `&'static` [`SpanWire`], and construct the span.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __dial9_span_build {
+    ($name:expr; [$( ($key:ident @ $kind:ident : $val:expr) )*]) => {{
+        // NOTE: the framework field names (`worker_id`, `span_id`,
+        // `parent_span_id`, `span_name`) are the on-wire field names the viewer
+        // looks for — they must match exactly. A user field with one of these
+        // names is a (compile-time) duplicate-field error.
+        //
+        // The wire schema name is made unique per call site
+        // (`SpanEnter:<file>:<line>:<col>`) so that two call sites with
+        // *different* field sets register *different* schemas. The viewer keys
+        // on the `SpanEnter:` / `SpanExit:` prefix, so the suffix is free to
+        // disambiguate. Without this, the encoder rejects a second call site
+        // that reuses the name with a different field set.
+        #[derive($crate::span::__rt::TraceEvent)]
+        #[traceevent(name = ::core::concat!(
+            "SpanEnter:", ::core::file!(), ":", ::core::line!(), ":", ::core::column!()
+        ))]
+        #[allow(non_snake_case)]
+        struct __Dial9SpanEnter {
+            #[traceevent(timestamp)]
+            timestamp_ns: u64,
+            worker_id: u64,
+            span_id: u64,
+            parent_span_id: ::std::option::Option<u64>,
+            span_name: $crate::span::__rt::InternedString,
+            $( $key: $crate::__dial9_field_ty!($kind), )*
+        }
+
+        #[derive($crate::span::__rt::TraceEvent)]
+        #[traceevent(name = ::core::concat!(
+            "SpanExit:", ::core::file!(), ":", ::core::line!(), ":", ::core::column!()
+        ))]
+        #[allow(non_snake_case)]
+        struct __Dial9SpanExit {
+            #[traceevent(timestamp)]
+            timestamp_ns: u64,
+            worker_id: u64,
+            span_id: u64,
+            span_name: $crate::span::__rt::InternedString,
+            $( $key: $crate::__dial9_field_ty!($kind), )*
+        }
+
+        fn __dial9_enter(
+            __enc: &mut $crate::span::__rt::ThreadLocalEncoder<'_>,
+            __e: $crate::span::__rt::SpanEmit<'_>,
+        ) {
+            let mut __vals = __e.field_values.iter();
+            let __ev = __Dial9SpanEnter {
+                timestamp_ns: __e.timestamp_ns,
+                worker_id: __e.worker_id,
+                span_id: __e.span_id,
+                parent_span_id: __e.parent_span_id,
+                span_name: __enc.intern_string(__e.name),
+                $( $key: $crate::__dial9_field_enc!(
+                    $kind, __enc,
+                    __vals.next().expect("field value count matches macro fields")
+                ), )*
+            };
+            __enc.encode(&__ev);
+        }
+
+        fn __dial9_exit(
+            __enc: &mut $crate::span::__rt::ThreadLocalEncoder<'_>,
+            __e: $crate::span::__rt::SpanEmit<'_>,
+        ) {
+            let mut __vals = __e.field_values.iter();
+            let __ev = __Dial9SpanExit {
+                timestamp_ns: __e.timestamp_ns,
+                worker_id: __e.worker_id,
+                span_id: __e.span_id,
+                span_name: __enc.intern_string(__e.name),
+                $( $key: $crate::__dial9_field_enc!(
+                    $kind, __enc,
+                    __vals.next().expect("field value count matches macro fields")
+                ), )*
+            };
+            __enc.encode(&__ev);
+        }
+
+        static __DIAL9_WIRE: $crate::span::__rt::SpanWire = $crate::span::__rt::SpanWire {
+            enter: __dial9_enter,
+            exit: __dial9_exit,
+        };
+
+        $crate::span::Dial9Span::__from_generated(
+            &__DIAL9_WIRE,
+            $name,
+            ::std::vec![ $( $val ),* ],
+        )
+    }};
+}
+
+#[cfg(test)]
+mod tests;

--- a/dial9-util/src/span/tests.rs
+++ b/dial9-util/src/span/tests.rs
@@ -1,0 +1,327 @@
+//! Tests for the ad-hoc span API.
+//!
+//! The round-trip tests build a real traced runtime, instrument work, then read
+//! the trace back and assert the emitted span events.
+
+#[test]
+fn span_id_is_in_adhoc_namespace() {
+    // Ad-hoc span ids set the top bit so they never collide with tracing span
+    // ids (which are small and assigned per-subscriber).
+    let span = dial9_span!("a");
+    assert!(span.id() & (1 << 63) != 0, "top bit must be set");
+    let span2 = dial9_span!("b");
+    assert_ne!(span.id(), span2.id(), "ids must be unique");
+}
+
+#[test]
+fn macro_accepts_fields_with_sigils() {
+    #[derive(Debug)]
+    struct Req;
+    // Should compile and not panic when telemetry is disabled on this thread.
+    let span = dial9_span!(
+        "handle",
+        bare = 1u32,
+        displayed = %"path",
+        debugged = ?Req,
+    );
+    // Values are formatted eagerly, in field order.
+    assert_eq!(span.field_values, vec!["1", "path", "Req"]);
+}
+
+#[test]
+fn derive_name_attribute_sets_event_name() {
+    // The generated span structs rely on `#[traceevent(name = ...)]` to get a
+    // wire name the viewer recognizes ("SpanEnter:" / "SpanExit:").
+    #[derive(dial9_trace_format::TraceEvent)]
+    #[traceevent(name = "SpanEnter:custom")]
+    #[allow(dead_code)]
+    struct Generated {
+        #[traceevent(timestamp)]
+        timestamp_ns: u64,
+        v: u64,
+    }
+    assert_eq!(
+        <Generated as dial9_trace_format::TraceEvent>::event_name(),
+        "SpanEnter:custom"
+    );
+}
+
+#[test]
+fn disabled_thread_is_a_noop() {
+    // No dial9 runtime on this thread: entering, exiting, and dropping must all
+    // be harmless no-ops.
+    let span = dial9_span!("orphan", k = "v");
+    {
+        let _entered = span.enter();
+    }
+    drop(span);
+}
+
+mod roundtrip {
+    use crate::span::Instrument;
+    use dial9_tokio_telemetry::telemetry::analysis::TraceReader;
+    use dial9_tokio_telemetry::telemetry::analysis_events::{CustomEvent, Dial9Event};
+    use dial9_tokio_telemetry::telemetry::{DiskWriter, TracedRuntime};
+    use dial9_trace_format::FieldValue;
+    use tempfile::TempDir;
+
+    /// Run `body` on a current-thread traced runtime, then return all custom
+    /// (span) events read back from the trace file.
+    ///
+    /// Dropping the guard drains the calling thread's buffer (where these span
+    /// events live, since the calling thread is the current-thread runtime's
+    /// worker) and finalizes the trace to disk.
+    fn capture(body: impl FnOnce(&tokio::runtime::Runtime)) -> Vec<CustomEvent> {
+        let dir = TempDir::new().unwrap();
+        let trace_path = dir.path().join("trace.bin");
+
+        let (runtime, guard) = TracedRuntime::build_and_start(
+            tokio::runtime::Builder::new_current_thread(),
+            DiskWriter::single_file(&trace_path).unwrap(),
+        )
+        .unwrap();
+
+        body(&runtime);
+        drop(guard);
+
+        let sealed = dir.path().join("trace.0.bin");
+        let reader = TraceReader::new(sealed.to_str().unwrap()).unwrap();
+        reader
+            .all_events
+            .into_iter()
+            .filter_map(|e| match e {
+                Dial9Event::Custom(c) => Some(c),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Like [`capture`], but returns the raw trace bytes so tests can inspect
+    /// the on-wire schema frames (field types), not just decoded values.
+    fn capture_bytes(body: impl FnOnce(&tokio::runtime::Runtime)) -> Vec<u8> {
+        let dir = TempDir::new().unwrap();
+        let trace_path = dir.path().join("trace.bin");
+
+        let (runtime, guard) = TracedRuntime::build_and_start(
+            tokio::runtime::Builder::new_current_thread(),
+            DiskWriter::single_file(&trace_path).unwrap(),
+        )
+        .unwrap();
+
+        body(&runtime);
+        drop(guard);
+
+        std::fs::read(dir.path().join("trace.0.bin")).unwrap()
+    }
+
+    fn field_str(ev: &CustomEvent, key: &str) -> Option<String> {
+        match ev.fields.get(key) {
+            Some(FieldValue::String(s)) => Some(s.clone()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn macro_inline_field_is_not_pooled() {
+        use dial9_trace_format::decoder::{DecodedFrame, Decoder};
+        use dial9_trace_format::types::FieldType;
+
+        let bytes = capture_bytes(|rt| {
+            rt.block_on(async {
+                // `route` interned (default), `id` inline via `~`.
+                let span = dial9_span!("req", route = "/users", id = ~"req-xyz");
+                let _e = span.enter();
+            });
+        });
+
+        let mut dec = Decoder::new(&bytes).unwrap();
+        let frames = dec.decode_all();
+        let enter = frames
+            .iter()
+            .find_map(|f| match f {
+                DecodedFrame::Schema(s) if s.name().starts_with("SpanEnter:") => Some(s),
+                _ => None,
+            })
+            .expect("SpanEnter schema present");
+
+        let ty = |name: &str| {
+            enter
+                .fields()
+                .iter()
+                .find(|f| f.name() == name)
+                .unwrap_or_else(|| panic!("field {name} present"))
+                .field_type()
+        };
+        assert_eq!(ty("route"), FieldType::PooledString, "interned -> pooled");
+        assert_eq!(ty("id"), FieldType::String, "inline (~) -> inline string");
+    }
+
+    #[test]
+    fn distinct_field_sets_across_callsites_do_not_collide() {
+        // Regression: every `dial9_span!` enter/exit schema is named uniquely per
+        // call site, so two call sites with *different* field sets register
+        // distinct schemas instead of colliding on a shared name (which the
+        // encoder rejects, panicking the program).
+        let events = capture(|rt| {
+            rt.block_on(async {
+                let s1 = dial9_span!("a", x = 1u32);
+                let _e1 = s1.enter();
+                let s2 = dial9_span!("b", y = 2u32, z = 3u32);
+                let _e2 = s2.enter();
+            });
+        });
+
+        let enters = events
+            .iter()
+            .filter(|e| e.name.starts_with("SpanEnter:"))
+            .count();
+        assert_eq!(
+            enters, 2,
+            "both distinct-field call sites must emit: {events:#?}"
+        );
+    }
+
+    #[test]
+    fn instrumented_future_emits_enter_exit_close() {
+        let events = capture(|rt| {
+            rt.block_on(async {
+                async {
+                    // Two polls (yield) → two enter/exit segments.
+                    tokio::task::yield_now().await;
+                }
+                .instrument(dial9_span!("handle_request", request_id = 7u32))
+                .await;
+            });
+        });
+
+        let enters: Vec<_> = events
+            .iter()
+            .filter(|e| e.name.starts_with("SpanEnter:"))
+            .collect();
+        let exits: Vec<_> = events
+            .iter()
+            .filter(|e| e.name.starts_with("SpanExit:"))
+            .collect();
+        let closes: Vec<_> = events
+            .iter()
+            .filter(|e| e.name == "SpanCloseEvent")
+            .collect();
+
+        assert!(
+            enters.len() >= 2,
+            "expected >=2 enter segments, got {}: {events:#?}",
+            enters.len()
+        );
+        assert_eq!(enters.len(), exits.len(), "enters and exits must pair");
+        assert_eq!(closes.len(), 1, "exactly one close per span");
+
+        // Field plumbing: span_name and the user field round-trip.
+        let enter = enters[0];
+        assert_eq!(
+            field_str(enter, "span_name").as_deref(),
+            Some("handle_request")
+        );
+        assert_eq!(field_str(enter, "request_id").as_deref(), Some("7"));
+        assert!(enter.fields.contains_key("worker_id"));
+        assert!(enter.fields.contains_key("span_id"));
+
+        // The single close references the same span id as the enters.
+        let span_id = enter.fields.get("span_id").cloned();
+        assert_eq!(closes[0].fields.get("span_id").cloned(), span_id);
+    }
+
+    #[test]
+    fn sync_enter_guard_emits_one_segment() {
+        let events = capture(|rt| {
+            rt.block_on(async {
+                let span = dial9_span!("compute");
+                let _entered = span.enter();
+            });
+        });
+
+        let enters = events
+            .iter()
+            .filter(|e| e.name.starts_with("SpanEnter:"))
+            .count();
+        let exits = events
+            .iter()
+            .filter(|e| e.name.starts_with("SpanExit:"))
+            .count();
+        assert_eq!(enters, 1);
+        assert_eq!(exits, 1);
+    }
+
+    #[test]
+    fn parent_link_is_recorded() {
+        let events = capture(|rt| {
+            rt.block_on(async {
+                let parent = dial9_span!("parent");
+                let parent_id = parent.id();
+                let child = dial9_span!("child").with_parent(&parent);
+                {
+                    let _p = parent.enter();
+                    let _c = child.enter();
+                }
+                // keep parent_id referenced
+                let _ = parent_id;
+            });
+        });
+
+        let child_enter = events
+            .iter()
+            .filter(|e| e.name.starts_with("SpanEnter:"))
+            .find(|e| field_str(e, "span_name").as_deref() == Some("child"))
+            .expect("child enter present");
+        assert!(
+            matches!(
+                child_enter.fields.get("parent_span_id"),
+                Some(FieldValue::Varint(_))
+            ),
+            "child must carry a parent_span_id: {child_enter:#?}"
+        );
+    }
+
+    #[cfg(feature = "tower-layer")]
+    #[test]
+    fn tower_layer_instruments_each_request() {
+        use crate::span::Dial9SpanLayer;
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+        use tower_layer::Layer;
+        use tower_service::Service;
+
+        // Minimal echo service.
+        #[derive(Clone)]
+        struct Echo;
+        impl Service<u32> for Echo {
+            type Response = u32;
+            type Error = ();
+            type Future = Pin<Box<dyn Future<Output = Result<u32, ()>> + Send>>;
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), ()>> {
+                Poll::Ready(Ok(()))
+            }
+            fn call(&mut self, req: u32) -> Self::Future {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    Ok(req)
+                })
+            }
+        }
+
+        let events = capture(|rt| {
+            rt.block_on(async {
+                let mut svc = Dial9SpanLayer::named("rpc").layer(Echo);
+                assert_eq!(svc.call(1).await, Ok(1));
+            });
+        });
+
+        assert!(
+            events.iter().any(|e| {
+                e.name.starts_with("SpanEnter:")
+                    && field_str(e, "span_name").as_deref() == Some("rpc")
+            }),
+            "expected an 'rpc' span enter from the tower layer: {events:#?}"
+        );
+    }
+}

--- a/dial9-util/src/span/tower.rs
+++ b/dial9-util/src/span/tower.rs
@@ -1,0 +1,113 @@
+//! [`tower`](https://docs.rs/tower) middleware that instruments each request
+//! future with a [`Dial9Span`].
+//!
+//! Requires the `tower-layer` feature.
+
+use super::{Dial9Span, Instrument, Instrumented};
+use std::fmt;
+use std::task::{Context, Poll};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// A [`tower::Layer`](tower_layer::Layer) that wraps a service so each request's
+/// response future is recorded as a span.
+///
+/// The span for each request is produced by a `make_span` closure, letting you
+/// give every request the same name or vary it per call. For a fixed name, use
+/// [`Dial9SpanLayer::named`].
+///
+/// ```no_run
+/// use dial9_util::span::Dial9SpanLayer;
+/// # use tower_layer::Layer;
+/// # fn demo<S>(service: S) {
+/// // Every request becomes a span named "http_request":
+/// let layer = Dial9SpanLayer::named("http_request");
+/// let instrumented = layer.layer(service);
+/// # let _ = instrumented;
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct Dial9SpanLayer<F> {
+    make_span: F,
+}
+
+impl<F> fmt::Debug for Dial9SpanLayer<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dial9SpanLayer").finish_non_exhaustive()
+    }
+}
+
+impl Dial9SpanLayer<()> {
+    /// Build a layer that names every request span `name`.
+    pub fn named(name: impl Into<String>) -> Dial9SpanLayer<impl Fn() -> Dial9Span + Clone> {
+        let name = name.into();
+        Dial9SpanLayer {
+            make_span: move || Dial9Span::new(name.clone()),
+        }
+    }
+}
+
+impl<F> Dial9SpanLayer<F>
+where
+    F: Fn() -> Dial9Span + Clone,
+{
+    /// Build a layer that produces a fresh span per request via `make_span`.
+    ///
+    /// Use this to attach fields, e.g.
+    /// `Dial9SpanLayer::new(|| dial9_span!("rpc", service = "auth"))`.
+    pub fn new(make_span: F) -> Self {
+        Self { make_span }
+    }
+}
+
+impl<S, F> Layer<S> for Dial9SpanLayer<F>
+where
+    F: Clone,
+{
+    type Service = Dial9SpanService<S, F>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Dial9SpanService {
+            inner,
+            make_span: self.make_span.clone(),
+        }
+    }
+}
+
+/// The [`Service`] produced by [`Dial9SpanLayer`]. Instruments each
+/// [`call`](Service::call)'s future with a freshly-created span.
+#[derive(Clone)]
+pub struct Dial9SpanService<S, F> {
+    inner: S,
+    make_span: F,
+}
+
+impl<S, F> fmt::Debug for Dial9SpanService<S, F>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dial9SpanService")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S, F, Req> Service<Req> for Dial9SpanService<S, F>
+where
+    S: Service<Req>,
+    F: Fn() -> Dial9Span,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Instrumented<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let span = (self.make_span)();
+        self.inner.call(req).instrument(span)
+    }
+}

--- a/dial9-util/src/span/wire.rs
+++ b/dial9-util/src/span/wire.rs
@@ -1,0 +1,35 @@
+//! On-wire identity helpers for ad-hoc spans.
+//!
+//! Span enter/exit events are emitted through per-call-site generated
+//! [`TraceEvent`](dial9_trace_format::TraceEvent) structs (see the
+//! [`dial9_span!`](crate::dial9_span) macro and [`Dial9Span::new`](super::Dial9Span::new)).
+//! Each call site registers two schemas, named `SpanEnter:<id>` and
+//! `SpanExit:<id>`, where `<id>` is unique per call site (the viewer keys on the
+//! `SpanEnter:` / `SpanExit:` prefix and groups by it). This matches the format
+//! emitted by the telemetry crate's `tracing` layer, so the viewer renders
+//! ad-hoc spans and `tracing` spans on the same timeline.
+
+use dial9_trace_format::TraceEvent;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Emitted once when a span is finalized (dropped). Tells the viewer the span
+/// will receive no further enter/exit segments.
+#[derive(TraceEvent)]
+#[traceevent(wire_slot)]
+pub(crate) struct SpanCloseEvent {
+    #[traceevent(timestamp)]
+    pub(crate) timestamp_ns: u64,
+    pub(crate) span_id: u64,
+}
+
+/// Ad-hoc spans live in a separate id space from `tracing` span ids (which are
+/// small and assigned per-subscriber). Setting the top bit keeps the two from
+/// colliding when both appear in the same trace.
+const ADHOC_SPAN_ID_BIT: u64 = 1 << 63;
+
+static NEXT_SPAN_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Allocate a process-unique id for an ad-hoc span.
+pub(crate) fn next_span_id() -> u64 {
+    NEXT_SPAN_ID.fetch_add(1, Ordering::Relaxed) | ADHOC_SPAN_ID_BIT
+}


### PR DESCRIPTION
Moves the `span` module (the `dial9_span!` macro, `Dial9Span`, the `Instrument` future combinator, the span guard, and the tower middleware) out of `dial9-tokio-telemetry` and into a new downstream `dial9-util` crate built entirely on the telemetry crate's public API.

Changes:

- New `dial9-util` crate depending on `dial9-tokio-telemetry` + `dial9-trace-format`. Users now import `dial9_util::dial9_span` / `dial9_util::span::*`.

- Drop the runtime dynamic-schema span path (`Dial9Span::new` + `with_field`/`with_inline_field`). Its only distinguishing capability was runtime-determined field *names*, which required the encoder's pub(crate) `write_event` primitive. Everything else rides the public `Encodable`/`encode` path. `Dial9Span::new` is retained as a name-only span (a generated zero-field event), so `Dial9SpanLayer::named` still works. Fields are attached via the `dial9_span!` macro.

- Revert the encoder `schema_slot_ids` fast-path in dial9-trace-format. It was an intermediate optimization superseded once the macro path switched to per-call-site `#[derive(TraceEvent)]` structs (which use the pre-existing type_slot/slot_cache fast path); the only remaining caller was the now-removed dynamic path.

- Fix a pre-existing panic: the macro named every enter/exit schema `"SpanEnter:"`/`"SpanExit:"`, so two call sites with different field sets collided ("schema already registered with different definition") and panicked. The derive's `name` attribute now accepts any `&'static str` expression, and the macro builds a per-call-site-unique name via `concat!("SpanEnter:", file!(), ":", line!(), ":", column!())`. The viewer keys on the `SpanEnter:`/`SpanExit:` prefix, so unique suffixes are safe. Adds a regression test.

- Gate `ThreadLocalEncoder::write_event` dead-code allow on the `tracing-layer` feature, its sole remaining in-crate caller.