### PR TITLE
Sample SchedStat::read_current in worker park/unpark

### DIFF
--- a/dial9-tokio-telemetry/benches/threadlocal_encode_iai.rs
+++ b/dial9-tokio-telemetry/benches/threadlocal_encode_iai.rs
@@ -73,7 +73,7 @@ fn encode_batch(encoder: &mut Encoder<Vec<u8>>, batch: &[(u64, WorkerId, TaskId)
         worker_id: batch[0].1,
         local_queue: 5,
         cpu_time_ns: 500_000,
-        sched_wait_ns: 1_000,
+        sched_wait_ns: Some(1_000),
         tid: 0,
     });
 }

--- a/dial9-tokio-telemetry/benches/writer_encode_iai.rs
+++ b/dial9-tokio-telemetry/benches/writer_encode_iai.rs
@@ -43,7 +43,7 @@ fn encode(workers: Vec<usize>) -> Vec<u8> {
                 worker_id: wid,
                 local_queue: 5,
                 cpu_time_ns: 500_000,
-                sched_wait_ns: 1_000,
+                sched_wait_ns: Some(1_000),
                 tid: 0,
             });
 

--- a/dial9-tokio-telemetry/benches/writer_write_encoded_iai.rs
+++ b/dial9-tokio-telemetry/benches/writer_write_encoded_iai.rs
@@ -40,7 +40,7 @@ fn make_encoded_batch(worker: usize) -> Batch {
             worker_id: wid,
             local_queue: 5,
             cpu_time_ns: 500_000,
-            sched_wait_ns: 1_000,
+            sched_wait_ns: Some(1_000),
             tid: 0,
         });
 

--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -148,8 +148,12 @@ pub struct WorkerStats {
     pub max_local_queue: usize,
     /// Maximum OS scheduling wait observed during any single unpark, in nanoseconds.
     pub max_sched_wait_ns: u64,
-    /// Cumulative OS scheduling wait across all unparks, in nanoseconds.
+    /// Cumulative OS scheduling wait across all *sampled* unparks, in nanoseconds.
     pub total_sched_wait_ns: u64,
+    /// Number of unparks that carried a schedstat sample. Since schedstat is
+    /// only read on a subset of parks (see `DIAL9_SCHED_WAIT_SAMPLE_RATE`), this
+    /// is the correct denominator for the sched-wait average, not `unpark_count`.
+    pub sched_wait_sample_count: usize,
 }
 
 /// Aggregated poll statistics for a single spawn location.
@@ -289,8 +293,13 @@ pub fn analyze_trace(events: &[Dial9Event]) -> TraceAnalysis {
                 let stats = worker_stats.entry(wid).or_default();
                 stats.max_local_queue = stats.max_local_queue.max(e.local_queue as usize);
                 stats.unpark_count += 1;
-                stats.total_sched_wait_ns += e.sched_wait_ns;
-                stats.max_sched_wait_ns = stats.max_sched_wait_ns.max(e.sched_wait_ns);
+                // Only fold sampled unparks into the sched-wait aggregates;
+                // unsampled ones (`None`) carry no measurement.
+                if let Some(sched_wait_ns) = e.sched_wait_ns {
+                    stats.sched_wait_sample_count += 1;
+                    stats.total_sched_wait_ns += sched_wait_ns;
+                    stats.max_sched_wait_ns = stats.max_sched_wait_ns.max(sched_wait_ns);
+                }
             }
             _ => {}
         }
@@ -420,10 +429,11 @@ pub fn print_analysis(analysis: &TraceAnalysis) {
             }
         );
         println!("  Max local queue: {}", stats.max_local_queue);
-        if stats.unpark_count > 0 {
+        if stats.sched_wait_sample_count > 0 {
             println!(
-                "  Sched wait: avg {:.1}µs, max {:.1}µs",
-                stats.total_sched_wait_ns as f64 / stats.unpark_count as f64 / 1000.0,
+                "  Sched wait ({} sampled): avg {:.1}µs, max {:.1}µs",
+                stats.sched_wait_sample_count,
+                stats.total_sched_wait_ns as f64 / stats.sched_wait_sample_count as f64 / 1000.0,
                 stats.max_sched_wait_ns as f64 / 1000.0,
             );
         }
@@ -555,13 +565,14 @@ pub fn detect_sched_delays(events: &[Dial9Event], threshold_ns: u64) -> Vec<Sche
             Dial9Event::WorkerUnparkEvent(e) => {
                 let wid = e.worker_id;
                 if let Some(park_ns) = park_times.remove(&wid)
-                    && e.sched_wait_ns >= threshold_ns
+                    && let Some(sched_wait_ns) = e.sched_wait_ns
+                    && sched_wait_ns >= threshold_ns
                 {
                     delays.push(SchedDelay {
                         worker_id: wid,
                         park_ns,
                         unpark_ns: e.timestamp_ns,
-                        sched_wait_ns: e.sched_wait_ns,
+                        sched_wait_ns,
                     });
                 }
             }
@@ -881,7 +892,7 @@ mod tests {
                 worker_id: WorkerId(0),
                 local_queue: 0,
                 cpu_time_ns: 0,
-                sched_wait_ns: 0,
+                sched_wait_ns: Some(0),
                 tid: 0,
             }),
         ];
@@ -890,6 +901,78 @@ mod tests {
         assert_eq!(idle[0].0, WorkerId(0));
         assert_eq!(idle[0].1, 4_000_000);
         assert_eq!(idle[0].2, 20);
+    }
+
+    #[test]
+    fn unsampled_unparks_are_excluded_from_sched_wait_stats() {
+        // Three unparks on worker 0: two carry a schedstat sample (300us and a
+        // genuine 0us wait), one is unsampled (`None`). The average must use the
+        // sampled count (2) as its denominator, and `Some(0)` must count as a
+        // real sample distinct from `None`.
+        let park = |ts| {
+            Dial9Event::WorkerParkEvent(WorkerParkEvent {
+                timestamp_ns: ts,
+                worker_id: WorkerId(0),
+                local_queue: 0,
+                cpu_time_ns: 0,
+                tid: 0,
+            })
+        };
+        let unpark = |ts, sched_wait_ns| {
+            Dial9Event::WorkerUnparkEvent(WorkerUnparkEvent {
+                timestamp_ns: ts,
+                worker_id: WorkerId(0),
+                local_queue: 0,
+                cpu_time_ns: 0,
+                sched_wait_ns,
+                tid: 0,
+            })
+        };
+        let events = vec![
+            park(1_000_000),
+            unpark(2_000_000, Some(300_000)),
+            park(3_000_000),
+            unpark(4_000_000, None),
+            park(5_000_000),
+            unpark(6_000_000, Some(0)),
+        ];
+
+        let analysis = analyze_trace(&events);
+        let stats = &analysis.worker_stats[&WorkerId(0)];
+        assert_eq!(stats.unpark_count, 3);
+        // Only the two sampled unparks contribute.
+        assert_eq!(stats.sched_wait_sample_count, 2);
+        assert_eq!(stats.total_sched_wait_ns, 300_000);
+        assert_eq!(stats.max_sched_wait_ns, 300_000);
+        // Average over sampled unparks is 150us, not 100us (which is what
+        // dividing by unpark_count would wrongly give).
+        let avg_us =
+            stats.total_sched_wait_ns as f64 / stats.sched_wait_sample_count as f64 / 1000.0;
+        assert_eq!(avg_us, 150.0);
+    }
+
+    #[test]
+    fn detect_sched_delays_skips_unsampled_unparks() {
+        // An unsampled unpark (`None`) must never be reported as a delay, even
+        // though a naive `>= threshold` on a zero-filled field would pass.
+        let events = vec![
+            Dial9Event::WorkerParkEvent(WorkerParkEvent {
+                timestamp_ns: 1_000_000,
+                worker_id: WorkerId(0),
+                local_queue: 0,
+                cpu_time_ns: 0,
+                tid: 0,
+            }),
+            Dial9Event::WorkerUnparkEvent(WorkerUnparkEvent {
+                timestamp_ns: 2_000_000,
+                worker_id: WorkerId(0),
+                local_queue: 0,
+                cpu_time_ns: 0,
+                sched_wait_ns: None,
+                tid: 0,
+            }),
+        ];
+        assert!(detect_sched_delays(&events, 0).is_empty());
     }
 
     #[test]
@@ -993,7 +1076,7 @@ mod tests {
                 worker_id: WorkerId(0),
                 local_queue: 0,
                 cpu_time_ns: 0,
-                sched_wait_ns: 200_000,
+                sched_wait_ns: Some(200_000),
                 tid: 0,
             }),
         ];
@@ -1020,7 +1103,7 @@ mod tests {
                 worker_id: WorkerId(0),
                 local_queue: 0,
                 cpu_time_ns: 0,
-                sched_wait_ns: 50_000,
+                sched_wait_ns: Some(50_000),
                 tid: 0,
             }),
         ];
@@ -1050,7 +1133,7 @@ mod tests {
                 worker_id: WorkerId(0),
                 local_queue: 0,
                 cpu_time_ns: 0,
-                sched_wait_ns: 500_000,
+                sched_wait_ns: Some(500_000),
                 tid: 0,
             }),
             Dial9Event::WorkerUnparkEvent(WorkerUnparkEvent {
@@ -1058,7 +1141,7 @@ mod tests {
                 worker_id: WorkerId(1),
                 local_queue: 0,
                 cpu_time_ns: 0,
-                sched_wait_ns: 10_000,
+                sched_wait_ns: Some(10_000),
                 tid: 0,
             }),
         ];
@@ -1332,7 +1415,7 @@ mod tests {
                 worker_id: WorkerId(0),
                 local_queue: 0,
                 cpu_time_ns: 0,
-                sched_wait_ns: 0,
+                sched_wait_ns: Some(0),
                 tid: 0,
             }),
         ];

--- a/dial9-tokio-telemetry/src/telemetry/analysis_events.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis_events.rs
@@ -140,8 +140,9 @@ pub struct WorkerUnparkEvent {
     pub local_queue: u8,
     /// Thread CPU time in nanoseconds.
     pub cpu_time_ns: u64,
-    /// Scheduling wait delta in nanoseconds.
-    pub sched_wait_ns: u64,
+    /// Scheduling wait delta in nanoseconds, or `None` when this park->unpark
+    /// pair was not sampled for schedstat. `None` is distinct from `Some(0)`.
+    pub sched_wait_ns: Option<u64>,
     /// OS thread ID.
     pub tid: u32,
 }
@@ -482,7 +483,7 @@ mod tests {
             worker_id: format::WorkerId::from(1u8),
             local_queue: 3,
             cpu_time_ns: 600_000,
-            sched_wait_ns: 100_000,
+            sched_wait_ns: Some(100_000),
             tid: 12345,
         })
         .unwrap();
@@ -623,7 +624,7 @@ mod tests {
         assert_eq!(e.worker_id, WorkerId(1));
         assert_eq!(e.local_queue, 3);
         assert_eq!(e.cpu_time_ns, 600_000);
-        assert_eq!(e.sched_wait_ns, 100_000);
+        assert_eq!(e.sched_wait_ns, Some(100_000));
         assert_eq!(e.tid, 12345);
 
         // 5. QueueSampleEvent

--- a/dial9-tokio-telemetry/src/telemetry/format.rs
+++ b/dial9-tokio-telemetry/src/telemetry/format.rs
@@ -123,8 +123,10 @@ pub struct WorkerUnparkEvent {
     pub local_queue: u8,
     /// Thread CPU time in nanoseconds.
     pub cpu_time_ns: u64,
-    /// Scheduling wait delta in nanoseconds.
-    pub sched_wait_ns: u64,
+    /// Scheduling wait delta in nanoseconds, or `None` when this park->unpark
+    /// pair was not sampled for schedstat (see `DIAL9_SCHED_WAIT_SAMPLE_RATE`).
+    /// `None` is distinct from `Some(0)`: the latter means "sampled, no wait".
+    pub sched_wait_ns: Option<u64>,
     /// OS thread ID of the unparking thread. On Linux/Android, the result of gettid();
     /// on other platforms, a synthetic per-process counter — see `events::current_tid`.
     pub tid: u32,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -90,7 +90,7 @@ fn sched_wait_sample_rate() -> u64 {
 /// process-global rate or a live schedstat read.
 fn advance_park_counter(counter: u64, rate: u64) -> (u64, bool) {
     let next = counter.wrapping_add(1);
-    (next, next % rate.max(1) == 0)
+    (next, next.is_multiple_of(rate.max(1)))
 }
 
 /// Returns a strictly monotonic timestamp for this thread.

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -427,17 +427,17 @@ pub(super) fn make_worker_unpark(ctx: &RuntimeContext, shared: &SharedState) -> 
     let cpu_time_nanos = crate::telemetry::events::thread_cpu_time_nanos();
     // Only read schedstat on unpark if the matching park sampled it, so the
     // delta below always pairs with a park-time reading. Reset the flag either
-    // way so a subsequent unsampled park can't reuse a stale pair.
+    // way so a subsequent unsampled park can't reuse a stale pair. Report `None`
+    // when unsampled so consumers can distinguish "not measured" from a genuine
+    // zero-wait unpark rather than diluting their averages with false zeros.
     let sampled = SCHED_SAMPLED_THIS_PARK.with(|c| c.replace(false));
     let sched_wait_delta_nanos = if sampled {
-        if let Ok(ss) = SchedStat::read_current() {
+        SchedStat::read_current().ok().map(|ss| {
             let prev = PARKED_SCHED_WAIT.with(|c| c.get());
             ss.wait_time_ns.saturating_sub(prev)
-        } else {
-            0
-        }
+        })
     } else {
-        0
+        None
     };
     WorkerUnparkEvent {
         timestamp_ns: crate::telemetry::events::clock_monotonic_ns(),

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -132,6 +132,10 @@ pub(crate) struct TokioRuntimesSource {
     /// used to skip the rebuild when nothing changed. See `segment_metadata` for
     /// what it is and why it is sufficient. `0` means "nothing emitted yet".
     last_fingerprint: usize,
+    /// Whether the fixed `sched.wait_sample_rate` metadata entry has been
+    /// emitted yet. It never changes, so it is emitted exactly once (the writer
+    /// keeps it in its merged cache and re-emits it on every rotation).
+    sched_rate_emitted: bool,
 }
 
 impl TokioRuntimesSource {
@@ -141,6 +145,7 @@ impl TokioRuntimesSource {
             last_sample: time_source().instant(),
             sample_interval: Duration::from_millis(10),
             last_fingerprint: 0,
+            sched_rate_emitted: false,
         }
     }
 }
@@ -169,6 +174,19 @@ impl Source for TokioRuntimesSource {
     }
 
     fn segment_metadata(&mut self, out: &mut Vec<(String, String)>) {
+        // Record the schedstat sampling rate once so a consumer reading
+        // `WorkerUnparkEvent::sched_wait_ns` knows the measurement represents
+        // roughly 1-in-N parks, not every park. Fixed for the process lifetime
+        // (the rate is read once via `OnceLock`), so emit it a single time; the
+        // writer keeps it in its merged cache and re-emits it on every rotation.
+        if !self.sched_rate_emitted {
+            out.push((
+                "sched.wait_sample_rate".to_string(),
+                sched_wait_sample_rate().to_string(),
+            ));
+            self.sched_rate_emitted = true;
+        }
+
         // Self-detected change: there is no external signal to keep in sync, so
         // a new caller that mutates runtime/worker metadata cannot forget to
         // announce it. The fingerprint is the runtime count plus the total
@@ -467,12 +485,18 @@ mod tests {
         let contexts: RuntimeContextRegistry = Arc::new(Mutex::new(Vec::new()));
         let mut source = TokioRuntimesSource::new(contexts.clone());
 
-        // Empty registry: nothing to append.
+        // Empty registry: no runtime metadata yet, but the fixed schedstat
+        // sample-rate entry is emitted once on the first call.
         let mut out = Vec::new();
         source.segment_metadata(&mut out);
-        assert!(out.is_empty());
+        assert_eq!(
+            out.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(),
+            vec!["sched.wait_sample_rate"],
+            "first call emits only the fixed sched-wait sample-rate entry"
+        );
 
-        // Register a runtime: the count grows, so the source rebuilds.
+        // Register a runtime: the count grows, so the source rebuilds. The
+        // sched-wait rate is not re-emitted (it is emitted exactly once).
         push_named_runtime(&contexts, "main", 0);
 
         out.clear();
@@ -491,6 +515,33 @@ mod tests {
         source.segment_metadata(&mut out);
         assert!(out.contains(&("runtime.main".to_string(), "0".to_string())));
         assert!(out.contains(&("runtime.io".to_string(), "1".to_string())));
+        // The sched-wait rate is fixed and emitted exactly once, so later
+        // change cycles never re-emit it.
+        assert!(!out.iter().any(|(k, _)| k == "sched.wait_sample_rate"));
+    }
+
+    #[test]
+    fn segment_metadata_reports_sched_wait_sample_rate_once() {
+        // The schedstat sampling rate is recorded in segment metadata so a
+        // consumer knows `sched_wait_ns` is 1-in-N sampled and knows N. It is
+        // fixed for the process lifetime, so it must be emitted exactly once.
+        let contexts: RuntimeContextRegistry = Arc::new(Mutex::new(Vec::new()));
+        let mut source = TokioRuntimesSource::new(contexts);
+
+        let mut out = Vec::new();
+        source.segment_metadata(&mut out);
+        let (_, value) = out
+            .iter()
+            .find(|(k, _)| k == "sched.wait_sample_rate")
+            .expect("first call emits the sched-wait sample-rate entry");
+        // The value is the process-global rate rendered as a positive integer.
+        assert_eq!(value, &sched_wait_sample_rate().to_string());
+        assert!(value.parse::<u64>().is_ok_and(|n| n >= 1));
+
+        // Emitted exactly once: a second call (no runtime change) appends nothing.
+        out.clear();
+        source.segment_metadata(&mut out);
+        assert!(out.is_empty());
     }
 
     #[test]

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -54,6 +54,43 @@ thread_local! {
 crate::primitives::thread_local! {
     /// schedstat wait_time_ns captured at park time, used to compute delta on unpark.
     static PARKED_SCHED_WAIT: Cell<u64> = const { Cell::new(0) };
+    /// Per-thread park counter used to sample `SchedStat::read_current`. See
+    /// [`sched_wait_sample_rate`]: schedstat is only read on 1-in-N parks to
+    /// bound the CPU cost of reading `/proc/self/task/<tid>/schedstat`.
+    static PARK_COUNTER: Cell<u64> = const { Cell::new(0) };
+    /// Whether the current park cycle successfully read schedstat at park time.
+    /// Unpark only computes a wait-time delta when this is `true`, guaranteeing
+    /// every reported `sched_wait_ns` comes from a matched park->unpark pair.
+    static SCHED_SAMPLED_THIS_PARK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// How often to read `SchedStat::read_current` in the worker park/unpark path.
+///
+/// Reading `/proc/self/task/<tid>/schedstat` on every park is measurable CPU
+/// overhead, and there is no need to catch every scheduler pause: periodic
+/// sampling still surfaces scheduling latency. We therefore only read schedstat
+/// on 1-in-N parks. `N` defaults to 10 and is overridable via the
+/// `DIAL9_SCHED_WAIT_SAMPLE_RATE` environment variable (values are clamped to at
+/// least 1; `1` restores read-on-every-park).
+fn sched_wait_sample_rate() -> u64 {
+    static RATE: OnceLock<u64> = OnceLock::new();
+    *RATE.get_or_init(|| {
+        std::env::var("DIAL9_SCHED_WAIT_SAMPLE_RATE")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(10)
+            .max(1)
+    })
+}
+
+/// Advance a per-thread park counter and decide whether this park should read
+/// schedstat. Samples every `rate`th park (`rate` is clamped to at least 1, so
+/// `rate == 1` samples every park). Returns the incremented counter and the
+/// sampling decision. Pure so the 1-in-N logic can be unit-tested without the
+/// process-global rate or a live schedstat read.
+fn advance_park_counter(counter: u64, rate: u64) -> (u64, bool) {
+    let next = counter.wrapping_add(1);
+    (next, next % rate.max(1) == 0)
 }
 
 /// Returns a strictly monotonic timestamp for this thread.
@@ -355,9 +392,24 @@ pub(super) fn make_worker_park(ctx: &RuntimeContext, shared: &SharedState) -> Wo
         .map(|(_, idx)| ctx.local_queue_depth(idx))
         .unwrap_or(0);
     let cpu_time_nanos = crate::telemetry::events::thread_cpu_time_nanos();
-    if let Ok(ss) = SchedStat::read_current() {
-        PARKED_SCHED_WAIT.with(|c| c.set(ss.wait_time_ns));
-    }
+    // Only read schedstat on 1-in-N parks. The counter and the "sampled this
+    // park" flag are thread-local, so the matching unpark on the same worker
+    // thread reads schedstat iff park did, keeping the wait-time delta a valid
+    // park->unpark pair.
+    let sample = PARK_COUNTER.with(|c| {
+        let (next, sample) = advance_park_counter(c.get(), sched_wait_sample_rate());
+        c.set(next);
+        sample
+    });
+    let sampled = sample
+        && match SchedStat::read_current() {
+            Ok(ss) => {
+                PARKED_SCHED_WAIT.with(|c| c.set(ss.wait_time_ns));
+                true
+            }
+            Err(_) => false,
+        };
+    SCHED_SAMPLED_THIS_PARK.with(|c| c.set(sampled));
     WorkerParkEvent {
         timestamp_ns: crate::telemetry::events::clock_monotonic_ns(),
         worker_id: resolved.map(|(id, _)| id).unwrap_or(WorkerId::UNKNOWN),
@@ -373,9 +425,17 @@ pub(super) fn make_worker_unpark(ctx: &RuntimeContext, shared: &SharedState) -> 
         .map(|(_, idx)| ctx.local_queue_depth(idx))
         .unwrap_or(0);
     let cpu_time_nanos = crate::telemetry::events::thread_cpu_time_nanos();
-    let sched_wait_delta_nanos = if let Ok(ss) = SchedStat::read_current() {
-        let prev = PARKED_SCHED_WAIT.with(|c| c.get());
-        ss.wait_time_ns.saturating_sub(prev)
+    // Only read schedstat on unpark if the matching park sampled it, so the
+    // delta below always pairs with a park-time reading. Reset the flag either
+    // way so a subsequent unsampled park can't reuse a stale pair.
+    let sampled = SCHED_SAMPLED_THIS_PARK.with(|c| c.replace(false));
+    let sched_wait_delta_nanos = if sampled {
+        if let Ok(ss) = SchedStat::read_current() {
+            let prev = PARKED_SCHED_WAIT.with(|c| c.get());
+            ss.wait_time_ns.saturating_sub(prev)
+        } else {
+            0
+        }
     } else {
         0
     };
@@ -431,6 +491,39 @@ mod tests {
         source.segment_metadata(&mut out);
         assert!(out.contains(&("runtime.main".to_string(), "0".to_string())));
         assert!(out.contains(&("runtime.io".to_string(), "1".to_string())));
+    }
+
+    #[test]
+    fn park_counter_samples_one_in_n() {
+        // rate == 1: every park samples.
+        let mut counter = 0u64;
+        for _ in 0..5 {
+            let (next, sample) = advance_park_counter(counter, 1);
+            counter = next;
+            assert!(sample);
+        }
+
+        // rate == 10 (the default): exactly one park in ten samples, and the
+        // sampled park is the 10th, not the 1st, so a burst of short parks is
+        // not over-counted.
+        counter = 0;
+        let mut sampled = 0;
+        let mut sampled_indices = Vec::new();
+        for i in 1..=30 {
+            let (next, sample) = advance_park_counter(counter, 10);
+            counter = next;
+            if sample {
+                sampled += 1;
+                sampled_indices.push(i);
+            }
+        }
+        assert_eq!(sampled, 3);
+        assert_eq!(sampled_indices, vec![10, 20, 30]);
+
+        // rate == 0 is clamped to 1 (defensive: the env parser already clamps,
+        // but the pure helper must not divide by zero).
+        let (_, sample) = advance_park_counter(0, 0);
+        assert!(sample);
     }
 
     mod steady_state_alloc {

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -335,7 +335,7 @@
      *   localQueue: number,
      *   globalQueue: number,
      *   cpuTime: number,
-     *   schedWait: number,
+     *   schedWait: number|null,
      *   taskId: number,
      *   spawnLocId: string|null,
      *   spawnLoc: string|null,
@@ -795,7 +795,12 @@
                     workerId: num(v.worker_id),
                     localQueue: num(v.local_queue),
                     cpuTime: num(v.cpu_time_ns),
-                    schedWait: num(v.sched_wait_ns),
+                    // sched_wait_ns is optional: null when this park->unpark
+                    // pair was not sampled for schedstat. Keep null distinct
+                    // from 0 (a sampled zero-wait) so downstream sched-delay
+                    // detection skips unsampled unparks rather than treating
+                    // them as instantaneous.
+                    schedWait: v.sched_wait_ns == null ? null : num(v.sched_wait_ns),
                     // tid was added later; old traces won't have it. Leave undefined
                     // so the block-in-place gap detection can skip them.
                     tid: v.tid != null ? num(v.tid) : undefined,


### PR DESCRIPTION
## Problem

`SchedStat::read_current` reads `/proc/self/task/<tid>/schedstat` on **every** worker park and unpark to measure kernel scheduling latency. That read costs measurable CPU, and per #557 there's no need to catch every scheduler pause: the problem is still visible with periodic sampling.

## Change

Read schedstat on only **1-in-N** parks. `N` defaults to `10` and is overridable via the `DIAL9_SCHED_WAIT_SAMPLE_RATE` environment variable (clamped to `>= 1`; `1` restores read-on-every-park). A per-thread `PARK_COUNTER` drives the decision.

The correctness constraint from the issue (*"we must record a park->unpark pair for the data to be accurate"*) is preserved: the park handler records whether it sampled in a thread-local `SCHED_SAMPLED_THIS_PARK` flag, and the matching unpark on the same worker thread reads schedstat (and computes the wait-time delta) **iff** the park did.

### `sched_wait_ns` is now `Option<u64>`

Because only a subset of unparks now carry a measurement, reporting `0` for the rest would be ambiguous with a genuine zero-wait unpark and would dilute downstream averages. `WorkerUnparkEvent::sched_wait_ns` becomes `Option<u64>`:

- `None` — this park->unpark pair was not sampled (or the read failed).
- `Some(delta)` — sampled; `Some(0)` is a real zero-wait measurement.

The wire format already supports optional fields, and the decode-side structs are `#[non_exhaustive]`, so old traces (which encode a plain `u64`) still deserialize.

Consumers updated accordingly:
- **analysis**: only `Some(..)` folds into `total_sched_wait_ns` / `max_sched_wait_ns`; added `sched_wait_sample_count` as the correct denominator for the average (instead of `unpark_count`); `detect_sched_delays` skips `None`.
- **viewer JS parser**: decodes `null` (not `0`) for unsampled unparks; the sched-delay overlay already treats a null/absent wait as "no delay".

## Testing

- `cargo test -p dial9-tokio-telemetry --features analysis` — all 153 lib tests pass, plus the `js_parser` round-trip test (Rust encode -> JS decode) and the Node viewer test suites (`test_trace_integrity`, `test_block_in_place`, `test_trace_analysis`).
- Added tests: `park_counter_samples_one_in_n` (1-in-N logic incl. rate 1 and the `rate == 0` guard), `unsampled_unparks_are_excluded_from_sched_wait_stats` (None excluded from the average, `Some(0)` counted), and `detect_sched_delays_skips_unsampled_unparks`.
- `cargo fmt --check` clean; `cargo clippy` clean (only a pre-existing unrelated dead-code warning).

## Notes

- The env-var default (10) matches the "1 in 10" suggested in #557. If you'd prefer this wired through a builder/`Config` field instead of an environment variable, happy to adjust.

Fixes #557
