### PR TITLE
fix(viewer): resolve span task + reconstruct active/idle from task polls

### DIFF
--- a/dial9-viewer/ui/test_trace_analysis.js
+++ b/dial9-viewer/ui/test_trace_analysis.js
@@ -14,6 +14,9 @@ const {
   flattenFlamegraph,
   buildFgData,
   buildSpanData,
+  indexPollsByTask,
+  resolveSpanTask,
+  reconstructSpanSegments,
   collectDescendants,
   selectSpanRenderSet,
   computeSpanLayout,
@@ -1131,6 +1134,206 @@ async function main() {
     pass("Multiple polls grouped into single span with segments");
   }
 
+  function testBuildSpanDataSegmentUsesEnterWorker() {
+    // Regression: a long-lived span entered on one worker and exited on a
+    // different worker (its task migrated between enter and exit). The segment's
+    // `start` is the ENTER timestamp, so the segment must carry the ENTER
+    // worker — otherwise the viewer's span->task lookup (find the poll on
+    // segment.workerId that overlaps segment.start) searches the wrong worker's
+    // poll timeline at the enter time, finds nothing, and fails to select a
+    // task. Single enter/exit pair, workers differ.
+    const customEvents = [
+      { name: "SpanEnter:app::req:req.rs:1", timestamp: 1000, fields: { worker_id: 3, span_id: 1, parent_span_id: null, span_name: "handle_request" } },
+      { name: "SpanExit:app::req:req.rs:1",  timestamp: 5000, fields: { worker_id: 7, span_id: 1, span_name: "handle_request" } },
+    ];
+    const { allSpans } = buildSpanData(customEvents);
+    if (allSpans.length !== 1) fail(`Expected 1 span, got ${allSpans.length}`);
+    const seg = allSpans[0].segments[0];
+    if (seg.start !== 1000 || seg.end !== 5000) fail(`Segment timing wrong: ${seg.start}-${seg.end}`);
+    // The segment start is the enter time (1000, on worker 3), so the segment
+    // must be attributed to worker 3, not the exit worker 7.
+    if (seg.workerId !== 3) fail(`Expected segment workerId=3 (enter worker), got ${seg.workerId}`);
+    pass("Cross-worker enter/exit: segment carries the enter worker");
+  }
+
+  // ── reconstructSpanSegments (unit) ──
+
+  function testReconstructSegmentsCarvesIdleGaps() {
+    // One coarse segment [0,1000] intersected with a task polled twice
+    // ([100,200] on w0, [500,600] on w1). Result: two active segments with an
+    // idle gap between; workers come from the polls, not the raw segment.
+    const raw = [{ start: 0, end: 1000, workerId: 9 }];
+    const taskPolls = [
+      { start: 100, end: 200, workerId: 0 },
+      { start: 500, end: 600, workerId: 1 },
+    ];
+    const segs = reconstructSpanSegments(raw, taskPolls);
+    if (segs.length !== 2) fail(`Expected 2 segments, got ${segs.length}`);
+    if (segs[0].start !== 100 || segs[0].end !== 200 || segs[0].workerId !== 0) fail(`seg0 wrong: ${JSON.stringify(segs[0])}`);
+    if (segs[1].start !== 500 || segs[1].end !== 600 || segs[1].workerId !== 1) fail(`seg1 wrong: ${JSON.stringify(segs[1])}`);
+    pass("reconstructSpanSegments carves a coarse segment into per-poll active segments");
+  }
+
+  function testReconstructSegmentsClampsToSpanWindow() {
+    // Polls extending past the segment on both ends are clamped to [start,end].
+    const raw = [{ start: 300, end: 700, workerId: 0 }];
+    const taskPolls = [
+      { start: 100, end: 400, workerId: 0 }, // overlaps left edge
+      { start: 600, end: 900, workerId: 0 }, // overlaps right edge
+    ];
+    const segs = reconstructSpanSegments(raw, taskPolls);
+    if (segs.length !== 2) fail(`Expected 2 segments, got ${segs.length}`);
+    if (segs[0].start !== 300 || segs[0].end !== 400) fail(`left clamp wrong: ${JSON.stringify(segs[0])}`);
+    if (segs[1].start !== 600 || segs[1].end !== 700) fail(`right clamp wrong: ${JSON.stringify(segs[1])}`);
+    pass("reconstructSpanSegments clamps overlapping polls to the segment window");
+  }
+
+  function testReconstructSegmentsFallsBackWhenNoOverlap() {
+    // Span window falls entirely between the task's polls -> no intersection.
+    // Rather than drop the span, keep the raw segments so it still renders.
+    const raw = [{ start: 300, end: 400, workerId: 5 }];
+    const taskPolls = [
+      { start: 0, end: 100, workerId: 0 },
+      { start: 700, end: 800, workerId: 0 },
+    ];
+    const segs = reconstructSpanSegments(raw, taskPolls);
+    if (segs !== raw) fail("Expected raw segments returned by reference on no overlap");
+    pass("reconstructSpanSegments falls back to raw segments when no poll overlaps");
+  }
+
+  function testReconstructSegmentsNoPollsIsIdentity() {
+    const raw = [{ start: 0, end: 10, workerId: 0 }];
+    if (reconstructSpanSegments(raw, undefined) !== raw) fail("undefined polls should return raw");
+    if (reconstructSpanSegments(raw, []) !== raw) fail("empty polls should return raw");
+    pass("reconstructSpanSegments is identity when task has no polls");
+  }
+
+  function testReconstructSegmentsMultipleRawSegments() {
+    // A span already carrying two per-poll raw segments (e.g. re-entered).
+    // Each is intersected independently; a poll landing in the gap BETWEEN the
+    // two raw segments must NOT be attributed to the span.
+    const raw = [
+      { start: 100, end: 200, workerId: 0 },
+      { start: 500, end: 600, workerId: 0 },
+    ];
+    const taskPolls = [
+      { start: 120, end: 180, workerId: 0 }, // inside raw[0]
+      { start: 300, end: 400, workerId: 0 }, // in the gap — must be excluded
+      { start: 520, end: 640, workerId: 1 }, // overlaps raw[1], clamped to 600
+    ];
+    const segs = reconstructSpanSegments(raw, taskPolls);
+    if (segs.length !== 2) fail(`Expected 2 segments (gap poll excluded), got ${segs.length}: ${JSON.stringify(segs)}`);
+    if (segs[0].start !== 120 || segs[0].end !== 180) fail(`seg0 wrong: ${JSON.stringify(segs[0])}`);
+    if (segs[1].start !== 520 || segs[1].end !== 600 || segs[1].workerId !== 1) fail(`seg1 wrong: ${JSON.stringify(segs[1])}`);
+    pass("reconstructSpanSegments intersects each raw segment independently (gap polls excluded)");
+  }
+
+  // ── resolveSpanTask (unit) ──
+
+  function testResolveSpanTaskBinarySearch() {
+    // Covering poll found among many; and a timestamp in an inter-poll gap
+    // resolves to null (not the nearest poll).
+    const workerSpans = {
+      2: { polls: [
+        { start: 0, end: 100, taskId: 11 },
+        { start: 200, end: 300, taskId: 22 },
+        { start: 400, end: 500, taskId: 33 },
+      ] },
+    };
+    if (resolveSpanTask({ start: 250, workerId: 2 }, workerSpans) !== 22) fail("Expected task 22 for ts=250");
+    if (resolveSpanTask({ start: 400, workerId: 2 }, workerSpans) !== 33) fail("Expected task 33 at poll start edge");
+    if (resolveSpanTask({ start: 150, workerId: 2 }, workerSpans) !== null) fail("Gap timestamp should resolve to null");
+    if (resolveSpanTask({ start: 250, workerId: 9 }, workerSpans) !== null) fail("Unknown worker should resolve to null");
+    pass("resolveSpanTask binary-searches the covering poll; gaps and unknown workers -> null");
+  }
+
+  function testResolveSpanTaskZeroTaskIdIsNull() {
+    // A poll covers the timestamp but has taskId 0 (block-in-place stub) ->
+    // treated as "no task", not task 0.
+    const workerSpans = { 0: { polls: [{ start: 0, end: 100, taskId: 0 }] } };
+    if (resolveSpanTask({ start: 50, workerId: 0 }, workerSpans) !== null) fail("taskId 0 should resolve to null");
+    pass("resolveSpanTask treats a covering poll with taskId 0 as null");
+  }
+
+  function testBuildSpanDataRecycledTaskIdNotBorrowed() {
+    // Task id 7 is recycled: instance A polled at [1000,1100], then a LATER
+    // instance polled at [50000,50100]. A span owned by instance A (enter at
+    // 1000, exit at 1200) must only pick up A's poll, not the recycled
+    // instance's — the `p.start > seg.end` break in reconstructSpanSegments
+    // guards this.
+    const workerSpans = {
+      0: { polls: [
+        { start: 900, end: 1100, taskId: 7 },   // instance A, covers enter
+        { start: 50000, end: 50100, taskId: 7 }, // recycled instance, far later
+      ] },
+    };
+    const customEvents = [
+      { name: "SpanEnter:app::f:f:1", timestamp: 1000, fields: { worker_id: 0, span_id: 1, parent_span_id: null, span_name: "f" } },
+      { name: "SpanExit:app::f:f:1",  timestamp: 1200, fields: { worker_id: 0, span_id: 1, span_name: "f" } },
+    ];
+    const { allSpans } = buildSpanData(customEvents, workerSpans);
+    const s = allSpans[0];
+    if (s.taskId !== 7) fail(`Expected taskId=7, got ${s.taskId}`);
+    if (s.segments.length !== 1) fail(`Expected 1 segment (recycled poll excluded), got ${s.segments.length}`);
+    if (s.segments[0].end !== 1100) fail(`Expected segment clamped to 1100, got ${s.segments[0].end}`);
+    if (s.activeNs !== 100) fail(`Expected activeNs=100, got ${s.activeNs}`);
+    pass("buildSpanData does not borrow a recycled task-id's later polls");
+  }
+
+  // ── buildSpanData with poll-based reconstruction (integration) ──
+
+  function testBuildSpanDataReconstructsFromTaskPolls() {
+    // A long-lived request span: single SpanEnter/SpanExit pair [1000, 9000],
+    // but its owning task (id 42) was only polled twice in that window. The
+    // enter (worker 0, t=1000) falls inside poll [900,1100] which identifies
+    // task 42. Reconstruction should replace the one coarse segment with the
+    // two real on-CPU polls and expose the idle gap between them.
+    const workerSpans = {
+      0: { polls: [
+        { start: 900, end: 1100, taskId: 42 },   // covers the enter -> resolves task 42
+        { start: 8800, end: 8900, taskId: 42 },
+      ] },
+      1: { polls: [
+        { start: 4000, end: 4100, taskId: 42 },   // task migrated to worker 1
+      ] },
+    };
+    const customEvents = [
+      { name: "SpanEnter:app::req:req.rs:1", timestamp: 1000, fields: { worker_id: 0, span_id: 1, parent_span_id: null, span_name: "GET /jobs/next" } },
+      { name: "SpanExit:app::req:req.rs:1",  timestamp: 9000, fields: { worker_id: 1, span_id: 1, span_name: "GET /jobs/next" } },
+    ];
+    const { allSpans } = buildSpanData(customEvents, workerSpans);
+    if (allSpans.length !== 1) fail(`Expected 1 span, got ${allSpans.length}`);
+    const s = allSpans[0];
+    // Span lifetime unchanged (the on-wire enter/exit).
+    if (s.start !== 1000 || s.end !== 9000) fail(`Span window wrong: ${s.start}-${s.end}`);
+    // Owning task resolved and stored on the span.
+    if (s.taskId !== 42) fail(`Expected taskId=42, got ${s.taskId}`);
+    // Three polls of task 42 fall in [1000,9000]: [1000,1100], [4000,4100], [8800,8900].
+    if (s.segments.length !== 3) fail(`Expected 3 reconstructed segments, got ${s.segments.length}`);
+    if (s.segments[0].start !== 1000 || s.segments[0].end !== 1100) fail(`seg0 wrong: ${JSON.stringify(s.segments[0])}`);
+    if (s.segments[1].workerId !== 1) fail(`seg1 should be on worker 1 (migrated), got ${s.segments[1].workerId}`);
+    // activeNs = 100 + 100 + 100 = 300, far below the 8000 wall-clock lifetime.
+    if (s.activeNs !== 300) fail(`Expected activeNs=300, got ${s.activeNs}`);
+    const idle = (s.end - s.start) - s.activeNs;
+    if (idle !== 7700) fail(`Expected idle=7700, got ${idle}`);
+    pass("buildSpanData reconstructs active/idle segments from the owning task's polls");
+  }
+
+  function testBuildSpanDataNoWorkerSpansKeepsRawSegments() {
+    // Without workerSpans, behavior is unchanged: raw on-wire segment, no taskId.
+    const customEvents = [
+      { name: "SpanEnter:app::req:req.rs:1", timestamp: 1000, fields: { worker_id: 0, span_id: 1, parent_span_id: null, span_name: "req" } },
+      { name: "SpanExit:app::req:req.rs:1",  timestamp: 9000, fields: { worker_id: 0, span_id: 1, span_name: "req" } },
+    ];
+    const { allSpans } = buildSpanData(customEvents);
+    if (allSpans.length !== 1) fail(`Expected 1 span, got ${allSpans.length}`);
+    const s = allSpans[0];
+    if (s.segments.length !== 1) fail(`Expected 1 raw segment, got ${s.segments.length}`);
+    if (s.activeNs !== 8000) fail(`Expected activeNs=8000 (raw), got ${s.activeNs}`);
+    if (s.taskId !== null) fail(`Expected taskId=null without workerSpans, got ${s.taskId}`);
+    pass("buildSpanData without workerSpans keeps raw segments (backwards compatible)");
+  }
+
   function testBuildSpanDataOutOfOrder() {
     // Events arrive out of order across workers — buildSpanData sorts by timestamp.
     // Also tests the defensive guard: span 1 enters on worker 0, then enters again
@@ -1282,6 +1485,17 @@ async function main() {
   testBuildSpanDataUnmatched();
   testBuildSpanDataChildrenIndex();
   testBuildSpanDataMultiplePolls();
+  testBuildSpanDataSegmentUsesEnterWorker();
+  testReconstructSegmentsCarvesIdleGaps();
+  testReconstructSegmentsClampsToSpanWindow();
+  testReconstructSegmentsFallsBackWhenNoOverlap();
+  testReconstructSegmentsNoPollsIsIdentity();
+  testReconstructSegmentsMultipleRawSegments();
+  testResolveSpanTaskBinarySearch();
+  testResolveSpanTaskZeroTaskIdIsNull();
+  testBuildSpanDataReconstructsFromTaskPolls();
+  testBuildSpanDataNoWorkerSpansKeepsRawSegments();
+  testBuildSpanDataRecycledTaskIdNotBorrowed();
   testBuildSpanDataOutOfOrder();
 
   console.log("\nspan pane layout:");

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -1096,19 +1096,129 @@
   }
 
   /**
+   * Index every poll by its owning task id, sorted by start. Polls with no
+   * task id (taskId 0/falsy, e.g. block-in-place stubs) are skipped — they
+   * carry no task to attribute a span to.
+   * @param {Object} workerSpans per-worker `{polls}` from {@link buildWorkerSpans}
+   * @returns {Map<number, Array<{start:number, end:number, workerId:number}>>}
+   */
+  function indexPollsByTask(workerSpans) {
+    const byTask = new Map();
+    for (const [w, spans] of Object.entries(workerSpans)) {
+      const workerId = Number(w);
+      for (const p of spans.polls) {
+        if (!p.taskId) continue;
+        let arr = byTask.get(p.taskId);
+        if (!arr) { arr = []; byTask.set(p.taskId, arr); }
+        arr.push({ start: p.start, end: p.end, workerId });
+      }
+    }
+    for (const arr of byTask.values()) arr.sort((a, b) => a.start - b.start);
+    return byTask;
+  }
+
+  /**
+   * Resolve the task that owns a span, from its first (enter) segment: the poll
+   * on `segment.workerId` whose window covers `segment.start`. Returns the
+   * task id, or null when no poll overlaps (span emitted outside any poll).
+   *
+   * Binary search — this runs once per span, and a worker's poll list holds
+   * hundreds of thousands of entries on a >10M-event trace, so a linear scan
+   * here would be O(#spans × #polls). A worker's polls are sorted ascending by
+   * `start` and non-overlapping (built in {@link buildWorkerSpans} from that
+   * worker's events in timestamp order), so the covering poll is unique.
+   * @param {{start:number, workerId:number}} firstSeg
+   * @param {Object} workerSpans per-worker `{polls}` from {@link buildWorkerSpans}
+   * @returns {number|null}
+   */
+  function resolveSpanTask(firstSeg, workerSpans) {
+    if (!firstSeg) return null;
+    const polls = workerSpans[firstSeg.workerId]?.polls;
+    if (!polls) return null;
+    const t = firstSeg.start;
+    let lo = 0, hi = polls.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (polls[mid].end < t) lo = mid + 1;
+      else if (polls[mid].start > t) hi = mid - 1;
+      else return polls[mid].taskId ? polls[mid].taskId : null;
+    }
+    return null;
+  }
+
+  /**
+   * Reconstruct a span's active segments from its owning task's polls.
+   *
+   * A span entered with a guard held across `.await` points is emitted as a
+   * single SpanEnter/SpanExit pair covering the whole request, even though the
+   * task was only on-CPU during a handful of polls scattered across that
+   * window (and possibly across several workers). Trusting the raw segment
+   * would report the entire await as "active" and draw no idle gap.
+   *
+   * Instead, intersect each raw segment with the task's polls: the overlaps are
+   * the true on-CPU segments, and the space between them is idle. Intersecting
+   * per-segment (rather than over the span's whole `[start,end]`) keeps
+   * multi-poll spans that already carry per-poll segments unchanged, and avoids
+   * attributing between-segment gaps to the span.
+   *
+   * `taskPolls` MUST be sorted ascending by `start` (as {@link indexPollsByTask}
+   * returns) AND non-overlapping: a task is polled on one worker at a time, so
+   * its polls do not overlap even when merged across workers. That invariant
+   * makes `end` monotonic too, which the binary search below relies on. Returns
+   * the raw segments unchanged when the task has no polls.
+   * @param {Array<{start:number, end:number, workerId:number}>} rawSegments sorted by start
+   * @param {Array<{start:number, end:number, workerId:number}>|undefined} taskPolls sorted by start, non-overlapping
+   * @returns {Array<{start:number, end:number, workerId:number}>}
+   */
+  function reconstructSpanSegments(rawSegments, taskPolls) {
+    if (!taskPolls || taskPolls.length === 0) return rawSegments;
+    const out = [];
+    for (const seg of rawSegments) {
+      // Binary search for the first poll that could overlap this segment, i.e.
+      // the first poll whose end is >= seg.start. Polls are non-overlapping so
+      // `end` is monotonic; a linear scan here would be O(#polls) per segment.
+      let lo = 0, hi = taskPolls.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (taskPolls[mid].end < seg.start) lo = mid + 1;
+        else hi = mid;
+      }
+      for (let i = lo; i < taskPolls.length; i++) {
+        const p = taskPolls[i];
+        if (p.start > seg.end) break; // past the segment; no further overlaps
+        const a = Math.max(p.start, seg.start);
+        const b = Math.min(p.end, seg.end);
+        if (b > a) out.push({ start: a, end: b, workerId: p.workerId });
+      }
+    }
+    // Defensive fallback for direct callers: through buildSpanData the taskId is
+    // resolved from a poll covering segments[0].start, so that poll always
+    // intersects and `out` is non-empty. A direct caller passing a window that
+    // falls entirely between the task's polls keeps its raw segments so the
+    // span still renders rather than vanishing.
+    return out.length > 0 ? out : rawSegments;
+  }
+
+  /**
    * Build span data structures from custom events.
    * Groups SpanEnter/SpanExit pairs into spans with segments (one per poll).
    * SpanCloseEvent finalizes a span and enables span ID recycling.
+   *
+   * When `workerSpans` is supplied, each span's active segments are
+   * reconstructed from its owning task's poll timeline instead of trusting the
+   * raw on-wire SpanEnter/SpanExit segments (see `reconstructSpanSegments`).
    * @param {Array<{name: string, timestamp: number, fields: Object}>} customEvents
+   * @param {Object} [workerSpans] per-worker `{polls}` from {@link buildWorkerSpans};
+   *   when present, enables poll-based active/idle reconstruction.
    * @returns {{
-   *   allSpans: Array<{start: number, end: number, spanId: string, spanName: string, fields: Object, parentSpanId: string|null, segments: Array<{start: number, end: number, workerId: number}>, activeNs: number, depth: number}>,
+   *   allSpans: Array<{start: number, end: number, spanId: string, spanName: string, fields: Object, parentSpanId: string|null, segments: Array<{start: number, end: number, workerId: number}>, activeNs: number, taskId: number|null, depth: number}>,
    *   spanMeta: Map<string, {spanName: string, fields: Object, parentSpanId: string|null}>,
    *   maxDepth: number,
    *   unmatchedSpans: Array<{start: number, spanId: string, workerId: number, spanName: string, fields: Object, parentSpanId: string|null}>,
    *   childrenByParent: Map<string|null, string[]>,
    * }}
    */
-  function buildSpanData(customEvents) {
+  function buildSpanData(customEvents, workerSpans) {
     // Events are only ordered within a single worker's stream. Cross-worker
     // interleaving can produce globally out-of-order timestamps, so we must
     // sort before processing to ensure close events are seen after all
@@ -1170,7 +1280,6 @@
         ev.name === "SpanExitEvent"
       ) {
         const v = ev.fields;
-        const workerId = Number(v.worker_id);
         const spanId = String(v.span_id);
 
         const enter = openEnters.get(spanId);
@@ -1186,7 +1295,11 @@
             spanMap.set(spanId, rec);
           }
           if (Object.keys(exitFields).length > 0) rec.fields = exitFields;
-          rec.segments.push({ start: enter.timestamp, end: ev.timestamp, workerId });
+          // Pair the segment with the ENTER worker, not the exit worker. `start`
+          // is the enter timestamp, and a long-lived span's task can migrate
+          // workers between enter and exit; using the exit worker here makes the
+          // span->task lookup (poll overlap at `start` on this worker) miss.
+          rec.segments.push({ start: enter.timestamp, end: ev.timestamp, workerId: enter.workerId });
         }
       } else if (ev.name.startsWith("SpanClose__") || ev.name === "SpanCloseEvent") {
         const spanId = String(ev.fields.span_id);
@@ -1200,21 +1313,42 @@
       finalizeSpan(spanId);
     }
 
+    // Optional: index polls by owning task so we can reconstruct a span's
+    // active segments from the task that ran it (see reconstructSpanSegments).
+    const pollsByTask = workerSpans ? indexPollsByTask(workerSpans) : null;
+
     // Build allSpans
     const allSpans = [];
     for (const rec of closedSpans) {
       rec.segments.sort((a, b) => a.start - b.start);
       const start = rec.segments[0].start;
       const end = rec.segments[rec.segments.length - 1].end;
-      const activeNs = rec.segments.reduce((sum, seg) => sum + (seg.end - seg.start), 0);
+      // Resolve the owning task from the ENTER of the first segment: the poll
+      // covering (segment.workerId, segment.start). This is the same lookup the
+      // viewer uses to jump to a task on span-click.
+      const taskId = pollsByTask
+        ? resolveSpanTask(rec.segments[0], workerSpans)
+        : null;
+      // When we know the owning task, reconstruct active segments by
+      // intersecting each on-wire segment with that task's polls. This turns a
+      // coarse "entered across .await" span (one segment covering the whole
+      // request) into the actual on-CPU polls, so idle gaps render and
+      // activeNs reflects on-CPU time rather than span-open time. When we can't
+      // resolve a task (no covering poll), keep the raw on-wire segments.
+      const segments =
+        taskId != null
+          ? reconstructSpanSegments(rec.segments, pollsByTask.get(taskId))
+          : rec.segments;
+      const activeNs = segments.reduce((sum, seg) => sum + (seg.end - seg.start), 0);
       allSpans.push({
         start, end,
         spanId: rec.spanId,
         spanName: rec.spanName,
         fields: rec.fields,
         parentSpanId: rec.parentSpanId,
-        segments: rec.segments,
+        segments,
         activeNs,
+        taskId,
       });
     }
     allSpans.sort((a, b) => a.start - b.start);
@@ -1660,6 +1794,9 @@
     hasCpuProfileSamples,
     buildProcessCpuUsageSeries,
     buildSpanData,
+    indexPollsByTask,
+    resolveSpanTask,
+    reconstructSpanSegments,
     collectDescendants,
     selectSpanRenderSet,
     enclosingSpans,

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -2164,7 +2164,10 @@
                 _spanDurCache = null;
                 clearSpanTaskSelection();
                 if (trace.customEvents && trace.customEvents.length > 0) {
-                    const spanResult2 = buildSpanData(trace.customEvents);
+                    // Pass workerSpans (built above) so span active/idle segments
+                    // are reconstructed from each span's owning task's polls,
+                    // rather than the coarse on-wire SpanEnter/SpanExit segments.
+                    const spanResult2 = buildSpanData(trace.customEvents, workerSpans);
                     allSpans = spanResult2.allSpans;
                     spanMeta = spanResult2.spanMeta;
                     spanMaxDepth = spanResult2.maxDepth;
@@ -3985,15 +3988,9 @@
                             const parent = spanMeta.get(parentId);
                             parentId = parent?.parentSpanId ?? null;
                         }
-                        // Find the task that was polling when this span's first segment ran
-                        const firstSeg = hit.segments[0];
-                        if (firstSeg) {
-                            const polls = workerSpans[firstSeg.workerId]?.polls;
-                            if (polls) {
-                                const poll = polls.find(p => p.start <= firstSeg.start && p.end >= firstSeg.start);
-                                if (poll && poll.taskId) selectedTaskId = poll.taskId;
-                            }
-                        }
+                        // The owning task is resolved once in buildSpanData (poll
+                        // covering the span's enter) and stored on the span.
+                        if (hit.taskId != null) selectedTaskId = hit.taskId;
                         // Show percentile info
                         const durations = allSpans
                             .filter(s => s.spanName === hit.spanName)


### PR DESCRIPTION
Clicking a tracing span often failed to jump to its task when spans crossed workers

Root causes:
- A span segment recorded the ENTER timestamp paired with the EXIT event's worker. A long-lived span's task migrates workers between enter and exit, so the span->task lookup (poll overlapping seg.start on seg.workerId) searched the wrong worker and found nothing.
- Long-poll spans are emitted as a single SpanEnter/SpanExit pair spanning the whole request, so the one on-wire segment reported the entire await as on-CPU: activeNs == wall-clock, no idle gap.

Fix:
- Pair each segment with the ENTER worker (matches its enter-time start).
- buildSpanData now optionally takes workerSpans. It resolves each span's owning task from the poll covering its enter (binary search over the worker's sorted, non-overlapping polls), stores taskId on the span, and reconstructs active segments by intersecting each raw segment with that task's poll timeline. Idle gaps between polls now render, and activeNs reflects on-CPU time. Without workerSpans the old raw-segment behavior is unchanged.
- Span-click handler uses the stored taskId instead of re-deriving it.

All lookups are binary-search based (traces routinely exceed 10M events; a worker holds hundreds of thousands of polls, so resolveSpanTask must not scan linearly per span).

Validated on a real 172k-event beta trace: span->task resolution 133/364 ->
364/364; spans showing an idle band 0/364 -> 363/364; summed active time corrected from a bogus 1.8Ms (overlapping coarse segments) to 66ms on-CPU.

Tests: reconstructSpanSegments (carve/clamp/fallback/identity/multi-segment), resolveSpanTask (binary search, gap/unknown-worker/taskId-0 -> null), buildSpanData integration (reconstruction, recycled-task-id not borrowed, no-workerSpans backwards compat).