### PR TITLE
fix(release): use slash in release-plz PR branch prefix

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,12 @@
 git_release_enable = true
 changelog_update = false
 semver_check = true
+# Use a slash in the release-PR branch prefix so the ephemeral branch is
+# `release-plz/<timestamp>` instead of `release-plz-<timestamp>`. The latter
+# matches the `release-*` branch-protection rulesets (including the admins-only
+# creation restriction), which blocks release-plz from pushing its PR branch.
+# GitHub's `release-*` glob does not cross `/`, so `release-plz/...` is exempt.
+pr_branch_prefix = "release-plz/"
 pr_body = """
 {% for release in releases %}
 {% if release.title %}


### PR DESCRIPTION
Backports the `release-plz.toml` fix (#633) to `release-0.3.x`.

## Why
release-plz creates its release PR from an ephemeral branch named `release-plz-<timestamp>`, which matches this repo's `release-*` branch-protection rulesets — including the admins-only **`Restrict release-* creation`** ruleset — so GitHub rejects the branch push (`Cannot create ref due to creations being restricted`).

## Fix
`pr_branch_prefix = "release-plz/"` → branch becomes `release-plz/<timestamp>`. GitHub's `release-*` glob does not cross `/`, so it's exempt.

**This must merge before the 0.3.14 release PR can be generated** on this branch.

Config-only; companion to #633 (same fix into main).