### PR TITLE
fix(release): use slash in release-plz PR branch prefix

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,12 @@
 git_release_enable = true
 changelog_update = false
 semver_check = true
+# Use a slash in the release-PR branch prefix so the ephemeral branch is
+# `release-plz/<timestamp>` instead of `release-plz-<timestamp>`. The latter
+# matches the `release-*` branch-protection rulesets (including the admins-only
+# creation restriction), which blocks release-plz from pushing its PR branch.
+# GitHub's `release-*` glob does not cross `/`, so `release-plz/...` is exempt.
+pr_branch_prefix = "release-plz/"
 pr_body = """
 {% for release in releases %}
 {% if release.title %}


### PR DESCRIPTION
## Problem
main's **Release PR** automation is currently broken. The last two runs failed with:

```
remote: - Cannot create ref due to creations being restricted.
 ! [remote rejected] release-plz-2026-07-09T02-15-23Z (push declined due to repository rule violations)
```

release-plz creates its release PR from an ephemeral branch named `release-plz-<timestamp>`. That name matches the repo's `release-*` branch-protection rulesets — specifically the admins-only **`Restrict release-* creation`** ruleset — so GitHub rejects the branch push and the workflow fails.

(These `release-*` rulesets were added recently to protect release maintenance branches; the collision with release-plz's bot branches was an unintended side effect.)

## Fix
Set `pr_branch_prefix = "release-plz/"` in `release-plz.toml`, so the branch becomes `release-plz/<timestamp>`. GitHub's `release-*` glob does **not** cross `/`, so the slash form is exempt from the rulesets while staying recognizable.

Verified against the live ruleset engine (`GET /repos/.../rules/branches/<name>`): `release-plz-<ts>` → matches `creation` rule (blocked); `release-plz/<ts>` → no rules (allowed).

## Scope
Config-only. Restores the Release PR automation on `main`. The same fix is being applied to `release-0.3.x` separately.