### PR TITLE
Handle role_arn in the viewer

### DIFF
--- a/dial9-viewer/ui/creds.js
+++ b/dial9-viewer/ui/creds.js
@@ -24,6 +24,9 @@
     secretAccessKey: "x-dial9-aws-secret-access-key",
     sessionToken: "x-dial9-aws-session-token",
     region: "x-dial9-aws-region",
+    // Assume-role path: name a role for the server to assume with its own
+    // identity, instead of supplying static keys. Alternative to the four above.
+    roleArn: "x-dial9-aws-role-arn",
   };
 
   // Resolve a storage backend. In the browser this is sessionStorage (creds die
@@ -57,15 +60,20 @@
     }
   }
 
-  /** True if a (at least partially) usable credential set is stored. */
+  /**
+   * True if a usable credential set is stored. That is either a static
+   * bring-your-own key pair, OR an assume-role ARN — both let the backend reach
+   * S3 on the user's behalf, so both count as "credentials are active" for the
+   * UI (green button, region header, re-run on change).
+   */
   function has() {
     const c = get();
-    return !!(c && c.accessKeyId && c.secretAccessKey);
+    return !!(c && ((c.accessKeyId && c.secretAccessKey) || c.roleArn));
   }
 
   /** Persist credentials and notify listeners. Returns the stored object.
    *
-   * @param {{accessKeyId, secretAccessKey, sessionToken?, region?}} creds
+   * @param {{accessKeyId?, secretAccessKey?, sessionToken?, region?, roleArn?}} creds
    */
   function store(creds) {
     const clean = {
@@ -73,6 +81,7 @@
       secretAccessKey: (creds.secretAccessKey || "").trim(),
       sessionToken: (creds.sessionToken || "").trim() || undefined,
       region: (creds.region || "").trim() || undefined,
+      roleArn: (creds.roleArn || "").trim() || undefined,
     };
     storage().setItem(STORAGE_KEY, JSON.stringify(clean));
     notifyChanged();
@@ -135,6 +144,49 @@
       );
     }
     return { accessKeyId, secretAccessKey, sessionToken, region };
+  }
+
+  /**
+   * Syntactic check that `arn` names a single IAM role, mirroring the server's
+   * `is_valid_role_arn` (src/server/credentials.rs) so the UI rejects a
+   * malformed value up front instead of round-tripping to a 400. Shape:
+   * `arn:{aws|aws-cn|aws-us-gov}:iam::{12-digit account}:role/{name}` (or
+   * `role/{path}/{name}`), name non-empty and wildcard-free.
+   */
+  function isValidRoleArn(arn) {
+    if (!arn || arn.length > 2048) return false;
+    // arn : partition : service : region : account : resource
+    const parts = arn.split(":");
+    if (parts.length < 6) return false;
+    const [prefix, partition, service, region, account] = parts;
+    const resource = parts.slice(5).join(":");
+    if (prefix !== "arn") return false;
+    if (!["aws", "aws-cn", "aws-us-gov"].includes(partition)) return false;
+    if (service !== "iam" || region !== "") return false;
+    if (!/^[0-9]{12}$/.test(account)) return false;
+    if (!resource.startsWith("role/")) return false;
+    const rest = resource.slice("role/".length);
+    return rest.length > 0 && !rest.includes("*") && !rest.includes("?");
+  }
+
+  /**
+   * Store an assume-role ARN as the active credential (the linkable
+   * `?aws_role_arn=…` path). Clears any static BYOC keys so the two transports
+   * never coexist — the server rejects both together (`ConflictingCredentials`).
+   * An optional `region` pins the S3 endpoint, exactly like the BYOC region.
+   *
+   * Throws on a malformed ARN so a bad link fails loudly rather than silently
+   * falling back to the server's default identity. Returns the stored object.
+   *
+   * @param {string} roleArn IAM role ARN the server should assume
+   * @param {{region?: string}} [opts]
+   */
+  function setRoleArn(roleArn, opts = {}) {
+    const arn = (roleArn || "").trim();
+    if (!isValidRoleArn(arn)) {
+      throw new Error(`invalid role ARN: ${roleArn}`);
+    }
+    return store({ roleArn: arn, region: opts.region });
   }
 
   /**
@@ -236,17 +288,36 @@
    * Build the `x-dial9-aws-*` request headers from the stored credentials.
    * Returns an empty object when nothing is stored (so it can be spread into any
    * fetch unconditionally). Token/region keys are omitted when unset.
+   *
+   * Two mutually-exclusive transports (the server rejects both at once with
+   * `ConflictingCredentials`):
+   *  - static BYOC keys → the four `access-key-id`/`secret-access-key`/
+   *    `session-token`/`region` headers;
+   *  - an assume-role ARN → the single `role-arn` header (+ optional `region`).
+   * Static keys win when both happen to be stored, since a full key set is the
+   * more specific intent; the region rides along either way.
    */
   function headers() {
     const c = get();
-    if (!c || !c.accessKeyId || !c.secretAccessKey) return {};
-    const h = {
-      [H.accessKeyId]: c.accessKeyId,
-      [H.secretAccessKey]: c.secretAccessKey,
-    };
-    if (c.sessionToken) h[H.sessionToken] = c.sessionToken;
-    if (c.region) h[H.region] = c.region;
-    return h;
+    if (!c) return {};
+
+    if (c.accessKeyId && c.secretAccessKey) {
+      const h = {
+        [H.accessKeyId]: c.accessKeyId,
+        [H.secretAccessKey]: c.secretAccessKey,
+      };
+      if (c.sessionToken) h[H.sessionToken] = c.sessionToken;
+      if (c.region) h[H.region] = c.region;
+      return h;
+    }
+
+    if (c.roleArn) {
+      const h = { [H.roleArn]: c.roleArn };
+      if (c.region) h[H.region] = c.region;
+      return h;
+    }
+
+    return {};
   }
 
   /** Fire a `dial9:credentials-changed` event so the UI can refresh. */
@@ -260,6 +331,8 @@
     get,
     has,
     set,
+    setRoleArn,
+    isValidRoleArn,
     parse,
     check,
     listBuckets,

--- a/dial9-viewer/ui/creds.js
+++ b/dial9-viewer/ui/creds.js
@@ -50,42 +50,111 @@
     return injectedStorage;
   }
 
-  /** Read the stored credentials, or null if none are set. */
+  /**
+   * Read the active credential, normalized to exactly one of two shapes (or null
+   * when nothing usable is stored):
+   *
+   *   { kind: "static", accessKeyId, secretAccessKey, sessionToken?, region? }
+   *   { kind: "role",   roleArn, region? }
+   *
+   * This mirrors the server's `CredSource` union (src/server/credentials.rs):
+   * exactly one transport is active per request, and the two never coexist.
+   * Normalizing on read (see [`classify`]) means every consumer — `has`,
+   * `headers`, `setRegion` — branches on `kind` instead of re-deriving which
+   * transport applies, and the "both at once" combination is unrepresentable
+   * rather than something downstream code has to defend against.
+   */
   function get() {
     try {
       const raw = storage().getItem(STORAGE_KEY);
-      return raw ? JSON.parse(raw) : null;
+      return raw ? classify(JSON.parse(raw)) : null;
     } catch {
       return null;
     }
   }
 
   /**
-   * True if a usable credential set is stored. That is either a static
-   * bring-your-own key pair, OR an assume-role ARN — both let the backend reach
-   * S3 on the user's behalf, so both count as "credentials are active" for the
-   * UI (green button, region header, re-run on change).
+   * Collapse a stored bag into the one canonical credential shape it represents,
+   * or null if it names no usable transport. This is the single place the
+   * "static and role never coexist" invariant is enforced: a bag carrying both a
+   * static key pair and a role ARN resolves to static (the more specific intent),
+   * so `headers`/`has` never see the ambiguous pair.
+   *
+   * Tolerant of the legacy flat bag (pre-discriminant, and the static-only shape
+   * that predates assume-role): those have no `kind`, so we derive it from the
+   * fields present. sessionStorage is tab-scoped, but a tab open across the
+   * upgrade can still hold one.
    */
-  function has() {
-    const c = get();
-    return !!(c && ((c.accessKeyId && c.secretAccessKey) || c.roleArn));
+  function classify(bag) {
+    if (!bag) return null;
+    const region = (bag.region || "").trim() || undefined;
+    if (bag.accessKeyId && bag.secretAccessKey) {
+      return {
+        kind: "static",
+        accessKeyId: bag.accessKeyId,
+        secretAccessKey: bag.secretAccessKey,
+        sessionToken: (bag.sessionToken || "").trim() || undefined,
+        region,
+      };
+    }
+    if (bag.roleArn) {
+      return { kind: "role", roleArn: bag.roleArn, region };
+    }
+    return null;
   }
 
-  /** Persist credentials and notify listeners. Returns the stored object.
-   *
-   * @param {{accessKeyId?, secretAccessKey?, sessionToken?, region?, roleArn?}} creds
-   */
-  function store(creds) {
-    const clean = {
+  /** True if a usable credential (static keys or a role ARN) is stored. */
+  function has() {
+    return !!get();
+  }
+
+  /** Write a fully-formed credential object to storage and notify listeners.
+   * The object is trusted as-is; callers build it via [`storeStatic`] /
+   * [`storeRole`] / [`setRegion`], which own the per-kind shape and trimming. */
+  function persist(obj) {
+    storage().setItem(STORAGE_KEY, JSON.stringify(obj));
+    notifyChanged();
+    return obj;
+  }
+
+  /** Persist a static bring-your-own key pair as the active credential. Replaces
+   * whatever was stored, so a prior role ARN cannot linger alongside the keys. */
+  function storeStatic(creds) {
+    return persist({
+      kind: "static",
       accessKeyId: (creds.accessKeyId || "").trim(),
       secretAccessKey: (creds.secretAccessKey || "").trim(),
       sessionToken: (creds.sessionToken || "").trim() || undefined,
       region: (creds.region || "").trim() || undefined,
-      roleArn: (creds.roleArn || "").trim() || undefined,
-    };
-    storage().setItem(STORAGE_KEY, JSON.stringify(clean));
-    notifyChanged();
-    return clean;
+    });
+  }
+
+  /** Persist an assume-role ARN as the active credential. Replaces whatever was
+   * stored, so static keys cannot linger alongside the ARN — the two transports
+   * never coexist (the server rejects both together, `ConflictingCredentials`).
+   * `roleArn` is trusted to be validated/trimmed by the caller ([`setRoleArn`]). */
+  function storeRole(roleArn, region) {
+    return persist({
+      kind: "role",
+      roleArn,
+      region: (region || "").trim() || undefined,
+    });
+  }
+
+  /**
+   * Patch the region onto whatever credential is currently stored, preserving
+   * its kind. This is the one region-update entry point for both transports:
+   * region auto-detection persists the resolved region here without caring
+   * whether the active credential is static keys or an assumed role. No-op (and
+   * returns null) when nothing is stored — the ambient path has no per-request
+   * region to pin. Returns the stored object.
+   *
+   * @param {string} region resolved AWS region name
+   */
+  function setRegion(region) {
+    const c = get();
+    if (!c) return null;
+    return persist({ ...c, region: (region || "").trim() || undefined });
   }
 
   /**
@@ -186,7 +255,7 @@
     if (!isValidRoleArn(arn)) {
       throw new Error(`invalid role ARN: ${roleArn}`);
     }
-    return store({ roleArn: arn, region: opts.region });
+    return storeRole(arn, opts.region);
   }
 
   /**
@@ -211,7 +280,7 @@
     }
 
     // Store first so the headers are available to the check request itself.
-    store(creds);
+    storeStatic(creds);
 
     const wantCheck =
       (creds.autoDetectRegion || !creds.region) &&
@@ -224,7 +293,7 @@
       const result = await check(creds.bucket);
       if (result.ok && result.region) {
         // Persist the resolved region for subsequent requests.
-        store({ ...get(), region: result.region });
+        setRegion(result.region);
       }
       // Intentionally do NOT clear the stored credentials when the check fails.
       // A failed check is often bucket-specific (wrong bucket name, or no access
@@ -285,39 +354,31 @@
   }
 
   /**
-   * Build the `x-dial9-aws-*` request headers from the stored credentials.
+   * Build the `x-dial9-aws-*` request headers for the active credential.
    * Returns an empty object when nothing is stored (so it can be spread into any
    * fetch unconditionally). Token/region keys are omitted when unset.
    *
-   * Two mutually-exclusive transports (the server rejects both at once with
+   * One transport per request, keyed off the stored credential's `kind` (the two
+   * are mutually exclusive — the server rejects both at once with
    * `ConflictingCredentials`):
-   *  - static BYOC keys → the four `access-key-id`/`secret-access-key`/
-   *    `session-token`/`region` headers;
+   *  - static BYOC keys → the `access-key-id`/`secret-access-key`/
+   *    `session-token` headers (+ optional `region`);
    *  - an assume-role ARN → the single `role-arn` header (+ optional `region`).
-   * Static keys win when both happen to be stored, since a full key set is the
-   * more specific intent; the region rides along either way.
    */
   function headers() {
     const c = get();
     if (!c) return {};
 
-    if (c.accessKeyId && c.secretAccessKey) {
-      const h = {
-        [H.accessKeyId]: c.accessKeyId,
-        [H.secretAccessKey]: c.secretAccessKey,
-      };
+    const h = {};
+    if (c.kind === "static") {
+      h[H.accessKeyId] = c.accessKeyId;
+      h[H.secretAccessKey] = c.secretAccessKey;
       if (c.sessionToken) h[H.sessionToken] = c.sessionToken;
-      if (c.region) h[H.region] = c.region;
-      return h;
+    } else if (c.kind === "role") {
+      h[H.roleArn] = c.roleArn;
     }
-
-    if (c.roleArn) {
-      const h = { [H.roleArn]: c.roleArn };
-      if (c.region) h[H.region] = c.region;
-      return h;
-    }
-
-    return {};
+    if (c.region) h[H.region] = c.region;
+    return h;
   }
 
   /** Fire a `dial9:credentials-changed` event so the UI can refresh. */
@@ -332,6 +393,7 @@
     has,
     set,
     setRoleArn,
+    setRegion,
     isValidRoleArn,
     parse,
     check,

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -757,6 +757,10 @@
         const state = {
             bucket: bucketInput.value.trim(),
             region: (storedCreds && storedCreds.region) || '',
+            // Keep the assume-role ARN in the URL so the read stays shareable
+            // (it's not a secret; static BYOC keys are never serialized). The
+            // store is the source of truth — echo whatever it holds.
+            roleArn: (storedCreds && storedCreds.roleArn) || '',
             prefix: prefixInput.value.trim(),
             tab: currentTab,
             tz: useLocalTz ? 'local' : 'utc',
@@ -787,12 +791,29 @@
     if (urlState.q) rawSearchInput.value = urlState.q;
     if (urlState.tab === 'raw') switchTab('raw');
 
+    // A shared link can carry an assume-role ARN (aws_role_arn): "read these
+    // traces as this role". Fold it into the credentials store as the
+    // assume-role transport, so every subsequent /api/* request carries the
+    // x-dial9-aws-role-arn header and the server assumes it with its own
+    // identity. A role ARN grants nothing on its own, which is why it is safe in
+    // a link. An invalid ARN throws (Dial9Creds.setRoleArn validates the shape);
+    // surface it rather than silently falling back to the server's identity.
+    if (urlState.roleArn && window.Dial9Creds) {
+        try {
+            Dial9Creds.setRoleArn(urlState.roleArn, { region: urlState.region });
+        } catch (e) {
+            console.warn('ignoring invalid aws_role_arn in URL:', e && e.message || e);
+        }
+    }
+
     // A shared link can pin the bucket's region (aws_region). Fold it into the
     // stored credentials so every subsequent request carries it as the region
     // header — this is what lets a cross-region bucket link load without a fresh
     // detection round trip. Prefill the panel field too so it's visible. Only
     // meaningful when credentials are present (region is header-only there); on
-    // the ambient path the server uses its own configured region.
+    // the ambient path the server uses its own configured region. (The
+    // assume-role branch above already stored the region alongside the ARN; this
+    // covers the static-BYOC case and is a no-op when the ARN path ran.)
     if (urlState.region && window.Dial9Creds) {
         const regionField = document.getElementById('creds-region');
         if (regionField && !regionField.value) regionField.value = urlState.region;

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -617,15 +617,11 @@
             if (result.ok) {
                 if (result.region) {
                     region.value = result.region;
-                    // Persist the resolved region so it rides on every request,
-                    // then mirror it into the URL (aws_region) so a shared link
-                    // reproduces the cross-region bucket.
-                    Dial9Creds.set({
-                        accessKeyId: akid.value,
-                        secretAccessKey: secret.value,
-                        sessionToken: token.value,
-                        region: result.region,
-                    });
+                    // Persist the resolved region onto whatever credential is
+                    // active (static keys or an assumed role), then mirror it
+                    // into the URL (aws_region) so a shared link reproduces the
+                    // cross-region bucket.
+                    Dial9Creds.setRegion(result.region);
                     syncUrl();
                 }
                 setStatus(`Using ${name}${result.region ? ` · region ${result.region}` : ''}`, 'ok');
@@ -811,15 +807,16 @@
     // header — this is what lets a cross-region bucket link load without a fresh
     // detection round trip. Prefill the panel field too so it's visible. Only
     // meaningful when credentials are present (region is header-only there); on
-    // the ambient path the server uses its own configured region. (The
-    // assume-role branch above already stored the region alongside the ARN; this
-    // covers the static-BYOC case and is a no-op when the ARN path ran.)
+    // the ambient path the server uses its own configured region. Applies to
+    // either transport via setRegion (a no-op when nothing is stored, and when
+    // the assume-role branch above already stored this same region alongside the
+    // ARN).
     if (urlState.region && window.Dial9Creds) {
         const regionField = document.getElementById('creds-region');
         if (regionField && !regionField.value) regionField.value = urlState.region;
         const stored = Dial9Creds.get();
-        if (stored && stored.accessKeyId && stored.region !== urlState.region) {
-            Dial9Creds.set({ ...stored, region: urlState.region, autoDetectRegion: false });
+        if (stored && stored.region !== urlState.region) {
+            Dial9Creds.setRegion(urlState.region);
         }
     }
 
@@ -907,7 +904,10 @@
                 const stored = Dial9Creds.get();
                 if (stored && stored.region !== result.region) {
                     // Persist without a second round trip (region is known now).
-                    Dial9Creds.set({ ...stored, region: result.region, autoDetectRegion: false });
+                    // setRegion keeps the active transport's kind, so this works
+                    // for an assumed-role credential too — a static-only set()
+                    // would throw here for the role path.
+                    Dial9Creds.setRegion(result.region);
                     const regionField = document.getElementById('creds-region');
                     if (regionField) regionField.value = result.region;
                     syncUrl();

--- a/dial9-viewer/ui/test_creds.js
+++ b/dial9-viewer/ui/test_creds.js
@@ -26,6 +26,9 @@ const H_AKID = "x-dial9-aws-access-key-id";
 const H_SECRET = "x-dial9-aws-secret-access-key";
 const H_TOKEN = "x-dial9-aws-session-token";
 const H_REGION = "x-dial9-aws-region";
+const H_ROLE_ARN = "x-dial9-aws-role-arn";
+
+const VALID_ARN = "arn:aws:iam::123456789012:role/dial9-reader";
 
 async function main() {
 
@@ -94,6 +97,70 @@ await testAsync("set() rejects when a required field is missing", async () => {
 await testAsync("clear() removes stored credentials", async () => {
   freshStore();
   await Dial9Creds.set({ accessKeyId: "AKIA", secretAccessKey: "secret" });
+  assert.strictEqual(Dial9Creds.has(), true);
+  Dial9Creds.clear();
+  assert.strictEqual(Dial9Creds.has(), false);
+  assert.deepStrictEqual(Dial9Creds.headers(), {});
+});
+
+// ── assume-role transport (setRoleArn / role-arn header) ──
+
+test("setRoleArn() stores the ARN and emits the role-arn header", () => {
+  freshStore();
+  Dial9Creds.setRoleArn(VALID_ARN);
+  assert.strictEqual(Dial9Creds.has(), true);
+  assert.deepStrictEqual(Dial9Creds.headers(), { [H_ROLE_ARN]: VALID_ARN });
+});
+
+test("setRoleArn() carries an optional region alongside the ARN", () => {
+  freshStore();
+  Dial9Creds.setRoleArn(VALID_ARN, { region: "us-west-2" });
+  assert.deepStrictEqual(Dial9Creds.headers(), {
+    [H_ROLE_ARN]: VALID_ARN,
+    [H_REGION]: "us-west-2",
+  });
+});
+
+test("setRoleArn() rejects a malformed ARN", () => {
+  freshStore();
+  assert.throws(() => Dial9Creds.setRoleArn("not-an-arn"), /invalid role ARN/);
+  // A rejected ARN must not leave anything stored.
+  assert.strictEqual(Dial9Creds.has(), false);
+});
+
+test("headers(): static BYOC keys win over a stored role ARN (never both)", () => {
+  // The server rejects a request carrying both transports
+  // (ConflictingCredentials), so headers() must emit exactly one. A full key set
+  // is the more specific intent, so it wins. Seed a store holding both directly
+  // to prove the guard.
+  const s = fakeStorage();
+  Dial9Creds._setStorage(s);
+  s.setItem(
+    "dial9.aws-credentials",
+    JSON.stringify({ accessKeyId: "AK", secretAccessKey: "SK", roleArn: VALID_ARN })
+  );
+  const h = Dial9Creds.headers();
+  assert.strictEqual(h[H_AKID], "AK");
+  assert.strictEqual(h[H_SECRET], "SK");
+  assert.ok(!(H_ROLE_ARN in h), "role-arn header omitted when static keys present");
+});
+
+test("isValidRoleArn() mirrors the server's shape check", () => {
+  assert.ok(Dial9Creds.isValidRoleArn(VALID_ARN));
+  assert.ok(Dial9Creds.isValidRoleArn("arn:aws:iam::123456789012:role/path/to/reader"));
+  assert.ok(Dial9Creds.isValidRoleArn("arn:aws-us-gov:iam::123456789012:role/r"));
+  // Rejections: wrong service, a region field, short account, wildcard, non-role.
+  assert.ok(!Dial9Creds.isValidRoleArn("arn:aws:sts::123456789012:role/r"));
+  assert.ok(!Dial9Creds.isValidRoleArn("arn:aws:iam:us-east-1:123456789012:role/r"));
+  assert.ok(!Dial9Creds.isValidRoleArn("arn:aws:iam::12345:role/r"));
+  assert.ok(!Dial9Creds.isValidRoleArn("arn:aws:iam::123456789012:role/*"));
+  assert.ok(!Dial9Creds.isValidRoleArn("arn:aws:iam::123456789012:user/u"));
+  assert.ok(!Dial9Creds.isValidRoleArn(""));
+});
+
+test("clear() removes a stored role ARN too", () => {
+  freshStore();
+  Dial9Creds.setRoleArn(VALID_ARN);
   assert.strictEqual(Dial9Creds.has(), true);
   Dial9Creds.clear();
   assert.strictEqual(Dial9Creds.has(), false);

--- a/dial9-viewer/ui/test_creds.js
+++ b/dial9-viewer/ui/test_creds.js
@@ -128,21 +128,83 @@ test("setRoleArn() rejects a malformed ARN", () => {
   assert.strictEqual(Dial9Creds.has(), false);
 });
 
-test("headers(): static BYOC keys win over a stored role ARN (never both)", () => {
+test("get(): a bag carrying both transports resolves to a single static kind", () => {
   // The server rejects a request carrying both transports
-  // (ConflictingCredentials), so headers() must emit exactly one. A full key set
-  // is the more specific intent, so it wins. Seed a store holding both directly
-  // to prove the guard.
+  // (ConflictingCredentials), so the store must resolve to exactly one. classify()
+  // is the single place that invariant lives: a full key set is the more specific
+  // intent, so it wins and the role ARN is dropped. Seed a store holding both
+  // directly (the writers never produce this) to prove classify().
   const s = fakeStorage();
   Dial9Creds._setStorage(s);
   s.setItem(
     "dial9.aws-credentials",
     JSON.stringify({ accessKeyId: "AK", secretAccessKey: "SK", roleArn: VALID_ARN })
   );
+  const c = Dial9Creds.get();
+  assert.strictEqual(c.kind, "static");
+  assert.ok(!("roleArn" in c), "role ARN dropped when static keys present");
   const h = Dial9Creds.headers();
   assert.strictEqual(h[H_AKID], "AK");
   assert.strictEqual(h[H_SECRET], "SK");
   assert.ok(!(H_ROLE_ARN in h), "role-arn header omitted when static keys present");
+});
+
+test("get(): a legacy flat bag (no kind) is classified by the fields present", () => {
+  // sessionStorage is tab-scoped, but a tab open across the upgrade to the
+  // discriminated shape can hold a pre-kind bag. Static-only and role-only legacy
+  // bags must still classify and emit the right headers.
+  const s = fakeStorage();
+  Dial9Creds._setStorage(s);
+  s.setItem(
+    "dial9.aws-credentials",
+    JSON.stringify({ accessKeyId: "AK", secretAccessKey: "SK", region: "us-east-1" })
+  );
+  assert.strictEqual(Dial9Creds.get().kind, "static");
+  assert.deepStrictEqual(Dial9Creds.headers(), {
+    [H_AKID]: "AK",
+    [H_SECRET]: "SK",
+    [H_REGION]: "us-east-1",
+  });
+
+  s.setItem("dial9.aws-credentials", JSON.stringify({ roleArn: VALID_ARN }));
+  assert.strictEqual(Dial9Creds.get().kind, "role");
+  assert.deepStrictEqual(Dial9Creds.headers(), { [H_ROLE_ARN]: VALID_ARN });
+});
+
+// ── setRegion(): shape-agnostic region patch (both transports) ──
+
+test("setRegion() pins the region on a static credential, preserving the keys", () => {
+  freshStore();
+  Dial9Creds.set({ accessKeyId: "AK", secretAccessKey: "SK", sessionToken: "TK" });
+  Dial9Creds.setRegion("us-west-2");
+  assert.deepStrictEqual(Dial9Creds.headers(), {
+    [H_AKID]: "AK",
+    [H_SECRET]: "SK",
+    [H_TOKEN]: "TK",
+    [H_REGION]: "us-west-2",
+  });
+});
+
+test("setRegion() pins the region on an assumed-role credential (the role path)", () => {
+  // Region auto-detection persists the resolved region via setRegion. With a role
+  // credential active this must keep the role transport — the old static-only
+  // set({...stored, region}) would have thrown here.
+  freshStore();
+  Dial9Creds.setRoleArn(VALID_ARN);
+  Dial9Creds.setRegion("eu-central-1");
+  assert.deepStrictEqual(Dial9Creds.headers(), {
+    [H_ROLE_ARN]: VALID_ARN,
+    [H_REGION]: "eu-central-1",
+  });
+  // Still a role credential — no static keys crept in.
+  assert.strictEqual(Dial9Creds.get().kind, "role");
+});
+
+test("setRegion() is a no-op when nothing is stored (ambient path)", () => {
+  freshStore();
+  assert.strictEqual(Dial9Creds.setRegion("us-east-1"), null);
+  assert.strictEqual(Dial9Creds.has(), false);
+  assert.deepStrictEqual(Dial9Creds.headers(), {});
 });
 
 test("isValidRoleArn() mirrors the server's shape check", () => {

--- a/dial9-viewer/ui/test_url_state.js
+++ b/dial9-viewer/ui/test_url_state.js
@@ -37,6 +37,37 @@ test("parse: reads aws_region into region", () => {
   assert.strictEqual(UrlState.parse("?bucket=b").region, undefined);
 });
 
+test("parse: reads aws_role_arn into roleArn", () => {
+  const arn = "arn:aws:iam::123456789012:role/dial9-reader";
+  const s = UrlState.parse("?bucket=b&aws_role_arn=" + encodeURIComponent(arn));
+  assert.strictEqual(s.roleArn, arn);
+  // An absent role ARN stays unset (ambient / static-BYOC path).
+  assert.strictEqual(UrlState.parse("?bucket=b").roleArn, undefined);
+});
+
+test("serialize: writes roleArn as aws_role_arn", () => {
+  const arn = "arn:aws:iam::123456789012:role/dial9-reader";
+  const qs = UrlState.serialize({ bucket: "b", region: "us-west-2", roleArn: arn });
+  assert.strictEqual(
+    qs,
+    "bucket=b&aws_region=us-west-2&aws_role_arn=" + encodeURIComponent(arn)
+  );
+  // Empty roleArn is omitted (static-BYOC / ambient path carries none).
+  assert.strictEqual(UrlState.serialize({ bucket: "b", roleArn: "" }), "bucket=b");
+});
+
+test("round-trip: assume-role link carries aws_role_arn", () => {
+  const state = {
+    bucket: "b",
+    region: "us-east-1",
+    roleArn: "arn:aws:iam::123456789012:role/dial9-reader",
+    prefix: "dial9-traces",
+    last: 1,
+  };
+  const back = UrlState.parse("?" + UrlState.serialize(state));
+  assert.deepStrictEqual(back, state);
+});
+
 test("parse: tab only accepts known values", () => {
   assert.strictEqual(UrlState.parse("?tab=raw").tab, "raw");
   assert.strictEqual(UrlState.parse("?tab=browse").tab, "browse");

--- a/dial9-viewer/ui/url_state.js
+++ b/dial9-viewer/ui/url_state.js
@@ -7,12 +7,19 @@
 // (loaded via require). Keep this dependency-free so both contexts can use it.
 //
 // State shape (all fields optional):
-//   { bucket, region, prefix, tab, tz, last, from, to, q }
+//   { bucket, region, roleArn, prefix, tab, tz, last, from, to, q }
 //     bucket : S3 bucket name (string)
 //     region : S3 region the bucket lives in (string) — serialized as
 //              `aws_region`. Carried so a cross-region bucket is signed for the
 //              right endpoint and a shared link reproduces it (the region is not
 //              a secret; the credentials are header-only and never in the URL).
+//     roleArn: IAM role the server should assume for this read (string) —
+//              serialized as `aws_role_arn`. This is the linkable assume-role
+//              path: a shared "read these traces as this role" link. A role ARN
+//              grants nothing on its own (the server's identity must be allowed
+//              to assume it), so it is safe in a URL — the same property the
+//              backend relies on, and why it round-trips like `aws_region`
+//              rather than being hidden like the secret BYOC keys.
 //     prefix : user-entered key prefix (string)
 //     tab    : 'browse' | 'raw'   (default 'browse' — omitted from URL)
 //     tz     : 'utc' | 'local'    (default 'utc'    — omitted from URL)
@@ -42,6 +49,13 @@
     // assume-role path, so one name means the same thing everywhere.
     const region = p.get("aws_region");
     if (region) out.region = region;
+
+    // `aws_role_arn` names a role for the server to assume (the linkable
+    // assume-role path — see the state-shape note). Validation of the ARN shape
+    // is left to the credentials store (Dial9Creds.setRoleArn), which index.html
+    // seeds from this on load.
+    const roleArn = p.get("aws_role_arn");
+    if (roleArn) out.roleArn = roleArn;
 
     const prefix = p.get("prefix");
     if (prefix) out.prefix = prefix;
@@ -81,6 +95,11 @@
 
     if (s.bucket) p.set("bucket", s.bucket);
     if (s.region) p.set("aws_region", s.region);
+    // `aws_role_arn` round-trips so the assume-role read stays shareable (a role
+    // ARN is not a secret — see the state-shape note). index.html feeds this
+    // from the active credential store on syncUrl, so a role loaded from the
+    // panel or a prior link is reflected back into the address bar.
+    if (s.roleArn) p.set("aws_role_arn", s.roleArn);
     if (s.prefix) p.set("prefix", s.prefix);
     // 'browse' is the default tab, so only the non-default 'raw' is recorded.
     if (s.tab === "raw") p.set("tab", s.tab);


### PR DESCRIPTION
the backend handled role_arn but the viewer didn't properly pass these through