### PR TITLE
fix(release): distinct release-plz branch prefix for release-0.3.x

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,12 +2,19 @@
 git_release_enable = true
 changelog_update = false
 semver_check = true
-# Use a slash in the release-PR branch prefix so the ephemeral branch is
-# `release-plz/<timestamp>` instead of `release-plz-<timestamp>`. The latter
-# matches the `release-*` branch-protection rulesets (including the admins-only
-# creation restriction), which blocks release-plz from pushing its PR branch.
-# GitHub's `release-*` glob does not cross `/`, so `release-plz/...` is exempt.
-pr_branch_prefix = "release-plz/"
+# Release-PR branch prefix for this maintenance branch.
+#
+# Two constraints:
+#   1. The slash matters: `release-plz-<timestamp>` (no slash) matches the
+#      `release-*` branch-protection rulesets (incl. the admins-only creation
+#      restriction) and gets rejected. GitHub's `release-*` glob does not cross
+#      `/`, so a `.../` form is exempt.
+#   2. It must NOT share a prefix with main's `release-plz/`. release-plz treats
+#      any open PR matching its configured prefix as its own and closes the
+#      "stale" ones — so if main and release-0.3.x share a prefix, a release-pr
+#      run on main will close release-0.3.x's release PR (and vice versa).
+#      A distinct `release-plz-0.3/` keeps the two release lines isolated.
+pr_branch_prefix = "release-plz-0.3/"
 pr_body = """
 {% for release in releases %}
 {% if release.title %}


### PR DESCRIPTION
## Problem
The 0.3.14 release PR (#636) was auto-closed, and a broken main release PR (#637, now closed) was generated carrying release-0.3.x's commits.

**Root cause:** both `main` and `release-0.3.x` used `pr_branch_prefix = "release-plz/"`. release-plz treats *any* open PR whose branch matches its configured prefix as its own release PR and closes the "stale" ones. So when main's `release-pr.yml` ran (on the #633 merge), it:
- closed #636 (release-0.3.x's release PR — same prefix), and
- opened #637 based on release-0.3.x's history but targeting main (CONFLICTING).

## Fix
Give this branch a **distinct** prefix: `release-plz-0.3/`. The two release lines now have disjoint PR namespaces and can't interfere. It's still slash-terminated, so it stays exempt from the `release-*` protection rulesets (verified against the live ruleset engine).

Config-only.

## Note on ordering
#636 (reopened) still uses the old `release-plz/...` branch name, so it remains vulnerable to a main release-pr run until it's merged. Recommend merging #636 promptly; future 0.3.x release PRs will use the new prefix.