### PR TITLE
fix(viewer): handle cross-region S3 buckets (region as a first-class param)

### DIFF
--- a/dial9-viewer/src/server/error.rs
+++ b/dial9-viewer/src/server/error.rs
@@ -12,6 +12,11 @@ pub fn storage_error_response(err: StorageError) -> (StatusCode, String) {
         StorageError::Unauthorized => (StatusCode::UNAUTHORIZED, err.to_string()),
         StorageError::AccountNotSignedUp => (StatusCode::FORBIDDEN, err.to_string()),
         StorageError::NotFound(_) => (StatusCode::NOT_FOUND, err.to_string()),
+        // 421 Misdirected Request: the request reached an endpoint (region) that
+        // cannot serve this bucket — semantically exact for an S3 region
+        // mismatch, and distinct from a generic 500 so the UI can surface the
+        // actionable "set the region" message.
+        StorageError::WrongRegion => (StatusCode::MISDIRECTED_REQUEST, err.to_string()),
         StorageError::Other(_) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }
 }

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -266,6 +266,16 @@ impl AppState {
     /// When BYO is disabled (local-dir mode) any supplied credentials are
     /// ignored and the default backend is used. A role-arn request against a
     /// server with no assumer wired is a 400 (the feature is off here).
+    ///
+    /// The ephemeral client is pinned to the region carried on the request (the
+    /// `x-dial9-aws-region` header or `aws_region` query param). A cross-region
+    /// bucket therefore requires the correct region to ride along — the UI
+    /// detects it once via `/api/credentials/check` and then keeps it in the
+    /// stored credentials and the URL, so every subsequent request carries it.
+    /// A request that reaches the wrong regional endpoint fails with
+    /// [`StorageError::WrongRegion`] rather than an opaque error.
+    ///
+    /// [`StorageError::WrongRegion`]: crate::storage::StorageError::WrongRegion
     pub async fn resolve(
         &self,
         creds: MaybeCreds,

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -163,6 +163,13 @@ pub enum StorageError {
     /// *wrong* identity (e.g. the server's ambient credentials instead of the
     /// pasted ones), so the message points the user there.
     AccountNotSignedUp,
+    /// The bucket lives in a different S3 region than the request was signed
+    /// for (S3 `PermanentRedirect` / HTTP 301), and the correct region could
+    /// not be resolved. Kept distinct from [`StorageError::Other`] so the HTTP
+    /// layer returns a clear, actionable "wrong region" message instead of an
+    /// opaque 500 — this is the failure the viewer's per-bucket region
+    /// auto-detection exists to prevent.
+    WrongRegion,
     Other(String),
 }
 
@@ -182,6 +189,14 @@ impl std::fmt::Display for StorageError {
                     "the AWS account used for this request is not signed up for S3 — \
                      this usually means the request was signed with the wrong identity. \
                      Make sure you clicked Apply after pasting your credentials."
+                )
+            }
+            StorageError::WrongRegion => {
+                write!(
+                    f,
+                    "this bucket is in a different AWS region than the request was \
+                     signed for. Set the region (or pick the bucket so its region is \
+                     detected automatically) and try again."
                 )
             }
             StorageError::Other(msg) => write!(f, "{msg}"),
@@ -219,6 +234,11 @@ where
         // Account-level: the credentials are valid but the account isn't signed
         // up for S3 in this region — typically the wrong identity signed it.
         Some("NotSignedUp" | "OptInRequired") => StorageError::AccountNotSignedUp,
+        // Region mismatch: the bucket lives in another region than the client
+        // was built for, so S3 refuses with `PermanentRedirect` (the classic
+        // form) or the generic `Redirect`. Surface a clear message rather than
+        // the opaque "unclassified S3 error" this used to fall through to.
+        Some("PermanentRedirect" | "Redirect") => StorageError::WrongRegion,
         // Unmapped error: keep the full SDK detail in the server log (it can
         // embed the access key id, region, and endpoint — server-eyes only) and
         // hand the client a generic message rather than reflecting it back.
@@ -1053,6 +1073,61 @@ mod tests {
             S3Backend::from_client(aws_sdk_s3::Client::from_conf(cfg)),
             http_client,
         )
+    }
+
+    /// Build an `S3Backend` whose HTTP layer replays a single error response
+    /// (status + body) for the next request, so the error-classification path
+    /// can be exercised without a live S3.
+    fn replay_error_backend(status: u16, body: &str) -> S3Backend {
+        use aws_smithy_http_client::test_util::{ReplayEvent, StaticReplayClient};
+        use aws_smithy_types::body::SdkBody;
+
+        let http_client = StaticReplayClient::new(vec![ReplayEvent::new(
+            http::Request::builder()
+                .uri("https://s3.amazonaws.com/")
+                .body(SdkBody::empty())
+                .unwrap(),
+            http::Response::builder()
+                .status(status)
+                .body(SdkBody::from(body))
+                .unwrap(),
+        )]);
+        let cfg = aws_sdk_s3::config::Builder::new()
+            .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
+            .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                "test", "test", None, None, "test",
+            ))
+            .region(aws_sdk_s3::config::Region::new("us-east-1"))
+            .http_client(http_client)
+            .build();
+        S3Backend::from_client(aws_sdk_s3::Client::from_conf(cfg))
+    }
+
+    /// A `PermanentRedirect` (the error S3 returns when a bucket is addressed in
+    /// the wrong region) must classify to [`StorageError::WrongRegion`], not the
+    /// opaque `Other` that produced the "unclassified S3 error" log. This is the
+    /// regression guard for the cross-region bucket bug.
+    #[tokio::test]
+    async fn permanent_redirect_classifies_as_wrong_region() {
+        // The XML S3 sends on a region mismatch (HTTP 301 + PermanentRedirect).
+        let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <Error>
+              <Code>PermanentRedirect</Code>
+              <Message>The bucket you are attempting to access must be addressed using the specified endpoint.</Message>
+              <Endpoint>my-bucket.s3.us-west-2.amazonaws.com</Endpoint>
+            </Error>"#;
+        let backend = replay_error_backend(301, body);
+
+        let err = backend
+            .list_prefixes("my-bucket", "")
+            .await
+            .expect_err("a PermanentRedirect must surface as an error");
+        assert!(
+            matches!(err, StorageError::WrongRegion),
+            "expected WrongRegion, got {err:?}"
+        );
+        // The message points the user at the fix (set/detect the region).
+        assert!(err.to_string().contains("region"), "message: {err}");
     }
 
     #[tokio::test]

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -512,34 +512,69 @@
         const bucketsRow = document.getElementById('creds-buckets-row');
         const bucketsBox = document.getElementById('creds-buckets');
 
-        // Render the bucket picker. Buckets whose name contains "dial9" are
-        // surfaced first and highlighted, since those are the trace buckets.
+        // Whether the picker is showing every visible bucket or just the dial9
+        // trace buckets. Defaults to the filtered view; the "Show all" toggle
+        // flips it. Retained across re-renders (e.g. re-listing on reload).
+        let showAllBuckets = false;
+        // The last full bucket list from /api/buckets, so the toggle can
+        // re-render without another list call.
+        let lastBucketNames = [];
+
+        // Buckets whose name contains "dial9" are the trace buckets — surfaced
+        // by default. Everything else is hidden unless "Show all" is on.
+        const isTraceBucket = (n) => n.toLowerCase().includes('dial9');
+
+        // Render the bucket picker from the last listing. Shows the dial9 trace
+        // buckets by default, or every visible bucket when "Show all" is on. A
+        // toggle button lets the user switch (some deployments don't put "dial9"
+        // in the bucket name, so the filtered view can hide the real bucket).
         function renderBucketPicker(names) {
+            if (names) lastBucketNames = names;
+            names = lastBucketNames;
             bucketsBox.innerHTML = '';
             bucketsRow.style.display = '';
 
-            // Only trace buckets are relevant — hard-filter to names containing
-            // "dial9" and hide everything else.
-            const isMatch = (n) => n.toLowerCase().includes('dial9');
-            const matches = names.filter(isMatch).sort((a, b) => a.localeCompare(b));
+            const all = [...names].sort((a, b) => a.localeCompare(b));
+            const matches = all.filter(isTraceBucket);
+            const shown = showAllBuckets ? all : matches;
 
-            if (!matches.length) {
+            // A toggle to switch between the filtered (dial9-only) and full list.
+            // Only useful when the two differ — i.e. there are non-dial9 buckets.
+            function appendToggle() {
+                if (all.length === matches.length) return;
+                const t = document.createElement('button');
+                t.textContent = showAllBuckets
+                    ? `Show dial9 only (${matches.length})`
+                    : `Show all (${all.length})`;
+                t.style.cssText = 'font-style:italic;opacity:0.85';
+                t.addEventListener('click', () => {
+                    showAllBuckets = !showAllBuckets;
+                    renderBucketPicker();
+                });
+                bucketsBox.appendChild(t);
+            }
+
+            if (!shown.length) {
                 bucketsBox.textContent = names.length
                     ? 'No dial9 trace buckets visible to these credentials.'
                     : 'No buckets visible to these credentials.';
+                appendToggle();
                 return;
             }
 
-            for (const name of matches) {
+            for (const name of shown) {
                 const b = document.createElement('button');
                 b.textContent = name;
-                b.classList.add('match');
+                // Highlight the trace buckets even within the full list.
+                if (isTraceBucket(name)) b.classList.add('match');
                 b.addEventListener('click', () => selectBucket(name, b));
                 bucketsBox.appendChild(b);
             }
+            appendToggle();
 
-            // Auto-select when there's exactly one dial9 bucket — the common case.
-            if (matches.length === 1) {
+            // Auto-select when there's exactly one dial9 bucket — the common
+            // case — but not in the "show all" view, where the user is browsing.
+            if (!showAllBuckets && matches.length === 1) {
                 selectBucket(matches[0], bucketsBox.firstChild);
             }
         }
@@ -556,13 +591,16 @@
             if (result.ok) {
                 if (result.region) {
                     region.value = result.region;
-                    // Persist the resolved region so it rides on every request.
+                    // Persist the resolved region so it rides on every request,
+                    // then mirror it into the URL (aws_region) so a shared link
+                    // reproduces the cross-region bucket.
                     Dial9Creds.set({
                         accessKeyId: akid.value,
                         secretAccessKey: secret.value,
                         sessionToken: token.value,
                         region: result.region,
                     });
+                    syncUrl();
                 }
                 setStatus(`Using ${name}${result.region ? ` · region ${result.region}` : ''}`, 'ok');
                 discoverPrefixes().then(() => reRunCurrentSearch());
@@ -685,8 +723,14 @@
     // `from`/`to` so it reproduces exactly regardless of the viewer's TZ toggle.
     function syncUrl() {
         if (restoring) return;
+        // The bucket's region rides in the URL (as aws_region) so a cross-region
+        // bucket is reproducible from a shared link. The credentials store is the
+        // source of truth — it's where region detection lands — and the secret
+        // keys themselves are header-only, never serialized here.
+        const storedCreds = window.Dial9Creds ? Dial9Creds.get() : null;
         const state = {
             bucket: bucketInput.value.trim(),
+            region: (storedCreds && storedCreds.region) || '',
             prefix: prefixInput.value.trim(),
             tab: currentTab,
             tz: useLocalTz ? 'local' : 'utc',
@@ -716,6 +760,21 @@
     if (urlState.prefix) prefixInput.value = urlState.prefix;
     if (urlState.q) rawSearchInput.value = urlState.q;
     if (urlState.tab === 'raw') switchTab('raw');
+
+    // A shared link can pin the bucket's region (aws_region). Fold it into the
+    // stored credentials so every subsequent request carries it as the region
+    // header — this is what lets a cross-region bucket link load without a fresh
+    // detection round trip. Prefill the panel field too so it's visible. Only
+    // meaningful when credentials are present (region is header-only there); on
+    // the ambient path the server uses its own configured region.
+    if (urlState.region && window.Dial9Creds) {
+        const regionField = document.getElementById('creds-region');
+        if (regionField && !regionField.value) regionField.value = urlState.region;
+        const stored = Dial9Creds.get();
+        if (stored && stored.accessKeyId && stored.region !== urlState.region) {
+            Dial9Creds.set({ ...stored, region: urlState.region, autoDetectRegion: false });
+        }
+    }
 
     // Restore the time range. A relative `last=N` re-anchors to now (so a shared
     // link always shows the last N hours); a precise `from`/`to` is restored
@@ -759,7 +818,13 @@
         // Server defaults (bucket/prefix) were filled programmatically above;
         // reflect them in the URL so the link is complete.
         syncUrl();
-        discoverPrefixes().then(autoSearch);
+        // If we're restoring a bucket with credentials but no region pinned in
+        // the URL (aws_region already seeds the store during restore above),
+        // detect it before discovery/search so the first signed call lands on
+        // the right regional endpoint. A pinned region makes this a fast no-op.
+        detectRegionForBucket(bucketInput.value.trim())
+            .then(() => discoverPrefixes())
+            .then(autoSearch);
     }).catch(() => { discoverPrefixes().then(autoSearch); });
 
     // The initial time range is restored from the URL (or defaulted to last
@@ -773,6 +838,37 @@
         autoSearched = true;
         if (bucketInput.value.trim() && !document.getElementById('search-btn').disabled) {
             doTimeRangeSearch();
+        }
+    }
+
+    // ── Region auto-detection ──
+    // A bring-your-own-credentials request signs S3 for the region carried in
+    // the stored credentials. If that region doesn't match the bucket's, S3
+    // rejects the read with a redirect (surfaced by the backend as 421 "wrong
+    // region"). Before hitting any data endpoint for a NEW bucket, resolve its
+    // real region via /api/credentials/check (a region-agnostic HeadBucket that
+    // returns the true region even from the wrong endpoint) and persist it, so
+    // every later request — and the shared URL — carries the right region.
+    //
+    // No-op without credentials: the ambient path uses the server's own
+    // configured region, and the check endpoint requires credentials anyway.
+    async function detectRegionForBucket(bucket) {
+        if (!bucket || !window.Dial9Creds || !Dial9Creds.has()) return;
+        try {
+            const result = await Dial9Creds.check(bucket);
+            if (result.ok && result.region) {
+                const stored = Dial9Creds.get();
+                if (stored && stored.region !== result.region) {
+                    // Persist without a second round trip (region is known now).
+                    Dial9Creds.set({ ...stored, region: result.region, autoDetectRegion: false });
+                    const regionField = document.getElementById('creds-region');
+                    if (regionField) regionField.value = result.region;
+                    syncUrl();
+                }
+            }
+        } catch {
+            // Best-effort: on failure, leave the prior region in place — the data
+            // request will surface the actual error (e.g. the 421 wrong-region).
         }
     }
 
@@ -840,7 +936,16 @@
     // Re-discover when bucket changes (on commit), and keep the URL in sync as
     // the user types. Prefix discovery hits the server, so only run it on the
     // less-frequent `change`; mirror to the URL on every keystroke.
-    bucketInput.addEventListener('change', () => { discoverPrefixes(); syncUrl(); });
+    //
+    // Detect the (possibly cross-region) bucket's region FIRST: prefix discovery
+    // is itself a signed S3 call, so it would hit the wrong regional endpoint if
+    // the stored region is stale from a previous bucket. This is the manual-entry
+    // counterpart to the picker's selectBucket() region detection.
+    bucketInput.addEventListener('change', async () => {
+        await detectRegionForBucket(bucketInput.value.trim());
+        discoverPrefixes();
+        syncUrl();
+    });
     bucketInput.addEventListener('input', syncUrl);
 
     // ── Timezone toggle ──

--- a/dial9-viewer/ui/test_url_state.js
+++ b/dial9-viewer/ui/test_url_state.js
@@ -30,6 +30,13 @@ test("parse: decodes percent-encoded values", () => {
   assert.strictEqual(s.prefix, "a/b c");
 });
 
+test("parse: reads aws_region into region", () => {
+  const s = UrlState.parse("?bucket=b&aws_region=us-west-2");
+  assert.strictEqual(s.region, "us-west-2");
+  // An absent region stays unset (falls back to detection / default).
+  assert.strictEqual(UrlState.parse("?bucket=b").region, undefined);
+});
+
 test("parse: tab only accepts known values", () => {
   assert.strictEqual(UrlState.parse("?tab=raw").tab, "raw");
   assert.strictEqual(UrlState.parse("?tab=browse").tab, "browse");
@@ -113,6 +120,15 @@ test("serialize: ignores non-positive 'last'", () => {
   assert.strictEqual(qs, "from=1000&to=2000");
 });
 
+test("serialize: writes region as aws_region", () => {
+  assert.strictEqual(
+    UrlState.serialize({ bucket: "b", region: "eu-central-1" }),
+    "bucket=b&aws_region=eu-central-1"
+  );
+  // Empty region is omitted (the ambient/default path needs no region).
+  assert.strictEqual(UrlState.serialize({ bucket: "b", region: "" }), "bucket=b");
+});
+
 test("serialize: stable key order", () => {
   const qs = UrlState.serialize({
     q: "x",
@@ -121,9 +137,13 @@ test("serialize: stable key order", () => {
     tz: "local",
     tab: "raw",
     prefix: "p",
+    region: "us-west-2",
     bucket: "b",
   });
-  assert.strictEqual(qs, "bucket=b&prefix=p&tab=raw&tz=local&from=1000&to=2000&q=x");
+  assert.strictEqual(
+    qs,
+    "bucket=b&aws_region=us-west-2&prefix=p&tab=raw&tz=local&from=1000&to=2000&q=x"
+  );
 });
 
 test("serialize: percent-encodes values", () => {
@@ -150,6 +170,12 @@ test("round-trip: precise window in raw tab, local tz", () => {
     to: 1700003600,
     q: "2026-04-09/1910",
   };
+  const back = UrlState.parse("?" + UrlState.serialize(state));
+  assert.deepStrictEqual(back, state);
+});
+
+test("round-trip: cross-region bucket carries aws_region", () => {
+  const state = { bucket: "b", region: "ap-southeast-2", prefix: "traces", last: 1 };
   const back = UrlState.parse("?" + UrlState.serialize(state));
   assert.deepStrictEqual(back, state);
 });

--- a/dial9-viewer/ui/url_state.js
+++ b/dial9-viewer/ui/url_state.js
@@ -7,8 +7,12 @@
 // (loaded via require). Keep this dependency-free so both contexts can use it.
 //
 // State shape (all fields optional):
-//   { bucket, prefix, tab, tz, last, from, to, q }
+//   { bucket, region, prefix, tab, tz, last, from, to, q }
 //     bucket : S3 bucket name (string)
+//     region : S3 region the bucket lives in (string) — serialized as
+//              `aws_region`. Carried so a cross-region bucket is signed for the
+//              right endpoint and a shared link reproduces it (the region is not
+//              a secret; the credentials are header-only and never in the URL).
 //     prefix : user-entered key prefix (string)
 //     tab    : 'browse' | 'raw'   (default 'browse' — omitted from URL)
 //     tz     : 'utc' | 'local'    (default 'utc'    — omitted from URL)
@@ -33,6 +37,11 @@
 
     const bucket = p.get("bucket");
     if (bucket) out.bucket = bucket;
+
+    // `aws_region` matches the query param the backend already reads for the
+    // assume-role path, so one name means the same thing everywhere.
+    const region = p.get("aws_region");
+    if (region) out.region = region;
 
     const prefix = p.get("prefix");
     if (prefix) out.prefix = prefix;
@@ -71,6 +80,7 @@
     const p = new URLSearchParams();
 
     if (s.bucket) p.set("bucket", s.bucket);
+    if (s.region) p.set("aws_region", s.region);
     if (s.prefix) p.set("prefix", s.prefix);
     // 'browse' is the default tab, so only the non-default 'raw' is recorded.
     if (s.tab === "raw") p.set("tab", s.tab);


### PR DESCRIPTION
## Problem

Specifying an S3 bucket **manually** in the viewer breaks when the bucket lives in a region other than the one the credentials were signed for. The bring-your-own-credentials path builds an ephemeral S3 client pinned to the request's region (defaulting to `us-east-1`), and S3 refuses a cross-region read with `PermanentRedirect`. That error fell through to the opaque `_` arm of `classify_s3_error`, producing the reported log:

```
WARN dial9_viewer::storage: unclassified S3 error error=... (PermanentRedirect): "The bucket you are attempting to access must be addressed using the specified endpoint..."
```

The bucket **picker** flow already avoided this because `selectBucket` calls `/api/credentials/check` (a region-agnostic `HeadBucket` that returns the true region even from the wrong endpoint) and persists the region. Manual entry never did.

## Fix

**Backend**
- Classify `PermanentRedirect` / `Redirect` into a new `StorageError::WrongRegion` with an actionable message, instead of the opaque `Other` → "unclassified S3 error". Mapped to HTTP **421 Misdirected Request**.

**Region as a first-class, respected query param**
- `aws_region` is now serialized into the viewer URL and mirrored from the credentials store (the browser/URL is the cache — no server-side cache). Secret keys stay header-only and are never put in the URL.
- **Manual bucket entry** now auto-detects the bucket's region before any signed call (prefix discovery, search), matching the picker. A shared cross-region link reproduces the bucket without a redetect.
- The backend already honored `aws_region` for BYOC/assume-role via `parse_cred_inputs`; this wires the UI to produce and carry it.

**Show all buckets**
- The bucket picker hard-filtered to names containing `dial9`. Added a **"Show all"** toggle that reveals every bucket the credentials can see (trace buckets stay highlighted), since not every deployment names buckets `*dial9*`.

## Tests
- Rust: regression test that `PermanentRedirect` (301) classifies as `WrongRegion` (via a `StaticReplayClient`).
- JS: `url_state` parse/serialize/round-trip for `aws_region`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features` (clean), `cargo nextest run -p dial9-viewer` (144 passed), stress run `--stress-duration 20s` (8 iterations passed), `cargo build -p dial9-viewer`, and the affected node UI tests all pass.

No trace-format changes, so the demo trace is untouched.