### PR TITLE
feat(release): parameterize publish workflow + document main vs release-branch releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,45 @@ permissions:
   contents: write
   id-token: write
 
+# Single, parameterized publish workflow. It always runs from `main` (so the
+# release logic has one source of truth and can't drift per release branch) and
+# releases whichever branch is passed in `release_branch`. The input is
+# required with no default, so publishing is always a deliberate choice of
+# branch (e.g. `main` or `release-0.3.x`).
+#
+# NOTE: because every run is dispatched against `main`, the `release`
+# environment's branch policy can no longer distinguish which branch is being
+# released — the "only main or release-* may publish" control lives in the
+# `validate-branch` job below. The `dial9-maintainers` approval on the `release`
+# environment still gates every publish regardless of input.
 on:
   workflow_dispatch:
+    inputs:
+      release_branch:
+        description: "Branch to release (main or a release-* branch)"
+        required: true
+        type: string
 
 jobs:
+  validate-branch:
+    name: Validate release branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure input is a releasable branch
+        env:
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+        run: |
+          case "$RELEASE_BRANCH" in
+            main | release-*)
+              echo "Releasing from '$RELEASE_BRANCH'." ;;
+            *)
+              echo "Refusing to release: '$RELEASE_BRANCH' is not 'main' or a 'release-*' branch." >&2
+              exit 1 ;;
+          esac
+
   release-plz-release:
     name: Release-plz release
+    needs: validate-branch
     runs-on: ubuntu-latest
     environment: release
     outputs:
@@ -21,6 +54,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ inputs.release_branch }}
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -68,6 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ inputs.release_branch }}
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,28 +72,95 @@ For other tests, `cargo nextest run` will run all of the normal tests.
 
 ## Doing releases
 
-Releases are human-initiated, not automatic. The process has two parts:
+Releases are human-initiated, not automatic. There are two kinds of release:
 
-### How it works
+- **Mainline releases** cut from `main` — the normal path for shipping new work.
+- **Maintenance releases** cut from a long-lived `release-*` branch (e.g.
+  `release-0.3.x`) — for backporting fixes to an older release series without
+  pulling in everything that has since landed on `main`.
 
-1. **Release PR (automatic):** On every push to `main`, the `release-pr.yml` workflow runs `release-plz release-pr`, which creates/updates a PR with version bumps and changelog entries based on [conventional commits]. This PR accumulates over time — you can merge many feature PRs before releasing.
-
-2. **Publishing (manual):** When you're ready to release, merge the release PR, then go to **Actions → "Publish release" → Run workflow** and click "Run". The `environment: release` gate requires approval before publishing proceeds.
-
-The `release.yml` workflow is authorized to publish releases to the dial9 crates via [trusted publishing]. No tokens need to be managed.
+Both use the same two-part shape (a release PR that bumps versions + updates the
+changelog, then a manual publish), and both publish to crates.io via [trusted
+publishing], so no tokens need to be managed. The differences are called out
+below.
 
 [trusted publishing]: https://rust-lang.github.io/rfcs/3691-trusted-publishing-cratesio.html
 [conventional commits]: https://www.conventionalcommits.org/en/v1.0.0/
 
-### Step by step
+### Releasing from `main`
 
-1. Merge your PRs to `main` using conventional commit messages (e.g. `feat:`, `fix:`, `feat!:` for breaking changes).
-2. The release PR will update automatically. Review the changelog and version bumps.
-3. If you need to adjust versions (e.g. force a major bump), edit `Cargo.toml` versions in the release PR before merging.
-4. **Trigger CI:** The release PR is created by `GITHUB_TOKEN`, which means GitHub won't automatically trigger CI workflows on it. Before merging, close and reopen the PR to trigger CI. Wait for the `CI Pass` check to go green.
-5. Merge the release PR.
-6. Go to Actions → "Publish release" → Run workflow → confirm.
-7. A team member approves the deployment in the `release` environment.
+1. **Release PR (automatic):** On every push to `main`, the `release-pr.yml`
+   workflow runs `release-plz release-pr`, which creates/updates a PR with
+   version bumps and changelog entries based on [conventional commits]. This PR
+   accumulates over time — you can merge many feature PRs before releasing.
+2. Review the changelog and version bumps. To force a bump (e.g. a major), edit
+   the `Cargo.toml` versions in the release PR before merging.
+3. **Trigger CI:** The release PR is created by `GITHUB_TOKEN`, so GitHub won't
+   automatically run CI on it. Before merging, close and reopen the PR to
+   trigger CI, and wait for the `CI Pass` check to go green.
+4. Merge the release PR.
+5. **Publish:** Go to **Actions → "Publish release" → Run workflow**, set
+   `release_branch` to `main`, and run. A `dial9-maintainers` member then
+   approves the deployment in the `release` environment before publishing
+   proceeds.
+
+### Releasing from a maintenance (`release-*`) branch
+
+Use this when you need to ship a fix on an older series (e.g. patch `0.3.x`
+while `main` is on `0.4.x`). The mechanics are the same, with a few
+branch-specific wrinkles.
+
+1. **Create the branch (once per series), if it doesn't exist.** Branch off the
+   latest tag of that series and push it, e.g.:
+
+   ```bash
+   git branch release-0.3.x dial9-tokio-telemetry-v0.3.13
+   git push origin release-0.3.x
+   ```
+
+   `release-*` branches are protected the same as `main` (PR review + `CI Pass`
+   required, no direct pushes), and **creating one is restricted to repo
+   admins** by a branch-protection ruleset, so no disabling of protection is
+   needed — an admin just pushes the new branch.
+
+2. **Backport your fix via a PR into the release branch.** Cherry-pick or
+   re-implement the change with `release-0.3.x` as the PR base (not `main`).
+   Keep changes API-compatible for the series where possible; `cargo-semver-checks`
+   in CI compares against the PR's base branch, so it will flag breaking changes
+   for that series specifically.
+
+3. **Generate the release PR.** The `release-pr.yml` automation only runs on
+   `main`, so for a release branch you run release-plz yourself from a checkout
+   of the branch:
+
+   ```bash
+   git checkout release-0.3.x && git pull
+   GIT_TOKEN="$(gh auth token)" release-plz release-pr --git-token "$(gh auth token)"
+   ```
+
+   This opens a version-bump/changelog PR against `release-0.3.x`. Review and
+   merge it as usual (close/reopen to trigger CI, wait for `CI Pass`).
+
+4. **Publish:** **Actions → "Publish release" → Run workflow**, set
+   `release_branch` to the release branch (e.g. `release-0.3.x`), and run. As
+   with `main`, a `dial9-maintainers` member approves the `release` environment
+   deployment.
+
+> **Why `release_branch` is an input.** `workflow_dispatch` runs the copy of a
+> workflow that lives on the dispatched ref, which would otherwise mean every
+> `release-*` branch carried (and drifted) its own copy of `release.yml`. The
+> publish workflow instead always runs from `main`'s copy and takes the target
+> branch as a required input, so the release logic has a single source of truth.
+> A `validate-branch` step rejects any input that isn't `main` or `release-*`.
+
+> **Note on `pr_branch_prefix`.** release-plz opens its release PR from an
+> ephemeral branch. `main` uses the `release-plz/` prefix and each maintenance
+> branch uses its own (e.g. `release-plz-0.3/`), configured via
+> `pr_branch_prefix` in `release-plz.toml`. Two things depend on this: the
+> prefix must **not** collide with the `release-*` protection glob (the trailing
+> slash keeps it exempt), and it must **differ per series** — release-plz closes
+> any open PR sharing its configured prefix, so a shared prefix would let a
+> `main` release run close a release branch's PR (and vice versa).
 
 ### Semver checks
 


### PR DESCRIPTION
## Motivation
`workflow_dispatch --ref <branch>` runs the copy of `release.yml` that lives **on that ref**. So each `release-*` branch carries its own fork of the publish workflow, and improvements made on `main` silently don't reach release branches until backported. This cycle we hit exactly that: `ci.yml` had to be fixed directly on `release-0.3.x` because the branch's copy was stale.

## Changes

**1. Parameterized publish workflow (`release.yml`)**
- New **required** `release_branch` input — **no default**, so publishing is always a deliberate choice of branch (`main` or e.g. `release-0.3.x`).
- Both jobs (`release-plz-release`, `build-viewer-binaries`) check out `ref: ${{ inputs.release_branch }}`.
- New `validate-branch` job runs first and rejects anything that isn't `main` or `release-*` (fails fast, before the environment approval prompt).
- All existing steps — crates.io auth, release-plz, viewer binary matrix, asset upload — preserved verbatim.

**2. Documentation (`CONTRIBUTING.md`)**
Split "Doing releases" into **mainline releases** (from `main`) and **maintenance releases** (from a `release-*` branch): creating a protected series branch (admin-only), backporting via a PR based on the release branch, generating the release PR by running release-plz locally (the auto `release-pr.yml` only runs on `main`), and publishing via the parameterized workflow. Also documents why `release_branch` is an input and why `pr_branch_prefix` must differ per series and stay slash-terminated.

## Enforcement tradeoff (intentional)
Since every run is now dispatched against `main`, the `release` environment's **branch policy** can no longer distinguish which branch is being released. The "only `main` or `release-*` may publish" allowlist moves from the environment policy into the `validate-branch` job. The **`dial9-maintainers` required-reviewer approval** is **unaffected** and still gates every publish.

## Follow-ups (not in this PR)
- Once merged, the per-branch `release.yml` copies on `release-*` branches are redundant and can be removed.
- The `release-pr.yml` (release-PR creation) side has the same drift shape and could be parameterized similarly.
- The `release` environment's branch policy could be simplified to just `main` to reflect the new model.