### PR TITLE
fix(viewer): browse-view + flamegraph-diff UI papercuts (#623)

### DIFF
--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -342,3 +342,19 @@
 .fgd-diff-dialog .fgd-swap {
     align-self: center; white-space: nowrap; padding: 6px 10px;
 }
+
+/* Diff-setup dialog: one-click presets (issue #624) */
+.fgd-presets {
+    display: flex; flex-wrap: wrap; gap: 16px;
+    margin: 4px 0 14px; padding-bottom: 14px;
+    border-bottom: 1px solid #333;
+}
+.fgd-preset-group { flex: 1; min-width: 200px; }
+.fgd-preset-group label { margin-top: 0; }
+.fgd-preset-group select.fgd-preset-host {
+    width: 100%; background: #2a2a4a; border: 1px solid #444; color: #e0e0e0;
+    padding: 6px 8px; border-radius: 4px; font-size: 0.82em;
+}
+.fgd-preset-btns { display: flex; gap: 8px; }
+.fgd-diff-dialog button.fgd-preset { padding: 6px 12px; }
+.fgd-preset-note { color: #888; font-size: 0.78em; margin: 4px 0 0; }

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -368,9 +368,71 @@
                         <button id="f-stop" style="background:#2a2a4a;color:#e0e0e0;${btnStyle};opacity:0.4;cursor:not-allowed" disabled>Stop</button>
                         <span style="flex:1"></span>
                         <button id="f-copylink" title="Copy a link that re-fetches this exact scope (bucket/prefix included; no credentials)" style="background:#2a2a4a;color:#e0e0e0;border:1px solid #444;padding:4px 14px;border-radius:3px;cursor:pointer;font-weight:600">Copy link</button>
+                        <button id="f-adddiff" title="Capture this view (current host/filters) as one side of a diff; pick a second host/scope and add it to compare" style="background:#2a2a4a;color:#e0e0e0;border:1px solid #444;padding:4px 14px;border-radius:3px;cursor:pointer;font-weight:600">+ Add to diff</button>
                         <button id="f-diff" title="Compare this flamegraph against another" style="background:#2a2a4a;color:#e0e0e0;border:1px solid #444;padding:4px 14px;border-radius:3px;cursor:pointer;font-weight:600">Diff…</button>
                     `;
                     document.querySelector(".fg-page-header").after(toolbar);
+
+                    // In-page "Add to diff" tray. Captures two scopes (A/B) from
+                    // this page's live view — respecting the Host dropdown's
+                    // selection — and launches a two-sided diff, so a host-vs-host
+                    // comparison needs no second tab / Copy-link paste. The tray
+                    // lives OUTSIDE #f-facets (which renderFacets rebuilds on every
+                    // SSE response), so it survives facet re-renders; the capture
+                    // state (diffCapture) is held in the enclosing closure for the
+                    // same reason. Mirrors the landing page's diff tray
+                    // (index.html), reusing the shared FlamegraphDiff codec.
+                    let diffCapture = { a: null, b: null };
+                    const diffTray = document.createElement("div");
+                    diffTray.style.cssText = "display:none;align-items:center;gap:12px;padding:6px 12px;background:#14142a;border-bottom:1px solid #333;font-size:0.8em;flex-shrink:0;flex-wrap:wrap;";
+                    toolbar.after(diffTray);
+
+                    // HTML-escape scope summaries before injecting into the tray.
+                    function escFg(s) {
+                        return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+                    }
+
+                    function renderDiffTray() {
+                        const { a, b } = diffCapture;
+                        if (!a && !b) { diffTray.style.display = "none"; return; }
+                        diffTray.style.display = "flex";
+                        function sideCell(label, scope, chipBg, chipFg, sideKey) {
+                            const set = !!scope;
+                            return `<div style="background:#1a1a2e;border:1px solid ${set ? chipFg : "#333"};border-radius:6px;padding:6px 10px;min-width:0">
+                                <div style="display:flex;align-items:center;gap:8px">
+                                    <span style="font-size:0.85em;font-weight:700;padding:2px 8px;border-radius:10px;background:${chipBg};color:${chipFg}">${label}</span>
+                                    ${set ? `<span style="flex:1"></span><button data-fgd-remove="${sideKey}" title="Remove ${label}" style="background:none;border:none;color:#888;cursor:pointer;font-size:1em">✕</button>` : ""}
+                                </div>
+                                <div style="color:#ccc;margin-top:4px;overflow-wrap:anywhere">${set ? escFg(summarizeScope(scope)) : '<span style="color:#666">pick a host/scope, then click "Add to diff"</span>'}</div>
+                            </div>`;
+                        }
+                        const ready = !!(a && b);
+                        diffTray.innerHTML =
+                            '<span style="color:#888;font-weight:600">Diff capture:</span>' +
+                            sideCell("A · left", a, "#1e3050", "#9ec1ff", "a") +
+                            sideCell("B · right", b, "#4a221c", "#ffb3a0", "b") +
+                            `<button data-fgd-swap ${ready ? "" : "disabled"} title="Swap which capture is A vs B" style="background:#2a2a4a;color:#e0e0e0;${btnStyle};opacity:${ready ? "1" : "0.4"};cursor:${ready ? "pointer" : "not-allowed"}">⇄ Swap</button>` +
+                            `<button data-fgd-open ${ready ? "" : "disabled"} title="Open a two-sided diff of A vs B" style="background:#6c63ff;color:#fff;border:none;padding:4px 14px;border-radius:3px;font-weight:600;opacity:${ready ? "1" : "0.4"};cursor:${ready ? "pointer" : "not-allowed"}">Open diff</button>` +
+                            `<button data-fgd-clear title="Clear both captured sides" style="background:#2a2a4a;color:#e0e0e0;${btnStyle}">Clear</button>`;
+                    }
+
+                    // Delegated handlers for the tray's (re-rendered) controls.
+                    diffTray.addEventListener("click", (e) => {
+                        const rm = e.target.closest("[data-fgd-remove]");
+                        if (rm) { diffCapture = FlamegraphDiff.removeDiffSide(diffCapture, rm.getAttribute("data-fgd-remove")); renderDiffTray(); return; }
+                        if (e.target.closest("[data-fgd-swap]")) { diffCapture = FlamegraphDiff.swapDiffCapture(diffCapture); renderDiffTray(); return; }
+                        if (e.target.closest("[data-fgd-clear]")) { diffCapture = { a: null, b: null }; renderDiffTray(); return; }
+                        if (e.target.closest("[data-fgd-open]")) {
+                            const { a, b } = diffCapture;
+                            if (!a || !b) return;
+                            // Both captured scopes already carry api=1
+                            // (currentScopeQuery sets it), so no per-side flag
+                            // fix-up is needed here.
+                            const search = FlamegraphDiff.diffSearch(a, b);
+                            window.open(window.location.pathname + "?" + search, "_blank");
+                        }
+                    });
 
                     const fStart = document.getElementById("f-start");
                     const fEnd = document.getElementById("f-end");
@@ -762,6 +824,15 @@
                             btn.textContent = res !== null ? "Copied!" : orig;
                         }
                         setTimeout(() => { btn.textContent = orig; }, 1500);
+                    });
+
+                    document.getElementById("f-adddiff").addEventListener("click", () => {
+                        // Capture the current view (respecting the Host dropdown's
+                        // selection — currentScopeQuery emits every filterState.hosts
+                        // entry, so a narrowed dropdown gives a single-host side and
+                        // "All" gives the full original host set) as one diff side.
+                        diffCapture = FlamegraphDiff.addDiffCapture(diffCapture, currentScopeQuery());
+                        renderDiffTray();
                     });
 
                     document.getElementById("f-diff").addEventListener("click", () => {

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -272,17 +272,70 @@
                     // "Copy link" URL for the other. `thisScope` is this tab's
                     // current scope (URLSearchParams). A (left, blue) defaults to
                     // this tab, B (right, red) to the pasted link; Swap flips them.
+                    //
+                    // Above the paste box are one-click PRESETS (issue #624) that
+                    // derive side B from side A (thisScope) without a second tab:
+                    // "same time, different host" (a dropdown of the hosts this tab
+                    // knows about) and "same scope, earlier window" (-1h/-24h/-7d).
+                    // Each preset builds scopeB via the pure FlamegraphDiff helpers
+                    // and opens the two-sided diff directly.
                     function openDiffDialog(thisScope) {
                         let otherScope = null; // parsed from the paste, or null
                         let thisIsA = true;
 
+                        // Hosts this tab knows about, for preset 1. availFacets is
+                        // scoped to the current query, so it only lists hosts
+                        // WITHIN thisScope — if the flamegraph was launched
+                        // constrained to a single host we can't offer others (the
+                        // preset is disabled below). Union the facet's hosts with
+                        // any hosts already on the scope so a seeded-but-not-yet-
+                        // responded tab still lists them.
+                        const hostSet = new Set(thisScope.getAll("host"));
+                        const hostFacet = availFacets["host"];
+                        if (hostFacet) for (const h of hostFacet.values) hostSet.add(h);
+                        const allHosts = [...hostSet].sort();
+                        const scopeHosts = thisScope.getAll("host");
+                        // A single-host scope B target excludes the host thisScope
+                        // is already pinned to (comparing a host to itself is a
+                        // no-op); when thisScope spans multiple hosts, offer them
+                        // all as the "other" host.
+                        const otherHosts = scopeHosts.length === 1
+                            ? allHosts.filter((h) => h !== scopeHosts[0])
+                            : allHosts;
+                        const canHostPreset = otherHosts.length > 0;
+                        // Time presets need a window on thisScope to shift.
+                        const canTimePreset = !!(thisScope.get("start_ns") && thisScope.get("end_ns"));
+
                         const back = document.createElement("div");
                         back.className = "fgd-dialog-backdrop";
+                        const hostOptions = otherHosts
+                            .map((h) => '<option value="' + escFg(h) + '">' + escFg(h) + '</option>')
+                            .join("");
+                        const presetHtml =
+                            '<div class="fgd-presets">' +
+                            '<div class="fgd-preset-group">' +
+                            '<label>Same time, different host</label>' +
+                            (canHostPreset
+                                ? '<select class="fgd-preset-host"><option value="">Pick a host to compare…</option>' + hostOptions + '</select>'
+                                : '<p class="fgd-preset-note">Scope covers a single host — launch the flamegraph over multiple hosts to compare.</p>') +
+                            '</div>' +
+                            '<div class="fgd-preset-group">' +
+                            '<label>Same scope, earlier window</label>' +
+                            (canTimePreset
+                                ? '<div class="fgd-preset-btns">' +
+                                  '<button class="ghost fgd-preset" data-shift="1h">-1h</button>' +
+                                  '<button class="ghost fgd-preset" data-shift="24h">-24h</button>' +
+                                  '<button class="ghost fgd-preset" data-shift="7d">-7d</button>' +
+                                  '</div>'
+                                : '<p class="fgd-preset-note">No time window on this scope to shift.</p>') +
+                            '</div>' +
+                            '</div>';
                         back.innerHTML =
                             '<div class="fgd-dialog fgd-diff-dialog">' +
                             '<h3>Compare against another flamegraph</h3>' +
-                            '<p>Paste another aggregate flamegraph\'s <b>Copy link</b> URL. ' +
-                            'The two are shown side by side — left vs right.</p>' +
+                            '<p>Pick a preset below, or paste another aggregate flamegraph\'s ' +
+                            '<b>Copy link</b> URL. The two are shown side by side — left vs right.</p>' +
+                            presetHtml +
                             '<label>Other flamegraph link</label>' +
                             '<textarea class="fgd-other" rows="2" placeholder="https://…/flamegraph.html?api=1&bucket=…"></textarea>' +
                             '<div class="fgd-ab">' +
@@ -330,6 +383,33 @@
                         }
                         refresh();
                         ta.addEventListener("input", refresh);
+
+                        // Preset launch: build scopeB from thisScope and open the
+                        // two-sided diff (thisScope stays side A). Same window.open
+                        // path as the Compare button below.
+                        function launchPreset(scopeB) {
+                            const search = FlamegraphDiff.diffSearch(thisScope, scopeB);
+                            window.open(window.location.pathname + "?" + search, "_blank");
+                            back.remove();
+                        }
+                        const hostSel = back.querySelector(".fgd-preset-host");
+                        if (hostSel) {
+                            hostSel.addEventListener("change", () => {
+                                if (!hostSel.value) return;
+                                launchPreset(FlamegraphDiff.scopeWithHost(thisScope, hostSel.value));
+                            });
+                        }
+                        const shiftDeltas = {
+                            "1h": FlamegraphDiff.DIFF_SHIFT_1H,
+                            "24h": FlamegraphDiff.DIFF_SHIFT_24H,
+                            "7d": FlamegraphDiff.DIFF_SHIFT_7D,
+                        };
+                        for (const btn of back.querySelectorAll(".fgd-preset")) {
+                            btn.addEventListener("click", () => {
+                                launchPreset(FlamegraphDiff.shiftScopeTime(thisScope, shiftDeltas[btn.getAttribute("data-shift")]));
+                            });
+                        }
+
                         back.querySelector(".fgd-swap").addEventListener("click", () => { thisIsA = !thisIsA; refresh(); });
                         back.querySelector(".fgd-cancel").addEventListener("click", () => back.remove());
                         back.addEventListener("click", (e) => { if (e.target === back) back.remove(); });

--- a/dial9-viewer/ui/flamegraph_diff.js
+++ b/dial9-viewer/ui/flamegraph_diff.js
@@ -278,6 +278,38 @@ function parseDiff(search) {
   return { a: decodeScope(a), b: decodeScope(b) };
 }
 
+// ---------------------------------------------------------------------------
+// Button routing: single scope vs captured A/B diff
+// ---------------------------------------------------------------------------
+
+// Decide which page + query string a viz button should open. This is the shared
+// routing seam behind the landing page's "Flamegraph"/"Tokio Stats" buttons and
+// the diff tray's launch buttons, so all of them agree on the single-vs-diff
+// decision. `kind` is "flamegraph" or "tokio". When `hasDiff` is true (a full
+// A/B diff has been captured) the target is the two-sided diff link
+// (?diff=1&a=..&b=..) built from `diffA`/`diffB`; otherwise it is the caller's
+// pre-built single-scope `singleQuery`. Pure/DOM-free so the routing is
+// unit-testable without a browser.
+//
+// Flamegraph diff scopes carry the client-only `api=1` flag per side (each side
+// hits /api/flamegraph in aggregate mode); tokio-stats does not use it.
+function chooseTarget(kind, opts) {
+  const page = kind === "tokio" ? "tokio_stats.html" : "flamegraph.html";
+  if (opts && opts.hasDiff) {
+    const withApi = (scope) => {
+      if (kind !== "flamegraph") return scope;
+      const s = new URLSearchParams(
+        typeof scope === "string" ? scope : scope.toString(),
+      );
+      s.set("api", "1");
+      return s;
+    };
+    return { page: page, search: diffSearch(withApi(opts.diffA), withApi(opts.diffB)) };
+  }
+  const single = opts && opts.singleQuery != null ? opts.singleQuery : "";
+  return { page: page, search: typeof single === "string" ? single : single.toString() };
+}
+
 var FlamegraphDiff = {
   newDiffNode,
   addSide,
@@ -292,6 +324,7 @@ var FlamegraphDiff = {
   decodeScope,
   diffSearch,
   parseDiff,
+  chooseTarget,
   SCOPE_KEYS_SINGLE,
 };
 

--- a/dial9-viewer/ui/flamegraph_diff.js
+++ b/dial9-viewer/ui/flamegraph_diff.js
@@ -220,6 +220,46 @@ function fullScopeQuery(params) {
   return out;
 }
 
+// ---------------------------------------------------------------------------
+// Diff presets (issue #624): derive side B from side A without a second tab
+// ---------------------------------------------------------------------------
+
+// Backward time-shift deltas for the "same scope, earlier window" presets, in
+// nanoseconds. Kept as BigInt: start_ns/end_ns are ~1.78e18, well above
+// Number.MAX_SAFE_INTEGER (~9.0e15), so Number arithmetic would silently
+// corrupt them.
+const DIFF_SHIFT_1H = 3600000000000n;
+const DIFF_SHIFT_24H = 86400000000000n;
+const DIFF_SHIFT_7D = 604800000000000n;
+
+// "Same time, different host": return a NEW URLSearchParams copy of `scope`
+// with ALL existing host params removed and a single host=<host> appended.
+// Everything else (bucket/prefix/service/start_ns/end_ns/…) is preserved. The
+// input is not mutated.
+function scopeWithHost(scope, host) {
+  const p = new URLSearchParams(scope);
+  p.delete("host");
+  p.append("host", host);
+  return p;
+}
+
+// "Same scope, earlier window": return a NEW URLSearchParams copy of `scope`
+// with start_ns/end_ns each shifted back by `deltaNs` (a BigInt or a value
+// BigInt() accepts). The window LENGTH is preserved. If the scope has no
+// start_ns/end_ns there is no window to shift, so the copy is returned
+// unchanged. Host/service/bucket are untouched. The input is not mutated.
+function shiftScopeTime(scope, deltaNs) {
+  const p = new URLSearchParams(scope);
+  const start = p.get("start_ns");
+  const end = p.get("end_ns");
+  if (start != null && end != null) {
+    const d = BigInt(deltaNs);
+    p.set("start_ns", (BigInt(start) - d).toString());
+    p.set("end_ns", (BigInt(end) - d).toString());
+  }
+  return p;
+}
+
 // base64url (no padding) of a UTF-8 string. Works in both the browser and Node.
 // Scope queries are ASCII (URLSearchParams percent-encodes the rest), but we
 // route through a UTF-8-safe path anyway so the codec is not input-fragile.
@@ -358,6 +398,11 @@ var FlamegraphDiff = {
   layoutSide,
   nodeAtPath,
   fullScopeQuery,
+  scopeWithHost,
+  shiftScopeTime,
+  DIFF_SHIFT_1H,
+  DIFF_SHIFT_24H,
+  DIFF_SHIFT_7D,
   b64urlEncode,
   b64urlDecode,
   encodeScope,

--- a/dial9-viewer/ui/flamegraph_diff.js
+++ b/dial9-viewer/ui/flamegraph_diff.js
@@ -310,6 +310,46 @@ function chooseTarget(kind, opts) {
   return { page: page, search: typeof single === "string" ? single : single.toString() };
 }
 
+// ---------------------------------------------------------------------------
+// Capture-tray state machine (in-page "Add to diff")
+// ---------------------------------------------------------------------------
+
+// The in-page "Add to diff" tray (flamegraph.html's aggregate toolbar, and the
+// landing page's heatmap tray) captures two scopes — A (left) and B (right) —
+// then launches a two-sided diff. State is `{ a, b }` where each side is a
+// scope (URLSearchParams) or null. These three transitions keep the invariant
+// "A fills before B" so there is never a B-without-A hole. Pure/DOM-free so the
+// tray wiring is unit-testable without a browser.
+
+// Capture one more scope: fill A first, then B; once both are set a further
+// add replaces B (the most recent), so the user can keep re-picking the
+// comparison side.
+function addDiffCapture(state, scope) {
+  const a = state && state.a ? state.a : null;
+  const b = state && state.b ? state.b : null;
+  if (!a) return { a: scope, b: b };
+  return { a: a, b: scope };
+}
+
+// Swap which capture is A vs B. Only meaningful when both sides are set;
+// swapping a lone side would move it into B and leave A empty, violating the
+// "fill A first" invariant — so it's a no-op then.
+function swapDiffCapture(state) {
+  const a = state && state.a ? state.a : null;
+  const b = state && state.b ? state.b : null;
+  if (!a || !b) return { a: a, b: b };
+  return { a: b, b: a };
+}
+
+// Remove one side. Clearing A promotes B to A so there is never a B-without-A
+// hole (the codec fills A first); clearing B just drops it.
+function removeDiffSide(state, side) {
+  const a = state && state.a ? state.a : null;
+  const b = state && state.b ? state.b : null;
+  if (side === "a") return { a: b, b: null };
+  return { a: a, b: null };
+}
+
 var FlamegraphDiff = {
   newDiffNode,
   addSide,
@@ -325,6 +365,9 @@ var FlamegraphDiff = {
   diffSearch,
   parseDiff,
   chooseTarget,
+  addDiffCapture,
+  swapDiffCapture,
+  removeDiffSide,
   SCOPE_KEYS_SINGLE,
 };
 

--- a/dial9-viewer/ui/flamegraph_diff_view.js
+++ b/dial9-viewer/ui/flamegraph_diff_view.js
@@ -71,6 +71,13 @@
     return s;
   }
 
+  // Whether a keydown should focus the highlight/search box: Ctrl/Cmd+F, or a
+  // bare "/" when the box isn't already focused (so a literal "/" can still be
+  // typed into the regex). Mirrors the single-flamegraph handler in flamegraph.js.
+  function isSearchFocusKey(e, activeIsSearch) {
+    return ((e.ctrlKey || e.metaKey) && e.key === "f") || (e.key === "/" && !activeIsSearch);
+  }
+
   // createDiffView(container, opts)
   //   opts.scopeA / opts.scopeB — URLSearchParams of each side's scope
   //   opts.headersFor(side)     — returns the credential headers for "a"/"b"
@@ -95,7 +102,7 @@
     const header = document.createElement("div");
     header.className = "fgd-header";
     header.innerHTML =
-      '<input class="fgd-search" placeholder="highlight frames (regex)…" />' +
+      '<input class="fgd-search" placeholder="highlight frames (regex)… (/)" />' +
       '<button class="fgd-reset">Reset zoom</button>' +
       '<button class="fgd-more" title="Fold more source files on both sides for a deeper sample" style="display:none">Load more data</button>' +
       '<span class="fgd-hotness" title="Overall sampling rate difference. Colors normalize this away (shape vs shape); this is the absolute volume signal."></span>' +
@@ -409,7 +416,12 @@
     searchInput.addEventListener("input", applySearch);
     resetBtn.addEventListener("click", () => { zoomPath = [rootName()]; render(); });
     const onKeydown = (e) => {
-      if (e.key === "Escape") { zoomPath = [rootName()]; render(); }
+      if (e.key === "Escape") { zoomPath = [rootName()]; render(); return; }
+      if (isSearchFocusKey(e, document.activeElement === searchInput)) {
+        e.preventDefault();
+        searchInput.focus();
+        searchInput.select();
+      }
     };
     window.addEventListener("resize", render);
     window.addEventListener("keydown", onKeydown);
@@ -606,7 +618,7 @@
     };
   }
 
-  const ex = { createDiffView, apiUrlFor, scopeLabel };
+  const ex = { createDiffView, apiUrlFor, scopeLabel, isSearchFocusKey };
   if (typeof module !== "undefined" && module.exports) module.exports = ex;
   else exports.FlamegraphDiffView = ex;
 })(typeof exports === "undefined" ? this : exports);

--- a/dial9-viewer/ui/heatmap.js
+++ b/dial9-viewer/ui/heatmap.js
@@ -208,12 +208,17 @@ function niceTimeTicks(tMin, tMax, targetCount) {
 
 // Decide whether a document-level click should clear the current heatmap
 // selection. The browse view clears the selection on any click that lands
-// outside the timeline and the actions bar. The one exception is the synthetic
-// click the browser fires at the end of a drag: when a selection drag ends
-// outside the #heatmap-view pane, the trailing click's target is an ancestor
-// above the pane, so both `targetInHeatmap`/`targetInActions` are false and the
-// just-created selection would be wiped. `wasDrag` suppresses exactly that
-// phantom click so a drag that ends outside the pane still registers.
+// outside the timeline, the actions bar, and the page header. The one exception
+// is the synthetic click the browser fires at the end of a drag: when a
+// selection drag ends outside the #heatmap-view pane, the trailing click's
+// target is an ancestor above the pane, so `targetInHeatmap`/`targetInActions`/
+// `targetInHeader` are all false and the just-created selection would be wiped.
+// `wasDrag` suppresses exactly that phantom click so a drag that ends outside
+// the pane still registers.
+//
+// Header chrome (the TZ toggle, the credentials button) is a control surface,
+// not a click-away-to-dismiss target: toggling TZ only relabels the axis and
+// must keep the selection, so clicks inside the header preserve it too.
 //
 // Returns true only when the selection should be cleared.
 function shouldClearSelectionOnClick({
@@ -222,10 +227,11 @@ function shouldClearSelectionOnClick({
     wasDrag,
     targetInHeatmap,
     targetInActions,
+    targetInHeader,
 }) {
     if (!isBrowseTab || !hasSelection) return false;
     if (wasDrag) return false; // synthetic click trailing a drag — keep selection
-    if (targetInHeatmap || targetInActions) return false;
+    if (targetInHeatmap || targetInActions || targetInHeader) return false;
     return true;
 }
 

--- a/dial9-viewer/ui/heatmap.js
+++ b/dial9-viewer/ui/heatmap.js
@@ -173,6 +173,29 @@ function totalBytes(segments) {
     return segments.reduce((sum, seg) => sum + (seg.size || 0), 0);
 }
 
+// Decide whether a document-level click should clear the current heatmap
+// selection. The browse view clears the selection on any click that lands
+// outside the timeline and the actions bar. The one exception is the synthetic
+// click the browser fires at the end of a drag: when a selection drag ends
+// outside the #heatmap-view pane, the trailing click's target is an ancestor
+// above the pane, so both `targetInHeatmap`/`targetInActions` are false and the
+// just-created selection would be wiped. `wasDrag` suppresses exactly that
+// phantom click so a drag that ends outside the pane still registers.
+//
+// Returns true only when the selection should be cleared.
+function shouldClearSelectionOnClick({
+    isBrowseTab,
+    hasSelection,
+    wasDrag,
+    targetInHeatmap,
+    targetInActions,
+}) {
+    if (!isBrowseTab || !hasSelection) return false;
+    if (wasDrag) return false; // synthetic click trailing a drag — keep selection
+    if (targetInHeatmap || targetInActions) return false;
+    return true;
+}
+
 // Map a normalized density value in [0, 1] to a CSS color. A value of 0 (no
 // data) returns the page background; positive values ramp dim-blue → purple →
 // red → yellow. A perceptual sqrt curve keeps a low baseline visible while
@@ -213,5 +236,6 @@ if (typeof module !== "undefined" && module.exports) {
         segmentsOverlapping,
         totalBytes,
         densityColor,
+        shouldClearSelectionOnClick,
     };
 }

--- a/dial9-viewer/ui/heatmap.js
+++ b/dial9-viewer/ui/heatmap.js
@@ -173,6 +173,39 @@ function totalBytes(segments) {
     return segments.reduce((sum, seg) => sum + (seg.size || 0), 0);
 }
 
+// Pick "nice" axis tick times for the epoch-second range [tMin, tMax], aiming
+// for at most `targetCount` ticks. Ticks snap to human-readable intervals (1/5/
+// 10/30s, 1/2/5/10/15/30m, 1/2/3/6/12h, 1/2/7d) and are aligned to multiples of
+// the chosen step so labels land on round wall-clock times. Returns the aligned
+// tick times (ascending, within [tMin, tMax]). A degenerate range (tMax <= tMin)
+// yields a single tick at tMin so callers never divide by an empty tick set.
+function niceTimeTicks(tMin, tMax, targetCount) {
+    if (!(tMax > tMin)) return [tMin];
+    const target = targetCount > 0 ? targetCount : 1;
+    // Candidate step sizes in seconds, ascending.
+    const steps = [
+        1, 2, 5, 10, 15, 30,
+        60, 120, 300, 600, 900, 1800,
+        3600, 7200, 10800, 21600, 43200,
+        86400, 172800, 604800,
+    ];
+    // Number of step-aligned ticks that fall within [tMin, tMax].
+    const alignedCount = (s) => Math.floor(tMax / s) - Math.ceil(tMin / s) + 1;
+    // Smallest step whose aligned tick count fits within the target.
+    let step = steps[steps.length - 1];
+    for (const s of steps) {
+        if (alignedCount(s) <= target) { step = s; break; }
+    }
+    // Spans larger than the biggest candidate step still need to fit the target,
+    // so fall back to an even division rounded up to a whole second.
+    if (alignedCount(step) > target) step = Math.max(1, Math.ceil((tMax - tMin) / target));
+    const out = [];
+    const first = Math.ceil(tMin / step) * step;
+    for (let t = first; t <= tMax + 1e-9; t += step) out.push(t);
+    if (!out.length) out.push(tMin);
+    return out;
+}
+
 // Decide whether a document-level click should clear the current heatmap
 // selection. The browse view clears the selection on any click that lands
 // outside the timeline and the actions bar. The one exception is the synthetic
@@ -237,5 +270,6 @@ if (typeof module !== "undefined" && module.exports) {
         totalBytes,
         densityColor,
         shouldClearSelectionOnClick,
+        niceTimeTicks,
     };
 }

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -1010,9 +1010,19 @@
         if (fromDate) document.getElementById('range-from').value = dateToPickerStr(fromDate);
         if (toDate) document.getElementById('range-to').value = dateToPickerStr(toDate);
 
-        // Re-render current view
+        // Re-render current view. Only the axis tick labels are TZ-dependent,
+        // so redraw the canvas (which relabels the axis via fmtTick) and re-lay
+        // the selection rect instead of calling renderHeatmap(), which would
+        // clear the current selection and reset the zoom. Mirrors the resize
+        // handler below.
         if (currentTab === 'browse') {
-            if (heatmapRows.length) renderHeatmap();
+            if (heatmapRows.length) {
+                drawHeatmapCanvas();
+                if (heatmapSelection && heatmapSelection.rows) {
+                    showSelRect(heatmapSelection.t0, heatmapSelection.t1,
+                        heatmapSelection.rows[0], heatmapSelection.rows[1]);
+                }
+            }
         } else {
             renderRawTable(rawObjects);
         }

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -164,6 +164,18 @@
             background: rgba(0,229,255,0.12);
             border: none; border-left: 1px solid #00e5ff; border-right: 1px solid #00e5ff;
         }
+        /* Hover cursor line + time readout — follow the pointer to answer
+           "what time am I looking at?". Hidden until the pointer enters the plot. */
+        #heatmap-cursor {
+            position: absolute; top: 0; width: 1px; pointer-events: none; display: none;
+            background: rgba(230,230,255,0.55);
+        }
+        #heatmap-cursor-label {
+            position: absolute; top: 2px; pointer-events: none; display: none;
+            transform: translateX(-50%); white-space: nowrap;
+            padding: 1px 5px; border-radius: 3px; font-size: 0.72em;
+            background: rgba(20,20,40,0.92); color: #e6e6ff; border: 1px solid #3a3a5e;
+        }
         #heatmap-axis {
             flex-shrink: 0; height: 22px; position: relative;
             border-top: 1px solid #222; font-size: 0.72em; color: #888;
@@ -296,7 +308,7 @@
             </div>
             <div id="heatmap-view" style="display:none">
                 <div id="heatmap-hint">
-                    <span>Drag to select a window, then open or profile it. <b>⌥ Option+drag</b> to zoom, double-click to reset.</span>
+                    <span>Click a segment to select just one · Drag to select a window · <b>⌥ Option+drag</b> to zoom · double-click to reset.</span>
                     <span class="legend">low <span class="bar"></span> high data density</span>
                     <span class="legend"><span class="gap-swatch"></span> gap (no data)</span>
                     <span style="color:#00e5ff">▏ boot change</span>
@@ -307,6 +319,8 @@
                     <div id="heatmap-plot">
                         <canvas id="heatmap-canvas"></canvas>
                         <div id="heatmap-sel"></div>
+                        <div id="heatmap-cursor"></div>
+                        <div id="heatmap-cursor-label"></div>
                     </div>
                 </div>
                 <div id="heatmap-axis"></div>
@@ -1450,22 +1464,63 @@
             ctx.fillRect(0, y + ROW_H - 1, W, 1);
         }
 
-        drawHeatmapAxis(W);
+        // Faint full-height vertical gridlines at each axis tick, so the tick
+        // labels below project onto the strips and segment start/stop times can
+        // be read off the timeline. Drawn last so they sit above the strips.
+        const ticks = niceTimeTicks(tMin, tMax, clamp(Math.floor(W / 130), 2, 8));
+        ctx.strokeStyle = 'rgba(120,120,160,0.18)';
+        ctx.lineWidth = 1;
+        for (const t of ticks) {
+            const gx = Math.round(timeToX(t, tMin, tMax, W)) + 0.5;
+            if (gx < 0 || gx > W) continue;
+            ctx.beginPath();
+            ctx.moveTo(gx, 0);
+            ctx.lineTo(gx, H);
+            ctx.stroke();
+        }
+
+        drawHeatmapAxis(W, ticks);
     }
 
-    function drawHeatmapAxis(W) {
+    // Does the epoch-second range [tMin, tMax] cross a calendar-day boundary?
+    // Uses the active TZ mode so the date label matches the tick times.
+    function spansMultipleDays(tMin, tMax) {
+        const dayKey = (epoch) => {
+            const d = new Date(epoch * 1000);
+            return useLocalTz
+                ? d.getFullYear() + '-' + d.getMonth() + '-' + d.getDate()
+                : d.getUTCFullYear() + '-' + d.getUTCMonth() + '-' + d.getUTCDate();
+        };
+        return dayKey(tMin) !== dayKey(tMax);
+    }
+
+    // Format a tick's date (YYYY-MM-DD) in the active TZ mode.
+    function fmtTickDate(epoch) {
+        const d = new Date(epoch * 1000);
+        const pad = n => String(n).padStart(2, '0');
+        return useLocalTz
+            ? d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate())
+            : d.getUTCFullYear() + '-' + pad(d.getUTCMonth() + 1) + '-' + pad(d.getUTCDate());
+    }
+
+    function drawHeatmapAxis(W, ticks) {
         const axis = document.getElementById('heatmap-axis');
         axis.innerHTML = '';
         const { tMin, tMax } = heatmapDomain;
-        const n = clamp(Math.floor(W / 130), 2, 8);
-        for (let i = 0; i <= n; i++) {
-            const frac = i / n;
+        if (!ticks) ticks = niceTimeTicks(tMin, tMax, clamp(Math.floor(W / 130), 2, 8));
+        // Show the date on the leftmost tick, or on every tick when the visible
+        // window crosses a day boundary, so the day is never ambiguous.
+        const showDates = spansMultipleDays(tMin, tMax);
+        ticks.forEach((t, i) => {
+            const x = timeToX(t, tMin, tMax, W);
+            if (x < 0 || x > W) return;
             const tick = document.createElement('div');
             tick.className = 'tick';
-            tick.style.left = (LABEL_W + frac * W) + 'px';
-            tick.textContent = fmtTick(tMin + frac * (tMax - tMin));
+            tick.style.left = (LABEL_W + x) + 'px';
+            const withDate = showDates || i === 0;
+            tick.textContent = withDate ? fmtTickDate(t) + ' ' + fmtTick(t) : fmtTick(t);
             axis.appendChild(tick);
-        }
+        });
     }
 
     // ── Region selection / zoom on the heatmap ──
@@ -1474,7 +1529,14 @@
     (function setupHeatmapInteraction() {
         const plot = document.getElementById('heatmap-plot');
         const sel = document.getElementById('heatmap-sel');
+        const cursor = document.getElementById('heatmap-cursor');
+        const cursorLabel = document.getElementById('heatmap-cursor-label');
         let dragging = false, zooming = false, startX = 0, startY = 0;
+
+        function hideCursor() {
+            cursor.style.display = 'none';
+            cursorLabel.style.display = 'none';
+        }
 
         function localXY(e) {
             const rect = plot.getBoundingClientRect();
@@ -1535,6 +1597,29 @@
                 finalizeSelection(Math.min(x, startX), Math.max(x, startX), Math.min(y, startY), Math.max(y, startY));
             }
         });
+        // Hover readout: while NOT dragging, follow the pointer with a thin
+        // cursor line and a label showing the full timestamp under it, so the
+        // user always knows what time they're looking at. Suppressed during a
+        // drag/zoom (the rubber-band already communicates the span) and when
+        // there's no data.
+        plot.addEventListener('mousemove', (e) => {
+            if (dragging || !heatmapRows.length || !heatmapDomain) { hideCursor(); return; }
+            const { x } = localXY(e);
+            const canvas = document.getElementById('heatmap-canvas');
+            const W = canvas.clientWidth || parseFloat(canvas.style.width) || 1;
+            const { tMin, tMax } = heatmapDomain;
+            const t = xToTime(x, tMin, tMax, W);
+            const H = heatmapRows.length * ROW_H;
+            cursor.style.left = Math.round(x) + 'px';
+            cursor.style.height = H + 'px';
+            cursor.style.display = 'block';
+            cursorLabel.textContent = formatEpoch(t);
+            // Clamp the label so it never overflows the plot's right/left edge.
+            const half = cursorLabel.offsetWidth / 2;
+            cursorLabel.style.left = clamp(x, half, W - half) + 'px';
+            cursorLabel.style.display = 'block';
+        });
+        plot.addEventListener('mouseleave', hideCursor);
         // Double-click anywhere on the plot resets to the full time range.
         plot.addEventListener('dblclick', () => resetHeatmapZoom());
     })();

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -438,6 +438,11 @@
     let heatmapCols = [];      // per-row Float64Array of bytes-per-column
     let heatmapColMax = 0;     // global max column value (for normalization)
     let heatmapSelection = null; // { keys:[], bytes, t0, t1 }
+    // Set on mouseup when a heatmap interaction was a real drag (region select or
+    // zoom) rather than a click. The document-level deselect handler consumes it
+    // to ignore the synthetic click the browser fires after a drag that ends
+    // outside the pane, which would otherwise wipe the just-created selection.
+    let justDraggedOnHeatmap = false;
     let rawObjects = [];       // raw search results
     let currentTab = 'browse';
     let aggregationEnabled = false; // server runs demand-driven aggregation
@@ -1486,6 +1491,7 @@
 
         plot.addEventListener('mousedown', (e) => {
             if (!heatmapRows.length) return;
+            justDraggedOnHeatmap = false; // reset for this fresh interaction
             dragging = true;
             zooming = e.altKey;
             const { x, y } = localXY(e);
@@ -1516,6 +1522,7 @@
             const { x, y } = localXY(e);
             if (zooming) {
                 zooming = false;
+                justDraggedOnHeatmap = true; // suppress the trailing synthetic click
                 sel.style.display = 'none'; // rubber-band was transient
                 zoomToX(Math.min(x, startX), Math.max(x, startX));
                 return;
@@ -1524,6 +1531,7 @@
             if (dx < 4 && dy < 4) {
                 selectSegmentAt(startX, startY); // treat as a click
             } else {
+                justDraggedOnHeatmap = true; // suppress the trailing synthetic click
                 finalizeSelection(Math.min(x, startX), Math.max(x, startX), Math.min(y, startY), Math.max(y, startY));
             }
         });
@@ -1684,10 +1692,21 @@
     // Clicking anywhere outside the timeline and the actions bar clears the
     // current selection. (Clicks inside the plot are handled by its own
     // mousedown/up; clicks on the action buttons must preserve the selection.)
+    // A drag that ends outside the pane fires a synthetic click whose target is
+    // above #heatmap-view, so consume `justDraggedOnHeatmap` on every click to
+    // keep that phantom click from wiping the just-created selection.
     document.addEventListener('click', (e) => {
-        if (currentTab !== 'browse' || !heatmapSelection) return;
-        if (e.target.closest('#heatmap-view') || e.target.closest('#actions-bar')) return;
-        setHeatmapSelection(null);
+        const wasDrag = justDraggedOnHeatmap;
+        justDraggedOnHeatmap = false;
+        if (shouldClearSelectionOnClick({
+            isBrowseTab: currentTab === 'browse',
+            hasSelection: !!heatmapSelection,
+            wasDrag,
+            targetInHeatmap: !!e.target.closest('#heatmap-view'),
+            targetInActions: !!e.target.closest('#actions-bar'),
+        })) {
+            setHeatmapSelection(null);
+        }
     });
 
     // Structured title metadata (svc / host / time window / segment count)

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -1789,6 +1789,7 @@
             wasDrag,
             targetInHeatmap: !!e.target.closest('#heatmap-view'),
             targetInActions: !!e.target.closest('#actions-bar'),
+            targetInHeader: !!e.target.closest('header'),
         })) {
             setHeatmapSelection(null);
         }

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -1761,6 +1761,11 @@
     // serve each whole file — no server-side event filtering is needed for a
     // working flamegraph. The selection is already size-capped.
     function viewCpuProfile() {
+        // A full A/B diff has been captured — the top button opens the diff
+        // rather than a single-scope flamegraph (issue #626). launchDiff early-
+        // returns unless BOTH sides are set, so a partial capture still falls
+        // through to the single-scope flamegraph of the current selection.
+        if (diffA && diffB) { launchDiff('flamegraph'); return; }
         if (!heatmapSelection || !heatmapSelection.keys.length) return;
         const bucket = bucketInput.value.trim();
         if (!bucket) { alert('Bucket is required'); return; }
@@ -1813,6 +1818,9 @@
     }
 
     function viewTokioStats() {
+        // In diff mode the top button opens the A/B diff (issue #626); a partial
+        // capture falls through to a single-scope tokio-stats view.
+        if (diffA && diffB) { launchDiff('tokio'); return; }
         if (!heatmapSelection || !heatmapSelection.keys.length) return;
         const bucket = bucketInput.value.trim();
         if (!bucket) { alert('Bucket is required'); return; }
@@ -1897,6 +1905,19 @@
             sideCell('A · left', diffA, '#1e3050', '#9ec1ff', 'a') +
             sideCell('B · right', diffB, '#4a221c', '#ffb3a0', 'b');
         launch.style.display = (diffA && diffB) ? 'flex' : 'none';
+        refreshDiffModeButtons();
+    }
+
+    // Relabel the top actions-bar buttons to reflect that, in diff mode, they now
+    // open the A/B diff instead of a single-scope view (issue #626). Called from
+    // both diff-state changes (renderDiffTray) and selection changes
+    // (updateSelectionCount) so the label stays in sync in both directions.
+    function refreshDiffModeButtons() {
+        const cpuBtn = document.getElementById('cpu-btn');
+        const healthBtn = document.getElementById('health-btn');
+        const diffMode = !!(diffA && diffB);
+        if (cpuBtn) cpuBtn.textContent = diffMode ? '🔥 Flamegraph diff' : '🔥 Flamegraph';
+        if (healthBtn) healthBtn.textContent = diffMode ? '⚡ Tokio Stats diff' : '⚡ Tokio Stats';
     }
 
     // Launch the captured A/B diff in the chosen viz. Uses the shared scope-link
@@ -1904,17 +1925,9 @@
     // encoding — the unified diff-handling seam between the two views.
     function launchDiff(kind) {
         if (!diffA || !diffB) return;
-        // Flamegraph scopes carry the client-only `api=1` flag; tokio-stats does
-        // not use it. Add it per-side only for the flamegraph target so each side
-        // hits /api/flamegraph in aggregate mode.
-        function scopeFor(base) {
-            if (kind !== 'flamegraph') return base;
-            const s = new URLSearchParams(base.toString());
-            s.set('api', '1');
-            return s;
-        }
-        const search = FlamegraphDiff.diffSearch(scopeFor(diffA), scopeFor(diffB));
-        const page = kind === 'tokio' ? 'tokio_stats.html' : 'flamegraph.html';
+        // chooseTarget owns the single-vs-diff routing and the per-side `api=1`
+        // flag for the flamegraph target (tokio-stats does not use it).
+        const { page, search } = FlamegraphDiff.chooseTarget(kind, { hasDiff: true, diffA, diffB });
         window.open(page + '?' + search, '_blank');
     }
 
@@ -2035,6 +2048,10 @@
         const diffAddBtn = document.getElementById('diff-add-btn');
         const warn = document.getElementById('selection-warn');
         const count = document.getElementById('selection-count');
+
+        // Keep the top-button labels ("Flamegraph" vs "Flamegraph diff") in sync
+        // as the selection changes (issue #626).
+        refreshDiffModeButtons();
 
         if (currentTab === 'browse') {
             const sel = heatmapSelection;

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -390,6 +390,18 @@
             <button onclick="clearDiff()" class="ghost" style="background:#2a2a44;color:#e0e0e0;border:1px solid #444;padding:3px 10px;border-radius:3px;cursor:pointer" title="Clear both sides">Clear</button>
         </div>
         <div id="diff-sides" style="display:grid;grid-template-columns:1fr 1fr;gap:10px"></div>
+        <!-- One-click presets to fill side B relative to side A (issue #624):
+             same window shifted back in time, or same window on a different
+             host in the browse view. Shown only when A is set and B is not. -->
+        <div id="diff-presets" style="display:none;margin-top:10px;align-items:center;gap:8px;flex-wrap:wrap">
+            <span style="color:#8b949e">Quick B:</span>
+            <button onclick="presetShiftB('1h')" class="ghost" style="background:#2a2a44;color:#e0e0e0;border:1px solid #444;padding:3px 10px;border-radius:3px;cursor:pointer" title="Side B = side A one hour earlier">−1h</button>
+            <button onclick="presetShiftB('24h')" class="ghost" style="background:#2a2a44;color:#e0e0e0;border:1px solid #444;padding:3px 10px;border-radius:3px;cursor:pointer" title="Side B = side A one day earlier">−24h</button>
+            <button onclick="presetShiftB('7d')" class="ghost" style="background:#2a2a44;color:#e0e0e0;border:1px solid #444;padding:3px 10px;border-radius:3px;cursor:pointer" title="Side B = side A one week earlier">−7d</button>
+            <select id="diff-preset-host" onchange="presetHostB(this.value)" style="background:#14142a;color:#e0e0e0;border:1px solid #444;padding:3px 8px;border-radius:3px;cursor:pointer" title="Side B = side A on a different host, same time window">
+                <option value="">same time, different host…</option>
+            </select>
+        </div>
         <div id="diff-launch" style="display:none;margin-top:10px;align-items:center;gap:8px">
             <span style="color:#8b949e">Compare in:</span>
             <button onclick="launchDiff('flamegraph')" style="background:#6c63ff;color:#fff;border:none;padding:4px 14px;border-radius:3px;cursor:pointer;font-weight:600">🔥 Flamegraph</button>
@@ -1991,8 +2003,73 @@
             sideCell('A · left', diffA, '#1e3050', '#9ec1ff', 'a') +
             sideCell('B · right', diffB, '#4a221c', '#ffb3a0', 'b');
         launch.style.display = (diffA && diffB) ? 'flex' : 'none';
+        renderDiffPresets();
         refreshDiffModeButtons();
     }
+
+    // Populate/toggle the "Quick B" presets (issue #624). They only make sense
+    // once side A is captured and side B is still empty: they derive B from A.
+    // The time-shift buttons need A to carry a window (start_ns/end_ns); the
+    // host dropdown lists every host in the current browse view except A's own.
+    function renderDiffPresets() {
+        const presets = document.getElementById('diff-presets');
+        if (!presets) return;
+        if (!diffA || diffB) { presets.style.display = 'none'; return; }
+        presets.style.display = 'flex';
+
+        // Shift presets are only meaningful with a window on side A.
+        const hasWindow = diffA.get('start_ns') != null && diffA.get('end_ns') != null;
+        for (const btn of presets.querySelectorAll('button')) {
+            btn.disabled = !hasWindow;
+            btn.style.opacity = hasWindow ? '1' : '0.4';
+            btn.style.cursor = hasWindow ? 'pointer' : 'not-allowed';
+        }
+
+        // Host dropdown: all service/host pairs in the browse window, minus the
+        // host(s) already on side A (comparing a host to itself is a no-op).
+        const sel = document.getElementById('diff-preset-host');
+        const aHosts = new Set(diffA.getAll('host'));
+        const seen = new Set();
+        const opts = ['<option value="">same time, different host…</option>'];
+        for (const row of heatmapRows) {
+            if (!row.host || aHosts.has(row.host) || seen.has(row.host)) continue;
+            seen.add(row.host);
+            const label = row.service ? row.service + ' / ' + row.host : row.host;
+            opts.push('<option value="' + escapeHtmlIdx(row.host) + '">' + escapeHtmlIdx(label) + '</option>');
+        }
+        sel.innerHTML = opts.join('');
+        // Disable the dropdown when there is no other host to pick.
+        const hasOther = opts.length > 1;
+        sel.disabled = !hasOther;
+        sel.style.opacity = hasOther ? '1' : '0.4';
+        sel.style.cursor = hasOther ? 'pointer' : 'not-allowed';
+    }
+
+    // Preset: side B = side A shifted back one hour / day / week (same window
+    // length). Reuses the shared shiftScopeTime helper AND the shared BigInt-ns
+    // shift constants so this matches the flamegraph Diff dialog exactly (#624).
+    const DIFF_SHIFTS = {
+        '1h': FlamegraphDiff.DIFF_SHIFT_1H,
+        '24h': FlamegraphDiff.DIFF_SHIFT_24H,
+        '7d': FlamegraphDiff.DIFF_SHIFT_7D,
+    };
+    function presetShiftB(which) {
+        if (!diffA || diffB) return;
+        const deltaNs = DIFF_SHIFTS[which];
+        if (deltaNs == null) return;
+        diffB = FlamegraphDiff.shiftScopeTime(diffA, deltaNs);
+        renderDiffTray();
+    }
+    window.presetShiftB = presetShiftB;
+
+    // Preset: side B = side A on a different host, same time window. Reuses the
+    // shared scopeWithHost helper (issue #624).
+    function presetHostB(host) {
+        if (!host || !diffA || diffB) return;
+        diffB = FlamegraphDiff.scopeWithHost(diffA, host);
+        renderDiffTray();
+    }
+    window.presetHostB = presetHostB;
 
     // Relabel the top actions-bar buttons to reflect that, in diff mode, they now
     // open the A/B diff instead of a single-scope view (issue #626). Called from

--- a/dial9-viewer/ui/test_flamegraph_diff.js
+++ b/dial9-viewer/ui/test_flamegraph_diff.js
@@ -365,6 +365,15 @@ assert(parseDiff(new URLSearchParams("diff=1&a=" + encodeScope("bucket=x") + "&b
   assertEq(V.scopeLabel(new URLSearchParams("service=svc"), "A"), "svc", "label: no host");
   assertEq(V.scopeLabel(new URLSearchParams("service=svc&host=a&host=b&host=c"), "A"), "svc @ 3 hosts", "label: host count");
   assertEq(V.scopeLabel(new URLSearchParams("host=h1"), "A"), "A @ h1", "label: no service falls back");
+
+  // isSearchFocusKey: "/" focuses the highlight box only when it isn't already
+  // focused (so a literal "/" can be typed into the regex); Ctrl/Cmd+F always
+  // focuses; other keys never do.
+  assertEq(V.isSearchFocusKey({ key: "/" }, false), true, "'/' focuses when not already in the search box");
+  assertEq(V.isSearchFocusKey({ key: "/" }, true), false, "'/' does not steal focus while typing in the search box");
+  assertEq(V.isSearchFocusKey({ key: "f", ctrlKey: true }, false), true, "Ctrl+F focuses the search box");
+  assertEq(V.isSearchFocusKey({ key: "f", metaKey: true }, false), true, "Cmd+F focuses the search box");
+  assertEq(V.isSearchFocusKey({ key: "a" }, false), false, "other keys do not focus the search box");
 }
 
 // ── Summary ──

--- a/dial9-viewer/ui/test_flamegraph_diff.js
+++ b/dial9-viewer/ui/test_flamegraph_diff.js
@@ -13,6 +13,11 @@ const {
   layoutSide,
   nodeAtPath,
   fullScopeQuery,
+  scopeWithHost,
+  shiftScopeTime,
+  DIFF_SHIFT_1H,
+  DIFF_SHIFT_24H,
+  DIFF_SHIFT_7D,
   b64urlEncode,
   b64urlDecode,
   encodeScope,
@@ -478,6 +483,70 @@ assert(parseDiff(new URLSearchParams("diff=1&a=" + encodeScope("bucket=x") + "&b
   assertEq(parsed.b.get("api"), "1", "side B carries api=1 (aggregate path)");
   assertEq(parsed.a.get("bucket"), "b", "shared bucket survives on A");
   assertEq(parsed.b.get("service"), "svc", "shared service survives on B");
+}
+
+// ── shiftScopeTime: earlier-window presets (issue #624) ──
+// start_ns/end_ns are ~1.78e18, far above Number.MAX_SAFE_INTEGER, so the shift
+// must use BigInt or the values corrupt. Assert exact string equality against
+// BigInt-computed expectations, that the window LENGTH is preserved, and that
+// non-time params are untouched.
+{
+  const scope = fullScopeQuery(new URLSearchParams(
+    "api=1&bucket=b&prefix=p&service=svc&host=h1&start_ns=1782155999000000000&end_ns=1782159599000000000"));
+
+  const shifted = shiftScopeTime(scope, DIFF_SHIFT_24H);
+  // 1782155999000000000 - 86400000000000 = 1782069599000000000
+  assertEq(shifted.get("start_ns"), "1782069599000000000", "-24h shifts start_ns back by exactly the delta");
+  assertEq(shifted.get("end_ns"), "1782073199000000000", "-24h shifts end_ns back by exactly the delta");
+  // Window length preserved.
+  const origLen = BigInt(scope.get("end_ns")) - BigInt(scope.get("start_ns"));
+  const newLen = BigInt(shifted.get("end_ns")) - BigInt(shifted.get("start_ns"));
+  assert(origLen === newLen, "-24h preserves the window length");
+  // Non-time params untouched.
+  assertEq(shifted.get("bucket"), "b", "shiftScopeTime leaves bucket untouched");
+  assertEq(shifted.get("service"), "svc", "shiftScopeTime leaves service untouched");
+  assertEq(shifted.get("host"), "h1", "shiftScopeTime leaves host untouched");
+
+  // -1h and -7d line up with their BigInt deltas too.
+  const s1h = shiftScopeTime(scope, DIFF_SHIFT_1H);
+  assertEq(s1h.get("start_ns"), (BigInt(scope.get("start_ns")) - DIFF_SHIFT_1H).toString(), "-1h start_ns matches BigInt delta");
+  const s7d = shiftScopeTime(scope, DIFF_SHIFT_7D);
+  assertEq(s7d.get("start_ns"), (BigInt(scope.get("start_ns")) - DIFF_SHIFT_7D).toString(), "-7d start_ns matches BigInt delta");
+
+  // No window -> returned unchanged (no start_ns/end_ns to shift).
+  const noWindow = fullScopeQuery(new URLSearchParams("api=1&bucket=b&service=svc&host=h1"));
+  const nwShifted = shiftScopeTime(noWindow, DIFF_SHIFT_24H);
+  assertEq(nwShifted.get("start_ns"), null, "no start_ns -> none introduced");
+  assertEq(nwShifted.get("end_ns"), null, "no end_ns -> none introduced");
+  assertEq(nwShifted.get("bucket"), "b", "windowless scope carries other params through");
+
+  // Input is not mutated.
+  assertEq(scope.get("start_ns"), "1782155999000000000", "shiftScopeTime does not mutate the input scope");
+}
+
+// ── scopeWithHost: same-time-different-host preset (issue #624) ──
+{
+  const scope = fullScopeQuery(new URLSearchParams(
+    "api=1&bucket=b&prefix=p&service=svc&host=h1&host=h2&start_ns=1000&end_ns=2000"));
+
+  const swapped = scopeWithHost(scope, "h3");
+  assertEq(swapped.getAll("host").join(","), "h3", "scopeWithHost replaces all hosts with exactly the chosen one");
+  assertEq(swapped.get("bucket"), "b", "scopeWithHost preserves bucket");
+  assertEq(swapped.get("prefix"), "p", "scopeWithHost preserves prefix");
+  assertEq(swapped.get("service"), "svc", "scopeWithHost preserves service");
+  assertEq(swapped.get("start_ns"), "1000", "scopeWithHost preserves start_ns");
+  assertEq(swapped.get("end_ns"), "2000", "scopeWithHost preserves end_ns");
+
+  // Input is not mutated.
+  assertEq(scope.getAll("host").join(","), "h1,h2", "scopeWithHost does not mutate the input scope");
+
+  // End-to-end through the existing codec: preset 1 builds a diff link whose
+  // side B is the chosen host at side A's window.
+  const parsed = parseDiff(diffSearch(scope, scopeWithHost(scope, "h3")));
+  assert(parsed != null, "preset 1 -> diffSearch -> parseDiff round-trips");
+  assertEq(parsed.b.get("host"), "h3", "preset 1: side B narrowed to the chosen host");
+  assertEq(parsed.b.get("start_ns"), scope.get("start_ns"), "preset 1: side B keeps side A's window (same time)");
+  assertEq(parsed.a.getAll("host").join(","), "h1,h2", "preset 1: side A scope unchanged");
 }
 
 // ── Summary ──

--- a/dial9-viewer/ui/test_flamegraph_diff.js
+++ b/dial9-viewer/ui/test_flamegraph_diff.js
@@ -19,6 +19,7 @@ const {
   decodeScope,
   diffSearch,
   parseDiff,
+  chooseTarget,
 } = require("./flamegraph_diff.js");
 
 let passed = 0;
@@ -334,6 +335,42 @@ assertEq(parseDiff("diff=1&a=abc"), null, "diff link missing b -> null");
 assertEq(parseDiff("diff=1"), null, "diff link missing both a and b -> null");
 assert(parseDiff(new URLSearchParams("diff=1&a=" + encodeScope("bucket=x") + "&b=" + encodeScope("bucket=y"))) != null,
   "parseDiff accepts a URLSearchParams as well as a string");
+
+// ── chooseTarget: single-scope vs captured A/B diff routing (issue #626) ──
+// The landing page's top "Flamegraph"/"Tokio Stats" buttons route through the
+// same seam as the diff tray's launch buttons, so once a full diff is captured
+// the top button opens the diff instead of a single scope.
+{
+  const diffA = fullScopeQuery(new URLSearchParams("bucket=ba&service=svc&host=h1"));
+  const diffB = fullScopeQuery(new URLSearchParams("bucket=bb&service=svc&host=h2"));
+
+  // hasDiff true -> diff link, correct page per kind, per-side api=1 for flamegraph.
+  const fg = chooseTarget("flamegraph", { hasDiff: true, diffA, diffB });
+  assertEq(fg.page, "flamegraph.html", "diff mode flamegraph -> flamegraph.html");
+  assert(fg.search.indexOf("diff=1&a=") === 0, "diff mode flamegraph search starts with diff=1&a=..");
+  assert(fg.search.indexOf("&b=") !== -1, "diff mode flamegraph search carries b=..");
+  const fgParsed = parseDiff(fg.search);
+  assertEq(fgParsed.a.get("bucket"), "ba", "diff mode flamegraph: side A scope round-trips");
+  assertEq(fgParsed.a.get("api"), "1", "diff mode flamegraph: per-side api=1 set on A");
+  assertEq(fgParsed.b.get("api"), "1", "diff mode flamegraph: per-side api=1 set on B");
+
+  const tk = chooseTarget("tokio", { hasDiff: true, diffA, diffB });
+  assertEq(tk.page, "tokio_stats.html", "diff mode tokio -> tokio_stats.html");
+  assert(tk.search.indexOf("diff=1&a=") === 0, "diff mode tokio search starts with diff=1&a=..");
+  const tkParsed = parseDiff(tk.search);
+  assertEq(tkParsed.a.get("api"), null, "diff mode tokio: no api flag (tokio-stats does not use it)");
+
+  // hasDiff false -> the caller's pre-built single-scope query, unchanged.
+  const single = chooseTarget("flamegraph", { hasDiff: false, singleQuery: "api=1&bucket=b&service=svc" });
+  assertEq(single.page, "flamegraph.html", "single mode -> flamegraph.html");
+  assertEq(single.search, "api=1&bucket=b&service=svc", "single mode passes the single-scope query through unchanged");
+  assert(parseDiff(single.search) == null, "single mode search is not a diff link");
+  assertEq(
+    chooseTarget("tokio", { hasDiff: false, singleQuery: "bucket=b&service=svc" }).page,
+    "tokio_stats.html",
+    "single mode tokio -> tokio_stats.html",
+  );
+}
 
 // ── flamegraph_diff_view: apiUrlFor / scopeLabel (DOM-free helpers) ──
 {

--- a/dial9-viewer/ui/test_flamegraph_diff.js
+++ b/dial9-viewer/ui/test_flamegraph_diff.js
@@ -20,6 +20,9 @@ const {
   diffSearch,
   parseDiff,
   chooseTarget,
+  addDiffCapture,
+  swapDiffCapture,
+  removeDiffSide,
 } = require("./flamegraph_diff.js");
 
 let passed = 0;
@@ -411,6 +414,70 @@ assert(parseDiff(new URLSearchParams("diff=1&a=" + encodeScope("bucket=x") + "&b
   assertEq(V.isSearchFocusKey({ key: "f", ctrlKey: true }, false), true, "Ctrl+F focuses the search box");
   assertEq(V.isSearchFocusKey({ key: "f", metaKey: true }, false), true, "Cmd+F focuses the search box");
   assertEq(V.isSearchFocusKey({ key: "a" }, false), false, "other keys do not focus the search box");
+}
+
+// ── addDiffCapture / swapDiffCapture / removeDiffSide: tray state machine ──
+// Backs the in-page "Add to diff" tray on the flamegraph aggregate toolbar
+// (issue #646): capture fills A first, then B, then replaces B; A always fills
+// before B (no B-without-A hole).
+{
+  const sa = new URLSearchParams("api=1&bucket=b&service=svc&host=host-a");
+  const sb = new URLSearchParams("api=1&bucket=b&service=svc&host=host-b");
+  const sc = new URLSearchParams("api=1&bucket=b&service=svc&host=host-c");
+
+  let st = { a: null, b: null };
+  st = addDiffCapture(st, sa);
+  assertEq(st.a, sa, "first add fills A");
+  assertEq(st.b, null, "first add leaves B empty");
+  st = addDiffCapture(st, sb);
+  assertEq(st.a, sa, "second add keeps A");
+  assertEq(st.b, sb, "second add fills B");
+  st = addDiffCapture(st, sc);
+  assertEq(st.a, sa, "third add keeps A");
+  assertEq(st.b, sc, "third add replaces B (most recent)");
+
+  // Swap flips A/B only when both are set.
+  const sw = swapDiffCapture(st);
+  assertEq(sw.a, sc, "swap makes old B the new A");
+  assertEq(sw.b, sa, "swap makes old A the new B");
+  const swLone = swapDiffCapture({ a: sa, b: null });
+  assertEq(swLone.a, sa, "swap with a lone A is a no-op (keeps A)");
+  assertEq(swLone.b, null, "swap with a lone A leaves B empty");
+
+  // Removing A promotes B so there is never a B-without-A hole.
+  const rmA = removeDiffSide({ a: sa, b: sb }, "a");
+  assertEq(rmA.a, sb, "removing A promotes B into A");
+  assertEq(rmA.b, null, "removing A leaves B empty");
+  const rmB = removeDiffSide({ a: sa, b: sb }, "b");
+  assertEq(rmB.a, sa, "removing B keeps A");
+  assertEq(rmB.b, null, "removing B clears B");
+
+  // Inputs are not mutated in place (transitions return fresh state objects).
+  const orig = { a: sa, b: null };
+  addDiffCapture(orig, sb);
+  assertEq(orig.b, null, "addDiffCapture does not mutate the input state");
+}
+
+// ── Capture → diff round-trip for host-vs-host (issue #646) ──
+// The core of the "Add to diff" flow: capture the current view narrowed to one
+// host as side A, re-narrow to a second host and capture as side B, then open
+// the two-sided diff. Both host selections must survive the codec independently,
+// as must the shared scope (api/bucket/service).
+{
+  const scopeA = fullScopeQuery(new URLSearchParams("api=1&bucket=b&prefix=p&service=svc&host=host-a"));
+  const scopeB = fullScopeQuery(new URLSearchParams("api=1&bucket=b&prefix=p&service=svc&host=host-b"));
+
+  let st = { a: null, b: null };
+  st = addDiffCapture(st, scopeA);
+  st = addDiffCapture(st, scopeB);
+  const parsed = parseDiff(diffSearch(st.a, st.b));
+  assert(parsed != null, "capture -> diffSearch -> parseDiff round-trips");
+  assertEq(parsed.a.get("host"), "host-a", "side A narrowed to host-a survives");
+  assertEq(parsed.b.get("host"), "host-b", "side B narrowed to host-b survives");
+  assertEq(parsed.a.get("api"), "1", "side A carries api=1 (aggregate path)");
+  assertEq(parsed.b.get("api"), "1", "side B carries api=1 (aggregate path)");
+  assertEq(parsed.a.get("bucket"), "b", "shared bucket survives on A");
+  assertEq(parsed.b.get("service"), "svc", "shared service survives on B");
 }
 
 // ── Summary ──

--- a/dial9-viewer/ui/test_heatmap.js
+++ b/dial9-viewer/ui/test_heatmap.js
@@ -14,6 +14,7 @@ const {
     totalBytes,
     densityColor,
     shouldClearSelectionOnClick,
+    niceTimeTicks,
 } = require("./heatmap.js");
 
 let failed = 0;
@@ -239,6 +240,38 @@ function seg(o) {
         isBrowseTab: true, hasSelection: false, wasDrag: false,
         targetInHeatmap: false, targetInActions: false,
     }) === false, "shouldClearSelectionOnClick: no selection → no clear");
+}
+
+// ── niceTimeTicks ──
+{
+    // Ticks are ascending and stay within [tMin, tMax].
+    const ticks = niceTimeTicks(1000, 1600, 6);
+    ok(ticks.length > 0, "niceTimeTicks: returns at least one tick");
+    ok(ticks.every((t, i) => i === 0 || t > ticks[i - 1]), "niceTimeTicks: strictly ascending");
+    ok(ticks.every((t) => t >= 1000 && t <= 1600), "niceTimeTicks: all ticks within range");
+
+    // A ~600s span with target 6 must snap to a round step (a multiple of a
+    // human interval like 120s), not an arbitrary 100s division.
+    const step = ticks[1] - ticks[0];
+    ok([60, 120].includes(step), `niceTimeTicks: snaps to a round step (got ${step})`);
+    ok(step % 60 === 0 || step % 30 === 0, "niceTimeTicks: step is a round interval");
+
+    // Count stays within the target.
+    ok(ticks.length <= 6, `niceTimeTicks: count <= target (got ${ticks.length})`);
+
+    // Ticks are aligned to multiples of the step so they land on round times.
+    ok(ticks.every((t) => t % step === 0), "niceTimeTicks: ticks aligned to the step");
+
+    // A wider span still respects the target.
+    const wide = niceTimeTicks(0, 86400, 8);
+    ok(wide.length <= 8, `niceTimeTicks: wide span respects target (got ${wide.length})`);
+    ok(wide.every((t, i) => i === 0 || t > wide[i - 1]), "niceTimeTicks: wide span ascending");
+}
+{
+    // Degenerate range (tMax <= tMin) returns a single tick without throwing.
+    ok(niceTimeTicks(500, 500, 6).length === 1, "niceTimeTicks: equal bounds → single tick");
+    ok(niceTimeTicks(500, 500, 6)[0] === 500, "niceTimeTicks: single tick is tMin");
+    ok(niceTimeTicks(900, 500, 6).length === 1, "niceTimeTicks: inverted bounds → single tick");
 }
 
 // ── constants ──

--- a/dial9-viewer/ui/test_heatmap.js
+++ b/dial9-viewer/ui/test_heatmap.js
@@ -13,6 +13,7 @@ const {
     segmentsOverlapping,
     totalBytes,
     densityColor,
+    shouldClearSelectionOnClick,
 } = require("./heatmap.js");
 
 let failed = 0;
@@ -201,6 +202,43 @@ function seg(o) {
     ok(low !== "rgb(26,26,46)", "densityColor: small positive is visible (not background)");
     ok(lum(low) < lum(mid) && lum(mid) < lum(hi), "densityColor: brighter with higher density");
     ok(densityColor(1) === "rgb(255,217,61)", "densityColor: 1 → hot yellow");
+}
+
+// ── shouldClearSelectionOnClick ──
+{
+    // The regression: a selection drag that ends outside the pane fires a
+    // synthetic click on an ancestor above #heatmap-view. That click must NOT
+    // clear the just-created selection.
+    ok(shouldClearSelectionOnClick({
+        isBrowseTab: true, hasSelection: true, wasDrag: true,
+        targetInHeatmap: false, targetInActions: false,
+    }) === false, "shouldClearSelectionOnClick: drag ending outside pane keeps selection");
+
+    // A genuine outside click (no drag) clears the selection.
+    ok(shouldClearSelectionOnClick({
+        isBrowseTab: true, hasSelection: true, wasDrag: false,
+        targetInHeatmap: false, targetInActions: false,
+    }) === true, "shouldClearSelectionOnClick: genuine outside click clears");
+
+    // Clicks inside the timeline or on the actions bar preserve the selection.
+    ok(shouldClearSelectionOnClick({
+        isBrowseTab: true, hasSelection: true, wasDrag: false,
+        targetInHeatmap: true, targetInActions: false,
+    }) === false, "shouldClearSelectionOnClick: click inside heatmap keeps selection");
+    ok(shouldClearSelectionOnClick({
+        isBrowseTab: true, hasSelection: true, wasDrag: false,
+        targetInHeatmap: false, targetInActions: true,
+    }) === false, "shouldClearSelectionOnClick: click on actions bar keeps selection");
+
+    // No-ops when not on browse tab or nothing is selected.
+    ok(shouldClearSelectionOnClick({
+        isBrowseTab: false, hasSelection: true, wasDrag: false,
+        targetInHeatmap: false, targetInActions: false,
+    }) === false, "shouldClearSelectionOnClick: not browse tab → no clear");
+    ok(shouldClearSelectionOnClick({
+        isBrowseTab: true, hasSelection: false, wasDrag: false,
+        targetInHeatmap: false, targetInActions: false,
+    }) === false, "shouldClearSelectionOnClick: no selection → no clear");
 }
 
 // ── constants ──

--- a/dial9-viewer/ui/test_heatmap.js
+++ b/dial9-viewer/ui/test_heatmap.js
@@ -231,6 +231,15 @@ function seg(o) {
         targetInHeatmap: false, targetInActions: true,
     }) === false, "shouldClearSelectionOnClick: click on actions bar keeps selection");
 
+    // Regression (#645/#644 interaction): the TZ toggle and credentials button
+    // live in the page <header>, which is neither the timeline nor the actions
+    // bar. Clicking header chrome must NOT clear the selection — toggling TZ
+    // only relabels the axis.
+    ok(shouldClearSelectionOnClick({
+        isBrowseTab: true, hasSelection: true, wasDrag: false,
+        targetInHeatmap: false, targetInActions: false, targetInHeader: true,
+    }) === false, "shouldClearSelectionOnClick: click in header (TZ toggle) keeps selection");
+
     // No-ops when not on browse tab or nothing is selected.
     ok(shouldClearSelectionOnClick({
         isBrowseTab: false, hasSelection: true, wasDrag: false,

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -95,4 +95,7 @@ node dial9-viewer/ui/test_flamegraph_export.js
 echo "--- Checking runtime grouping (multi-runtime lanes) ---"
 node dial9-viewer/ui/test_runtime_groups.js
 
+echo "--- Checking browse density-timeline / heatmap helpers ---"
+node dial9-viewer/ui/test_heatmap.js
+
 echo "All E2E trace checks passed."


### PR DESCRIPTION
Batch of UI usability fixes from the #623 tracking issue. Each fix is an isolated commit; they're grouped into one PR because they overlap heavily on `index.html`, `flamegraph_diff.js`, `flamegraph.html`, and `test_flamegraph_diff.js` (separate PRs would force cross-PR rebase conflicts).

`#625` (flamegraph Export in aggregated mode) is **not** here — it ships separately in #650.

## Fixes

- **#622** `fix(viewer): add keyboard search focus to diff flamegraph` — pressing `/` (and Ctrl/Cmd+F) in the flamegraph **diff** view now focuses the highlight/search box, matching the single-flamegraph view.
- **#645** `fix(viewer): preserve heatmap selection on timezone toggle` — toggling TZ (UTC/Local) on the browse page no longer wipes the current selection/zoom; only the axis relabels.
- **#644** `fix(viewer): clear heatmap selection on click outside timeline` — dragging a selection whose mouseup lands outside the pane now registers instead of being dropped by the synthetic drag-tail click.
- **#626** `fix(viewer): route landing buttons to A/B diff when captured` — clicking Flamegraph / Tokio Stats while an A/B diff is captured opens the **diff**, not a single-scope view.
- **#631** `feat(viewer): add gridlines, hover time readout, click-select to heatmap` — browse timeline gets vertical time gridlines, a hover time readout, and easier single-segment selection.
- **#646** `feat(viewer): add in-page "Add to diff" capture tray to flamegraph` — capture two host/scope selections and open a two-sided diff without copy-pasting a link.
- **#624** `feat(viewer): add one-click diff presets to flamegraph dialog` — "same time, different host" and "same scope, shifted -1h/-24h/-7d" presets in the Diff dialog.

## Testing

JS/HTML-only (no trace-format change), per `AGENTS.md`. Validated on **Node 24** (matches CI):
- `test_flamegraph_diff.js` (160 assertions), `test_heatmap.js` (57), `test_flamegraph_export.js`, `test_flamegraph_api.js`, `test_url_state.js`, `test_focus_timebase.js` — all pass.
- New tests registered in `scripts/e2e-trace-tests.sh` where added.
- `cargo build -p dial9-viewer` confirms `rust-embed` bundles the updated UI.

Fixes #622, 
Fixes #645, 
Fixes #644, 
Fixes #626, 
Fixes #631, 
Fixes #646, 
Fixes #624