### PR TITLE
Backport #619 (schedstat park/unpark sampling) to release-0.3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: ["1.94.1", nightly]
+        toolchain: ["1.94.1"]
         # aarch64 Linux exercises arch-specific unwind asm, PAC stripping,
         # and ucontext layout that x86_64 Linux doesn't cover.
         include:
@@ -62,6 +62,50 @@ jobs:
       - uses: ./.github/actions/rust-build
         with:
           toolchain: ${{ matrix.toolchain }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  # TEMPORARY: the nightly build is disabled while aws-runtime fails to compile
+  # on nightly rustc (E0282 type-inference regression upstream). This gate skips
+  # `build-nightly` until 2026-07-20 (UTC), after which the job re-enables
+  # automatically. Remove this `nightly-gate` job and the `needs:`/`if:` lines on
+  # `build-nightly` once the upstream issue resolves.
+  nightly-gate:
+    name: Nightly build gate
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        run: |
+          if [[ "$(date -u +%Y-%m-%d)" < "2026-07-20" ]]; then
+            echo "Nightly build temporarily disabled until 2026-07-20; skipping."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-nightly:
+    name: Build (${{ matrix.os }}, nightly)
+    runs-on: ${{ matrix.os }}
+    # Nightly builds against the LATEST dependency versions (the rust-build
+    # action deletes Cargo.lock on nightly). This is an early-warning canary for
+    # toolchain/ecosystem breakage and is intentionally NOT part of `ci-pass`, so
+    # a nightly rustc regression or a freshly published dependency does not block
+    # PRs. Watch it on main; fix forward when it goes red.
+    needs: nightly-gate
+    if: needs.nightly-gate.outputs.enabled == 'true'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/rust-build
+        with:
+          toolchain: nightly
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
   feature-check:
@@ -213,7 +257,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # Need full history so cargo-semver-checks can use origin/main as the baseline.
+          # Need full history so cargo-semver-checks can use the PR's base branch
+          # (origin/${{ github.base_ref }}) as the baseline.
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -228,14 +273,16 @@ jobs:
       - name: Check semver compliance
         env:
           RUSTFLAGS: "--cfg tokio_unstable"
-        # Compare against origin/main rather than the latest crates.io release. This
-        # surfaces only breaking changes introduced *by this PR* — accumulated breaks
-        # already on main don't relitigate on every PR. release-plz's own
-        # semver_check (at release time) is the gate that ensures a major bump
-        # before publishing.
+        # Compare against the PR's base branch rather than the latest crates.io
+        # release. This surfaces only breaking changes introduced *by this PR* —
+        # accumulated breaks already on the base don't relitigate on every PR.
+        # Using `github.base_ref` (not a hardcoded `main`) keeps this correct on
+        # release maintenance branches, whose API legitimately differs from main.
+        # release-plz's own semver_check (at release time) is the gate that
+        # ensures a major bump before publishing.
         run: |
           cargo semver-checks \
-            --baseline-rev origin/main \
+            --baseline-rev "origin/${{ github.base_ref }}" \
             -p dial9-trace-format-derive \
             -p dial9-trace-format \
             -p dial9-perf-self-profile \

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -1,4 +1,4 @@
-use super::shared_state::{PARKED_SCHED_WAIT, SharedState};
+use super::shared_state::{PARK_COUNTER, PARKED_SCHED_WAIT, SCHED_SAMPLED_THIS_PARK, SharedState};
 use crate::telemetry::buffer::{Encodable, ThreadLocalEncoder};
 use crate::telemetry::events::SchedStat;
 use crate::telemetry::format::{
@@ -268,15 +268,59 @@ pub(super) fn make_poll_end(ctx: &RuntimeContext, shared: &SharedState) -> PollE
     }
 }
 
+/// How often to read `SchedStat::read_current` in the worker park/unpark path.
+///
+/// Reading `/proc/self/task/<tid>/schedstat` on every park is measurable CPU
+/// overhead, and there is no need to catch every scheduler pause: periodic
+/// sampling still surfaces scheduling latency. We therefore only read schedstat
+/// on 1-in-N parks. `N` defaults to 10 and is overridable via the
+/// `DIAL9_SCHED_WAIT_SAMPLE_RATE` environment variable (values are clamped to at
+/// least 1; `1` restores read-on-every-park).
+fn sched_wait_sample_rate() -> u64 {
+    static RATE: OnceLock<u64> = OnceLock::new();
+    *RATE.get_or_init(|| {
+        std::env::var("DIAL9_SCHED_WAIT_SAMPLE_RATE")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(10)
+            .max(1)
+    })
+}
+
+/// Advance a per-thread park counter and decide whether this park should read
+/// schedstat. Samples every `rate`th park (`rate` is clamped to at least 1, so
+/// `rate == 1` samples every park). Returns the incremented counter and the
+/// sampling decision. Pure so the 1-in-N logic can be unit-tested without the
+/// process-global rate or a live schedstat read.
+fn advance_park_counter(counter: u64, rate: u64) -> (u64, bool) {
+    let next = counter.wrapping_add(1);
+    (next, next.is_multiple_of(rate.max(1)))
+}
+
 pub(super) fn make_worker_park(ctx: &RuntimeContext, shared: &SharedState) -> WorkerParkEvent {
     let resolved = ctx.resolve_worker(shared);
     let worker_local_queue_depth = resolved
         .map(|(_, idx)| ctx.local_queue_depth(idx))
         .unwrap_or(0);
     let cpu_time_nanos = crate::telemetry::events::thread_cpu_time_nanos();
-    if let Ok(ss) = SchedStat::read_current() {
-        PARKED_SCHED_WAIT.with(|c| c.set(ss.wait_time_ns));
-    }
+    // Only read schedstat on 1-in-N parks. The counter and the "sampled this
+    // park" flag are thread-local, so the matching unpark on the same worker
+    // thread reads schedstat iff park did, keeping the wait-time delta a valid
+    // park->unpark pair.
+    let sample = PARK_COUNTER.with(|c| {
+        let (next, sample) = advance_park_counter(c.get(), sched_wait_sample_rate());
+        c.set(next);
+        sample
+    });
+    let sampled = sample
+        && match SchedStat::read_current() {
+            Ok(ss) => {
+                PARKED_SCHED_WAIT.with(|c| c.set(ss.wait_time_ns));
+                true
+            }
+            Err(_) => false,
+        };
+    SCHED_SAMPLED_THIS_PARK.with(|c| c.set(sampled));
     WorkerParkEvent {
         timestamp_ns: crate::telemetry::events::clock_monotonic_ns(),
         worker_id: resolved.map(|(id, _)| id).unwrap_or(WorkerId::UNKNOWN),
@@ -292,9 +336,18 @@ pub(super) fn make_worker_unpark(ctx: &RuntimeContext, shared: &SharedState) -> 
         .map(|(_, idx)| ctx.local_queue_depth(idx))
         .unwrap_or(0);
     let cpu_time_nanos = crate::telemetry::events::thread_cpu_time_nanos();
-    let sched_wait_delta_nanos = if let Ok(ss) = SchedStat::read_current() {
-        let prev = PARKED_SCHED_WAIT.with(|c| c.get());
-        ss.wait_time_ns.saturating_sub(prev)
+    // Only read schedstat on unpark if the matching park sampled it, so the
+    // delta below always pairs with a park-time reading. Reset the flag either
+    // way so a subsequent unsampled park can't reuse a stale pair. Unsampled
+    // unparks report a wait delta of 0.
+    let sampled = SCHED_SAMPLED_THIS_PARK.with(|c| c.replace(false));
+    let sched_wait_delta_nanos = if sampled {
+        if let Ok(ss) = SchedStat::read_current() {
+            let prev = PARKED_SCHED_WAIT.with(|c| c.get());
+            ss.wait_time_ns.saturating_sub(prev)
+        } else {
+            0
+        }
     } else {
         0
     };
@@ -305,5 +358,43 @@ pub(super) fn make_worker_unpark(ctx: &RuntimeContext, shared: &SharedState) -> 
         cpu_time_ns: cpu_time_nanos,
         sched_wait_ns: sched_wait_delta_nanos,
         tid: crate::telemetry::events::current_tid(),
+    }
+}
+
+#[cfg(all(test, not(shuttle)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn park_counter_samples_one_in_n() {
+        // rate == 1: every park samples.
+        let mut counter = 0u64;
+        for _ in 0..5 {
+            let (next, sample) = advance_park_counter(counter, 1);
+            counter = next;
+            assert!(sample);
+        }
+
+        // rate == 10 (the default): exactly one park in ten samples, and the
+        // sampled park is the 10th, not the 1st, so a burst of short parks is
+        // not over-counted.
+        counter = 0;
+        let mut sampled = 0;
+        let mut sampled_indices = Vec::new();
+        for i in 1..=30 {
+            let (next, sample) = advance_park_counter(counter, 10);
+            counter = next;
+            if sample {
+                sampled += 1;
+                sampled_indices.push(i);
+            }
+        }
+        assert_eq!(sampled, 3);
+        assert_eq!(sampled_indices, vec![10, 20, 30]);
+
+        // rate == 0 is clamped to 1 (defensive: the env parser already clamps,
+        // but the pure helper must not divide by zero).
+        let (_, sample) = advance_park_counter(0, 0);
+        assert!(sample);
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/shared_state.rs
@@ -16,6 +16,15 @@ use super::RuntimeContext;
 crate::primitives::thread_local! {
     /// schedstat wait_time_ns captured at park time, used to compute delta on unpark.
     pub(super) static PARKED_SCHED_WAIT: Cell<u64> = const { Cell::new(0) };
+    /// Per-thread park counter used to sample `SchedStat::read_current`. See
+    /// [`super::runtime_context::sched_wait_sample_rate`]: schedstat is only read
+    /// on 1-in-N parks to bound the CPU cost of reading
+    /// `/proc/self/task/<tid>/schedstat`.
+    pub(super) static PARK_COUNTER: Cell<u64> = const { Cell::new(0) };
+    /// Whether the current park cycle successfully read schedstat at park time.
+    /// Unpark only computes a wait-time delta when this is `true`, guaranteeing
+    /// every reported `sched_wait_ns` comes from a matched park->unpark pair.
+    pub(super) static SCHED_SAMPLED_THIS_PARK: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Runtime-agnostic core recording state.


### PR DESCRIPTION
Backports the **sampling half** of #619 onto the `release-0.3.x` maintenance branch. Primary purpose: exercise the end-to-end release machinery (branch protection → merge queue-free merge → release-plz publish) for the 0.3.x series.

## What's included
- **Commit 1 of #619** — sample `SchedStat::read_current` on only 1-in-N worker parks (N defaults to 10, override via `DIAL9_SCHED_WAIT_SAMPLE_RATE`). Reading `/proc/self/task/<tid>/schedstat` on every park/unpark is measurable CPU; periodic sampling still surfaces scheduler latency (#557).
- **Commit 3 of #619** — the `is_multiple_of` clippy fix, folded in.

## What's deliberately NOT included
- **Commit 2 (`sched_wait_ns: u64` → `Option<u64>`)** is skipped. That is a **trace-format change** and would require regenerating `demo-trace.bin`. To keep the release series format-stable, `WorkerUnparkEvent::sched_wait_ns` stays `u64` and **unsampled unparks report a delta of `0`** instead of `None`.

Because the format is unchanged, no demo-trace regeneration is needed and the JS parser / analysis consumers are untouched.

## Divergence notes
This is a manual port, not a clean cherry-pick: `release-0.3.x` is ~77 commits behind `main`, and the sampling thread-locals live in `shared_state.rs` here (vs a separate block on `main`). Behavior matches #619's sampling logic exactly.

## Testing
- `cargo nextest run -p dial9-tokio-telemetry` — 392 passed
- `cargo nextest run -p dial9-tokio-telemetry --stress-duration 20s` — 2 iterations, 0 failures
- `cargo clippy -p dial9-tokio-telemetry --all-targets` — clean
- `cargo fmt --check` — clean
- New unit test `park_counter_samples_one_in_n` covers the 1-in-N decision (incl. rate=1 and the divide-by-zero guard at rate=0).

Refs #557, #619