### PR TITLE
feat(viewer): Tokio Stats "Longest polls" rollup + focus deep-link

### DIFF
--- a/dial9-viewer/src/server/tokio_stats.rs
+++ b/dial9-viewer/src/server/tokio_stats.rs
@@ -29,6 +29,14 @@ use arrow::array::Array;
 /// Floor: only send polls longer than this to the client (saves bandwidth).
 const DURATION_FLOOR_NS: i64 = 100_000; // 100µs
 
+/// Number of longest polls shipped to the client. Ported from IRIS's top-100.
+const LONG_POLL_TOP: usize = 100;
+/// Compact the long-poll buffer once it grows past this, keeping the top
+/// [`LONG_POLL_TOP`]. The 4× headroom mirrors IRIS's `analyze.rs` (buffer 400,
+/// truncate to 100) — it amortizes the sort while keeping memory bounded
+/// regardless of scope size.
+const LONG_POLL_SOFT_CAP: usize = LONG_POLL_TOP * 4;
+
 #[derive(Deserialize)]
 pub struct TokioStatsParams {
     pub bucket: Option<String>,
@@ -52,6 +60,14 @@ pub struct TokioStatsResponse {
     /// Source bucket (for constructing viewer deep links in the UI).
     pub bucket: String,
     pub by_spawn_loc: Vec<SpawnLocStats>,
+    /// Longest individual polls across the whole scope, ranked by duration — the
+    /// single futures that held a worker thread longest in one poll (these starve
+    /// other tasks on that worker). Bounded server-side to the top
+    /// [`LONG_POLL_TOP`]: `task_id` is high-cardinality, so this is a reduction,
+    /// not a per-poll axis shipped to the client. Each row carries the
+    /// coordinates to deep-link its trace segment. Ported from IRIS's
+    /// `longPolls.top` (rust-ingest `analyze.rs`).
+    pub top_long_polls: Vec<LongPoll>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coverage: Option<aggregate::Coverage>,
 }
@@ -74,6 +90,24 @@ pub struct PollExemplar {
     pub start_ns: i64,
     pub end_ns: i64,
     pub duration_ns: i64,
+    pub host: String,
+    /// Source trace file key for constructing the viewer deep link.
+    pub source_key: String,
+}
+
+/// One long-running poll, for the top-N "Longest polls" list. Ported from IRIS's
+/// `longPolls.top` — its `(durMs, worker, taskId, spawnLoc, startMs)` tuple, plus
+/// the `host` + `source_key` dial9 needs to deep-link the poll into the viewer.
+#[derive(Serialize, Clone)]
+pub struct LongPoll {
+    pub duration_ns: i64,
+    pub worker_id: u32,
+    pub task_id: u64,
+    /// Where the future was spawned; `None` when the trace didn't record it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spawn_loc: Option<String>,
+    pub start_ns: i64,
+    pub end_ns: i64,
     pub host: String,
     /// Source trace file key for constructing the viewer deep link.
     pub source_key: String,
@@ -329,6 +363,7 @@ fn snapshot_event(
         total_polls: acc.total_polls,
         bucket: ctx.source_bucket.clone(),
         by_spawn_loc,
+        top_long_polls: acc.top_long_polls(),
         coverage: Some(aggregate::Coverage {
             files_matched: ctx.resolved.files_matched,
             files_folded,
@@ -358,6 +393,34 @@ struct TokioStatsAccum {
     min_ts: Option<i64>,
     max_ts: Option<i64>,
     by_loc: HashMap<String, LocAccum>,
+    /// Longest polls seen so far, kept bounded by [`TokioStatsAccum::push_long_poll`].
+    /// Unsorted between compactions; [`TokioStatsAccum::top_long_polls`] produces
+    /// the final ranked list.
+    long_polls: Vec<LongPoll>,
+}
+
+impl TokioStatsAccum {
+    /// Record a candidate long poll, compacting to the top [`LONG_POLL_TOP`] by
+    /// duration whenever the buffer exceeds the soft cap. Mirrors IRIS's
+    /// `analyze.rs` grow-then-truncate strategy so the buffer stays bounded no
+    /// matter how many files fold in.
+    fn push_long_poll(&mut self, poll: LongPoll) {
+        self.long_polls.push(poll);
+        if self.long_polls.len() > LONG_POLL_SOFT_CAP {
+            self.long_polls
+                .sort_unstable_by_key(|p| std::cmp::Reverse(p.duration_ns));
+            self.long_polls.truncate(LONG_POLL_TOP);
+        }
+    }
+
+    /// The final ranked top-N longest polls (descending by duration). Clones so
+    /// repeated SSE snapshots don't consume the still-growing accumulator.
+    fn top_long_polls(&self) -> Vec<LongPoll> {
+        let mut top = self.long_polls.clone();
+        top.sort_unstable_by_key(|p| std::cmp::Reverse(p.duration_ns));
+        top.truncate(LONG_POLL_TOP);
+        top
+    }
 }
 
 struct LocAccum {
@@ -432,6 +495,15 @@ fn read_polls_part(
         let host_arr = batch
             .column_by_name("host")
             .and_then(|c| c.as_any().downcast_ref::<arrow::array::StringArray>());
+        // worker_id / task_id feed the top-long-polls list. Both are already in
+        // the polls schema (parquet_writer.rs); older part-files without them
+        // just yield None here and the columns are skipped.
+        let worker_arr = batch
+            .column_by_name("worker_id")
+            .and_then(|c| c.as_any().downcast_ref::<arrow::array::UInt32Array>());
+        let task_arr = batch
+            .column_by_name("task_id")
+            .and_then(|c| c.as_any().downcast_ref::<arrow::array::UInt64Array>());
 
         let Some(duration_arr) = duration_arr else {
             continue;
@@ -487,16 +559,41 @@ fn read_polls_part(
             };
             la.durations.push((dur, class));
 
+            // Borrowed here; each consumer below owns its copy only when it
+            // actually stores the row, so a poll that is neither a new worst
+            // exemplar nor pushed (old part-file lacking worker/task) allocates
+            // nothing.
+            let host = host_arr
+                .and_then(|a| if a.is_null(i) { None } else { Some(a.value(i)) })
+                .unwrap_or("");
+
             let slot = &mut la.worst_by_class[class as usize];
             if slot.as_ref().is_none_or(|w| dur > w.duration_ns) {
                 *slot = Some(PollExemplar {
                     start_ns: start_arr.map_or(0, |a| a.value(i)),
                     end_ns: end_arr.map_or(0, |a| a.value(i)),
                     duration_ns: dur,
-                    host: host_arr
-                        .and_then(|a| if a.is_null(i) { None } else { Some(a.value(i)) })
-                        .unwrap_or("")
-                        .to_string(),
+                    host: host.to_string(),
+                    source_key: source_key.to_string(),
+                });
+            }
+
+            // Top longest polls (IRIS `longPolls.top`): a poll is only useful in
+            // this list if we can attribute it to a worker + task, so skip rows
+            // from older part-files that predate those columns rather than
+            // fabricating zeros (AGENTS.md: no plausible-default masking).
+            if let (Some(workers), Some(tasks)) = (worker_arr, task_arr) {
+                let spawn_loc = spawn_loc_arr
+                    .and_then(|a| if a.is_null(i) { None } else { Some(a.value(i)) })
+                    .map(str::to_string);
+                acc.push_long_poll(LongPoll {
+                    duration_ns: dur,
+                    worker_id: workers.value(i),
+                    task_id: tasks.value(i),
+                    spawn_loc,
+                    start_ns: start_arr.map_or(0, |a| a.value(i)),
+                    end_ns: end_arr.map_or(0, |a| a.value(i)),
+                    host: host.to_string(),
                     source_key: source_key.to_string(),
                 });
             }
@@ -542,9 +639,32 @@ mod tests {
             .filter(|la| la.worst_by_class.iter().any(|e| e.is_some()))
             .count();
         assert!(with_exemplar > 0);
+
+        // Top longest polls: populated, bounded to LONG_POLL_TOP, ranked
+        // descending by duration, and each carries the coordinates the viewer
+        // needs to deep-link the poll (source_key + host).
+        let top = acc.top_long_polls();
+        assert!(!top.is_empty(), "expected some notable long polls");
+        assert!(top.len() <= LONG_POLL_TOP);
+        assert!(
+            top.windows(2).all(|w| w[0].duration_ns >= w[1].duration_ns),
+            "top long polls must be ranked descending by duration"
+        );
+        assert!(
+            top.iter().all(|p| !p.source_key.is_empty()),
+            "each long poll must carry a source key for deep-linking"
+        );
+        assert!(
+            top[0].duration_ns >= DURATION_FLOOR_NS,
+            "long polls must clear the notable floor"
+        );
         eprintln!(
-            "tokio-stats: {} total, {} above floor, {} locs with exemplars",
-            acc.total_polls, notable, with_exemplar
+            "tokio-stats: {} total, {} above floor, {} locs with exemplars, {} long polls (worst {}ns)",
+            acc.total_polls,
+            notable,
+            with_exemplar,
+            top.len(),
+            top[0].duration_ns,
         );
     }
 }

--- a/dial9-viewer/ui/test_focus_timebase.js
+++ b/dial9-viewer/ui/test_focus_timebase.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+"use strict";
+
+// Regression test for the Tokio-stats "Longest polls" deep-link timebase.
+//
+// The bug: the aggregate polls Parquet stores poll `start_ns`/`end_ns` in
+// WALL-CLOCK ns (decode.rs adds the segment's clock offset), but the trace
+// viewer's timeline (minTs/maxTs/viewStart) is RAW MONOTONIC ns. A deep link
+// that fed a wall-clock timestamp straight into the viewer's `focusOnWindow`
+// landed billions of ns past maxTs, clamped to an empty [maxTs, maxTs] window,
+// and showed a blank worker lane. The fix converts wall→monotonic by
+// subtracting `trace.clockOffsetNs` — the same offset decode.rs applied.
+//
+// This test pins the invariant the fix depends on, using the real demo trace:
+//   1. the demo carries a wall-clock offset (so the mismatch is exercised),
+//   2. a wall-clock poll timestamp is OUTSIDE the monotonic [minTs, maxTs]
+//      (this is what produced the empty view), and
+//   3. subtracting clockOffsetNs brings it back inside — i.e. the conversion
+//      focusOnWindow performs is correct.
+
+const fs = require("fs");
+const zlib = require("zlib");
+const path = require("path");
+const { parseTrace } = require(path.resolve(__dirname, "trace_parser.js"));
+
+let passed = 0;
+let failed = 0;
+function assert(cond, desc) {
+  if (cond) {
+    console.log(`✓ ${desc}`);
+    passed++;
+  } else {
+    console.log(`✗ ${desc}`);
+    failed++;
+  }
+}
+
+(async () => {
+  const raw = fs.readFileSync(path.resolve(__dirname, "demo-trace.bin"));
+  let buf = raw;
+  try {
+    buf = zlib.gunzipSync(raw);
+  } catch (e) {
+    /* already-raw trace */
+  }
+  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  const trace = await parseTrace(ab, {});
+
+  assert(Number.isFinite(trace.minTs) && Number.isFinite(trace.maxTs), "trace has finite monotonic bounds");
+  assert(trace.clockOffsetNs != null && trace.clockOffsetNs > 0, "demo trace carries a wall-clock offset");
+
+  // A poll one millisecond into the trace, as the aggregate would store it:
+  // wall-clock = monotonic + offset.
+  const pollMonotonic = trace.minTs + 1e6;
+  const pollWallClock = pollMonotonic + trace.clockOffsetNs;
+
+  const inBounds = (ns) => ns >= trace.minTs && ns <= trace.maxTs;
+
+  // 2. The raw wall-clock value is off the monotonic timeline (the bug).
+  assert(!inBounds(pollWallClock), "wall-clock poll timestamp falls OUTSIDE the viewer's monotonic bounds");
+
+  // 3. focusOnWindow's correction (wall - clockOffsetNs) round-trips it back.
+  const corrected = pollWallClock - trace.clockOffsetNs;
+  assert(inBounds(corrected), "subtracting clockOffsetNs brings it back inside bounds");
+
+  // Recovery is APPROXIMATE, not exact: the wall-clock value (~1.78e18) is past
+  // Number.MAX_SAFE_INTEGER (~9e15), so as a JS double its ULP is ~256ns. Every
+  // timestamp in the viewer is a double at this magnitude (minTs/maxTs/viewStart
+  // alike), so this is consistent with the whole timeline — and the focus window
+  // is padded to >=1ms, so a sub-microsecond error is invisible. Assert the
+  // recovery is within 1µs (comfortably under that 1ms floor), not bit-exact.
+  const errNs = Math.abs(corrected - pollMonotonic);
+  assert(errNs < 1000, `correction recovers the monotonic timestamp within 1µs (off by ${errNs}ns)`);
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+})().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});

--- a/dial9-viewer/ui/test_tokio_stats_api.js
+++ b/dial9-viewer/ui/test_tokio_stats_api.js
@@ -9,6 +9,7 @@
 const {
   exemplarViewerUrl,
   formatTokioCoverage,
+  latencyHeat,
   canRefineMore,
 } = require("./tokio_stats_api.js");
 
@@ -78,6 +79,45 @@ function assertEq(actual, expected, desc) {
   assertEq(q.has("start"), false, "window dropped even when provided");
 }
 
+// A focus window lands on the exact poll via the NON-DESTRUCTIVE focus_* params
+// (never start/end): focus_start pans the view, worker/task/end refine it.
+{
+  const url = exemplarViewerUrl({
+    bucket: "b",
+    sourceKey: "k.bin.gz",
+    focusStartNs: "1782687631093903000",
+    focusEndNs: "1782687631102430000",
+    focusWorker: 3,
+    focusTask: 42,
+  });
+  const q = new URLSearchParams(url.slice(url.indexOf("?") + 1));
+  assertEq(q.get("focus_start"), "1782687631093903000", "focus_start emitted");
+  assertEq(q.get("focus_end"), "1782687631102430000", "focus_end emitted");
+  assertEq(q.get("focus_worker"), "3", "focus_worker emitted");
+  assertEq(q.get("focus_task"), "42", "focus_task emitted");
+  // Must still be the focus params, NOT the destructive parse filter.
+  assertEq(q.has("start"), false, "focus link does not emit start");
+  assertEq(q.has("end"), false, "focus link does not emit end");
+}
+
+// focus_start alone is enough (spawn-loc exemplars have no worker/task); the
+// refining params are simply omitted rather than sent empty.
+{
+  const url = exemplarViewerUrl({ bucket: "b", sourceKey: "k.bin.gz", focusStartNs: 500 });
+  const q = new URLSearchParams(url.slice(url.indexOf("?") + 1));
+  assertEq(q.get("focus_start"), "500", "focus_start emitted on its own");
+  assertEq(q.has("focus_end"), false, "focus_end omitted when absent");
+  assertEq(q.has("focus_worker"), false, "focus_worker omitted when absent");
+  assertEq(q.has("focus_task"), false, "focus_task omitted when absent");
+}
+
+// No focus window (plain segment link) emits no focus_* params at all.
+{
+  const url = exemplarViewerUrl({ bucket: "b", sourceKey: "k.bin.gz" });
+  const q = new URLSearchParams(url.slice(url.indexOf("?") + 1));
+  assertEq(q.has("focus_start"), false, "no focus params without a window");
+}
+
 assertEq(exemplarViewerUrl({ bucket: "b" }), "", "no source key -> empty link");
 assertEq(exemplarViewerUrl({}), "", "no opts -> empty link");
 
@@ -114,6 +154,16 @@ assertEq(
   "poll count omitted when not provided",
 );
 assertEq(formatTokioCoverage(null, 100), "", "no coverage -> empty badge");
+
+// ── latencyHeat ──
+// Thresholds match IRIS's latencyHeat: ≥3ms red, ≥1ms amber, else green. Input
+// is nanoseconds (the wire unit for poll durations).
+assertEq(latencyHeat(500_000), "#3fb950", "sub-1ms poll is green");
+assertEq(latencyHeat(999_999), "#3fb950", "just under 1ms is still green");
+assertEq(latencyHeat(1_000_000), "#d29922", "1ms poll is amber");
+assertEq(latencyHeat(2_500_000), "#d29922", "1–3ms poll is amber");
+assertEq(latencyHeat(3_000_000), "#f85149", "3ms poll is red");
+assertEq(latencyHeat(50_000_000), "#f85149", "50ms poll is red");
 
 // ── canRefineMore ──
 assertEq(canRefineMore({ files_matched: 480, files_folded: 24 }), true, "folded < matched -> more");

--- a/dial9-viewer/ui/tokio_stats.html
+++ b/dial9-viewer/ui/tokio_stats.html
@@ -262,15 +262,20 @@
 
   function exemplarLink(ex, data) {
     if (!ex || !ex.start_ns) return "";
-    // We intentionally do not forward the exemplar's [start_ns, end_ns] window:
-    // the viewer treats those as a hard parse filter and a single poll's window
-    // is far too narrow — it would drop every surrounding event and load empty.
-    // Link to the whole segment instead. See exemplarViewerUrl.
+    // Forward the poll's window as a NON-DESTRUCTIVE focus (focus_*), not the
+    // start/end parse filter — see exemplarViewerUrl. worker_id/task_id are
+    // present on long-poll rows (they refine the framing + highlight the task)
+    // and absent on spawn-loc exemplars, where focus_start alone still pans the
+    // view to the poll.
     return exemplarViewerUrl({
       bucket: (data && data.bucket) || params.get("bucket") || "",
       sourceKey: ex.source_key,
       svc: params.get("service") || undefined,
       host: ex.host || undefined,
+      focusStartNs: ex.start_ns,
+      focusEndNs: ex.end_ns,
+      focusWorker: ex.worker_id,
+      focusTask: ex.task_id,
     });
   }
 
@@ -396,7 +401,39 @@
       </tr>`;
     }
     html += "</tbody></table>";
+    html += renderLongPolls(data, threshNs);
     tableEl.innerHTML = html;
+  }
+
+  // "Longest polls": the single futures that held a worker thread longest in one
+  // poll — long polls starve every other task on that worker. Ported from IRIS's
+  // "Longest polls" card; the server ranks them (top_long_polls), the client
+  // filters by the threshold slider so it stays consistent with the table above.
+  // Each row deep-links its trace segment via the same exemplar path.
+  function renderLongPolls(data, threshNs) {
+    const polls = (data && data.top_long_polls) || [];
+    const rows = polls.filter(p => p.duration_ns >= threshNs).slice(0, 50);
+    if (!rows.length) return "";
+    // host column only earns its space when the scope spans more than one host.
+    const multiHost = new Set(rows.map(p => p.host || "")).size > 1;
+    let html = `<h3 style="margin:20px 0 8px">🕒 Longest polls</h3>
+      <p style="font-size:0.8em;color:#8b949e;margin-bottom:6px">Single polls that held a worker thread longest — long polls starve other tasks on that worker. Click a row to open its trace segment.</p>
+      <table><thead><tr>
+        <th>Duration</th><th>Worker</th><th>Task</th><th>Spawn Location</th>${multiHost ? "<th>Host</th>" : ""}
+      </tr></thead><tbody>`;
+    for (const p of rows) {
+      const url = exemplarLink(p, data); // p carries source_key + host, like an exemplar
+      const durCell = `<span style="color:${latencyHeat(p.duration_ns)};font-weight:600">${formatDuration(p.duration_ns)}</span>`;
+      const cells = `<td>${durCell}</td>
+        <td>w${p.worker_id}</td>
+        <td><code>${p.task_id}</code></td>
+        <td><code>${escapeHtml(p.spawn_loc || "(unknown)")}</code></td>${multiHost ? `<td>${escapeHtml(p.host || "")}</td>` : ""}`;
+      html += url
+        ? `<tr style="cursor:pointer" onclick="openExemplar(this)" data-url="${url.replace(/"/g, "&quot;")}">${cells}</tr>`
+        : `<tr>${cells}</tr>`;
+    }
+    html += "</tbody></table>";
+    return html;
   }
 
   function renderDiffView(stats, threshNs, sumEl, tableEl) {

--- a/dial9-viewer/ui/tokio_stats_api.js
+++ b/dial9-viewer/ui/tokio_stats_api.js
@@ -9,20 +9,21 @@
 // attach as globals via the top-level `function` declarations. The refinement
 // loop also reuses `nextMaxFiles` from flamegraph_api.js (a shared global).
 
-// Build the viewer deep link for a poll exemplar.
+// Build the viewer deep link for a poll exemplar / long poll.
 //
 // The viewer fetches each `trace=` component (here a single `/api/object`
 // request that streams the still-gzipped segment) and gunzips it client-side,
 // attaching the bring-your-own-credentials headers from sessionStorage.
 //
-// NOTE: we deliberately do NOT pass the exemplar's time range (`start`/`end`).
-// In the viewer those params are a *hard parse filter*: it re-parses the trace
-// keeping only events inside [start, end] (see getParseOptions in viewer.html).
-// A poll exemplar is a single sub-millisecond-to-millisecond window inside a
-// ~60s segment, so filtering to it drops essentially every event and the page
-// loads empty/broken. Until the viewer can open at a time range *without*
-// discarding the surrounding events, we link to the whole segment and let the
-// user navigate to the poll. (Tracked in the codebase notes / memory.)
+// To land on the exact poll, we pass a `focus_*` window (start/end + optional
+// worker/task). These are DISTINCT from `start`/`end`: the viewer treats
+// start/end as a *hard parse filter* that re-parses keeping only events inside
+// the window (getParseOptions in viewer.html), so pointing them at one poll's
+// sub-millisecond window drops every surrounding event and loads an empty page.
+// `focus_*` instead pans/zooms the already-parsed trace to the window and
+// highlights the task (focusOnWindow in viewer.html) — non-destructive, so the
+// surrounding context is still there. When no window is given we just open the
+// whole segment. NEVER emit start/end here.
 //
 // Returns "" when there is no source key to link to.
 function exemplarViewerUrl(opts) {
@@ -39,6 +40,14 @@ function exemplarViewerUrl(opts) {
   p.set("trace", traceUrl);
   if (o.svc) p.set("svc", o.svc);
   if (o.host) p.set("host", o.host);
+  // Non-destructive focus on the exact poll. `focus_start` alone is enough to
+  // pan the view; worker/task/end refine the framing and highlight.
+  if (o.focusStartNs != null) {
+    p.set("focus_start", String(o.focusStartNs));
+    if (o.focusEndNs != null) p.set("focus_end", String(o.focusEndNs));
+    if (o.focusWorker != null) p.set("focus_worker", String(o.focusWorker));
+    if (o.focusTask != null) p.set("focus_task", String(o.focusTask));
+  }
   return "viewer.html?" + p.toString();
 }
 
@@ -72,6 +81,17 @@ function formatTokioCoverage(coverage, totalPolls) {
   return s;
 }
 
+// Map a poll/latency duration (ns) to a severity color, matching IRIS's
+// `latencyHeat`: ≥3ms red, ≥1ms amber, else green. Hex values are dial9's own
+// palette (the .off-cpu / .card.warn / .card.good colors in tokio_stats.html),
+// so the heat reads consistently with the rest of the page.
+function latencyHeat(ns) {
+  const ms = Number(ns) / 1e6;
+  if (ms >= 3) return "#f85149"; // red — over the ~3ms hop budget
+  if (ms >= 1) return "#d29922"; // amber — 1–3ms
+  return "#3fb950"; // green — sub-millisecond
+}
+
 // Whether a coverage block still has matched files left to fold (so "Load more"
 // can deepen the sample). False when fully folded or coverage is absent.
 function canRefineMore(coverage) {
@@ -85,6 +105,7 @@ if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     exemplarViewerUrl,
     formatTokioCoverage,
+    latencyHeat,
     canRefineMore,
   };
 }

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -1298,6 +1298,11 @@
             let currentPoiIndex = -1;
             // Task selection state
             let selectedTaskId = null;
+            // Pending one-shot focus request from `focus_*` URL params (a poll
+            // deep-linked from Tokio-stats). Applied after the first successful
+            // load, then cleared so a later Set/Clear-Range re-parse doesn't
+            // yank the view back to it. Null when no focus was requested.
+            let pendingFocus = null;
             // A clicked custom event: {events, timestamp, taskId, name} —
             // draws a labeled vertical marker across all lanes and, if the
             // event ran inside a poll, selects that task.
@@ -1630,6 +1635,13 @@
                 currentTraceBuffer = buffer;
                 currentTraceName = name;
                 showViewer(name);
+                // Apply a one-shot deep-link focus now that lanes exist, then
+                // consume it so a later Set/Clear-Range re-parse doesn't reapply.
+                if (pendingFocus) {
+                    const focus = pendingFocus;
+                    pendingFocus = null;
+                    focusOnWindow(focus);
+                }
                 // Record the TOTAL load time including the analysis+render phase
                 // that just ran in showViewer. The live `loadStartTime` timer was
                 // already frozen above (before analysis), so we measure here from
@@ -1991,6 +2003,21 @@
                 else params.delete('end');
                 const newUrl = window.location.pathname + '?' + params.toString();
                 window.history.replaceState(null, '', newUrl);
+            }
+
+            // One-shot focus window from `focus_*` params (Tokio-stats "Longest
+            // polls" deep link). Unlike `start`/`end` (a hard parse filter),
+            // these only pan/zoom the view after load — see focusOnWindow.
+            {
+                const fs = urlParams.get('focus_start');
+                if (fs != null) {
+                    pendingFocus = {
+                        startNs: fs,
+                        endNs: urlParams.get('focus_end'),
+                        worker: urlParams.get('focus_worker'),
+                        taskId: urlParams.get('focus_task'),
+                    };
+                }
             }
 
             const urlScope = Dial9TraceScope.readScope(urlParams);
@@ -2498,6 +2525,36 @@
                 scrollToWorkerLane(poi.worker);
 
                 updatePoiCounter();
+                renderAll();
+            }
+
+            // Focus the view on an explicit [start, end] time window (e.g. a
+            // specific poll deep-linked from the Tokio-stats "Longest polls"
+            // list). Non-destructive: like jumpToPoi it only moves the view and
+            // scrolls the lane — it does NOT re-parse to the window (that would
+            // drop every surrounding event and land on an empty page). Pads the
+            // window so the poll sits in context, optionally scrolls to its
+            // worker lane, and selects its task so the poll is highlighted.
+            function focusOnWindow({ startNs, endNs, worker, taskId }) {
+                if (startNs == null || !Number.isFinite(minTs)) return;
+                // The Tokio-stats aggregate stores poll timestamps in WALL-CLOCK
+                // ns (decode.rs adds the segment's clock offset), but the viewer's
+                // timeline (minTs/maxTs/viewStart) is RAW MONOTONIC ns. Convert
+                // back to monotonic by subtracting the same offset the aggregate
+                // applied — the trace's clock-sync offset, derived from the same
+                // segment's first ClockSyncEvent, so it round-trips. Traces with
+                // no clock sync stored raw monotonic already (offset null → 0).
+                const offset = (trace && trace.clockOffsetNs != null) ? trace.clockOffsetNs : 0;
+                const s = Number(startNs) - offset;
+                const e = (endNs != null ? Number(endNs) : Number(startNs)) - offset;
+                const span = Math.max(e - s, 0);
+                // Show ~5x the poll's span (min 1ms), poll offset ~30% from the
+                // left — same framing jumpToPoi uses for span POIs.
+                const viewDur = Math.max(span * 5, 1e6);
+                viewStart = Math.max(minTs, s - viewDur * 0.3);
+                viewEnd = Math.min(maxTs, viewStart + viewDur);
+                if (taskId != null) selectedTaskId = Number(taskId);
+                if (worker != null) scrollToWorkerLane(Number(worker));
                 renderAll();
             }
 

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -77,6 +77,9 @@ node dial9-viewer/ui/test_flamegraph_diff.js
 echo "--- Checking tokio-stats API helpers (exemplar link + coverage) ---"
 node dial9-viewer/ui/test_tokio_stats_api.js
 
+echo "--- Checking Tokio-stats deep-link focus timebase (wall→monotonic) ---"
+node dial9-viewer/ui/test_focus_timebase.js
+
 echo "--- Checking SSE frame decoder ---"
 node dial9-viewer/ui/test_sse.js
 


### PR DESCRIPTION
Add a top-N longest-polls rollup to the Tokio Stats page: the single futures that held a worker thread longest in one poll (these starve other tasks on that worker). The server ranks polls by duration and ships a bounded top-100 (task_id is high-cardinality, so this is a server-side reduction, not a per-poll axis); the UI renders a threshold-filtered "Longest polls" card with duration heat coloring.

Each row deep-links into the trace viewer focused on the exact poll via new non-destructive focus_* URL params. These are distinct from start/end (a hard parse filter that drops surrounding events and loads an empty page): focus_* pans/zooms the already-parsed trace to the poll window, scrolls to its worker lane, and highlights the task.

The aggregate stores poll timestamps in wall-clock ns while the viewer timeline is raw monotonic ns, so focusOnWindow converts wall->monotonic by subtracting the trace's clock offset (the same offset the decoder applied), keeping the deep link on-timeline.

No trace-format change: worker_id/task_id are already in the polls Parquet and already decoded; the endpoint just wasn't reading them. New response fields are additive.

Tests: extend the demo-trace tokio-stats test (top-N populated, bounded, ranked, carries deep-link coords); add JS coverage for the latency-heat helper and focus_* deep-link params; add test_focus_timebase.js pinning the wall->monotonic round-trip (registered in e2e-trace-tests.sh).