### PR TITLE
fix(viewer): browse finds local traces without date-structured paths

### DIFF
--- a/dial9-viewer/src/ingest/aggregate.rs
+++ b/dial9-viewer/src/ingest/aggregate.rs
@@ -210,10 +210,11 @@ fn is_date(s: &str) -> bool {
 }
 
 /// True if a raw source key is a trace segment (not our own Parquet output).
-fn is_trace_segment(key: &str) -> bool {
+pub(crate) fn is_trace_segment(key: &str) -> bool {
     (key.ends_with(".bin.gz") || key.ends_with(".bin"))
         && !key.contains("/samples/")
         && !key.contains("/dict/")
+        && !key.contains("/flamegraph-data/")
 }
 
 /// Filter a raw source listing down to the files a [`Scope`] selects, then sort

--- a/dial9-viewer/src/server/browse.rs
+++ b/dial9-viewer/src/server/browse.rs
@@ -1,4 +1,6 @@
 //! `browse` finds all trace files for a given timerange / filter set
+use std::sync::Arc;
+
 use axum::Extension;
 use axum::Json;
 use axum::extract::{Query, State};
@@ -11,7 +13,7 @@ use crate::server::AppState;
 use crate::server::credentials::MaybeCreds;
 use crate::server::error::storage_error_response;
 use crate::server::metrics::OperationMetrics;
-use crate::storage::{ObjectInfo, StorageError};
+use crate::storage::{ObjectInfo, StorageBackend, StorageError};
 
 /// Per-prefix object cap. A 10-minute (or minute) prefix can legitimately fan
 /// out across many hosts; 10k absorbs a very busy bucket while still bounding
@@ -101,13 +103,58 @@ pub async fn browse(
     };
 
     let window = params.to - params.from;
+
+    // Local mode: flat listing (no date-prefix fan-out).
+    if !state.allow_byo_creds {
+        return browse_local(backend, &bucket, &base).await;
+    }
+
+    browse_s3(backend, &bucket, &base, params.from, params.to, window).await
+}
+
+/// Local mode: flat listing filtered to trace segments.
+/// Called when `allow_byo_creds == false` (i.e. `--local-dir`).
+/// No time filtering — the frontend shows all results, positioned by mtime.
+async fn browse_local(
+    backend: Arc<dyn StorageBackend>,
+    bucket: &str,
+    base: &str,
+) -> Result<BrowseOk, (StatusCode, String)> {
+    let page = backend
+        .list_objects(bucket, base, PER_PREFIX_CAP)
+        .await
+        .map_err(storage_error_response)?;
+    let objects: Vec<ObjectInfo> = page
+        .objects
+        .into_iter()
+        .filter(|o| crate::ingest::aggregate::is_trace_segment(&o.key))
+        .collect();
+    let op = OperationMetrics::browse(objects.len(), 0, page.truncated, false);
+    Ok((
+        Extension(op),
+        Json(BrowseResponse {
+            objects,
+            truncated: page.truncated,
+        }),
+    ))
+}
+
+/// S3 mode: date-prefix fan-out with overflow refinement.
+async fn browse_s3(
+    backend: Arc<dyn StorageBackend>,
+    bucket: &str,
+    base: &str,
+    from: i64,
+    to: i64,
+    window: i64,
+) -> Result<BrowseOk, (StatusCode, String)> {
     let gran = if window < MINUTE_GRANULARITY_THRESHOLD_SECS {
         Granularity::Minute
     } else {
         Granularity::Hour
     };
 
-    let (prefixes, range_truncated) = time_prefixes(&base, params.from, params.to, gran);
+    let (prefixes, range_truncated) = time_prefixes(base, from, to, gran);
 
     // Per-request operational detail — the request-rate/latency signal lives in
     // the per-request EMF metrics now, so keep this at debug to avoid log spam.
@@ -132,7 +179,7 @@ pub async fn browse(
         futures::stream::iter(prefixes.clone())
             .map(|p| {
                 let backend = backend.clone();
-                let bucket = bucket.clone();
+                let bucket = bucket.to_string();
                 async move { backend.list_objects(&bucket, &p, PER_PREFIX_CAP).await }
             })
             .buffered(LIST_CONCURRENCY)
@@ -173,7 +220,7 @@ pub async fn browse(
             futures::stream::iter(refined)
                 .map(|p| {
                     let backend = backend.clone();
-                    let bucket = bucket.clone();
+                    let bucket = bucket.to_string();
                     async move { backend.list_objects(&bucket, &p, PER_PREFIX_CAP).await }
                 })
                 .buffer_unordered(LIST_CONCURRENCY)

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -275,7 +275,8 @@ async fn setup_s3_test(
     // but they share the same filesystem root)
     let backend = S3Backend::from_client(fake_s3_client(s3_root.path()));
 
-    let state = AppState::new(Arc::new(backend), default_bucket, default_prefix);
+    let state =
+        AppState::new(Arc::new(backend), default_bucket, default_prefix).with_byo_creds(true);
     let base = start_server(state).await;
     (upload_client, base, s3_root)
 }
@@ -706,7 +707,8 @@ async fn browse_overflow_attribution_survives_out_of_order_completion() {
         release_tx: std::sync::Mutex::new(Some(tx)),
         release_rx: std::sync::Mutex::new(Some(rx)),
     };
-    let state = AppState::new(Arc::new(backend), Some("traces-bucket".into()), None);
+    let state =
+        AppState::new(Arc::new(backend), Some("traces-bucket".into()), None).with_byo_creds(true);
     let base = start_server(state).await;
     let client = reqwest::Client::new();
 
@@ -1003,6 +1005,59 @@ async fn local_prefixes_lists_subdirs() {
         .unwrap();
     check!(resp.contains(&"2026-04-09/1910/".to_string()));
     check!(resp.contains(&"2026-04-09/1920/".to_string()));
+}
+
+/// In local mode (allow_byo_creds=false), browse does a flat mtime-based
+/// listing and finds on-disk buffer traces regardless of path structure.
+#[tokio::test]
+async fn browse_local_mode_finds_buffer_traces() {
+    let dir = tempfile::tempdir().unwrap();
+    let boot_dir = dir.path().join("aczi-148206");
+    std::fs::create_dir_all(&boot_dir).unwrap();
+    std::fs::write(boot_dir.join("trace.0.bin"), b"TRC\0fake-trace").unwrap();
+    std::fs::write(boot_dir.join("trace.1.bin"), b"TRC\0fake-trace-2").unwrap();
+    std::fs::write(boot_dir.join(".lock"), b"").unwrap();
+
+    let boot_dir2 = dir.path().join("bxyz-999999");
+    std::fs::create_dir_all(&boot_dir2).unwrap();
+    std::fs::write(boot_dir2.join("trace.0.bin.gz"), gzip_bytes(b"TRC\0other")).unwrap();
+
+    // No with_byo_creds → local mode → flat listing
+    let state = AppState::new(
+        Arc::new(LocalBackend::new(dir.path())),
+        Some("local".into()),
+        None,
+    );
+    let base = start_server(state).await;
+    let client = reqwest::Client::new();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let resp = client
+        .get(format!(
+            "{base}/api/browse?bucket=local&from={}&to={}",
+            now - 86400,
+            now + 60
+        ))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let objects = body["objects"].as_array().unwrap();
+
+    check!(
+        objects.len() == 3,
+        "expected 3 traces, got {}",
+        objects.len()
+    );
+    let keys: Vec<&str> = objects.iter().map(|o| o["key"].as_str().unwrap()).collect();
+    check!(keys.contains(&"aczi-148206/trace.0.bin"));
+    check!(keys.contains(&"aczi-148206/trace.1.bin"));
+    check!(keys.contains(&"bxyz-999999/trace.0.bin.gz"));
 }
 
 // --- trace upload tests ---

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -441,6 +441,7 @@
     let rawObjects = [];       // raw search results
     let currentTab = 'browse';
     let aggregationEnabled = false; // server runs demand-driven aggregation
+    let localMode = false;             // true when server is local-dir (no BYO creds)
     let currentQuickRange = null;   // hours, when a "Last Nhr" quick range is active
                                     // (null once the user edits the range manually)
 
@@ -858,6 +859,7 @@
         // When the server runs demand-driven aggregation, the flamegraph button
         // drives the sampled server-side loop instead of decoding raw traces.
         aggregationEnabled = !!config.aggregation_enabled;
+        localMode = !config.supports_byo_credentials;
         if (config.supports_byo_credentials) initCredsUi();
         // Server defaults (bucket/prefix) were filled programmatically above;
         // reflect them in the URL so the link is complete.
@@ -1058,6 +1060,16 @@
     const parseKey = (key) => Dial9TraceScope.parseKey(key);
     const extractPrefix = (key) => Dial9TraceScope.extractPrefix(key);
 
+    // Parse last_modified into epoch seconds. The local backend sends numeric
+    // epoch seconds; S3 sends ISO 8601 strings. Returns 0 when absent/unparseable.
+    function epochSeconds(lastModified) {
+        if (!lastModified) return 0;
+        const n = Number(lastModified);
+        if (!isNaN(n) && n > 0) return n;
+        const ms = new Date(lastModified).getTime();
+        return isNaN(ms) ? 0 : ms / 1000;
+    }
+
     function toLocalDatetime(d) {
         const pad = n => String(n).padStart(2, '0');
         return d.getFullYear() + '-' + pad(d.getMonth()+1) + '-' + pad(d.getDate()) +
@@ -1178,7 +1190,7 @@
                 const p = parseKey(obj.key);
                 if (!p.epoch) return true; // keep if we can't parse
                 // Include if segment overlaps the range (use last_modified as end proxy)
-                const end = obj.last_modified ? new Date(obj.last_modified).getTime() / 1000 : p.epoch;
+                const end = epochSeconds(obj.last_modified) || p.epoch;
                 return p.epoch <= toEpoch && end >= fromEpoch;
             });
 
@@ -1213,10 +1225,9 @@
             // spread uniformly across it when rendering density.
             heatmapSegments = allObjects.map(obj => {
                 const p = parseKey(obj.key);
-                const start = p.epoch;
-                const end = obj.last_modified
-                    ? new Date(obj.last_modified).getTime() / 1000
-                    : start;
+                const mtime = epochSeconds(obj.last_modified);
+                const start = p.epoch || mtime;
+                const end = mtime || start;
                 return {
                     key: obj.key, size: obj.size, start, end,
                     service: p.service, host: p.host, bootId: p.bootId,
@@ -2036,6 +2047,16 @@
         if (keys.length === 0) return;
 
         const bucket = bucketInput.value.trim();
+
+        // Local mode: open traces directly by key (no scope resolution needed,
+        // and the scope can't be derived from buffer-style key names anyway).
+        if (localMode) {
+            const traceParams = keys.map(k =>
+                'trace=' + encodeURIComponent('/api/object?key=' + encodeURIComponent(k))
+            ).join('&');
+            window.open('viewer.html?' + traceParams, '_blank');
+            return;
+        }
 
         // Carry the selection as a compact *scope* (bucket/prefix/service/
         // host-set + time window) instead of one trace= component per file. The

--- a/examples/simple-local/src/main.rs
+++ b/examples/simple-local/src/main.rs
@@ -44,11 +44,7 @@ async fn main() {
         h.await.unwrap();
     }
 
-    let trace_path = format!("{}/trace.bin", TRACE_DIR);
-    println!("\n✓ Trace files written to: {}", trace_path);
-    println!(
-        "  You can view them with: cargo run --package dial9-viewer -- --local-dir {}",
-        TRACE_DIR
-    );
-    println!("  Then open http://localhost:3000 in your browser");
+    println!("\n✓ Trace written to: {TRACE_DIR}");
+    println!("  View with: cargo run -p dial9-viewer -- serve --local-dir {TRACE_DIR}");
+    println!("  Then open http://localhost:3000");
 }


### PR DESCRIPTION
https://github.com/dial9-rs/dial9/issues/620

In local mode (--local-dir), browse now does a flat listing instead of date-prefix fan-out, so on-disk buffer traces ({boot_id}/trace.{N}.bin) are discoverable. The heatmap falls back to file mtime when the filename has no epoch, and clicking opens traces directly by key.

If we want more consistency, we could also change the on-disk writer to produce date-structured paths. This would be a breaking change and might require some refactoring because the writer doesn't know the date until seal time (the base_path is set up front).