### PR TITLE
feat(viewer): carry aws_region in viewer/flamegraph/tokio-stats URLs

### DIFF
--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -112,6 +112,23 @@
                 const statsEl = document.getElementById("fg-stats");
                 const foldWarnEl = document.getElementById("fold-warning");
 
+                // A shared link pins the bucket's region — as `aws_region` on an
+                // aggregate/diff link, or `s_region` inside an exact-decode scope
+                // (see trace_scope.js and credentials::QUERY_REGION). Region is a
+                // property of the bucket, not a secret. Fold it into the
+                // credentials store so every /api/* request from this tab carries
+                // the x-dial9-aws-region header, exactly like the home page does
+                // on load. Without this, a cross-region bucket (e.g. one in
+                // us-west-2) is signed for the server's default region, the S3
+                // listing comes back empty, and the flamegraph 404s with "no
+                // source files match this scope". No-op when no creds are stored
+                // (region is header-only) or no region is in the URL.
+                const urlRegion = params.get("aws_region") || params.get("s_region");
+                if (urlRegion && window.Dial9Creds) {
+                    const stored = Dial9Creds.get();
+                    if (stored && stored.region !== urlRegion) Dial9Creds.setRegion(urlRegion);
+                }
+
                 function showError(msg) {
                     loadingEl.classList.add("hidden");
                     errorEl.style.display = "flex";
@@ -412,11 +429,20 @@
                     const scopeService = params.get("service");
                     const scopeBucket = params.get("bucket");
                     const scopePrefix = params.get("prefix");
+                    // The bucket's region. Already folded into the creds store
+                    // above (so it rides as a header), but we also keep it in the
+                    // address bar and any copy/diff link so a shared URL stays
+                    // self-contained rather than depending on the tab's store.
+                    const scopeRegion = params.get("aws_region");
 
                     function buildApiUrl() {
                         const u = new URL("/api/flamegraph", window.location.origin);
                         if (params.get("data_dir")) u.searchParams.set("data_dir", params.get("data_dir"));
                         if (scopeBucket) u.searchParams.set("bucket", scopeBucket);
+                        // Region also travels as a header (Dial9Creds), but naming
+                        // it on the URL keeps the request self-describing and works
+                        // even on the ambient (no-creds) path.
+                        if (scopeRegion) u.searchParams.set("aws_region", scopeRegion);
                         if (scopePrefix) u.searchParams.set("prefix", scopePrefix);
                         if (scopeService) u.searchParams.set("service", scopeService);
                         for (const h of filterState.hosts) u.searchParams.append("host", h);
@@ -441,6 +467,7 @@
                         p.set("api", "1");
                         if (params.get("data_dir")) p.set("data_dir", params.get("data_dir"));
                         if (scopeBucket) p.set("bucket", scopeBucket);
+                        if (scopeRegion) p.set("aws_region", scopeRegion);
                         if (scopePrefix) p.set("prefix", scopePrefix);
                         if (scopeService) p.set("service", scopeService);
                         for (const h of filterState.hosts) p.append("host", h);
@@ -727,6 +754,7 @@
                         p.set("api", "1");
                         if (params.get("data_dir")) p.set("data_dir", params.get("data_dir"));
                         if (scopeBucket) p.set("bucket", scopeBucket);
+                        if (scopeRegion) p.set("aws_region", scopeRegion);
                         if (scopePrefix) p.set("prefix", scopePrefix);
                         if (scopeService) p.set("service", scopeService);
                         for (const h of filterState.hosts) p.append("host", h);

--- a/dial9-viewer/ui/flamegraph_diff.js
+++ b/dial9-viewer/ui/flamegraph_diff.js
@@ -197,6 +197,9 @@ const SCOPE_KEYS_SINGLE = [
   "api",
   "data_dir",
   "bucket",
+  // The bucket's region (a property of the bucket, not a credential), so a
+  // scope/diff link signs the right regional S3 endpoint on its own.
+  "aws_region",
   "prefix",
   "service",
   "thread_class",

--- a/dial9-viewer/ui/flamegraph_diff_view.js
+++ b/dial9-viewer/ui/flamegraph_diff_view.js
@@ -39,7 +39,7 @@
   // Server flamegraph endpoint keys; the rest of a scope (e.g. the client-only
   // `api` flag) is not forwarded.
   const SERVER_KEYS = [
-    "data_dir", "bucket", "prefix", "service",
+    "data_dir", "bucket", "aws_region", "prefix", "service",
     "thread_class", "source", "spawn_location", "start_ns", "end_ns", "max_files",
   ];
 

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -1691,6 +1691,20 @@
     }
 
 
+    // The bucket's region, for stamping onto every link this page opens
+    // (flamegraph / tokio-stats / viewer) so the opened tab's URL is
+    // self-contained — it signs the right regional S3 endpoint without relying
+    // on having inherited a detected region from this page. Source of truth is
+    // the credentials store (where region detection lands on Apply / bucket
+    // pick); the panel's region field is the fallback. Empty string when unknown
+    // (the server then uses its default region).
+    function currentRegion() {
+        const stored = window.Dial9Creds ? Dial9Creds.get() : null;
+        if (stored && stored.region) return stored.region;
+        const field = document.getElementById('creds-region');
+        return (field && field.value.trim()) || '';
+    }
+
     // Build the aggregate SCOPE (bucket/prefix/service/host-set/time window) for
     // the current heatmap selection, as a URLSearchParams. This is the single
     // source of truth shared by the flamegraph button, the tokio-stats button,
@@ -1709,7 +1723,7 @@
         // wrap the query back into the URLSearchParams the diff tray works with,
         // and warn if the host set was too large to name in the link (the capture
         // then covers all hosts in the window).
-        const scope = Dial9TraceScope.scopeFromKeys(bucket, heatmapSelection.keys, heatmapSelection.t0, heatmapSelection.t1);
+        const scope = Dial9TraceScope.scopeFromKeys(bucket, heatmapSelection.keys, heatmapSelection.t0, heatmapSelection.t1, currentRegion());
         const { query, hostsDropped } = Dial9TraceScope.encodeAggregationParams(new URLSearchParams(), scope);
         if (hostsDropped) warnHostsDropped();
         return new URLSearchParams(query);
@@ -1739,7 +1753,7 @@
             // (A box spanning >1 service sends no service filter — all services
             // in the box — matching exact mode, rather than the old "first
             // service wins" which silently dropped the others.)
-            const scope = Dial9TraceScope.scopeFromKeys(bucket, keys, heatmapSelection.t0, heatmapSelection.t1);
+            const scope = Dial9TraceScope.scopeFromKeys(bucket, keys, heatmapSelection.t0, heatmapSelection.t1, currentRegion());
             const base = new URLSearchParams();
             base.set('api', '1');
             const { query, hostsDropped } = Dial9TraceScope.encodeAggregationParams(base, scope);
@@ -1755,7 +1769,7 @@
         // can't overflow CloudFront's 8192-byte request-URI cap and 414 the tab)
         // and stateless (so a shared deep link re-resolves in any browser).
         const fgParams = traceTitleParams(keys);
-        const scope = Dial9TraceScope.scopeFromKeys(bucket, keys, heatmapSelection.t0, heatmapSelection.t1);
+        const scope = Dial9TraceScope.scopeFromKeys(bucket, keys, heatmapSelection.t0, heatmapSelection.t1, currentRegion());
         const { query, hostsDropped } = Dial9TraceScope.encodeScope(fgParams, scope);
         if (hostsDropped) warnHostsDropped();
         window.open('flamegraph.html?' + query, '_blank');
@@ -1779,7 +1793,7 @@
         const keys = heatmapSelection.keys;
         // Same scope the aggregation flamegraph uses, same param vocabulary —
         // /api/tokio-stats reads bucket/prefix/service/host + start_ns/end_ns.
-        const scope = Dial9TraceScope.scopeFromKeys(bucket, keys, heatmapSelection.t0, heatmapSelection.t1);
+        const scope = Dial9TraceScope.scopeFromKeys(bucket, keys, heatmapSelection.t0, heatmapSelection.t1, currentRegion());
         const { query, hostsDropped } = Dial9TraceScope.encodeAggregationParams(new URLSearchParams(), scope);
         if (hostsDropped) warnHostsDropped();
         window.open('tokio_stats.html?' + query, '_blank');
@@ -2048,7 +2062,7 @@
         const titleParams = traceTitleParams(keys);
         const t0 = heatmapSelection ? heatmapSelection.t0 : null;
         const t1 = heatmapSelection ? heatmapSelection.t1 : null;
-        const scope = Dial9TraceScope.scopeFromKeys(bucket, keys, t0, t1);
+        const scope = Dial9TraceScope.scopeFromKeys(bucket, keys, t0, t1, currentRegion());
         // Raw mode passes no window, so scopeFromKeys derives it from the keys'
         // epochs. It returns null when none parse (an unrecognized key layout);
         // there is no window to build a scope from, so tell the user rather than

--- a/dial9-viewer/ui/test_flamegraph_diff.js
+++ b/dial9-viewer/ui/test_flamegraph_diff.js
@@ -234,6 +234,7 @@ assertEq(
   const src = new URLSearchParams();
   src.set("api", "1");
   src.set("bucket", "my-bucket");
+  src.set("aws_region", "us-west-2");
   src.set("prefix", "traces/svc");
   src.set("service", "svc");
   src.append("host", "h1");
@@ -250,6 +251,7 @@ assertEq(
 
   const out = fullScopeQuery(src);
   assertEq(out.get("bucket"), "my-bucket", "bucket survives (fixes lossy address bar)");
+  assertEq(out.get("aws_region"), "us-west-2", "region survives (cross-region bucket link)");
   assertEq(out.get("prefix"), "traces/svc", "prefix survives");
   assertEq(out.get("max_files"), "256", "max_files survives");
   assertEq(out.getAll("host").join(","), "h1,h2", "repeatable host set survives in order");
@@ -339,11 +341,13 @@ assert(parseDiff(new URLSearchParams("diff=1&a=" + encodeScope("bucket=x") + "&b
 {
   const V = require("./flamegraph_diff_view.js");
   const scope = new URLSearchParams(
-    "api=1&bucket=b&prefix=traces/svc&service=svc&host=h1&host=h2&source=cpu&start_ns=100&max_files=64",
+    "api=1&bucket=b&aws_region=us-west-2&prefix=traces/svc&service=svc&host=h1&host=h2&source=cpu&start_ns=100&max_files=64",
   );
   const u = V.apiUrlFor({ scope, origin: "https://viewer.example.com" });
   assertEq(u.pathname, "/api/flamegraph", "apiUrlFor targets /api/flamegraph");
   assertEq(u.searchParams.get("bucket"), "b", "apiUrlFor forwards bucket");
+  assertEq(u.searchParams.get("aws_region"), "us-west-2",
+    "apiUrlFor forwards region (side B often has a cross-region bucket)");
   assertEq(u.searchParams.get("max_files"), "64", "apiUrlFor forwards max_files");
   assertEq(u.searchParams.getAll("host").join(","), "h1,h2", "apiUrlFor forwards repeatable hosts");
   assertEq(u.searchParams.get("api"), null, "apiUrlFor does NOT forward the client-only api flag");

--- a/dial9-viewer/ui/test_trace_scope.js
+++ b/dial9-viewer/ui/test_trace_scope.js
@@ -71,6 +71,7 @@ test("parseKey: compound instance path is best-effort, never throws", () => {
 test("encodeScope/readScope round-trips a scope", () => {
   const s = {
     bucket: "cell1-prod-pdx-dial9-traces",
+    region: "us-west-2",
     prefix: "traces",
     service: "shale",
     hosts: ["ip-10-2-1-1", "ip-10-2-1-2"],
@@ -80,6 +81,24 @@ test("encodeScope/readScope round-trips a scope", () => {
   const { query } = scope.encodeScope(new URLSearchParams(), s);
   const got = scope.readScope(new URLSearchParams(query));
   assert.deepStrictEqual(got, s);
+});
+
+test("encodeScope/readScope round-trips an empty region as ''", () => {
+  // A region-less scope (bucket in the server's default region, or unknown)
+  // must still round-trip cleanly: encodeScope omits s_region, readScope
+  // normalizes the absence back to "".
+  const s = {
+    bucket: "b",
+    region: "",
+    prefix: "traces",
+    service: "shale",
+    hosts: ["h1"],
+    from: 1,
+    to: 2,
+  };
+  const { query } = scope.encodeScope(new URLSearchParams(), s);
+  assert.strictEqual(new URLSearchParams(query).get("s_region"), null, "empty region not serialized");
+  assert.deepStrictEqual(scope.readScope(new URLSearchParams(query)), s);
 });
 
 test("readScope returns null when no time window is present", () => {
@@ -102,6 +121,7 @@ test("encodeScope preserves unrelated base params and namespaces its own", () =>
 test("encodeAggregationParams emits the un-namespaced names + ns window", () => {
   const s = {
     bucket: "bkt",
+    region: "us-west-2",
     prefix: "traces",
     service: "shale",
     hosts: ["h1", "h2"],
@@ -117,6 +137,9 @@ test("encodeAggregationParams emits the un-namespaced names + ns window", () => 
   assert.strictEqual(p.get("bucket"), "bkt");
   assert.strictEqual(p.get("prefix"), "traces");
   assert.strictEqual(p.get("service"), "shale");
+  // Region rides as `aws_region` — the same param the server reads — so a link
+  // straight to /api/flamegraph signs the right regional endpoint on its own.
+  assert.strictEqual(p.get("aws_region"), "us-west-2");
   assert.deepStrictEqual(p.getAll("host"), ["h1", "h2"], "repeatable host set");
   // Window converts seconds -> nanoseconds for the aggregation endpoints.
   assert.strictEqual(p.get("start_ns"), "1782760000000000000");
@@ -194,6 +217,29 @@ test("scopeFromKeys derives service/hosts/prefix/window", () => {
   assert.strictEqual(s.prefix, "traces");
   assert.strictEqual(s.from, 1782760000);
   assert.strictEqual(s.to, 1782760800);
+});
+
+test("scopeFromKeys carries the region when supplied, else ''", () => {
+  const keys = [key("h1", 1782760100, 1)];
+  assert.strictEqual(
+    scope.scopeFromKeys("bkt", keys, 1782760000, 1782760800, "us-west-2").region,
+    "us-west-2",
+    "region threaded through",
+  );
+  // Trailing/optional: existing 4-arg callers get an empty region, not undefined.
+  assert.strictEqual(scope.scopeFromKeys("bkt", keys, 1782760000, 1782760800).region, "");
+});
+
+test("scopeFromKeys region survives an aggregation round-trip", () => {
+  // End-to-end: a heatmap selection in a us-west-2 bucket produces an
+  // /api/flamegraph link that carries aws_region, so the opened tab signs the
+  // right endpoint without inheriting a detected region.
+  const keys = [key("h1", 1782760100, 1), key("h1", 1782760200, 2)];
+  const s = scope.scopeFromKeys("cell1-prod-pdx-dial9-traces", keys, 1782760000, 1782760800, "us-west-2");
+  const base = new URLSearchParams();
+  base.set("api", "1");
+  const { query } = scope.encodeAggregationParams(base, s);
+  assert.strictEqual(new URLSearchParams(query).get("aws_region"), "us-west-2");
 });
 
 test("scopeFromKeys derives the window from key epochs when none is supplied", () => {

--- a/dial9-viewer/ui/tokio_stats.html
+++ b/dial9-viewer/ui/tokio_stats.html
@@ -71,6 +71,18 @@
   const params = new URLSearchParams(window.location.search);
   const COLORS = ["#58a6ff", "#d2a8ff", "#7ee787", "#ffa657"];
 
+  // A shared link pins the bucket's region (`aws_region`). Fold it into the
+  // credentials store so every /api/tokio-stats request carries the
+  // x-dial9-aws-region header — same seam the home page uses on load. Region is
+  // a property of the bucket, not a secret; without it a cross-region bucket is
+  // signed for the server's default region and the listing comes back empty.
+  // No-op when no creds are stored (region is header-only).
+  const urlRegion = params.get("aws_region");
+  if (urlRegion && window.Dial9Creds) {
+    const stored = Dial9Creds.get();
+    if (stored && stored.region !== urlRegion) Dial9Creds.setRegion(urlRegion);
+  }
+
   // Periods: each has {id, startNs, endNs, data (cached response), scope?, label?}.
   // `scope` (a URLSearchParams) is set only in diff mode, where each side (A/B)
   // is a fully independent aggregate scope — bucket/prefix/service/host may all
@@ -119,7 +131,10 @@
   function effectiveScope(period) {
     const out = new URLSearchParams();
     const src = period.scope || params;
-    for (const k of ["bucket", "prefix", "service"]) {
+    // `aws_region` rides alongside the bucket so a cross-region bucket signs the
+    // right S3 endpoint (also folded into the creds header below; naming it here
+    // keeps the request self-describing and per-side correct in diff mode).
+    for (const k of ["bucket", "aws_region", "prefix", "service"]) {
       const v = src.get(k);
       if (v) out.set(k, v);
     }
@@ -242,7 +257,7 @@
       return;
     }
     const u = new URLSearchParams();
-    for (const k of ["bucket", "prefix", "service"]) { if (params.get(k)) u.set(k, params.get(k)); }
+    for (const k of ["bucket", "aws_region", "prefix", "service"]) { if (params.get(k)) u.set(k, params.get(k)); }
     for (const h of params.getAll("host")) u.append("host", h);
     periods.forEach((p, i) => {
       if (p.startNs) u.set(`p${i+1}_start_ns`, p.startNs);

--- a/dial9-viewer/ui/trace_scope.js
+++ b/dial9-viewer/ui/trace_scope.js
@@ -33,6 +33,7 @@
   // existing `host`/`from`/`to` title params or `start`/`end` zoom params.
   const P = {
     bucket: "s_bucket",
+    region: "s_region", // AWS region the bucket lives in (see scopeFromKeys)
     prefix: "s_prefix",
     service: "s_svc",
     host: "s_host", // repeatable
@@ -123,7 +124,15 @@
   // Derive a scope from a heatmap selection's keys + [t0,t1] window (epoch
   // seconds). `hosts` is the distinct host set; a single service is assumed (a
   // box almost always spans one). Returns null when there is nothing to scope.
-  function scopeFromKeys(bucket, keys, t0, t1) {
+  //
+  // `region` is the AWS region the bucket lives in — a property of the bucket,
+  // not a credential, so it travels in the (shareable) scope alongside the
+  // bucket. Carrying it makes the opened tab's URL self-contained: a
+  // cross-region bucket (e.g. one in us-west-2) is signed for the right S3
+  // endpoint without relying on the tab having inherited a region-detection
+  // result from the page that opened it. Optional and trailing so existing
+  // callers keep working; falsy region simply isn't carried.
+  function scopeFromKeys(bucket, keys, t0, t1, region) {
     if (!keys || !keys.length) return null;
     const parsed = keys.map(parseKey);
     const services = [...new Set(parsed.map((p) => p.service).filter(Boolean))];
@@ -140,6 +149,7 @@
     const to = t1 != null ? Math.ceil(t1) : Math.max(...epochs);
     return {
       bucket: bucket || "",
+      region: region || "",
       prefix: extractPrefix(keys[0]),
       service: services.length === 1 ? services[0] : "",
       hosts,
@@ -167,6 +177,7 @@
     const limit = o.limit != null ? o.limit : URI_SAFE_QUERY_LIMIT;
     const base = new URLSearchParams(baseParams ? baseParams.toString() : "");
     if (scope.bucket) base.set(P.bucket, scope.bucket);
+    if (scope.region) base.set(P.region, scope.region);
     if (scope.prefix) base.set(P.prefix, scope.prefix);
     if (scope.service) base.set(P.service, scope.service);
     if (scope.from != null) base.set(P.from, String(scope.from));
@@ -201,6 +212,10 @@
     const limit = o.limit != null ? o.limit : URI_SAFE_QUERY_LIMIT;
     const base = new URLSearchParams(baseParams ? baseParams.toString() : "");
     if (scope.bucket) base.set("bucket", scope.bucket);
+    // The un-namespaced `aws_region` is exactly the query param the server reads
+    // for the bucket's region (credentials::QUERY_REGION), so a scope link that
+    // points straight at /api/flamegraph or /api/tokio-stats is self-contained.
+    if (scope.region) base.set("aws_region", scope.region);
     if (scope.prefix) base.set("prefix", scope.prefix);
     if (scope.service) base.set("service", scope.service);
     if (scope.from != null) base.set("start_ns", String(Math.round(scope.from * 1e9)));
@@ -225,6 +240,7 @@
     if (from == null || to == null) return null;
     return {
       bucket: params.get(P.bucket) || "",
+      region: params.get(P.region) || "",
       prefix: params.get(P.prefix) || "",
       service: params.get(P.service) || "",
       hosts: params.getAll(P.host),

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1933,6 +1933,20 @@
             // Render profiler: ?prof=1 (or window.D9PROF=1 from the console).
             if (urlParams.get('prof') === '1') window.D9PROF = 1;
 
+            // A shared link pins the bucket's region — as `s_region` inside a
+            // scope, or `aws_region` on a direct link. Fold it into the
+            // credentials store so every /api/{browse,object,…} request from this
+            // tab carries the x-dial9-aws-region header (same seam the home page
+            // uses on load). Region is a property of the bucket, not a secret.
+            // Without it a cross-region bucket (e.g. one in us-west-2) is signed
+            // for the server's default region and the listing comes back empty.
+            // No-op when no creds are stored (region is header-only).
+            const urlRegion = urlParams.get('s_region') || urlParams.get('aws_region');
+            if (urlRegion && window.Dial9Creds) {
+                const stored = Dial9Creds.get();
+                if (stored && stored.region !== urlRegion) Dial9Creds.setRegion(urlRegion);
+            }
+
             // Credentialed JSON fetch for scope resolution: same BYO-credentials
             // headers loadTraceFromUrl attaches, so /api/browse runs under the
             // user's creds (BYOC) or the task's ambient identity (no creds).


### PR DESCRIPTION
## Problem

The bucket's region is a property of the bucket, not a credential — yet it only ever traveled as a per-request header derived from the tab's session credentials. So a viewer/flamegraph/tokio-stats link was **not self-contained**: region survived only because a same-origin new tab inherited the `sessionStorage` creds (which carry the region the home page detected on Apply).

Open the same URL in a fresh tab with no creds yet — a shared deep link, or a bring-your-own-credentials landing flow — and the region is gone: every `/api/*` call signs S3 for the server's default region (`us-east-1`), the cross-region listing comes back empty, and the flamegraph 404s with **"no source files match this scope"**.

(The empty-listing → 404 is worth a separate look: `refine::resolve` swallows a wrong-region `ListObjects` error into an empty `Vec`, so a region mismatch surfaces as a confusing "no source files" rather than an actionable "wrong region". Not addressed here.)

## Fix

Thread region through the same seam #615 used for `aws_role_arn` — the scope, and the `Dial9Creds` store:

- **`trace_scope.js`**: scope gains a `region` dimension. `scopeFromKeys(bucket, keys, t0, t1, region)` carries it (optional/trailing arg — 4-arg callers still work); `encodeScope` emits it as `s_region`; `encodeAggregationParams` emits it as `aws_region` (exactly `credentials::QUERY_REGION`, so a link straight to `/api/{flamegraph,tokio-stats}` is self-contained); `readScope` reads it back.
- **`index.html`**: `currentRegion()` (creds store, region-field fallback) stamps region onto every flamegraph / tokio-stats / viewer link the home page opens.
- **`flamegraph.html` / `viewer.html` / `tokio_stats.html`**: on load, fold the URL's region (`aws_region`, or `s_region` for an exact-decode scope) into the creds store via `setRegion`, so every subsequent `/api/*` request carries the `x-dial9-aws-region` header. Region is also preserved in the address bar / copy link.
- **`flamegraph_diff.js` (`fullScopeQuery`) + `flamegraph_diff_view.js` (`apiUrlFor`)**: add `aws_region` to the scope-key allowlists so per-side diff scopes keep it — side B often names a cross-region bucket.

Region is not a secret and grants nothing on its own (like `bucket` and `aws_role_arn`), so it is safe in a shared URL; the static BYOC keys remain header-only and are never serialized.

**No server change** — `parse_cred_inputs` already reads `aws_region` from the query for the BYOC path (`header_region.or(query_region)`).

## Tests

Extended `test_trace_scope.js` (region round-trip incl. empty, `scopeFromKeys` threading, aggregation round-trip) and `test_flamegraph_diff.js` (`fullScopeQuery` + `apiUrlFor` carry `aws_region`). All UI logic test suites pass.