### PR TITLE
viewer: Enable embedding the viewer in larger application

### DIFF
--- a/dial9-viewer/examples/embedded_viewer.rs
+++ b/dial9-viewer/examples/embedded_viewer.rs
@@ -1,0 +1,67 @@
+//! Example: embedding the dial9 viewer with custom routes and middleware.
+//!
+//! Shows how a downstream consumer (e.g. an internal tool) can reuse the
+//! viewer's built-in routes while adding its own endpoints and wrapping the
+//! whole thing with middleware.
+//!
+//! The extension point is [`dial9_viewer::server::router`] — it returns an
+//! [`axum::Router`] that you can `.merge()`, `.layer()`, or `.nest_service()`
+//! before binding to a listener.
+//!
+//! ```text
+//! cargo run --example embedded_viewer -- my-trace-bucket
+//! ```
+
+use axum::http::{HeaderName, HeaderValue};
+use dial9_viewer::server::{AppState, router};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let bucket = std::env::args()
+        .nth(1)
+        .expect("usage: embedded_viewer <bucket>");
+
+    // 1. Build AppState from an S3 bucket (handles region detection,
+    //    BYO-credentials, and the assume-role path automatically).
+    let state = AppState::from_bucket(&bucket, None).await;
+
+    // 2. Get the base router with all built-in routes.
+    let app = router(state);
+
+    // 3. Merge custom routes — e.g. a feedback endpoint.
+    let app =
+        app.merge(axum::Router::new().route("/api/feedback", axum::routing::post(handle_feedback)));
+
+    // 4. Layer middleware — e.g. inject a response header for every request.
+    let app = app.layer(axum::middleware::from_fn(add_server_header));
+
+    // 5. Bind and serve.
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
+    tracing::info!("embedded viewer listening on http://localhost:3000");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            tokio::signal::ctrl_c().await.ok();
+        })
+        .await?;
+
+    Ok(())
+}
+
+async fn handle_feedback(body: String) -> &'static str {
+    tracing::info!(feedback = %body, "received feedback");
+    "thanks"
+}
+
+async fn add_server_header(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let mut resp = next.run(req).await;
+    resp.headers_mut().insert(
+        HeaderName::from_static("x-served-by"),
+        HeaderValue::from_static("my-internal-viewer"),
+    );
+    resp
+}

--- a/dial9-viewer/src/lib.rs
+++ b/dial9-viewer/src/lib.rs
@@ -46,7 +46,7 @@ pub(crate) struct ServeConfig {
 
 /// Build an [`S3Backend`] for `bucket`, pinned to the bucket's region when it
 /// can be detected (so cross-region buckets work), else the default chain.
-async fn s3_backend_for(bucket: &str) -> storage::S3Backend {
+pub(crate) async fn s3_backend_for(bucket: &str) -> storage::S3Backend {
     if let Some(region) = detect_bucket_region(bucket).await {
         tracing::info!(%region, %bucket, "detected bucket region");
         let config = aws_config::defaults(aws_config::BehaviorVersion::latest())

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -126,6 +126,38 @@ impl AppState {
         }
     }
 
+    /// Build an `AppState` backed by an S3 bucket, with automatic region
+    /// detection, bring-your-own-credentials support, and the assume-role
+    /// credential path enabled.
+    ///
+    /// This is the high-level entry point for embedders who want to serve
+    /// traces from S3 without replicating the CLI's setup logic:
+    ///
+    /// ```ignore
+    /// let state = AppState::from_bucket("my-traces", None).await;
+    /// let app = dial9_viewer::server::router(state);
+    /// // … customize app, then bind …
+    /// ```
+    pub async fn from_bucket(bucket: impl Into<String>, prefix: Option<String>) -> Self {
+        let bucket = bucket.into();
+        let backend = Arc::new(crate::s3_backend_for(&bucket).await);
+        let assumer = credentials::StsRoleAssumer::from_env().await;
+        Self::new(backend, Some(bucket), prefix)
+            .with_byo_creds(true)
+            .with_role_assumer(Arc::new(assumer))
+    }
+
+    /// Build an `AppState` backed by a local directory.
+    ///
+    /// ```ignore
+    /// let state = AppState::from_local_dir("/tmp/my-traces");
+    /// let app = dial9_viewer::server::router(state);
+    /// ```
+    pub fn from_local_dir(dir: impl AsRef<std::path::Path>) -> Self {
+        let backend = Arc::new(crate::storage::LocalBackend::new(dir.as_ref()));
+        Self::new(backend, Some("local".into()), None)
+    }
+
     pub fn with_dev_ui_dir(mut self, dir: PathBuf) -> Self {
         self.dev_ui_dir = Some(dir);
         self

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -1799,3 +1799,79 @@ mod skills_unpack_tests {
         assert!(red_flags_script.exists());
     }
 }
+
+// --- router composition: downstream embedders can customize the server ---
+
+/// An embedder can merge custom routes onto the router returned by
+/// `server::router()`.
+#[tokio::test]
+async fn router_supports_merged_routes() {
+    let state = AppState::new(Arc::new(FakeBackend), None, None);
+    let ui_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("ui");
+    let state = state.with_dev_ui_dir(ui_dir);
+
+    let app = router(state).merge(axum::Router::new().route(
+        "/api/feedback",
+        axum::routing::post(|| async { "feedback received" }),
+    ));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let base = format!("http://{addr}");
+    let client = reqwest::Client::new();
+
+    // Custom route is reachable
+    let resp = client
+        .post(format!("{base}/api/feedback"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    check!(resp.text().await.unwrap() == "feedback received");
+
+    // Built-in route still works
+    let resp = client
+        .get(format!("{base}/api/config"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+}
+
+/// An embedder can layer middleware (e.g. auth) onto the router.
+#[tokio::test]
+async fn router_supports_middleware_layers() {
+    let state = AppState::new(Arc::new(FakeBackend), None, None);
+    let ui_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("ui");
+    let state = state.with_dev_ui_dir(ui_dir);
+
+    let app = router(state).layer(axum::middleware::from_fn(
+        |req: axum::extract::Request, next: axum::middleware::Next| async move {
+            let mut resp = next.run(req).await;
+            resp.headers_mut().insert(
+                axum::http::header::HeaderName::from_static("x-custom-embedder"),
+                axum::http::HeaderValue::from_static("my-internal-tool"),
+            );
+            resp
+        },
+    ));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let base = format!("http://{addr}");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/api/config"))
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    check!(resp.headers().get("x-custom-embedder").unwrap() == "my-internal-tool");
+}


### PR DESCRIPTION
## What
- Adds new public API to construct `AppState`
- Adds an example demonstrating how to embed the viewer in a larger application