### PR TITLE
feat: explicit CPU profiling backend selection via CpuProfilingConfig constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Explicit CPU profiling backend selection via `CpuProfilingConfig::with_perf_backend()` and `CpuProfilingConfig::with_ctimer_backend()` constructors. The default (Auto: try perf, fall back to ctimer) is unchanged ([#579](https://github.com/dial9-rs/dial9/issues/579), [#660](https://github.com/dial9-rs/dial9/pull/660))
 - In-memory writer (`InMemoryWriter`): run the trace pipeline with no filesystem dependency, encoded segments are held in process memory and shipped by the existing processor pipeline ([#435](https://github.com/dial9-rs/dial9/pull/435))
 - `#[dial9_tokio_telemetry::main]` now performs an implicit graceful shutdown after the async body returns: it drops the runtime and drains the background worker so the final segment is symbolized, compressed, and uploaded. Configure the deadline with `Dial9Config::builder()...graceful_shutdown(Duration)` (default 1s) or skip it with `.disable_graceful_shutdown()`. The low-level `TracedRuntime` API is unchanged — call `TelemetryGuard::graceful_shutdown` yourself ([#479](https://github.com/dial9-rs/dial9/issues/479))
 - `SegmentProcessor::finalize_dump`: custom processors can flush per-dump state when an on-demand dump completes ([#549](https://github.com/dial9-rs/dial9/pull/549))

--- a/dial9-tokio-telemetry/README.md
+++ b/dial9-tokio-telemetry/README.md
@@ -287,6 +287,21 @@ Dial9Config::builder()
     // ...
 ```
 
+By default, dial9 tries the perf backend and falls back to ctimer if
+`perf_event_open` is blocked. You can select the backend explicitly:
+
+```rust,ignore
+// Use ctimer directly — zero thread lifecycle overhead, ideal for workloads
+// with high thread churn (e.g. saturated block_in_place usage).
+CpuProfilingConfig::with_ctimer_backend()
+
+// Require perf — fail instead of silently degrading. Needed for kernel
+// stacks or hardware event sources.
+CpuProfilingConfig::with_perf_backend()
+    .event_source(EventSource::SwCpuClock)
+    .include_kernel(true)
+```
+
 To use dial9 as a CPU profiler without installing Tokio runtime hooks, keep
 telemetry enabled and disable only Tokio instrumentation:
 

--- a/perf-self-profile/src/cpu_source.rs
+++ b/perf-self-profile/src/cpu_source.rs
@@ -132,10 +132,50 @@ pub(crate) fn read_thread_name(tid: u32) -> Option<String> {
 
 // ── Config types ────────────────────────────────────────────────────────────
 
+/// Which CPU profiling backend to use.
+///
+/// The backend determines how stack samples are collected. Each variant only
+/// exposes configuration knobs that the backend actually supports, making
+/// invalid combinations (e.g. ctimer + kernel stacks) unrepresentable.
+///
+/// # `DIAL9_FORCE_CTIMER` interaction
+///
+/// The `DIAL9_FORCE_CTIMER` environment variable is only respected by
+/// [`Auto`](CpuBackend::Auto). When [`Perf`](CpuBackend::Perf) or
+/// [`Ctimer`](CpuBackend::Ctimer) is specified explicitly, the env var is
+/// ignored — the caller has already made a deterministic choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CpuBackend {
+    /// Try perf first; falls back to ctimer if `perf_event_open` is blocked.
+    Auto,
+    /// Perf backend via `perf_event_open`. Fails if perf is blocked.
+    Perf,
+    /// Ctimer backend (userspace frame-pointer unwinding via `SIGPROF`).
+    Ctimer,
+}
+
 /// Configuration for CPU profiling integration.
+///
+/// # Examples
+///
+/// ```ignore
+/// use dial9_perf_self_profile::{CpuProfilingConfig, EventSource};
+///
+/// // Default: try perf, fall back to ctimer:
+/// let config = CpuProfilingConfig::default();
+///
+/// // Explicit perf with kernel stacks:
+/// let config = CpuProfilingConfig::with_perf_backend()
+///     .event_source(EventSource::SwCpuClock)
+///     .include_kernel(true);
+///
+/// // Explicit ctimer:
+/// let config = CpuProfilingConfig::with_ctimer_backend();
+/// ```
 #[derive(Debug, Clone)]
 pub struct CpuProfilingConfig {
     frequency_hz: u64,
+    backend: CpuBackend,
     event_source: EventSource,
     include_kernel: bool,
 }
@@ -144,6 +184,7 @@ impl Default for CpuProfilingConfig {
     fn default() -> Self {
         Self {
             frequency_hz: 99,
+            backend: CpuBackend::Auto,
             event_source: EventSource::SwCpuClock,
             include_kernel: false,
         }
@@ -151,19 +192,51 @@ impl Default for CpuProfilingConfig {
 }
 
 impl CpuProfilingConfig {
+    // ── Constructors ────────────────────────────────────────────────────────
+
+    /// Use the **perf** backend exclusively — no ctimer fallback.
+    ///
+    /// Fails at start time if `perf_event_open` is blocked. Use this when you
+    /// need capabilities only perf can provide (kernel stacks, hardware
+    /// counters, event-based sources).
+    pub fn with_perf_backend() -> Self {
+        Self {
+            backend: CpuBackend::Perf,
+            ..Self::default()
+        }
+    }
+
+    /// Use the **ctimer** backend exclusively — no perf attempt.
+    ///
+    /// Avoids perf's per-CPU inherited context overhead entirely. Only supports
+    /// frequency-based userspace CPU-time sampling (frame-pointer unwinding via
+    /// `SIGPROF`). Cannot capture kernel stacks or hardware events.
+    pub fn with_ctimer_backend() -> Self {
+        Self {
+            backend: CpuBackend::Ctimer,
+            ..Self::default()
+        }
+    }
+
+    // ── Setters ─────────────────────────────────────────────────────────────
+
     /// Sampling frequency in Hz. Default: 99 (low overhead).
     pub fn frequency_hz(mut self, hz: u64) -> Self {
         self.frequency_hz = hz;
         self
     }
 
-    /// Which perf event source to use.
+    /// Which perf event source to sample on. Default: `SwCpuClock`.
+    ///
+    /// Ignored by [`Ctimer`](CpuBackend::Ctimer).
     pub fn event_source(mut self, source: EventSource) -> Self {
         self.event_source = source;
         self
     }
 
-    /// Whether to include kernel stack frames.
+    /// Whether to include kernel stack frames. Default: `false`.
+    ///
+    /// Ignored by [`Ctimer`](CpuBackend::Ctimer).
     pub fn include_kernel(mut self, yes: bool) -> Self {
         self.include_kernel = yes;
         self
@@ -212,12 +285,25 @@ pub struct CpuProfiler {
 impl CpuProfiler {
     /// Start the process-wide CPU profiler with the given config.
     pub fn start(config: CpuProfilingConfig) -> io::Result<Self> {
-        let sampler = PerfSampler::start(
-            SamplerConfig::default()
-                .event_source(config.event_source)
-                .sampling(SamplingMode::FrequencyHz(config.frequency_hz))
-                .include_kernel(config.include_kernel),
-        )?;
+        let sampler = match config.backend {
+            CpuBackend::Auto => PerfSampler::start(
+                SamplerConfig::default()
+                    .event_source(config.event_source)
+                    .sampling(SamplingMode::FrequencyHz(config.frequency_hz))
+                    .include_kernel(config.include_kernel),
+            )?,
+            CpuBackend::Perf => PerfSampler::start_perf_only(
+                SamplerConfig::default()
+                    .event_source(config.event_source)
+                    .sampling(SamplingMode::FrequencyHz(config.frequency_hz))
+                    .include_kernel(config.include_kernel),
+            )?,
+            CpuBackend::Ctimer => PerfSampler::start_ctimer_only(
+                SamplerConfig::default()
+                    .sampling(SamplingMode::FrequencyHz(config.frequency_hz))
+                    .include_kernel(false),
+            )?,
+        };
         Ok(Self {
             sampler,
             pid: std::process::id(),

--- a/perf-self-profile/src/sys/linux/sampler.rs
+++ b/perf-self-profile/src/sys/linux/sampler.rs
@@ -35,8 +35,29 @@ pub(crate) fn is_perf_blocked(err: &io::Error) -> bool {
 
 impl PerfSampler {
     /// Start sampling the current process.
+    ///
+    /// Tries perf first, falls back to ctimer if `perf_event_open` is blocked.
+    /// Also respects the `DIAL9_FORCE_CTIMER` environment variable.
     pub fn start(config: SamplerConfig) -> io::Result<Self> {
         Self::start_for_pid(0, config)
+    }
+
+    /// Start sampling using only the perf backend. No ctimer fallback.
+    ///
+    /// Returns an error if `perf_event_open` is blocked or fails for any reason.
+    pub(crate) fn start_perf_only(config: SamplerConfig) -> io::Result<Self> {
+        let perf = PerfSamplerImpl::start_for_pid(0, &config)?;
+        Ok(Self {
+            inner: Box::new(perf),
+        })
+    }
+
+    /// Start sampling using only the ctimer backend. No perf attempt.
+    ///
+    /// Only supports frequency-based sampling. Returns an error for
+    /// period-based configurations.
+    pub(crate) fn start_ctimer_only(config: SamplerConfig) -> io::Result<Self> {
+        Self::with_ctimer_process_wide(&config)
     }
 
     /// Start sampling a specific process.

--- a/perf-self-profile/src/sys/unsupported.rs
+++ b/perf-self-profile/src/sys/unsupported.rs
@@ -22,6 +22,14 @@ impl PerfSampler {
         unsupported()
     }
 
+    pub(crate) fn start_perf_only(_config: SamplerConfig) -> io::Result<Self> {
+        unsupported()
+    }
+
+    pub(crate) fn start_ctimer_only(_config: SamplerConfig) -> io::Result<Self> {
+        unsupported()
+    }
+
     pub fn new_per_thread(_config: SamplerConfig) -> io::Result<Self> {
         unsupported()
     }


### PR DESCRIPTION
Introduce CpuProfilingConfig::with_perf_backend() and CpuProfilingConfig::with_ctimer_backend() constructors for explicit backend selection:

- with_perf_backend() — perf only, no ctimer fallback. Fails if
  perf_event_open is blocked.
- with_ctimer_backend() — ctimer only, avoids perf's per-CPU inherited
  context overhead on thread-heavy workloads.

https://github.com/dial9-rs/dial9/issues/579