### PR TITLE
fix(viewer): recognize date layer when aux sibling folders share the root

### DIFF
--- a/dial9-viewer/ui/prefix_detect.js
+++ b/dial9-viewer/ui/prefix_detect.js
@@ -18,13 +18,23 @@ function lastSegment(prefix) {
 // (YYYY-MM-DD/) rather than genuine key prefixes. The default S3 key
 // layout is `{prefix}/{YYYY-MM-DD}/{HHMM}/{service}/…`; when there is no
 // prefix, the date layer sits directly at the listing root. Those dates
-// are NOT selectable prefixes — the prefix is empty. We only treat the
-// listing as a date layer when *every* child looks like a date, so a
-// bucket that mixes a real prefix with stray date keys keeps showing
+// are NOT selectable prefixes — the prefix is empty.
+//
+// We treat the listing as a date layer when date partitions are a strict
+// majority of the root children. Requiring *every* child to be a date was
+// too strict: dial9 writes auxiliary sibling folders next to the date layer
+// (`diagnostics/` from crash capture, `flamegraph-data/` from on-demand
+// aggregation), and a handful of those must not stop us recognizing a bucket
+// whose trace data lives directly under the dates. We still refuse to empty
+// the prefix when dates are only a minority — a real key-prefix bucket with a
+// few stray date keys — so an ambiguous 50/50 listing keeps showing
 // suggestions rather than silently emptying the prefix.
 function isDateLayer(prefixes) {
   if (!prefixes || prefixes.length === 0) return false;
-  return prefixes.every((p) => /^\d{4}-\d{2}-\d{2}$/.test(lastSegment(p)));
+  const dateCount = prefixes.filter((p) =>
+    /^\d{4}-\d{2}-\d{2}$/.test(lastSegment(p)),
+  ).length;
+  return dateCount * 2 > prefixes.length;
 }
 
 if (typeof module !== "undefined" && module.exports) {

--- a/dial9-viewer/ui/test_prefix_detection.js
+++ b/dial9-viewer/ui/test_prefix_detection.js
@@ -48,11 +48,38 @@ assert(
     "single real prefix → not a date layer",
 );
 
-// Mixed dates + real prefix → not a clean date layer (be conservative,
-// keep offering suggestions rather than silently emptying the prefix).
+// Mixed dates + real prefix, dates NOT a majority → not a clean date layer
+// (be conservative, keep offering suggestions rather than silently emptying
+// the prefix).
 assert(
     isDateLayer(["2026-06-12/", "traces/"]) === false,
-    "mixed dates and prefix → not a date layer",
+    "50/50 dates and prefix → not a date layer",
+);
+
+// Regression for the gamma bucket that broke browse: many date partitions
+// plus dial9's own auxiliary sibling folder (`diagnostics/`, written by crash
+// capture; `flamegraph-data/` from on-demand aggregation behaves the same).
+// Dates are a strict majority, so this IS a date layer and the prefix must be
+// emptied. Before the majority fix, the lone `diagnostics/` made `.every()`
+// return false, the dates were offered as prefix suggestions, and searching
+// under a `YYYY-MM-DD/` prefix returned zero objects — an empty browse page.
+assert(
+    isDateLayer([
+        "2026-06-11/",
+        "2026-06-12/",
+        "2026-06-13/",
+        "diagnostics/",
+    ]) === true,
+    "many dates + one auxiliary sibling → date layer",
+);
+assert(
+    isDateLayer([
+        "2026-06-11/",
+        "2026-06-12/",
+        "2026-06-13/",
+        "flamegraph-data/",
+    ]) === true,
+    "many dates + flamegraph-data sibling → date layer",
 );
 
 // Empty input → not a date layer.


### PR DESCRIPTION
## Problem

The dial9 viewer's browse page renders empty for buckets that store traces directly under `YYYY-MM-DD/` date partitions **when an auxiliary folder shares the bucket root**.


## Root cause

The browse UI has a special case (issue #471) for prefix-less buckets: when the root children are all dates, it treats the listing as a "date layer", sets the search prefix to **empty**, and does not offer the dates as clickable prefix suggestions. `isDateLayer()` gated this on `.every()` child being a date:

```js
return prefixes.every((p) => /^\d{4}-\d{2}-\d{2}$/.test(lastSegment(p)));
```

The lone `diagnostics/` child makes `.every()` return `false`, so the dates get offered as prefix buttons. Using a `YYYY-MM-DD/` value as the *key prefix* makes the server prepend it, producing paths like `2026-07-09/2026-07-09/2220/...` that match nothing. Verified live: `browse?prefix=2026-07-09` → **0 objects**; empty-prefix browse → **100k+ objects**.

dial9 itself writes such sibling folders: `diagnostics/` (crash capture) and `flamegraph-data/` (on-demand aggregation), so this hits any real bucket that has been aggregated or captured a crash.

## Fix

Recognize a date layer when date partitions are a **strict majority** of the root children, tolerating a few auxiliary siblings while still refusing to empty the prefix on an ambiguous 50/50 listing (a real key-prefix bucket with a few stray date keys).

## Verification

- All existing `test_prefix_detection.js` cases pass; added two regressions (dates + `diagnostics/`, dates + `flamegraph-data/`).
- Ran the viewer binary in `--dev` mode against the live bucket (ReadOnly creds): served `prefix_detect.js` now returns `isDateLayer(live root) = true`, and the empty-prefix browse returns the traces.
- `test_url_state.js` and `test_parse_key.js` also pass.

Note: the fix is in the embedded UI asset, so the deployed viewer needs a rebuild (`rust_embed` bakes the UI into the binary) to pick it up.