### PR TITLE
viewer: classify S3 NoSuchBucket/NoSuchKey as 404, not 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Viewer: browsing a nonexistent bucket now returns HTTP 404 instead of 500. The S3 `NoSuchBucket`/`NoSuchKey` error codes were falling through to the generic error arm, which logged an "unclassified S3 error" and reported a server `fault` — so a user typo in the bucket name polluted the viewer's fault metric. They now classify as `NotFound`.
+- Viewer: browsing a nonexistent bucket now returns HTTP 404 instead of 500, and a syntactically invalid bucket name returns HTTP 400. The S3 `NoSuchBucket`/`NoSuchKey` and `InvalidBucketName` error codes were falling through to the generic error arm, which logged an "unclassified S3 error" and reported a server `fault` — so a user typo in the bucket name polluted the viewer's fault metric. They now classify as `NotFound` (404) and `BadRequest` (400) respectively.
 
 ## [0.3.13](https://github.com/dial9-rs/dial9/compare/dial9-tokio-telemetry-v0.3.12...dial9-tokio-telemetry-v0.3.13) - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** removed `MemoryProfilerGuard`. Memory profiling now drains for the session/guard lifetime (like CPU profiling) rather than being a permanent process-wide install ([#591](https://github.com/dial9-rs/dial9/pull/591))
 - **Breaking:** renamed `Dial9Allocator` to `SamplingAllocator`, the global-allocator wrapper now lives in `dial9-perf-self-profile` and works without dial9 ([#591](https://github.com/dial9-rs/dial9/pull/591))
 
+### Fixed
+
+- Viewer: browsing a nonexistent bucket now returns HTTP 404 instead of 500. The S3 `NoSuchBucket`/`NoSuchKey` error codes were falling through to the generic error arm, which logged an "unclassified S3 error" and reported a server `fault` — so a user typo in the bucket name polluted the viewer's fault metric. They now classify as `NotFound`.
+
 ## [0.3.13](https://github.com/dial9-rs/dial9/compare/dial9-tokio-telemetry-v0.3.12...dial9-tokio-telemetry-v0.3.13) - 2026-05-29
 
 ### Added

--- a/dial9-viewer/src/server/error.rs
+++ b/dial9-viewer/src/server/error.rs
@@ -17,6 +17,9 @@ pub fn storage_error_response(err: StorageError) -> (StatusCode, String) {
         // mismatch, and distinct from a generic 500 so the UI can surface the
         // actionable "set the region" message.
         StorageError::WrongRegion => (StatusCode::MISDIRECTED_REQUEST, err.to_string()),
+        // Client-side malformed input (e.g. an invalid bucket name): a 400, not
+        // a 500 `fault` — the mistake is in the request, not the server.
+        StorageError::BadRequest(_) => (StatusCode::BAD_REQUEST, err.to_string()),
         StorageError::Other(_) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }
 }

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -239,6 +239,17 @@ where
         // form) or the generic `Redirect`. Surface a clear message rather than
         // the opaque "unclassified S3 error" this used to fall through to.
         Some("PermanentRedirect" | "Redirect") => StorageError::WrongRegion,
+        // Missing bucket/key: the user pointed at something that does not exist
+        // (typo'd bucket name, deleted object). This is a client mistake, so map
+        // it to 404 rather than letting it fall through to the `Other` arm —
+        // which logged an "unclassified S3 error" and returned a 500 `fault`,
+        // polluting the fault metric with user input. The list/prefix paths hit
+        // this via the bucket-level `NoSuchBucket`; `GetObject`'s `NoSuchKey` is
+        // additionally handled at the call site (with the bucket/key in the
+        // message), so plain code matching here is the fallback.
+        Some("NoSuchBucket" | "NoSuchKey" | "NotFound") => {
+            StorageError::NotFound("the specified bucket or object does not exist".to_string())
+        }
         // Unmapped error: keep the full SDK detail in the server log (it can
         // embed the access key id, region, and endpoint — server-eyes only) and
         // hand the client a generic message rather than reflecting it back.
@@ -1131,6 +1142,32 @@ mod tests {
         );
         // The message points the user at the fix (set/detect the region).
         assert!(err.to_string().contains("region"), "message: {err}");
+    }
+
+    /// A `NoSuchBucket` (the error S3 returns when the bucket name does not
+    /// exist — typically a user typo) must classify to [`StorageError::NotFound`]
+    /// (→ HTTP 404), not the opaque `Other` that produced an "unclassified S3
+    /// error" log and a 500 `fault`. Guards against user input polluting the
+    /// server-fault metric.
+    #[tokio::test]
+    async fn no_such_bucket_classifies_as_not_found() {
+        // The XML S3 sends when the bucket does not exist (HTTP 404).
+        let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <Error>
+              <Code>NoSuchBucket</Code>
+              <Message>The specified bucket does not exist</Message>
+              <BucketName>test-shanks</BucketName>
+            </Error>"#;
+        let backend = replay_error_backend(404, body);
+
+        let err = backend
+            .list_prefixes("test-shanks", "")
+            .await
+            .expect_err("a NoSuchBucket must surface as an error");
+        assert!(
+            matches!(err, StorageError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -170,6 +170,12 @@ pub enum StorageError {
     /// opaque 500 — this is the failure the viewer's per-bucket region
     /// auto-detection exists to prevent.
     WrongRegion,
+    /// The request was malformed by the client — e.g. an S3 `InvalidBucketName`
+    /// for a bucket name that violates the naming rules (bad characters, wrong
+    /// length). Kept distinct from [`StorageError::Other`] so the HTTP layer
+    /// returns a `400` with an actionable message instead of an opaque `500`
+    /// `fault`; the mistake is in the user's input, not the server.
+    BadRequest(String),
     Other(String),
 }
 
@@ -199,6 +205,7 @@ impl std::fmt::Display for StorageError {
                      detected automatically) and try again."
                 )
             }
+            StorageError::BadRequest(msg) => write!(f, "{msg}"),
             StorageError::Other(msg) => write!(f, "{msg}"),
         }
     }
@@ -249,6 +256,15 @@ where
         // message), so plain code matching here is the fallback.
         Some("NoSuchBucket" | "NoSuchKey" | "NotFound") => {
             StorageError::NotFound("the specified bucket or object does not exist".to_string())
+        }
+        // Malformed bucket name: the name itself violates S3's naming rules (bad
+        // characters, wrong length), so S3 rejects it with `InvalidBucketName`
+        // (HTTP 400) before it can look anything up. Like `NoSuchBucket` this is
+        // user input, not a server fault — but it's a *bad request*, not a
+        // missing resource, so map it to 400 rather than 404 and don't let it
+        // fall through to the `Other` arm's 500 `fault`.
+        Some("InvalidBucketName") => {
+            StorageError::BadRequest("the bucket name is not valid".to_string())
         }
         // Unmapped error: keep the full SDK detail in the server log (it can
         // embed the access key id, region, and endpoint — server-eyes only) and
@@ -1167,6 +1183,32 @@ mod tests {
         assert!(
             matches!(err, StorageError::NotFound(_)),
             "expected NotFound, got {err:?}"
+        );
+    }
+
+    /// An `InvalidBucketName` (S3's error for a syntactically invalid bucket
+    /// name, HTTP 400) must classify to [`StorageError::BadRequest`] (→ HTTP
+    /// 400), not the opaque `Other` that produced an "unclassified S3 error"
+    /// log and a 500 `fault`. Like `NoSuchBucket` it's user input, but it's a
+    /// malformed request rather than a missing resource.
+    #[tokio::test]
+    async fn invalid_bucket_name_classifies_as_bad_request() {
+        // The XML S3 sends when the bucket name violates the naming rules.
+        let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <Error>
+              <Code>InvalidBucketName</Code>
+              <Message>The specified bucket is not valid.</Message>
+              <BucketName>Not_A_Valid_Bucket</BucketName>
+            </Error>"#;
+        let backend = replay_error_backend(400, body);
+
+        let err = backend
+            .list_prefixes("Not_A_Valid_Bucket", "")
+            .await
+            .expect_err("an InvalidBucketName must surface as an error");
+        assert!(
+            matches!(err, StorageError::BadRequest(_)),
+            "expected BadRequest, got {err:?}"
         );
     }
 


### PR DESCRIPTION
Browsing a nonexistent bucket returned HTTP 500 with a server `fault`. The S3 `NoSuchBucket`/`NoSuchKey` error codes fell through the `classify_s3_error` catch-all to `StorageError::Other`, which logged an "unclassified S3 error" and mapped to 500. A user typo in the bucket name is a client mistake, not a server fault — but it was the only source of faults in a 24h prod sample, so it polluted the viewer's fault metric and gave the user an opaque "500 Internal Server Error" instead of an actionable message.

Map those codes to `StorageError::NotFound` (→ 404), mirroring the existing `PermanentRedirect` → `WrongRegion` treatment and the call-site `NoSuchKey` handling in `get_object`. Add a regression test.