### PR TITLE
feat(viewer): v0 of flamegraph inspect

### DIFF
--- a/dial9-viewer/ui/flamegraph.css
+++ b/dial9-viewer/ui/flamegraph.css
@@ -8,6 +8,10 @@
     background: #16213e;
     border-bottom: 1px solid #222;
     flex-shrink: 0;
+    /* Anchor the absolutely-positioned search-results dropdown (top:100%) to the
+       bar itself; without this it resolves against #fg-container and lands at
+       the bottom of the viewport. */
+    position: relative;
 }
 .fg-search-input {
     background: #2a2a4a;
@@ -165,6 +169,135 @@
     max-width: min(600px, calc(100vw - 24px));
     overflow-wrap: anywhere;
     color: #e0e0e0;
+}
+
+/* ── Right-click context menu (Inspect / Zoom out / Copy name) ── */
+.fg-ctx-menu {
+    position: fixed;
+    z-index: 250;
+    background: #16213e;
+    border: 1px solid #444;
+    border-radius: 5px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.5);
+    padding: 4px;
+    min-width: 150px;
+}
+.fg-ctx-menu button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    color: #ddd;
+    cursor: pointer;
+    font-size: 0.85em;
+    padding: 6px 10px;
+    border-radius: 3px;
+    white-space: nowrap;
+}
+.fg-ctx-menu button:hover { background: #2a2a4a; color: #fff; }
+.fg-ctx-menu .fg-ctx-inspect { color: #b7b0ff; }
+
+/* ── Search results dropdown (issue #653) ── */
+.fg-search-results {
+    position: absolute;
+    top: 100%;
+    left: 12px;
+    margin-top: 4px;
+    background: #16213e;
+    border: 1px solid #444;
+    border-radius: 5px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+    z-index: 30;
+    width: 460px;
+    max-width: calc(100vw - 24px);
+    max-height: 420px;
+    overflow-y: auto;
+    padding: 4px;
+}
+.fg-sr-header {
+    color: #9aa;
+    font-size: 0.75em;
+    padding: 4px 8px 6px;
+    border-bottom: 1px solid #2a2a4a;
+    margin-bottom: 2px;
+}
+.fg-sr-empty { color: #888; font-size: 0.82em; padding: 8px 10px; }
+.fg-sr-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-radius: 3px;
+    cursor: pointer;
+    position: relative;
+}
+.fg-sr-row:hover { background: #2a2a4a; }
+.fg-sr-bar {
+    flex: 0 0 auto;
+    height: 10px;
+    min-width: 2px;
+    max-width: 90px;
+    border-radius: 2px;
+    opacity: 0.85;
+}
+.fg-sr-name {
+    flex: 1 1 auto;
+    color: #e0e0e0;
+    font-family: monospace;
+    font-size: 0.82em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.fg-sr-size {
+    flex: 0 0 auto;
+    color: #9aa;
+    font-size: 0.76em;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+/* ── Inspect (butterfly) view (issue #652) ── */
+/* The whole butterfly scrolls as one unit inside .fg-body; the focus band is
+   sticky so it stays on screen while scrolling through tall stacks. */
+.fg-inspect { display: flex; flex-direction: column; }
+.fg-inspect-label { color: #b7b0ff; flex-shrink: 0; }
+/* The focused frame. Deliberately NOT tinted by the per-frame hash color and
+   NOT rounded — it's chrome, not a flame frame, so it always looks identical:
+   a flat accent band with a bright left rule and a soft glow that lifts it off
+   the frames it's pinned over. */
+.fg-focus-band {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 6px 12px 6px 14px;
+    background: #2b2748;
+    border-left: 4px solid #6c63ff;
+    border-top: 1px solid rgba(108, 99, 255, 0.5);
+    border-bottom: 1px solid rgba(108, 99, 255, 0.5);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
+    overflow: hidden;
+    flex-shrink: 0;
+    /* Pin the band to the top of the scroll viewport while scrolling down into
+       callers, and to the bottom while scrolling up into callees. */
+    position: sticky;
+    top: 0;
+    bottom: 0;
+    z-index: 5;
+}
+.fg-focus-name {
+    font-family: monospace;
+    font-weight: 700;
+    color: #fff;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.fg-focus-stat {
+    color: #b7b0ff;
+    font-size: 0.8em;
+    white-space: nowrap;
 }
 
 /* ── Two-sided differential flamegraph (diff=1) ── */

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -135,6 +135,35 @@
                     errorEl.textContent = msg;
                 }
 
+                // ── View state <-> URL (single source of truth) ──────────────
+                // "Deep-link anything" means the URL IS the store for the
+                // flamegraph's view state (the zoom path + the inspect/butterfly
+                // focus). Rather than a framework, we centralize the encode/decode
+                // in these two pure helpers so every mode (exact-trace and API
+                // aggregate) serializes and restores focus identically — a shared
+                // link always reproduces the exact focus position. The renderer
+                // owns the live state; these functions are the only place that
+                // maps it to/from URL params.
+                function writeViewState(p, fg) {
+                    const z = fg.getZoomPath();
+                    if (z.worker && z.worker.length) p.set("worker-zoom", z.worker.join("\t"));
+                    else p.delete("worker-zoom");
+                    if (z.offworker && z.offworker.length) p.set("offworker-zoom", z.offworker.join("\t"));
+                    else p.delete("offworker-zoom");
+                    const inspect = fg.getInspectFocus();
+                    if (inspect) p.set("inspect", inspect);
+                    else p.delete("inspect");
+                    return p;
+                }
+                function restoreViewState(fg, p) {
+                    const wz = p.get("worker-zoom");
+                    const oz = p.get("offworker-zoom");
+                    if (wz) fg.zoomToPath("worker", wz.split("\t"));
+                    if (oz) fg.zoomToPath("offworker", oz.split("\t"));
+                    const inspect = p.get("inspect");
+                    if (inspect) fg.focusInspectByKey(inspect);
+                }
+
                 // --- Diff mode: two-sided differential flamegraph (?diff=1) ---
                 // Side A (left) and side B (right) are independent aggregate
                 // scopes (each a base64url'd query in `a=`/`b=`). Both default to
@@ -464,7 +493,7 @@
                         <button id="f-more" style="background:#2a2a4a;color:#e0e0e0;${btnStyle}">Refine more</button>
                         <button id="f-stop" style="background:#2a2a4a;color:#e0e0e0;${btnStyle};opacity:0.4;cursor:not-allowed" disabled>Stop</button>
                         <span style="flex:1"></span>
-                        <button id="f-copylink" title="Copy a link that re-fetches this exact scope (bucket/prefix included; no credentials)" style="background:#2a2a4a;color:#e0e0e0;border:1px solid #444;padding:4px 14px;border-radius:3px;cursor:pointer;font-weight:600">Copy link</button>
+                        <button id="f-copylink" title="Copy a link that re-opens this exact view — scope (bucket/prefix included; no credentials) plus your current zoom/inspect focus" style="background:#2a2a4a;color:#e0e0e0;border:1px solid #444;padding:4px 14px;border-radius:3px;cursor:pointer;font-weight:600">Copy link</button>
                         <button id="f-adddiff" title="Capture this view (current host/filters) as one side of a diff; pick a second host/scope and add it to compare" style="background:#2a2a4a;color:#e0e0e0;border:1px solid #444;padding:4px 14px;border-radius:3px;cursor:pointer;font-weight:600">+ Add to diff</button>
                         <button id="f-diff" title="Compare this flamegraph against another" style="background:#2a2a4a;color:#e0e0e0;border:1px solid #444;padding:4px 14px;border-radius:3px;cursor:pointer;font-weight:600">Diff…</button>
                     `;
@@ -621,7 +650,24 @@
                         const endNs = pickerUtcToNs(fEnd.value);
                         if (startNs) p.set("start_ns", startNs);
                         if (endNs) p.set("end_ns", endNs);
+                        // Carry the live zoom/inspect focus so the address bar (and
+                        // anything copied from it) always reproduces the exact view.
+                        if (fg) writeViewState(p, fg);
                         history.pushState(null, "", window.location.pathname + "?" + p.toString());
+                    }
+
+                    // Fired by the renderer on every zoom/inspect change. Rewrites
+                    // the address bar in place (no history spam) so the URL always
+                    // reflects the current focus — deep-linkable at any moment.
+                    // A genuine (user-driven) change also ends URL-restore attempts
+                    // so a late-arriving snapshot can never snap the view back.
+                    let restoringView = false;
+                    function onApiViewChange() {
+                        if (!fg) return;
+                        if (!restoringView) viewRestored = true;
+                        const p = new URLSearchParams(window.location.search);
+                        writeViewState(p, fg);
+                        history.replaceState(null, "", window.location.pathname + "?" + p.toString());
                     }
 
                     // Build the data-driven facet controls from the backend's
@@ -739,7 +785,7 @@
                         return { name: node.name, count: node.count, self: node.self, children: m };
                     }
 
-                    const fg = FlamegraphRenderer.createFlamegraph(containerEl);
+                    const fg = FlamegraphRenderer.createFlamegraph(containerEl, onApiViewChange);
 
                     // Build the base stats string ("N samples \u00b7 M hosts \u00b7 \u2026")
                     // from the response metadata, shared by every event.
@@ -762,6 +808,9 @@
                     // stream that has since been superseded.
                     let streamToken = 0;
                     let abortCtl = null;
+                    // One-time guard: restore zoom/inspect focus from the URL on
+                    // the first streamed snapshot only.
+                    let viewRestored = false;
                     // The last-rendered coverage badge (without the trailing status
                     // suffix), so close/stop handlers can re-stamp it. `lastCoverage`
                     // feeds the "Refine more" ceiling computation.
@@ -802,6 +851,33 @@
                         loadingEl.classList.add("hidden");
                         containerEl.style.display = "flex";
                         fg.setTreeDirect(toFgTree(resp.tree), resp.tree.count);
+
+                        // Restore any zoom/inspect focus carried on the shared
+                        // link. The aggregate tree STREAMS in and refines, so a
+                        // deep target frame may not exist in the first snapshot —
+                        // we retry on each snapshot until the focus is applied
+                        // EXACTLY as the link asked. Each attempt resets the view
+                        // first so re-applying is idempotent (zoomToPath appends).
+                        // A genuine user interaction flips viewRestored via
+                        // onApiViewChange, which stops us from ever snapping their
+                        // view back to the URL.
+                        if (!viewRestored) {
+                            const wantW = params.get("worker-zoom");
+                            const wantO = params.get("offworker-zoom");
+                            const wantInspect = params.get("inspect");
+                            restoringView = true;
+                            fg.resetView();
+                            restoreViewState(fg, params);
+                            restoringView = false;
+                            const z = fg.getZoomPath();
+                            const zoomOk =
+                                (!wantW || z.worker.join("\t") === wantW) &&
+                                (!wantO || z.offworker.join("\t") === wantO);
+                            const inspectOk = !wantInspect || fg.getInspectFocus() != null;
+                            // Done once the link's focus is fully in place (or the
+                            // link carried no focus at all).
+                            if (zoomOk && inspectOk) viewRestored = true;
+                        }
 
                         const cov = resp.coverage;
                         lastCoverage = cov;
@@ -916,8 +992,14 @@
                     }
 
                     document.getElementById("f-copylink").addEventListener("click", async () => {
+                        // The Copy link carries the full scope PLUS the live
+                        // zoom/inspect focus, so a coworker opening it lands on the
+                        // exact same focus position. (currentScopeQuery stays
+                        // focus-free so diff captures compare scopes, not views.)
+                        const q = currentScopeQuery();
+                        writeViewState(q, fg);
                         const url = window.location.origin + window.location.pathname +
-                            "?" + currentScopeQuery().toString();
+                            "?" + q.toString();
                         const btn = document.getElementById("f-copylink");
                         const orig = btn.textContent;
                         try {
@@ -1081,12 +1163,7 @@
                 containerEl.style.display = "flex";
 
                 function updateUrlZoom() {
-                    const p = new URLSearchParams(window.location.search);
-                    const z = fg.getZoomPath();
-                    if (z.worker.length > 0) p.set("worker-zoom", z.worker.join("\t"));
-                    else p.delete("worker-zoom");
-                    if (z.offworker.length > 0) p.set("offworker-zoom", z.offworker.join("\t"));
-                    else p.delete("offworker-zoom");
+                    const p = writeViewState(new URLSearchParams(window.location.search), fg);
                     const newUrl = window.location.pathname + "?" + p.toString();
                     window.history.replaceState(null, "", newUrl);
                 }
@@ -1097,12 +1174,10 @@
                     runtimeWorkers: trace.runtimeWorkers,
                 });
 
-                // Restore zoom from URL (only if time range filter succeeded, otherwise tree differs)
+                // Restore zoom + inspect focus from URL (only if time range filter
+                // succeeded, otherwise the tree differs and the path won't match)
                 if (timeRangeMatched) {
-                    const wz = params.get("worker-zoom");
-                    const oz = params.get("offworker-zoom");
-                    if (wz) fg.zoomToPath("worker", wz.split("\t"));
-                    if (oz) fg.zoomToPath("offworker", oz.split("\t"));
+                    restoreViewState(fg, params);
                 }
 
                 // Responsive resize

--- a/dial9-viewer/ui/flamegraph.html
+++ b/dial9-viewer/ui/flamegraph.html
@@ -84,6 +84,7 @@
         <script src="format.js"></script>
         <script src="flamegraph_api.js"></script>
         <script src="sse.js"></script>
+        <script src="flamegraph_view_state.js"></script>
         <script src="flamegraph_diff.js"></script>
         <script src="flamegraph_diff_view.js"></script>
         <script src="decode.js"></script>
@@ -137,31 +138,19 @@
 
                 // ── View state <-> URL (single source of truth) ──────────────
                 // "Deep-link anything" means the URL IS the store for the
-                // flamegraph's view state (the zoom path + the inspect/butterfly
-                // focus). Rather than a framework, we centralize the encode/decode
-                // in these two pure helpers so every mode (exact-trace and API
-                // aggregate) serializes and restores focus identically — a shared
-                // link always reproduces the exact focus position. The renderer
-                // owns the live state; these functions are the only place that
-                // maps it to/from URL params.
+                // flamegraph's view state (zoom path + inspect/butterfly focus +
+                // search/filters). The encode/decode lives in
+                // flamegraph_view_state.js — one codec shared with the unit tests
+                // — and the renderer owns the live state via
+                // getViewState/applyViewState. These two thin adapters bridge the
+                // two so every mode (exact-trace and API aggregate) serializes and
+                // restores identically: a shared link always reproduces the view.
+                const ViewState = window.Dial9FlamegraphViewState;
                 function writeViewState(p, fg) {
-                    const z = fg.getZoomPath();
-                    if (z.worker && z.worker.length) p.set("worker-zoom", z.worker.join("\t"));
-                    else p.delete("worker-zoom");
-                    if (z.offworker && z.offworker.length) p.set("offworker-zoom", z.offworker.join("\t"));
-                    else p.delete("offworker-zoom");
-                    const inspect = fg.getInspectFocus();
-                    if (inspect) p.set("inspect", inspect);
-                    else p.delete("inspect");
-                    return p;
+                    return ViewState.writeState(p, fg.getViewState());
                 }
                 function restoreViewState(fg, p) {
-                    const wz = p.get("worker-zoom");
-                    const oz = p.get("offworker-zoom");
-                    if (wz) fg.zoomToPath("worker", wz.split("\t"));
-                    if (oz) fg.zoomToPath("offworker", oz.split("\t"));
-                    const inspect = p.get("inspect");
-                    if (inspect) fg.focusInspectByKey(inspect);
+                    fg.applyViewState(ViewState.readState(p));
                 }
 
                 // --- Diff mode: two-sided differential flamegraph (?diff=1) ---
@@ -276,11 +265,22 @@
                         });
                     }
 
+                    // Persist the diff view's zoom + highlight to the URL so any
+                    // position is a shareable link. The scope keys (diff/a/b) are
+                    // already in the address bar; writeDiffState only touches its
+                    // own diff_zoom/diff_search keys, so it composes with them.
+                    function onDiffViewChange(st) {
+                        const p = new URLSearchParams(window.location.search);
+                        ViewState.writeDiffState(p, st);
+                        history.replaceState(null, "", window.location.pathname + "?" + p.toString());
+                    }
                     view = FlamegraphDiffView.createDiffView(containerEl, {
                         scopeA: diffParsed.a,
                         scopeB: diffParsed.b,
                         headersFor: headersFor,
                         onSideError: onSideError,
+                        onChange: onDiffViewChange,
+                        initialState: ViewState.readDiffState(params),
                     });
                     statsEl.textContent = "A (left) vs B (right) · blue = heavier in A, red = heavier in B";
                     return;
@@ -856,26 +856,25 @@
                         // link. The aggregate tree STREAMS in and refines, so a
                         // deep target frame may not exist in the first snapshot —
                         // we retry on each snapshot until the focus is applied
-                        // EXACTLY as the link asked. Each attempt resets the view
-                        // first so re-applying is idempotent (zoomToPath appends).
-                        // A genuine user interaction flips viewRestored via
-                        // onApiViewChange, which stops us from ever snapping their
-                        // view back to the URL.
+                        // EXACTLY as the link asked. applyViewState resets the
+                        // view first, so re-applying over successive snapshots is
+                        // idempotent. A genuine user interaction flips
+                        // viewRestored via onApiViewChange, which stops us from
+                        // ever snapping their view back to the URL.
                         if (!viewRestored) {
-                            const wantW = params.get("worker-zoom");
-                            const wantO = params.get("offworker-zoom");
-                            const wantInspect = params.get("inspect");
+                            const want = ViewState.readState(params);
                             restoringView = true;
-                            fg.resetView();
-                            restoreViewState(fg, params);
+                            fg.applyViewState(want);
                             restoringView = false;
                             const z = fg.getZoomPath();
                             const zoomOk =
-                                (!wantW || z.worker.join("\t") === wantW) &&
-                                (!wantO || z.offworker.join("\t") === wantO);
-                            const inspectOk = !wantInspect || fg.getInspectFocus() != null;
+                                (!want.workerZoom || z.worker.join("\t") === want.workerZoom.join("\t")) &&
+                                (!want.offworkerZoom || z.offworker.join("\t") === want.offworkerZoom.join("\t"));
+                            const inspectOk = !want.inspect || fg.getInspectFocus() != null;
                             // Done once the link's focus is fully in place (or the
-                            // link carried no focus at all).
+                            // link carried no focus at all). search/spawn/runtime
+                            // apply synchronously, so zoom+inspect are the only
+                            // pieces that can lag a streamed snapshot.
                             if (zoomOk && inspectOk) viewRestored = true;
                         }
 

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -763,6 +763,9 @@
       unpinTooltip();
       renderAll();
       renderBreadcrumb();
+      // Entering/re-pivoting inspect is a view-state change, so notify the host
+      // (flamegraph.html) to persist the new focus into the URL for deep links.
+      onZoomChange();
     }
 
     // Clear all inspect state without triggering a re-render. Used both by the
@@ -785,6 +788,8 @@
       setInspectVisible(false);
       renderAll();
       renderBreadcrumb();
+      // Leaving inspect clears the persisted focus from the URL.
+      onZoomChange();
     }
 
     function renderInspect() {
@@ -1645,6 +1650,56 @@
       if (stack.length > 0) renderAll();
     }
 
+    // Deep-link support for the inspect (butterfly) focus. The focus is
+    // identified by its frameKey (fullName || name) so it survives tree
+    // rebuilds and streamed refinements, and can be reconstructed from a URL.
+    function getInspectFocus() {
+      return inspectActive && inspectFocusSrc ? frameKey(inspectFocusSrc) : null;
+    }
+
+    // Find a source-tree node whose frameKey matches `key`, anywhere in the tree.
+    function findNodeByKey(tree, key) {
+      let found = null;
+      function dfs(node) {
+        if (frameKey(node) === key) { found = node; return true; }
+        for (const child of node.children.values()) {
+          if (dfs(child)) return true;
+        }
+        return false;
+      }
+      for (const child of tree.children.values()) {
+        if (dfs(child)) break;
+      }
+      return found;
+    }
+
+    // Restore inspect mode focused on the frame identified by `key`. No-op if
+    // the frame is not present in the current trees (e.g. filtered out).
+    function focusInspectByKey(key) {
+      if (!key) return false;
+      for (const root of sourceRoots()) {
+        const node = findNodeByKey(root, key);
+        if (node) { enterInspect(node, false); return true; }
+      }
+      return false;
+    }
+
+    // Clear zoom + inspect WITHOUT notifying the host. Used by flamegraph.html's
+    // URL-restore retries (the aggregate tree streams in, so restore may run over
+    // several snapshots): each attempt resets first, making re-applying a URL
+    // zoom path idempotent (zoomToPath appends, so it must start from a clean
+    // stack). Not part of the user-facing zoom-out flow — that's resetZoom(),
+    // which does notify.
+    function resetView() {
+      workerZoomStack = [];
+      offworkerZoomStack = [];
+      if (inspectActive) {
+        resetInspectState();
+        setInspectVisible(false);
+      }
+      renderAll();
+    }
+
     function setTreeDirect(tree, totalCount) {
       // For API mode: set a pre-built tree directly (no worker/off-worker split)
       // Preserve the current zoom by finding the same node in the new tree.
@@ -1693,7 +1748,7 @@
       renderAll();
     }
 
-    return { setData, setTreeDirect, resize, destroy, handleEscape, isZoomed, getZoomPath, zoomToPath };
+    return { setData, setTreeDirect, resize, destroy, handleEscape, isZoomed, getZoomPath, zoomToPath, getInspectFocus, focusInspectByKey, resetView };
   }
 
   const fgExports = {

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -103,19 +103,214 @@
     return { nodes, maxDepth: maxD };
   }
 
-  // Count matching frames and their self-samples for search stats.
-  function countSearchMatches(root, queryLower) {
-    let selfCount = 0;
-    let frameCount = 0;
+  // Aggregate stats for the compact "N frames · X% of samples" line next to the
+  // search box. Kept consistent with the results dropdown and the inspect focus
+  // band, which both report INCLUSIVE weight:
+  //   - functions: distinct matching functions (by frameKey), matching the
+  //     dropdown's "N matching frames" — not raw tree-node count.
+  //   - covered:   inclusive sample union — samples whose stack contains at
+  //     least one match, counted once at the top-most match on each stack so
+  //     nested matches aren't double-counted. For a single matching function
+  //     this equals that frame's inclusive total (what inspect shows).
+  function searchAggregate(roots, queryLower) {
+    const rootList = Array.isArray(roots) ? roots : [roots];
+    const fns = new Set();
+    let covered = 0;
+    let rootTotal = 0;
+    function walk(node, ancestorMatched) {
+      const matched =
+        node.name.toLowerCase().includes(queryLower) ||
+        (node.fullName && node.fullName.toLowerCase().includes(queryLower));
+      if (matched) {
+        fns.add(node.fullName || node.name);
+        if (!ancestorMatched) covered += node.count;
+      }
+      const childAncestorMatched = ancestorMatched || matched;
+      for (const child of node.children.values()) walk(child, childAncestorMatched);
+    }
+    for (const root of rootList) {
+      if (!root) continue;
+      rootTotal += root.count || 0;
+      for (const child of root.children.values()) walk(child, false);
+    }
+    return { functions: fns.size, covered: covered, rootTotal: rootTotal };
+  }
+
+  // ── Inspect / butterfly (issue #652) ────────────────────────────────────
+  // Two frames are "the same function" when their identity key matches. The
+  // exact-trace tree keys children by symbol (fullName); aggregated/API trees
+  // (built by toFgTree) have no fullName, so fall back to the display name.
+  function frameKey(node) {
+    return node.fullName || node.name;
+  }
+
+  // Fresh inspect-tree node, copying the display metadata (location/docsUrl) of
+  // a source tree node so tooltips and the Ctrl-click docs link keep working.
+  function newInspectNode(name, fullName, src) {
+    return {
+      name: name,
+      fullName: fullName || null,
+      location: src ? src.location || null : null,
+      docsUrl: src ? src.docsUrl || null : null,
+      count: 0,
+      self: 0,
+      children: new Map(),
+    };
+  }
+
+  // Deep-merge `src`'s subtree into `dst` (both inspect nodes), accumulating
+  // counts. Used to aggregate the callee subtrees of every occurrence of the
+  // focus frame into one downward "code called by <focus>" tree.
+  function mergeSubtree(dst, src) {
+    dst.count += src.count;
+    dst.self += src.self;
+    for (const child of src.children.values()) {
+      const k = frameKey(child);
+      let d = dst.children.get(k);
+      if (!d) {
+        d = newInspectNode(child.name, child.fullName, child);
+        dst.children.set(k, d);
+      }
+      mergeSubtree(d, child);
+    }
+  }
+
+  // Build the butterfly ("inspect") view of `focus` across the whole `root`
+  // tree. Returns two trees, both rooted at the focus function:
+  //   - callees: code called *by* focus (paths out of it), merged over every
+  //     occurrence. Rendered growing up, above the focus band.
+  //   - callers: the inverted caller chains (paths *into* focus), each
+  //     occurrence contributing its own weight. Rendered growing down.
+  // Recursion is handled by only treating the *top-most* occurrence on each
+  // stack as a call site (so focus-calls-focus is not double-counted); nested
+  // self-samples are still tallied so `self` stays exact.
+  // `roots` may be a single tree root or an array of roots (e.g. the worker and
+  // off-worker lanes), letting the butterfly span the whole profile.
+  function buildInspect(roots, focus) {
+    const rootList = Array.isArray(roots) ? roots : [roots];
+    const focusKey = frameKey(focus);
+    const focusName = focus.name;
+    const focusFullName = focus.fullName || null;
+    const occurrences = [];
+    let inclusiveTotal = 0;
+    let selfTotal = 0;
+    let rootTotal = 0;
+    const path = [];
+    let inside = 0;
+    function dfs(node) {
+      const matched = frameKey(node) === focusKey;
+      path.push(node);
+      if (matched) {
+        selfTotal += node.self;
+        if (inside === 0) {
+          occurrences.push({ node: node, path: path.slice() });
+          inclusiveTotal += node.count;
+        }
+        inside++;
+      }
+      for (const child of node.children.values()) dfs(child);
+      if (matched) inside--;
+      path.pop();
+    }
+    // Iterate each root's children so the synthetic "(all)" root is not treated
+    // as a caller (it would just add a full-width, meaningless band). The shared
+    // `inside`/`path` counters return to their base between roots because every
+    // push is matched by a pop, so sequential DFS over multiple roots is safe.
+    for (const root of rootList) {
+      if (!root) continue;
+      rootTotal += root.count || 0;
+      for (const child of root.children.values()) dfs(child);
+    }
+
+    const callees = newInspectNode(focusName, focusFullName, focus);
+    for (const occ of occurrences) mergeSubtree(callees, occ.node);
+    callees.self = selfTotal; // exact self incl. nested recursion
+
+    const callers = newInspectNode(focusName, focusFullName, focus);
+    callers.count = inclusiveTotal;
+    callers.self = selfTotal;
+    for (const occ of occurrences) {
+      const p = occ.path; // [outermostCaller, ..., focus]
+      const c = occ.node.count;
+      let cur = callers;
+      for (let i = p.length - 2; i >= 0; i--) {
+        const anc = p[i];
+        const k = frameKey(anc);
+        let d = cur.children.get(k);
+        if (!d) {
+          d = newInspectNode(anc.name, anc.fullName, anc);
+          cur.children.set(k, d);
+        }
+        d.count += c;
+        cur = d;
+      }
+    }
+
+    return {
+      focusName: focusName,
+      focusFullName: focusFullName,
+      focusKey: focusKey,
+      location: focus.location || null,
+      docsUrl: focus.docsUrl || null,
+      callers: callers,
+      callees: callees,
+      total: inclusiveTotal,
+      self: selfTotal,
+      rootTotal: rootTotal,
+      occurrences: occurrences.length,
+    };
+  }
+
+  // Collect search matches grouped by function (issue #653). Each result is one
+  // function whose display name or symbol contains `queryLower`, with:
+  //   - total: inclusive samples with the function anywhere on the stack
+  //     (counted once per stack, at the top-most occurrence — no recursion
+  //     double-count), i.e. how "big" the frame is across the whole graph.
+  //   - self:  leaf samples attributed to the function (always exact).
+  //   - sites: number of top-most call sites.
+  function collectSearchResults(roots, queryLower) {
+    const rootList = Array.isArray(roots) ? roots : [roots];
+    const byKey = new Map();
+    const active = new Map(); // frameKey -> nesting depth on current path
     function walk(node) {
-      if (node.name.toLowerCase().includes(queryLower) || (node.fullName && node.fullName.toLowerCase().includes(queryLower))) {
-        selfCount += node.self;
-        frameCount++;
+      const matched =
+        node.name.toLowerCase().includes(queryLower) ||
+        (node.fullName && node.fullName.toLowerCase().includes(queryLower));
+      let k = null;
+      if (matched) {
+        k = frameKey(node);
+        let e = byKey.get(k);
+        if (!e) {
+          e = {
+            key: k,
+            name: node.name,
+            fullName: node.fullName || null,
+            location: node.location || null,
+            docsUrl: node.docsUrl || null,
+            total: 0,
+            self: 0,
+            sites: 0,
+          };
+          byKey.set(k, e);
+        }
+        e.self += node.self;
+        const act = active.get(k) || 0;
+        if (act === 0) {
+          e.total += node.count;
+          e.sites++;
+        }
+        active.set(k, act + 1);
       }
       for (const child of node.children.values()) walk(child);
+      if (matched) active.set(k, active.get(k) - 1);
     }
-    walk(root);
-    return { selfCount, frameCount };
+    // Walk each root's children (skip the synthetic "(all)" root itself so it is
+    // never a search hit). `active` returns to base between roots by pop-parity.
+    for (const root of rootList) {
+      if (!root) continue;
+      for (const child of root.children.values()) walk(child);
+    }
+    return [...byKey.values()];
   }
 
   function filterCpuSamples(cpuSamples, startNs, endNs) {
@@ -142,7 +337,20 @@
     // segment metadata. Empty when the trace has a single runtime (or none),
     // in which case the runtime filter stays hidden.
     let workerRuntime = new Map();
-    const hitRegions = { worker: [], offworker: [] };
+    const hitRegions = { worker: [], offworker: [], callees: [], callers: [] };
+
+    // ── Inspect / butterfly state (issue #652) ──
+    // When active, the normal worker/off-worker canvases are hidden and the
+    // butterfly (callers below, callees above a focus band) takes over. The
+    // focus always spans the FULL trees (not the current zoom), so inspect
+    // answers "all paths into/out of this frame across the entire flamegraph".
+    let inspectActive = false;
+    let inspectFocusSrc = null; // the source-tree node currently focused
+    let inspectResult = null; // buildInspect() output for inspectFocusSrc
+    let inspectCalleesData = null; // flattened callees (grows up)
+    let inspectCallersData = null; // flattened callers (grows down)
+    let inspectHistory = []; // pivot trail of prior focus nodes (for back/breadcrumb)
+    let pushInspectScroll = false; // center the focus band on the next inspect render
 
     // DOM
     const searchBar = document.createElement("div");
@@ -183,12 +391,13 @@
       '<div class="fg-help-content">' +
       '<h3>\u2328 Flamegraph Shortcuts</h3>' +
       '<table>' +
-      '<tr><td class="fg-help-key">Click</td><td>Zoom into frame</td></tr>' +
+      '<tr><td class="fg-help-key">Click</td><td>Zoom into frame (or re-pivot while inspecting)</td></tr>' +
       '<tr><td class="fg-help-key">Option / Alt + click</td><td>Pin tooltip (selectable text, links)</td></tr>' +
       '<tr><td class="fg-help-key">' + (isMac ? '\u2318' : 'Ctrl') + ' + click</td><td>Open docs.rs (when available)</td></tr>' +
-      '<tr><td class="fg-help-key">Right-click</td><td>Zoom out one level</td></tr>' +
-      '<tr><td class="fg-help-key">' + (isMac ? '\u2318' : 'Ctrl') + ' + F or /</td><td>Search frames</td></tr>' +
-      '<tr><td class="fg-help-key">Esc</td><td>Unpin \u2192 clear search \u2192 reset zoom \u2192 close</td></tr>' +
+      '<tr><td class="fg-help-key">Right-click</td><td>Menu: Inspect frame / Zoom out / Copy name</td></tr>' +
+      '<tr><td class="fg-help-key">Inspect</td><td>All paths into (below) &amp; out of (above) a frame</td></tr>' +
+      '<tr><td class="fg-help-key">' + (isMac ? '\u2318' : 'Ctrl') + ' + F or /</td><td>Search frames \u2192 click a result to inspect</td></tr>' +
+      '<tr><td class="fg-help-key">Esc</td><td>Unpin \u2192 close menu \u2192 clear search \u2192 exit inspect \u2192 reset zoom</td></tr>' +
       '</table>' +
       '<div class="fg-help-dismiss">Press Esc or click outside to close</div>' +
       '</div>';
@@ -296,6 +505,7 @@
       searchInput.value = "";
       searchQuery = "";
       searchClear.style.display = "none";
+      hideSearchResults();
       repaint();
       searchInput.focus();
     });
@@ -328,11 +538,72 @@
     offworkerCanvas.className = "fg-canvas";
     body.appendChild(offworkerCanvas);
 
+    // ── Inspect (butterfly) DOM. Hidden until inspect mode is entered. ──
+    // Layout, top → bottom:
+    //   [callees label]  "Callees — code called by <focus>"
+    //   [callees canvas] grows UP toward the focus band (leaves at the top)
+    //   [focus band]     the inspected frame, full width
+    //   [callers canvas] grows DOWN (immediate callers first, then their callers)
+    //   [callers label]  "Callers — paths into <focus>"
+    const inspectView = document.createElement("div");
+    inspectView.className = "fg-inspect";
+    inspectView.style.display = "none";
+
+    const inspectCalleesLabel = document.createElement("div");
+    inspectCalleesLabel.className = "fg-section-label fg-inspect-label";
+    inspectView.appendChild(inspectCalleesLabel);
+
+    // The whole butterfly scrolls as ONE unit inside the shared .fg-body scroll
+    // region (like the normal graph), rather than each half scrolling
+    // separately. The focus band is position:sticky so it stays visible while
+    // you scroll through tall caller/callee stacks. Callees grow up (immediate
+    // callees adjacent to the band at the canvas bottom); callers grow down.
+    const calleesCanvas = document.createElement("canvas");
+    calleesCanvas.className = "fg-canvas";
+    inspectView.appendChild(calleesCanvas);
+
+    const focusBand = document.createElement("div");
+    focusBand.className = "fg-focus-band";
+    inspectView.appendChild(focusBand);
+
+    const callersCanvas = document.createElement("canvas");
+    callersCanvas.className = "fg-canvas";
+    inspectView.appendChild(callersCanvas);
+
+    const inspectCallersLabel = document.createElement("div");
+    inspectCallersLabel.className = "fg-section-label fg-inspect-label";
+    inspectView.appendChild(inspectCallersLabel);
+
+    body.appendChild(inspectView);
+
     const tooltip = document.createElement("div");
     tooltip.className = "fg-tooltip";
     document.body.appendChild(tooltip);
 
-    function renderCanvas(canvas, data, hitKey) {
+    // ── Right-click context menu (Inspect / Zoom out / Copy name) ──
+    const ctxMenu = document.createElement("div");
+    ctxMenu.className = "fg-ctx-menu";
+    ctxMenu.style.display = "none";
+    ctxMenu.innerHTML =
+      '<button type="button" class="fg-ctx-inspect">🔍 Inspect frame</button>' +
+      '<button type="button" class="fg-ctx-zoomout">⤺ Zoom out</button>' +
+      '<button type="button" class="fg-ctx-copy">⧉ Copy name</button>';
+    document.body.appendChild(ctxMenu);
+    const ctxInspectBtn = ctxMenu.querySelector(".fg-ctx-inspect");
+    const ctxZoomOutBtn = ctxMenu.querySelector(".fg-ctx-zoomout");
+    const ctxCopyBtn = ctxMenu.querySelector(".fg-ctx-copy");
+    let ctxTarget = null; // { node, hitKey } captured at right-click time
+
+    // ── Search results dropdown (issue #653) ──
+    const searchResults = document.createElement("div");
+    searchResults.className = "fg-search-results";
+    searchResults.style.display = "none";
+    searchBar.appendChild(searchResults);
+
+    // `invert` (used by the inspect callers canvas) draws depth 0 at the TOP and
+    // deeper frames downward, so the caller chains fan out below the focus band.
+    // The default (invert=false) draws depth 0 at the bottom, growing up.
+    function renderCanvas(canvas, data, hitKey, invert) {
       if (!data) {
         canvas.width = 0;
         canvas.height = 0;
@@ -354,15 +625,20 @@
       const regions = [];
       const padL = 4, padR = 4, drawW = pw - padL - padR;
       const baseY = ph - 4;
+      const topPad = 4;
       ctx.font = "11px monospace";
       ctx.textBaseline = "middle";
       const qLower = searchQuery.toLowerCase();
-      const searching = searchQuery.length > 0;
+      // In inspect mode the search box drives a results dropdown, not the
+      // dim-non-matches overlay, so don't dim the butterfly by the query.
+      const searching = searchQuery.length > 0 && !inspectActive;
 
       for (const node of data.nodes) {
         const x = padL + node.x * drawW;
         const w = node.w * drawW;
-        const y = baseY - (node.depth + 1) * FG_ROW_H;
+        const y = invert
+          ? topPad + node.depth * FG_ROW_H
+          : baseY - (node.depth + 1) * FG_ROW_H;
         if (w < 0.5) continue;
 
         const isAncestor = !!node.isAncestor;
@@ -417,7 +693,17 @@
       };
     }
 
+    // All source roots the butterfly/search should span — both the exact-trace
+    // worker + off-worker lanes, or the single aggregated (API mode) tree.
+    function sourceRoots() {
+      return [workerTree, offworkerTree].filter(Boolean);
+    }
+
     function renderAll() {
+      if (inspectActive) {
+        renderInspect();
+        return;
+      }
       workerData = rebuildData("worker");
       offworkerData = rebuildData("offworker");
 
@@ -431,12 +717,140 @@
     }
 
     function repaint() {
+      if (inspectActive) {
+        renderCanvas(calleesCanvas, inspectCalleesData, "callees", false);
+        renderCanvas(callersCanvas, inspectCallersData, "callers", true);
+        return;
+      }
       renderCanvas(workerCanvas, workerData, "worker");
       renderCanvas(offworkerCanvas, offworkerData, "offworker");
       updateSearchStats();
     }
 
+    // ── Inspect (butterfly) render/enter/exit (issue #652) ──
+
+    // Toggle which section of the DOM (normal lanes vs. butterfly) is visible.
+    function setInspectVisible(on) {
+      workerLabel.style.display = on ? "none" : (workerData ? "" : "none");
+      workerCanvas.style.display = on ? "none" : (workerData ? "" : "none");
+      offworkerLabel.style.display = on ? "none" : (offworkerData ? "" : "none");
+      offworkerCanvas.style.display = on ? "none" : (offworkerData ? "" : "none");
+      inspectView.style.display = on ? "" : "none";
+    }
+
+    // Enter (or re-pivot) inspect mode focused on source-tree node `srcNode`.
+    // `pushHistory` records the previous focus so the breadcrumb can walk back.
+    function enterInspect(srcNode, pushHistory) {
+      if (!srcNode) return;
+      const res = buildInspect(sourceRoots(), srcNode);
+      if (res.total <= 0) return; // frame not present (shouldn't happen)
+      if (inspectActive && pushHistory !== false && inspectFocusSrc) {
+        inspectHistory.push(inspectFocusSrc);
+      }
+      inspectActive = true;
+      inspectFocusSrc = srcNode;
+      inspectResult = res;
+      pushInspectScroll = true; // recenter the band for this new focus
+      closeContextMenu();
+      // Dismiss the search box: the dropdown was just consumed, and leaving stale
+      // query text would make the first Esc clear it instead of exiting inspect.
+      // A fresh search while inspecting still works to pivot to another frame.
+      searchInput.value = "";
+      searchQuery = "";
+      searchClear.style.display = "none";
+      hideSearchResults();
+      unpinTooltip();
+      renderAll();
+      renderBreadcrumb();
+    }
+
+    // Clear all inspect state without triggering a re-render. Used both by the
+    // Esc/exit path and whenever the underlying trees are rebuilt (filters,
+    // setTreeDirect) so the focus never dangles onto a stale tree.
+    function resetInspectState() {
+      inspectActive = false;
+      inspectFocusSrc = null;
+      inspectResult = null;
+      inspectCalleesData = null;
+      inspectCallersData = null;
+      inspectHistory = [];
+      hitRegions.callees = [];
+      hitRegions.callers = [];
+    }
+
+    function exitInspect() {
+      if (!inspectActive) return;
+      resetInspectState();
+      setInspectVisible(false);
+      renderAll();
+      renderBreadcrumb();
+    }
+
+    function renderInspect() {
+      const res = inspectResult;
+      const total = res.total || 1;
+      // Both trees are rooted at the focus; render their CHILDREN (depth 0+).
+      const calleesFlat = flattenFromNode(res.callees, total, []);
+      const callersFlat = flattenFromNode(res.callers, total, []);
+      inspectCalleesData = {
+        nodes: calleesFlat.nodes, maxDepth: calleesFlat.maxDepth,
+        totalSamples: total, rootTotal: res.rootTotal,
+      };
+      inspectCallersData = {
+        nodes: callersFlat.nodes, maxDepth: callersFlat.maxDepth,
+        totalSamples: total, rootTotal: res.rootTotal,
+      };
+
+      setInspectVisible(true);
+
+      const pct = res.rootTotal > 0
+        ? ((res.total / res.rootTotal) * 100).toFixed(1) + "% of all samples"
+        : "";
+      const selfPct = res.total > 0
+        ? ((res.self / res.total) * 100).toFixed(1) + "% self"
+        : "";
+      inspectCalleesLabel.textContent =
+        "⬆ Callees — code called by " + res.focusName;
+      inspectCallersLabel.textContent =
+        "⬇ Callers — paths into " + res.focusName;
+
+      // Focus band: the inspected frame, full width, with its aggregate stats.
+      focusBand.innerHTML = "";
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "fg-focus-name";
+      nameSpan.textContent = res.focusName;
+      nameSpan.title = res.focusFullName || res.focusName;
+      focusBand.appendChild(nameSpan);
+      const statSpan = document.createElement("span");
+      statSpan.className = "fg-focus-stat";
+      const bits = [res.total.toLocaleString() + " samples"];
+      if (pct) bits.push(pct);
+      if (selfPct) bits.push(selfPct);
+      bits.push(res.occurrences + (res.occurrences === 1 ? " site" : " sites"));
+      statSpan.textContent = bits.join(" · ");
+      focusBand.appendChild(statSpan);
+      // Fixed accent color (set in CSS) — the focus band is deliberately NOT
+      // tinted by the per-frame hash color, so the pivot always looks the same.
+
+      repaint();
+
+      // Center the focus band in the scroll viewport on (re-)entry so both the
+      // nearest callees (above) and immediate callers (below) are visible. The
+      // band is sticky, so this just picks a sensible starting offset.
+      if (pushInspectScroll && typeof focusBand.offsetTop === "number") {
+        const bandTop = focusBand.offsetTop;
+        const bandH = focusBand.offsetHeight || 0;
+        const viewH = body.clientHeight || 0;
+        body.scrollTop = Math.max(0, bandTop - (viewH - bandH) / 2);
+      }
+      pushInspectScroll = false;
+    }
+
     function renderBreadcrumb() {
+      if (inspectActive) {
+        renderInspectBreadcrumb();
+        return;
+      }
       const wZoomed = workerZoomStack.length > 0;
       const oZoomed = offworkerZoomStack.length > 0;
       if (!wZoomed && !oZoomed) {
@@ -494,46 +908,175 @@
       }
     }
 
+    // Breadcrumb while inspecting: an exit link back to the flamegraph, then the
+    // pivot trail (each earlier focus is clickable to jump back to it), ending at
+    // the current focus.
+    function renderInspectBreadcrumb() {
+      breadcrumbBar.style.display = "flex";
+      breadcrumbBar.innerHTML = "";
+
+      const exitSpan = document.createElement("span");
+      exitSpan.className = "fg-breadcrumb-item fg-breadcrumb-link";
+      exitSpan.textContent = "⬅ Flamegraph";
+      exitSpan.title = "Exit inspect (Esc)";
+      exitSpan.addEventListener("click", exitInspect);
+      breadcrumbBar.appendChild(exitSpan);
+
+      const tag = document.createElement("span");
+      tag.className = "fg-breadcrumb-sep";
+      tag.textContent = "  ·  inspecting:  ";
+      breadcrumbBar.appendChild(tag);
+
+      const trail = inspectHistory.concat([inspectFocusSrc]);
+      for (let i = 0; i < trail.length; i++) {
+        if (i > 0) {
+          const arrow = document.createElement("span");
+          arrow.className = "fg-breadcrumb-sep";
+          arrow.textContent = " › ";
+          breadcrumbBar.appendChild(arrow);
+        }
+        const isLast = i === trail.length - 1;
+        const span = document.createElement("span");
+        span.className = "fg-breadcrumb-item" + (isLast ? "" : " fg-breadcrumb-link");
+        span.textContent = trail[i].name;
+        span.title = trail[i].fullName || trail[i].name;
+        if (!isLast) {
+          const idx = i;
+          span.addEventListener("click", () => {
+            const target = trail[idx];
+            inspectHistory = trail.slice(0, idx);
+            enterInspect(target, false);
+          });
+        }
+        breadcrumbBar.appendChild(span);
+      }
+    }
+
     function updateSearchStats() {
       if (!searchQuery) {
         searchStats.textContent = "";
         return;
       }
-      const qLower = searchQuery.toLowerCase();
-      let matchedSelf = 0;
-      let matchedFrames = 0;
-      let totalSelf = 0;
-      const wRoot = workerZoomStack.length > 0 ? workerZoomStack[workerZoomStack.length - 1] : workerTree;
-      const oRoot = offworkerZoomStack.length > 0 ? offworkerZoomStack[offworkerZoomStack.length - 1] : offworkerTree;
-      if (wRoot) {
-        const m = countSearchMatches(wRoot, qLower);
-        matchedSelf += m.selfCount;
-        matchedFrames += m.frameCount;
-        totalSelf += wRoot.count;
-      }
-      if (oRoot) {
-        const m = countSearchMatches(oRoot, qLower);
-        matchedSelf += m.selfCount;
-        matchedFrames += m.frameCount;
-        totalSelf += oRoot.count;
-      }
-      if (matchedFrames === 0) {
+      // Only the match COUNT here. A per-frame percentage is what's actually
+      // useful, and it lives where it's unambiguous: on each dropdown row and in
+      // the inspect focus band after you click a result. We deliberately do NOT
+      // show an aggregate "% of samples" \u2014 for a multi-function query that's the
+      // inclusive union across all matches, which reads as if it were one
+      // frame's weight (e.g. a query hitting a root frame shows ~100%).
+      const agg = searchAggregate(sourceRoots(), searchQuery.toLowerCase());
+      if (agg.functions === 0) {
         searchStats.textContent = "no matches";
         return;
       }
-      let text = matchedFrames + (matchedFrames === 1 ? " frame" : " frames");
-      if (matchedSelf > 0 && totalSelf > 0) {
-        const pct = ((matchedSelf / totalSelf) * 100).toFixed(1);
-        text += ` \u00b7 ${pct}% of samples`;
-      }
-      searchStats.textContent = text;
+      searchStats.textContent =
+        agg.functions + (agg.functions === 1 ? " frame" : " frames");
     }
 
     searchInput.addEventListener("input", onSearchInput);
     function onSearchInput() {
       searchQuery = searchInput.value;
       searchClear.style.display = searchQuery ? "" : "none";
+      renderSearchResults();
       repaint();
+    }
+
+    // Focus the search box → re-show the results if a query is already present.
+    searchInput.addEventListener("focus", function () {
+      if (searchQuery) renderSearchResults();
+    });
+
+    // ── Search results dropdown (issue #653) ──
+    // Max rows to render; searching a huge trace for a common substring can
+    // match thousands of distinct functions and building that many DOM rows
+    // janks the input. We render the biggest N and note the remainder.
+    const SEARCH_RESULT_LIMIT = 200;
+
+    function hideSearchResults() {
+      searchResults.style.display = "none";
+      searchResults.innerHTML = "";
+    }
+
+    // buildInspect matches occurrences by frameKey and only reads the focus
+    // node's display fields, so a search-result row can pivot into inspect via a
+    // lightweight synthetic focus node (no need to locate the real tree node).
+    function inspectFromSearchResult(r) {
+      enterInspect(
+        { name: r.name, fullName: r.fullName, location: r.location, docsUrl: r.docsUrl },
+        false
+      );
+    }
+
+    function renderSearchResults() {
+      const q = searchQuery.trim();
+      if (!q) { hideSearchResults(); return; }
+      const roots = sourceRoots();
+      if (roots.length === 0) { hideSearchResults(); return; }
+      const rootTotal = roots.reduce((n, r) => n + (r.count || 0), 0) || 1;
+      const results = collectSearchResults(roots, q.toLowerCase());
+      results.sort((a, b) => b.total - a.total || b.self - a.self);
+
+      searchResults.innerHTML = "";
+      if (results.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "fg-sr-empty";
+        empty.textContent = "No matching frames";
+        searchResults.appendChild(empty);
+        searchResults.style.display = "block";
+        return;
+      }
+
+      const header = document.createElement("div");
+      header.className = "fg-sr-header";
+      const shown = Math.min(results.length, SEARCH_RESULT_LIMIT);
+      header.textContent =
+        results.length === 1
+          ? "1 matching frame — click to inspect"
+          : results.length + " matching frames — click to inspect" +
+            (shown < results.length ? " (top " + shown + " shown)" : "");
+      searchResults.appendChild(header);
+
+      for (let i = 0; i < shown; i++) {
+        const r = results[i];
+        const pct = ((r.total / rootTotal) * 100).toFixed(1);
+        const row = document.createElement("div");
+        row.className = "fg-sr-row";
+        row.title = (r.fullName || r.name) + "\n" + r.total.toLocaleString() +
+          " samples · " + r.self.toLocaleString() + " self · " +
+          r.sites + (r.sites === 1 ? " site" : " sites");
+
+        const bar = document.createElement("span");
+        bar.className = "fg-sr-bar";
+        bar.style.width = Math.max(2, Math.round(pct)) + "%";
+        bar.style.background = flamegraphColor(r.name);
+
+        const name = document.createElement("span");
+        name.className = "fg-sr-name";
+        name.textContent = r.name;
+
+        const size = document.createElement("span");
+        size.className = "fg-sr-size";
+        size.textContent = pct + "% · " + r.total.toLocaleString() +
+          (r.sites > 1 ? " · " + r.sites + " sites" : "");
+
+        row.appendChild(bar);
+        row.appendChild(name);
+        row.appendChild(size);
+        // Hovering a result lights up that function's frames in the graph below
+        // (and dims the rest) via the shared highlight path. Match by the row's
+        // display name — the same key renderCanvas highlights on.
+        row.addEventListener("mouseenter", function () {
+          setHighlight(r.name);
+        });
+        row.addEventListener("mouseleave", function () {
+          if (highlightName === r.name) setHighlight(null);
+        });
+        row.addEventListener("click", function (e) {
+          e.stopPropagation();
+          inspectFromSearchResult(r);
+        });
+        searchResults.appendChild(row);
+      }
+      searchResults.style.display = "block";
     }
 
     function zoomTo(key, treeNode) {
@@ -557,12 +1100,20 @@
 
     let tooltipPinned = false;
 
+    function canvasKey(c) {
+      if (c === workerCanvas) return "worker";
+      if (c === offworkerCanvas) return "offworker";
+      if (c === calleesCanvas) return "callees";
+      if (c === callersCanvas) return "callers";
+      return "worker";
+    }
+
     function hitTest(e) {
       const c = e.target;
       const rect = c.getBoundingClientRect();
       const mx = e.clientX - rect.left;
       const my = e.clientY - rect.top;
-      const key = c === workerCanvas ? "worker" : "offworker";
+      const key = canvasKey(c);
       const regions = hitRegions[key] || [];
       for (let i = regions.length - 1; i >= 0; i--) {
         const r = regions[i];
@@ -654,17 +1205,22 @@
       }
     }
 
+    // Set the highlighted frame name (or null to clear) and repaint on the next
+    // frame. Shared by canvas hover and search-result hover so both light up
+    // matching frames the same way.
+    function setHighlight(name) {
+      if (name === highlightName) return;
+      highlightName = name;
+      if (!repaintQueued) {
+        repaintQueued = true;
+        requestAnimationFrame(() => { repaintQueued = false; repaint(); });
+      }
+    }
+
     function canvasMouseMove(e) {
       if (tooltipPinned) return;
       const { hit } = hitTest(e);
-      const newHighlight = hit ? hit.node.name : null;
-      if (newHighlight !== highlightName) {
-        highlightName = newHighlight;
-        if (!repaintQueued) {
-          repaintQueued = true;
-          requestAnimationFrame(() => { repaintQueued = false; repaint(); });
-        }
-      }
+      setHighlight(hit ? hit.node.name : null);
       if (hit) {
         showTooltip(hit, e.clientX, e.clientY, false);
         e.target.style.cursor = "pointer";
@@ -676,13 +1232,7 @@
 
     function canvasMouseLeave() {
       if (!tooltipPinned) tooltip.style.display = "none";
-      if (highlightName !== null) {
-        highlightName = null;
-        if (!repaintQueued) {
-          repaintQueued = true;
-          requestAnimationFrame(() => { repaintQueued = false; repaint(); });
-        }
-      }
+      setHighlight(null);
     }
 
     function canvasClick(e, hitKey) {
@@ -695,6 +1245,11 @@
       } else if (e.altKey) {
         tooltipPinned = true;
         showTooltip(hit, e.clientX, e.clientY, true);
+      } else if (inspectActive) {
+        // In the butterfly, a plain click on any caller/callee re-pivots the
+        // inspection onto that frame (issue #652 "click to enter inspect mode").
+        unpinTooltip();
+        enterInspect(tn, true);
       } else {
         unpinTooltip();
         if (tn.children && tn.children.size > 0) {
@@ -711,18 +1266,64 @@
       }
     }
 
+    // Right-click opens the context menu (Inspect / Zoom out / Copy name). On a
+    // frame, the menu acts on that frame; on empty space it closes any open menu.
     function canvasContextMenu(e, hitKey) {
       e.preventDefault();
-      // Zoom out the canvas you right-clicked, fall back to the other
-      const primary = hitKey === "offworker" ? offworkerZoomStack : workerZoomStack;
-      const fallback = hitKey === "offworker" ? workerZoomStack : offworkerZoomStack;
+      const { hit } = hitTest(e);
+      if (!hit) { closeContextMenu(); return; }
+      ctxTarget = { node: hit.node.treeNode || { name: hit.node.name }, hitKey: hitKey };
+      openContextMenu(e.clientX, e.clientY);
+    }
+
+    function openContextMenu(x, y) {
+      // "Zoom out" only makes sense in the normal zoomable view.
+      ctxZoomOutBtn.style.display = inspectActive ? "none" : "";
+      ctxMenu.style.display = "block";
+      const mw = ctxMenu.offsetWidth, mh = ctxMenu.offsetHeight;
+      ctxMenu.style.left = Math.min(x, window.innerWidth - mw - 4) + "px";
+      ctxMenu.style.top = Math.min(y, window.innerHeight - mh - 4) + "px";
+    }
+
+    function closeContextMenu() {
+      if (ctxMenu.style.display === "none") return;
+      ctxMenu.style.display = "none";
+      ctxTarget = null;
+    }
+
+    ctxInspectBtn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      const t = ctxTarget;
+      closeContextMenu();
+      if (t && t.node) enterInspect(t.node, true);
+    });
+
+    ctxZoomOutBtn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      const t = ctxTarget;
+      closeContextMenu();
+      if (!t || inspectActive) return;
+      // Zoom out the lane you right-clicked, falling back to the other.
+      const primary = t.hitKey === "offworker" ? offworkerZoomStack : workerZoomStack;
+      const fallback = t.hitKey === "offworker" ? workerZoomStack : offworkerZoomStack;
       const stack = primary.length > 0 ? primary : fallback;
       if (stack.length > 0) {
         stack.pop();
         renderAll();
         onZoomChange();
       }
-    }
+    });
+
+    ctxCopyBtn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      const t = ctxTarget;
+      closeContextMenu();
+      if (!t || !t.node) return;
+      const text = t.node.fullName || t.node.name || "";
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).catch(() => {});
+      }
+    });
 
     // Named handlers so destroy() can remove them
     function onWorkerMove(e) { canvasMouseMove(e); }
@@ -731,6 +1332,12 @@
     function onOffworkerClick(e) { canvasClick(e, "offworker"); }
     function onWorkerContext(e) { canvasContextMenu(e, "worker"); }
     function onOffworkerContext(e) { canvasContextMenu(e, "offworker"); }
+    function onCalleesMove(e) { canvasMouseMove(e); }
+    function onCallersMove(e) { canvasMouseMove(e); }
+    function onCalleesClick(e) { canvasClick(e, "callees"); }
+    function onCallersClick(e) { canvasClick(e, "callers"); }
+    function onCalleesContext(e) { canvasContextMenu(e, "callees"); }
+    function onCallersContext(e) { canvasContextMenu(e, "callers"); }
 
     workerCanvas.addEventListener("mousemove", onWorkerMove);
     offworkerCanvas.addEventListener("mousemove", onOffworkerMove);
@@ -740,6 +1347,14 @@
     offworkerCanvas.addEventListener("click", onOffworkerClick);
     workerCanvas.addEventListener("contextmenu", onWorkerContext);
     offworkerCanvas.addEventListener("contextmenu", onOffworkerContext);
+    calleesCanvas.addEventListener("mousemove", onCalleesMove);
+    callersCanvas.addEventListener("mousemove", onCallersMove);
+    calleesCanvas.addEventListener("mouseleave", canvasMouseLeave);
+    callersCanvas.addEventListener("mouseleave", canvasMouseLeave);
+    calleesCanvas.addEventListener("click", onCalleesClick);
+    callersCanvas.addEventListener("click", onCallersClick);
+    calleesCanvas.addEventListener("contextmenu", onCalleesContext);
+    callersCanvas.addEventListener("contextmenu", onCallersContext);
 
     function onKeyDown(e) {
       if (container.offsetHeight === 0) return;
@@ -751,10 +1366,23 @@
     }
     document.addEventListener("keydown", onKeyDown);
 
+    function isFgCanvas(t) {
+      return t === workerCanvas || t === offworkerCanvas ||
+             t === calleesCanvas || t === callersCanvas;
+    }
+
     function onDocClick(e) {
-      if (tooltipPinned && !tooltip.contains(e.target) &&
-          e.target !== workerCanvas && e.target !== offworkerCanvas) {
+      if (tooltipPinned && !tooltip.contains(e.target) && !isFgCanvas(e.target)) {
         unpinTooltip();
+      }
+      // Close the context menu on any click outside it (its own buttons
+      // stopPropagation, so they never reach here).
+      if (ctxMenu.style.display !== "none" && !ctxMenu.contains(e.target)) {
+        closeContextMenu();
+      }
+      // Close the search-results dropdown when clicking outside the search bar.
+      if (searchResults.style.display !== "none" && !searchBar.contains(e.target)) {
+        hideSearchResults();
       }
     }
     document.addEventListener("click", onDocClick);
@@ -762,6 +1390,10 @@
     // Returns true if consumed (search cleared or zoom reset),
     // false if nothing to do (caller should close the panel).
     function handleEscape() {
+      if (ctxMenu.style.display !== "none") {
+        closeContextMenu();
+        return true;
+      }
       if (tooltipPinned) {
         unpinTooltip();
         return true;
@@ -774,11 +1406,19 @@
         helpOverlay.style.display = "none";
         return true;
       }
+      if (searchResults.style.display !== "none") {
+        hideSearchResults();
+        return true;
+      }
       if (searchQuery) {
         searchInput.value = "";
         searchQuery = "";
         searchClear.style.display = "none";
         renderAll();
+        return true;
+      }
+      if (inspectActive) {
+        exitInspect();
         return true;
       }
       if (isZoomed()) {
@@ -814,6 +1454,10 @@
 
       workerZoomStack = [];
       offworkerZoomStack = [];
+      // The focus node points into trees we just rebuilt; drop inspect state and
+      // any stale search dropdown so nothing dangles onto the old trees.
+      resetInspectState();
+      hideSearchResults();
 
       workerLabel.textContent =
         `${workerLabelPrefix} \u2014 ${workerSamples.length} samples`;
@@ -890,6 +1534,11 @@
     }
 
     function resize() {
+      if (inspectActive) {
+        renderCanvas(calleesCanvas, inspectCalleesData, "callees", false);
+        renderCanvas(callersCanvas, inspectCallersData, "callers", true);
+        return;
+      }
       renderCanvas(workerCanvas, workerData, "worker");
       renderCanvas(offworkerCanvas, offworkerData, "offworker");
     }
@@ -906,8 +1555,17 @@
       offworkerCanvas.removeEventListener("click", onOffworkerClick);
       workerCanvas.removeEventListener("contextmenu", onWorkerContext);
       offworkerCanvas.removeEventListener("contextmenu", onOffworkerContext);
+      calleesCanvas.removeEventListener("mousemove", onCalleesMove);
+      callersCanvas.removeEventListener("mousemove", onCallersMove);
+      calleesCanvas.removeEventListener("mouseleave", canvasMouseLeave);
+      callersCanvas.removeEventListener("mouseleave", canvasMouseLeave);
+      calleesCanvas.removeEventListener("click", onCalleesClick);
+      callersCanvas.removeEventListener("click", onCallersClick);
+      calleesCanvas.removeEventListener("contextmenu", onCalleesContext);
+      callersCanvas.removeEventListener("contextmenu", onCallersContext);
       searchInput.removeEventListener("input", onSearchInput);
       if (tooltip.parentNode) tooltip.parentNode.removeChild(tooltip);
+      if (ctxMenu.parentNode) ctxMenu.parentNode.removeChild(ctxMenu);
       container.innerHTML = "";
     }
 
@@ -1013,13 +1671,37 @@
       // Enable the Export control now that an aggregated tree is rendered \u2014 the
       // exact-trace path does this in applyFilters(), but API mode bypasses it.
       updateExportState();
+      hideSearchResults();
+      // API mode streams refinements: if the user is inspecting a frame, keep
+      // the butterfly live by re-computing it against the freshly-set tree
+      // (buildInspect only reads the focus's identity, so the old focus node is
+      // still a valid seed). Otherwise fall back to the normal render.
+      if (inspectActive && inspectFocusSrc) {
+        const res = buildInspect(sourceRoots(), inspectFocusSrc);
+        if (res.total > 0) {
+          inspectResult = res;
+          renderAll();
+          renderBreadcrumb();
+          return;
+        }
+        // Focus vanished from the new tree \u2014 drop back to the flamegraph.
+        resetInspectState();
+        setInspectVisible(false);
+      }
       renderAll();
     }
 
     return { setData, setTreeDirect, resize, destroy, handleEscape, isZoomed, getZoomPath, zoomToPath };
   }
 
-  const fgExports = { createFlamegraph: createFlamegraph, filterCpuSamples: filterCpuSamples };
+  const fgExports = {
+    createFlamegraph: createFlamegraph,
+    filterCpuSamples: filterCpuSamples,
+    // Pure helpers exported for tests (issues #652/#653).
+    buildInspect: buildInspect,
+    collectSearchResults: collectSearchResults,
+    searchAggregate: searchAggregate,
+  };
   if (typeof module !== "undefined" && module.exports) {
     module.exports = fgExports;
   } else {

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -267,7 +267,8 @@
   //     (counted once per stack, at the top-most occurrence — no recursion
   //     double-count), i.e. how "big" the frame is across the whole graph.
   //   - self:  leaf samples attributed to the function (always exact).
-  //   - sites: number of top-most call sites.
+  //   - sites: number of distinct call paths (top-most occurrences) into the
+  //     function; rendered as "call paths" in the UI.
   function collectSearchResults(roots, queryLower) {
     const rootList = Array.isArray(roots) ? roots : [roots];
     const byKey = new Map();
@@ -826,7 +827,7 @@
       const bits = [res.total.toLocaleString() + " samples"];
       if (pct) bits.push(pct);
       if (selfPct) bits.push(selfPct);
-      bits.push(res.occurrences + (res.occurrences === 1 ? " site" : " sites"));
+      bits.push(res.occurrences + (res.occurrences === 1 ? " call path" : " call paths"));
       statSpan.textContent = bits.join(" · ");
       focusBand.appendChild(statSpan);
       // Fixed accent color (set in CSS) — the focus band is deliberately NOT
@@ -1042,7 +1043,7 @@
         row.className = "fg-sr-row";
         row.title = (r.fullName || r.name) + "\n" + r.total.toLocaleString() +
           " samples · " + r.self.toLocaleString() + " self · " +
-          r.sites + (r.sites === 1 ? " site" : " sites");
+          r.sites + (r.sites === 1 ? " call path" : " call paths");
 
         const bar = document.createElement("span");
         bar.className = "fg-sr-bar";
@@ -1056,7 +1057,7 @@
         const size = document.createElement("span");
         size.className = "fg-sr-size";
         size.textContent = pct + "% · " + r.total.toLocaleString() +
-          (r.sites > 1 ? " · " + r.sites + " sites" : "");
+          (r.sites > 1 ? " · " + r.sites + " paths" : "");
 
         row.appendChild(bar);
         row.appendChild(name);
@@ -1162,7 +1163,8 @@
           '<span style="color:#555"> (' + (isMac ? '\u2318' : 'Ctrl') + ' + click)</span>';
       }
       if (!pinned) {
-        h += '<br><span style="color:#555">' + (isMac ? '\u2325' : 'Alt') + ' + click to pin</span>';
+        h += '<br><span style="color:#555">' + (isMac ? '\u2325' : 'Alt') +
+          ' + click to pin \u00b7 right-click to inspect</span>';
       }
       return h;
     }

--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -323,6 +323,16 @@
 
   function createFlamegraph(container, onZoomChange) {
     onZoomChange = onZoomChange || function () {};
+    // While restoring view state from a URL we mutate zoom/inspect/search/filters
+    // programmatically; those must NOT fire the persist callback (which would
+    // rewrite the address bar mid-restore, and — via writeState's delete-on-
+    // absence — could clobber a URL key the restore hasn't applied yet). All
+    // internal "view changed" notifications go through notifyChange() so restore
+    // can suspend them; genuine user interactions run with it un-suspended.
+    let suspendNotify = false;
+    function notifyChange() {
+      if (!suspendNotify) onZoomChange();
+    }
     let workerTree = null;
     let offworkerTree = null;
     let workerData = null;
@@ -334,6 +344,11 @@
     let repaintQueued = false;
     let allSamples = [];
     let currentSymbols = null;
+    // True once setTreeDirect() has installed a pre-built (aggregated/API) tree.
+    // In that mode there are no raw `allSamples`, so the spawn/runtime filters
+    // (which rebuild the trees from samples) do not apply and must not run —
+    // applyFilters() over an empty sample set would wipe the direct-set tree.
+    let directMode = false;
     // Map of workerId -> runtime name, derived from the trace's runtime.<name>
     // segment metadata. Empty when the trace has a single runtime (or none),
     // in which case the runtime filter stays hidden.
@@ -509,6 +524,7 @@
       hideSearchResults();
       repaint();
       searchInput.focus();
+      notifyChange();
     });
 
     const breadcrumbBar = document.createElement("div");
@@ -765,7 +781,7 @@
       renderBreadcrumb();
       // Entering/re-pivoting inspect is a view-state change, so notify the host
       // (flamegraph.html) to persist the new focus into the URL for deep links.
-      onZoomChange();
+      notifyChange();
     }
 
     // Clear all inspect state without triggering a re-render. Used both by the
@@ -789,7 +805,7 @@
       renderAll();
       renderBreadcrumb();
       // Leaving inspect clears the persisted focus from the URL.
-      onZoomChange();
+      notifyChange();
     }
 
     function renderInspect() {
@@ -886,7 +902,7 @@
         if (key === "worker") workerZoomStack = [];
         else offworkerZoomStack = [];
         renderAll();
-        onZoomChange();
+        notifyChange();
       });
       breadcrumbBar.appendChild(rootSpan);
 
@@ -907,7 +923,7 @@
             if (key === "worker") workerZoomStack = workerZoomStack.slice(0, idx + 1);
             else offworkerZoomStack = offworkerZoomStack.slice(0, idx + 1);
             renderAll();
-            onZoomChange();
+            notifyChange();
           });
         }
         breadcrumbBar.appendChild(span);
@@ -984,6 +1000,8 @@
       searchClear.style.display = searchQuery ? "" : "none";
       renderSearchResults();
       repaint();
+      // Persist the query so a shared link reproduces the same search.
+      notifyChange();
     }
 
     // Focus the search box → re-show the results if a query is already present.
@@ -1090,14 +1108,14 @@
       if (key === "worker") workerZoomStack.push(treeNode);
       else offworkerZoomStack.push(treeNode);
       renderAll();
-      onZoomChange();
+      notifyChange();
     }
 
     function resetZoom() {
       workerZoomStack = [];
       offworkerZoomStack = [];
       renderAll();
-      onZoomChange();
+      notifyChange();
     }
 
     function isZoomed() {
@@ -1265,7 +1283,7 @@
             if (hitKey === "worker") workerZoomStack = [tn];
             else offworkerZoomStack = [tn];
             renderAll();
-            onZoomChange();
+            notifyChange();
           } else {
             zoomTo(hitKey, tn);
           }
@@ -1317,7 +1335,7 @@
       if (stack.length > 0) {
         stack.pop();
         renderAll();
-        onZoomChange();
+        notifyChange();
       }
     });
 
@@ -1422,6 +1440,7 @@
         searchQuery = "";
         searchClear.style.display = "none";
         renderAll();
+        notifyChange();
         return true;
       }
       if (inspectActive) {
@@ -1476,14 +1495,22 @@
       renderAll();
     }
 
-    spawnFilter.addEventListener("change", applyFilters);
-    runtimeFilter.addEventListener("change", applyFilters);
+    // User-driven filter change: rebuild the trees AND persist the new filter
+    // to the URL. applyFilters() itself stays notify-free so the initial load
+    // (setData → applyFilters) doesn't churn the address bar.
+    function onFilterChange() {
+      applyFilters();
+      notifyChange();
+    }
+    spawnFilter.addEventListener("change", onFilterChange);
+    runtimeFilter.addEventListener("change", onFilterChange);
 
     let workerLabelPrefix = "Worker threads";
     let offworkerLabelPrefix = "Off-worker (sampler thread)";
     let formatCount = null;
 
     function setData(samples, callframeSymbols, opts) {
+      directMode = false;
       allSamples = samples;
       currentSymbols = callframeSymbols;
       formatCount = (opts && opts.formatCount) || null;
@@ -1684,6 +1711,110 @@
       return false;
     }
 
+    // The current search query (the frames-search box text), or "" when empty.
+    function getSearch() {
+      return searchQuery;
+    }
+
+    // Programmatically set the search query (used by view-state restore). Mirrors
+    // the input handler minus the notify — restore drives this under suspend.
+    function setSearch(q) {
+      q = q || "";
+      searchInput.value = q;
+      searchQuery = q;
+      searchClear.style.display = q ? "" : "none";
+      renderSearchResults();
+      repaint();
+    }
+
+    // The active spawn-location / runtime filter values ("" = no filter). Empty
+    // in aggregated/API mode, where these controls are hidden and inapplicable.
+    function getSpawnFilter() {
+      return directMode ? "" : (spawnFilter.value || "");
+    }
+    function getRuntimeFilter() {
+      return directMode ? "" : (runtimeFilter.value || "");
+    }
+
+    // Set a filter's value only if that exact option exists (a stale link into a
+    // trace lacking the option is ignored rather than selecting an empty value).
+    function setSelectIfPresent(sel, value) {
+      if (!value) { sel.value = ""; return; }
+      for (const opt of sel.options) {
+        if (opt.value === value) { sel.value = value; return; }
+      }
+    }
+
+    // The complete, serializable view state — the exact shape the URL codec in
+    // flamegraph_view_state.js reads/writes. Absent pieces are simply omitted so
+    // the codec deletes their keys. `inspect` carries the name/symbol split so a
+    // restored link re-derives the same identity key (fullName || name).
+    function getViewState() {
+      const z = getZoomPath();
+      const out = {};
+      if (z.worker && z.worker.length) out.workerZoom = z.worker;
+      if (z.offworker && z.offworker.length) out.offworkerZoom = z.offworker;
+      if (inspectActive && inspectFocusSrc) {
+        out.inspect = {
+          name: inspectFocusSrc.name,
+          fullName: inspectFocusSrc.fullName || inspectFocusSrc.name,
+        };
+      }
+      if (searchQuery) out.search = searchQuery;
+      const spawn = getSpawnFilter();
+      if (spawn) out.spawn = spawn;
+      const runtime = getRuntimeFilter();
+      if (runtime) out.runtime = runtime;
+      return out;
+    }
+
+    // Restore a view state produced by getViewState (typically decoded from the
+    // URL). Silent by default: mutating zoom/inspect/search/filters here must not
+    // fire the persist callback (that would rewrite the URL mid-restore). Order
+    // matters: filters rebuild the trees and reset zoom, so they run FIRST, then
+    // the zoom path, then inspect, then search.
+    function applyViewState(state, opts) {
+      state = state || {};
+      const silent = !opts || opts.silent !== false;
+      const prev = suspendNotify;
+      if (silent) suspendNotify = true;
+      try {
+        // Full restore (not a merge): drive every dimension to the state's value,
+        // including "absent" → cleared, so re-applying the same URL over several
+        // streamed snapshots converges instead of accumulating.
+        resetView();
+        // Filters only apply in exact mode (raw samples present). Applying them
+        // rebuilds the trees + resets zoom, so they must precede zoom/inspect.
+        // resetView above does not touch the filter <select>s, so set them here
+        // (to the target, or "" to clear) and rebuild — but only when the value
+        // actually changes, to avoid a redundant full tree rebuild on the common
+        // fresh-load case where no filter is being restored.
+        if (!directMode) {
+          const wantSpawn = state.spawn || "";
+          const wantRuntime = state.runtime || "";
+          if (spawnFilter.value !== wantSpawn || runtimeFilter.value !== wantRuntime) {
+            setSelectIfPresent(spawnFilter, wantSpawn);
+            setSelectIfPresent(runtimeFilter, wantRuntime);
+            applyFilters();
+          }
+        }
+        if (state.workerZoom && state.workerZoom.length) {
+          zoomToPath("worker", state.workerZoom);
+        }
+        if (state.offworkerZoom && state.offworkerZoom.length) {
+          zoomToPath("offworker", state.offworkerZoom);
+        }
+        if (state.inspect) {
+          // The identity key is fullName || name — the same key focusInspectByKey
+          // matches on and getInspectFocus reports.
+          focusInspectByKey(state.inspect.fullName || state.inspect.name);
+        }
+        setSearch(state.search || "");
+      } finally {
+        suspendNotify = prev;
+      }
+    }
+
     // Clear zoom + inspect WITHOUT notifying the host. Used by flamegraph.html's
     // URL-restore retries (the aggregate tree streams in, so restore may run over
     // several snapshots): each attempt resets first, making re-applying a URL
@@ -1701,6 +1832,7 @@
     }
 
     function setTreeDirect(tree, totalCount) {
+      directMode = true;
       // For API mode: set a pre-built tree directly (no worker/off-worker split)
       // Preserve the current zoom by finding the same node in the new tree.
       const prevTarget = workerZoomStack.length > 0
@@ -1748,7 +1880,13 @@
       renderAll();
     }
 
-    return { setData, setTreeDirect, resize, destroy, handleEscape, isZoomed, getZoomPath, zoomToPath, getInspectFocus, focusInspectByKey, resetView };
+    return {
+      setData, setTreeDirect, resize, destroy, handleEscape, isZoomed,
+      getZoomPath, zoomToPath, getInspectFocus, focusInspectByKey, resetView,
+      // Consolidated view-state accessors (shape matches flamegraph_view_state.js).
+      getViewState, applyViewState,
+      getSearch, setSearch, getSpawnFilter, getRuntimeFilter,
+    };
   }
 
   const fgExports = {

--- a/dial9-viewer/ui/flamegraph_diff_view.js
+++ b/dial9-viewer/ui/flamegraph_diff_view.js
@@ -89,6 +89,13 @@
     const scopeB = opts.scopeB;
     const headersFor = opts.headersFor || (() => ({}));
     const onSideError = opts.onSideError || (() => {});
+    // Fired whenever the user changes the view (zoom or highlight), so the host
+    // can persist { zoom, search } to the URL for a shareable deep link. `zoom`
+    // is the full path from the merged root down (root INCLUDED as element 0),
+    // matching flamegraph_view_state.js's readDiffState/writeDiffState contract.
+    const onChange = opts.onChange || (() => {});
+    // Optional { zoom, search } to seed the view from a shared link.
+    const initialState = opts.initialState || {};
     const labelA = scopeLabel(scopeA, "A");
     const labelB = scopeLabel(scopeB, "B");
 
@@ -157,6 +164,16 @@
     let treeB = null; // server JSON tree, side B
     let merged = D.mergeTrees(null, null);
     let zoomPath = ["(all)"];
+    // A URL-restore zoom target (full path from the merged root down, root at
+    // index 0) we keep trying to LAND as the sides stream in: the merged tree is
+    // empty until the first snapshot, and a deep target may only appear as
+    // folding deepens. render() promotes it into zoomPath once it resolves;
+    // seeding zoomPath directly would be wiped by render()'s "path gone → root"
+    // fallback on the first (empty) paint. Cleared once it lands or the user
+    // takes control of the zoom.
+    let pendingZoom = (initialState.zoom && initialState.zoom.length)
+      ? initialState.zoom.slice()
+      : null;
     const SEP = String.fromCharCode(31);
     // `coverage` is the last-seen coverage block (files_folded/files_matched),
     // used to decide whether "Load more" can still deepen the sample and to
@@ -201,6 +218,16 @@
     // zoom change, and resize.
     function render() {
       merged = D.mergeTrees(treeA, treeB);
+      // A shared link's zoom target may not exist until the sides stream in (or
+      // fold deeper), so retry landing it on each render; adopt it only once it
+      // resolves against the current merged tree. Until then we stay at the root
+      // rather than discarding the target.
+      if (pendingZoom) {
+        if (D.nodeAtPath(merged, pendingZoom)) {
+          zoomPath = pendingZoom.slice();
+          pendingZoom = null;
+        }
+      }
       // Resolve the zoom focus; if a prior zoom path no longer exists in the
       // merged tree (pruned away), fall back to the root.
       let focus = D.nodeAtPath(merged, zoomPath);
@@ -321,11 +348,11 @@
       });
       p.canvas.addEventListener("click", (e) => {
         const box = boxAtEvent(side, e);
-        if (box && box.path.length > zoomPath.length) { zoomPath = box.path.slice(); render(); }
+        if (box && box.path.length > zoomPath.length) { commitZoom(box.path.slice()); }
       });
       p.canvas.addEventListener("contextmenu", (e) => {
         e.preventDefault();
-        if (zoomPath.length > 1) { zoomPath = zoomPath.slice(0, -1); render(); }
+        if (zoomPath.length > 1) { commitZoom(zoomPath.slice(0, -1)); }
       });
     }
     setupPanelEvents("a");
@@ -348,7 +375,7 @@
         span.textContent = zoomPath[i];
         if (!isLast) {
           const idx = i;
-          span.addEventListener("click", () => { zoomPath = zoomPath.slice(0, idx + 1); render(); });
+          span.addEventListener("click", () => { commitZoom(zoomPath.slice(0, idx + 1)); });
         }
         breadcrumb.appendChild(span);
       }
@@ -404,6 +431,25 @@
       return d.innerHTML;
     }
 
+    // Persist the current user-facing view state (zoom path + highlight query)
+    // via the host callback so a shared URL reproduces it. `zoom` omits the
+    // root-only path (nothing zoomed) so the URL stays clean at the top level.
+    function persistState() {
+      const zoom = zoomPath.length > 1 ? zoomPath.slice() : [];
+      onChange({ zoom: zoom, search: searchInput.value.trim() });
+    }
+
+    // A user-driven zoom: cancel any not-yet-landed URL-restore target (so a
+    // late-arriving snapshot can't snap the view away from where the user just
+    // navigated — mirrors the single-flamegraph viewRestored guard), set the new
+    // path, repaint, and persist to the URL.
+    function commitZoom(path) {
+      pendingZoom = null;
+      zoomPath = path;
+      render();
+      persistState();
+    }
+
     // ── Search ──
     // Recompiles the highlight regex and repaints; matched/faded state is drawn
     // by paint() (per-box alpha), not per-element class toggles.
@@ -413,10 +459,10 @@
       if (q) { try { searchRe = new RegExp(q, "i"); } catch (e) { searchRe = null; } }
       repaint();
     }
-    searchInput.addEventListener("input", applySearch);
-    resetBtn.addEventListener("click", () => { zoomPath = [rootName()]; render(); });
+    searchInput.addEventListener("input", () => { applySearch(); persistState(); });
+    resetBtn.addEventListener("click", () => { commitZoom([rootName()]); });
     const onKeydown = (e) => {
-      if (e.key === "Escape") { zoomPath = [rootName()]; render(); return; }
+      if (e.key === "Escape") { commitZoom([rootName()]); return; }
       if (isSearchFocusKey(e, document.activeElement === searchInput)) {
         e.preventDefault();
         searchInput.focus();
@@ -601,6 +647,14 @@
       repollSide("a");
       repollSide("b");
     });
+
+    // Seed the highlight box from a shared link (before the first paint so the
+    // restored highlight is visible immediately). This does not re-persist —
+    // restore must not write back over the URL it came from.
+    if (initialState.search) {
+      searchInput.value = initialState.search;
+      applySearch();
+    }
 
     updateStats();
     render();

--- a/dial9-viewer/ui/flamegraph_diff_view.js
+++ b/dial9-viewer/ui/flamegraph_diff_view.js
@@ -434,8 +434,16 @@
     // Persist the current user-facing view state (zoom path + highlight query)
     // via the host callback so a shared URL reproduces it. `zoom` omits the
     // root-only path (nothing zoomed) so the URL stays clean at the top level.
+    // While a URL-restore target is still in flight (pendingZoom set, not yet
+    // landed because data hasn't arrived), persist THAT target rather than the
+    // current root-only zoomPath — otherwise a highlight keystroke before the
+    // zoom lands would wipe diff_zoom from the URL even though the view will
+    // still jump to it. commitZoom clears pendingZoom first, so an explicit
+    // user navigation always persists where they actually are.
     function persistState() {
-      const zoom = zoomPath.length > 1 ? zoomPath.slice() : [];
+      const zoom = pendingZoom
+        ? pendingZoom.slice()
+        : (zoomPath.length > 1 ? zoomPath.slice() : []);
       onChange({ zoom: zoom, search: searchInput.value.trim() });
     }
 

--- a/dial9-viewer/ui/flamegraph_view_state.js
+++ b/dial9-viewer/ui/flamegraph_view_state.js
@@ -1,0 +1,163 @@
+"use strict";
+
+// flamegraph_view_state.js — serialize/restore the *interactive* state of a
+// flamegraph view (zoom, inspect focus, search, filters) to and from the URL
+// query string, so ANY position a user navigates to is a shareable link that
+// reproduces the exact same focus for a coworker.
+//
+// This is deliberately separate from url_state.js (which owns the landing
+// page's search/scope) and from flamegraph_diff.js's scope codec (which owns
+// the server-bound aggregate scope). Those describe WHICH samples to load; this
+// describes WHERE THE USER IS LOOKING once they are loaded. Keeping it here and
+// dependency-free lets both the browser (via <script src>) and the unit tests
+// (via require) share one source of truth.
+//
+// Single-flamegraph state shape (all fields optional):
+//   { workerZoom, offworkerZoom, inspect, search, spawn, runtime }
+//     workerZoom    : array of frame names from the worker-lane root down to the
+//                     zoom target (NOT including the synthetic root). Serialized
+//                     as `worker-zoom`, tab-joined — the pre-existing exact-mode
+//                     key, kept verbatim so old shared links still restore.
+//     offworkerZoom : same, for the off-worker lane (`offworker-zoom`). Empty in
+//                     aggregated/API mode (single tree).
+//     inspect       : { name, fullName } of the focused ("butterfly") frame, or
+//                     null. Serialized as `inspect` (display name) plus
+//                     `inspect_full` (symbol) — the latter only when it differs
+//                     from the name, since that pair is what re-derives the
+//                     frame's identity key (fullName || name) on restore.
+//     search        : the frames search query (`search`).
+//     spawn         : spawn-location filter value (`spawn`), exact mode only.
+//     runtime       : runtime filter value (`runtime`), exact mode only.
+//
+// Diff-view state shape:
+//   { zoom, search }
+//     zoom   : array of frame names from the merged root down to the zoom focus,
+//              INCLUDING the root as element 0 (the diff renderer's zoomPath
+//              carries it). Serialized as `diff_zoom`, tab-joined.
+//     search : the highlight regex (`diff_search`).
+//
+// A tab (	) separates path segments: it can't occur in a Rust symbol or a
+// frame display name, and it matches the separator the exact-mode zoom links
+// already used, so nothing here changes how a pre-existing link decodes.
+
+(function (exports) {
+  var SEP = "\t";
+
+  // Keys this module owns in the query string. Callers that rebuild the URL
+  // from scratch (API mode) delete these first, then re-add via writeState, so
+  // a view key never leaks from a previous navigation.
+  var STATE_KEYS = [
+    "worker-zoom", "offworker-zoom",
+    "inspect", "inspect_full", "search", "spawn", "runtime",
+  ];
+  var DIFF_STATE_KEYS = ["diff_zoom", "diff_search"];
+
+  function splitPath(v) {
+    if (!v) return [];
+    // Filter out empty segments so a stray leading/trailing tab can't inject a
+    // "" frame that would never match a real node.
+    return v.split(SEP).filter(function (s) { return s.length > 0; });
+  }
+
+  // Parse the single-flamegraph view state out of a query string or
+  // URLSearchParams. Missing/empty fields are simply absent from the result so
+  // callers keep their own defaults.
+  function readState(search) {
+    var p = search instanceof URLSearchParams
+      ? search
+      : new URLSearchParams(search || "");
+    var out = {};
+
+    var wz = splitPath(p.get("worker-zoom"));
+    if (wz.length) out.workerZoom = wz;
+    var oz = splitPath(p.get("offworker-zoom"));
+    if (oz.length) out.offworkerZoom = oz;
+
+    var inspect = p.get("inspect");
+    if (inspect) {
+      // `inspect_full` is the symbol (identity key); it is only serialized when
+      // it differs from the display name, so fall back to the name otherwise.
+      var full = p.get("inspect_full");
+      out.inspect = { name: inspect, fullName: full || inspect };
+    }
+
+    var q = p.get("search");
+    if (q) out.search = q;
+
+    var spawn = p.get("spawn");
+    if (spawn) out.spawn = spawn;
+
+    var runtime = p.get("runtime");
+    if (runtime) out.runtime = runtime;
+
+    return out;
+  }
+
+  // Write the single-flamegraph view state INTO an existing URLSearchParams,
+  // mutating it in place: present fields are set, absent ones deleted. Returns
+  // the same params for chaining. Deleting on absence is what keeps a URL clean
+  // as the user zooms back out or exits inspect (matching the pre-existing
+  // exact-mode zoom behavior).
+  function writeState(params, state) {
+    var s = state || {};
+
+    setOrDelete(params, "worker-zoom", (s.workerZoom && s.workerZoom.length) ? s.workerZoom.join(SEP) : null);
+    setOrDelete(params, "offworker-zoom", (s.offworkerZoom && s.offworkerZoom.length) ? s.offworkerZoom.join(SEP) : null);
+
+    if (s.inspect && s.inspect.name) {
+      params.set("inspect", s.inspect.name);
+      // Only emit the symbol when it carries information beyond the name.
+      if (s.inspect.fullName && s.inspect.fullName !== s.inspect.name) {
+        params.set("inspect_full", s.inspect.fullName);
+      } else {
+        params.delete("inspect_full");
+      }
+    } else {
+      params.delete("inspect");
+      params.delete("inspect_full");
+    }
+
+    setOrDelete(params, "search", s.search || null);
+    setOrDelete(params, "spawn", s.spawn || null);
+    setOrDelete(params, "runtime", s.runtime || null);
+
+    return params;
+  }
+
+  // Parse the diff-view state (zoom path incl. root, highlight regex).
+  function readDiffState(search) {
+    var p = search instanceof URLSearchParams
+      ? search
+      : new URLSearchParams(search || "");
+    var out = {};
+    var zoom = splitPath(p.get("diff_zoom"));
+    if (zoom.length) out.zoom = zoom;
+    var q = p.get("diff_search");
+    if (q) out.search = q;
+    return out;
+  }
+
+  function writeDiffState(params, state) {
+    var s = state || {};
+    setOrDelete(params, "diff_zoom", (s.zoom && s.zoom.length) ? s.zoom.join(SEP) : null);
+    setOrDelete(params, "diff_search", s.search || null);
+    return params;
+  }
+
+  function setOrDelete(params, key, value) {
+    if (value != null && value !== "") params.set(key, value);
+    else params.delete(key);
+  }
+
+  exports.readState = readState;
+  exports.writeState = writeState;
+  exports.readDiffState = readDiffState;
+  exports.writeDiffState = writeDiffState;
+  exports.STATE_KEYS = STATE_KEYS;
+  exports.DIFF_STATE_KEYS = DIFF_STATE_KEYS;
+
+  // Browser: expose on window as the stable scripting contract.
+  if (typeof window !== "undefined") {
+    window.Dial9FlamegraphViewState = exports;
+  }
+})(typeof exports === "undefined" ? {} : exports);

--- a/dial9-viewer/ui/test_flamegraph_deeplink.js
+++ b/dial9-viewer/ui/test_flamegraph_deeplink.js
@@ -1,0 +1,276 @@
+"use strict";
+
+// Deep-link support: the flamegraph's view state (zoom path + inspect focus)
+// must be readable and restorable so a shared URL reproduces the exact focus
+// position. This exercises the renderer API that flamegraph.html serializes
+// to/from the URL: getZoomPath/zoomToPath and getInspectFocus/focusInspectByKey,
+// plus the onZoomChange callback firing on inspect enter/exit.
+//
+// The repo has no jsdom, so — like test_flamegraph_inspect_dom.js — we install a
+// minimal DOM that records listeners and can dispatch synthetic events.
+
+const { assert, test, summarize } = require("./test_harness.js");
+
+function makeCtx() {
+  return {
+    scale() {}, fillRect() {}, save() {}, restore() {}, beginPath() {},
+    rect() {}, clip() {}, fillText() {}, measureText() { return { width: 0 }; },
+    fillStyle: "", font: "", textBaseline: "", globalAlpha: 1,
+  };
+}
+
+function makeDom() {
+  const registry = {};
+  const byClass = {};
+
+  function makeEl(tag) {
+    const listeners = {};
+    const el = {
+      tagName: tag || "div",
+      _listeners: listeners,
+      style: {},
+      dataset: {},
+      children: [],
+      _className: "",
+      _rect: { left: 0, top: 0, width: 1200, height: 400, right: 1200, bottom: 400 },
+      classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+      get className() { return el._className; },
+      set className(v) {
+        el._className = v;
+        for (const cls of String(v).split(/\s+/)) {
+          if (!cls) continue;
+          (byClass[cls] = byClass[cls] || []).push(el);
+        }
+      },
+      innerHTML: "",
+      textContent: "",
+      title: "",
+      value: "",
+      offsetWidth: 1200,
+      offsetHeight: 400,
+      clientWidth: 1200,
+      clientHeight: 400,
+      width: 0,
+      height: 0,
+      querySelector(sel) { return (registry[sel] = registry[sel] || makeEl()); },
+      querySelectorAll() { return []; },
+      appendChild(c) { el.children.push(c); c.parentNode = el; c.parentElement = el; return c; },
+      removeChild(c) { return c; },
+      insertBefore(c) { return c; },
+      remove() {},
+      setAttribute() {},
+      removeAttribute() {},
+      getAttribute() { return null; },
+      contains() { return false; },
+      focus() {}, select() {}, blur() {}, click() {},
+      getContext() { return makeCtx(); },
+      getBoundingClientRect() { return el._rect; },
+      addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+      removeEventListener(type, fn) {
+        if (!listeners[type]) return;
+        listeners[type] = listeners[type].filter((f) => f !== fn);
+      },
+      dispatchEvent(ev) {
+        ev.target = ev.target || el;
+        const fns = listeners[ev.type] || [];
+        for (const fn of fns.slice()) fn(ev);
+        return true;
+      },
+    };
+    el.parentElement = null;
+    el.parentNode = null;
+    return el;
+  }
+
+  const prevDocument = global.document;
+  const prevNavigatorDesc = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const prevWindow = global.window;
+  const prevDpr = global.devicePixelRatio;
+
+  const doc = makeEl();
+  doc.body = makeEl();
+  doc.createElement = (tag) => makeEl(tag);
+  const docListeners = {};
+  doc.addEventListener = (type, fn) => { (docListeners[type] = docListeners[type] || []).push(fn); };
+  doc.removeEventListener = (type, fn) => {
+    if (docListeners[type]) docListeners[type] = docListeners[type].filter((f) => f !== fn);
+  };
+  doc._listeners = docListeners;
+  global.document = doc;
+  Object.defineProperty(globalThis, "navigator", {
+    value: { platform: "", clipboard: { writeText() { return Promise.resolve(); } } },
+    configurable: true,
+    writable: true,
+  });
+  global.window = {
+    innerWidth: 1600, innerHeight: 900, open() { return null; },
+    addEventListener() {}, removeEventListener() {},
+  };
+  global.devicePixelRatio = 1;
+  global.requestAnimationFrame = (fn) => { fn(); return 0; };
+
+  function restore() {
+    global.document = prevDocument;
+    if (prevNavigatorDesc) Object.defineProperty(globalThis, "navigator", prevNavigatorDesc);
+    else delete globalThis.navigator;
+    global.window = prevWindow;
+    global.devicePixelRatio = prevDpr;
+  }
+
+  return { document: doc, registry, byClass, makeEl, restore };
+}
+
+function tree(name, count, self, children) {
+  const m = new Map();
+  for (const c of children || []) m.set(c.fullName || c.name, c);
+  return { name, fullName: name, location: null, count, self, children: m };
+}
+
+// root → a(10) → mid(10) → leaf(10 self)
+// root → b(5)  → mid(5)  → leaf(5 self)
+function sampleTree() {
+  const leafA = tree("leaf", 10, 10, []);
+  const midA = tree("mid", 10, 0, [leafA]);
+  const a = tree("a", 10, 0, [midA]);
+  const leafB = tree("leaf", 5, 5, []);
+  const midB = tree("mid", 5, 0, [leafB]);
+  const b = tree("b", 5, 0, [midB]);
+  return tree("", 15, 0, [a, b]);
+}
+
+function fire(el, type, props) {
+  const ev = Object.assign({
+    type, target: el, clientX: 100, clientY: 100,
+    preventDefault() {}, stopPropagation() {},
+    metaKey: false, ctrlKey: false, altKey: false,
+  }, props || {});
+  el.dispatchEvent(ev);
+  return ev;
+}
+
+test("zoom path round-trips through zoomToPath/getZoomPath", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    // Nothing zoomed initially.
+    assert.deepStrictEqual(fg.getZoomPath().worker, [], "no zoom initially");
+
+    // Restore a nested zoom the way flamegraph.html does from the URL.
+    fg.zoomToPath("worker", ["a", "mid", "leaf"]);
+    assert.deepStrictEqual(
+      fg.getZoomPath().worker, ["a", "mid", "leaf"],
+      "getZoomPath reproduces the restored nested path");
+    assert.strictEqual(fg.isZoomed(), true, "isZoomed true after restore");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("inspect focus round-trips through focusInspectByKey/getInspectFocus", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    assert.strictEqual(fg.getInspectFocus(), null, "no inspect focus initially");
+
+    // Restore inspect focus the way flamegraph.html does from the ?inspect= key.
+    const ok = fg.focusInspectByKey("mid");
+    assert.strictEqual(ok, true, "focusInspectByKey found the frame");
+    assert.strictEqual(fg.getInspectFocus(), "mid", "getInspectFocus reports the restored focus");
+
+    // The inspect (butterfly) view is visible and names the frame.
+    const inspectView = dom.byClass["fg-inspect"] && dom.byClass["fg-inspect"][0];
+    assert.strictEqual(inspectView.style.display, "", "inspect view visible after restore");
+    const band = dom.byClass["fg-focus-band"][0];
+    assert.ok(band.children.some((c) => c.textContent === "mid"), "focus band names 'mid'");
+
+    // Exiting clears the focus so a subsequent link carries no ?inspect=.
+    assert.strictEqual(fg.handleEscape(), true, "Esc consumed by inspect exit");
+    assert.strictEqual(fg.getInspectFocus(), null, "focus cleared after exit");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("focusInspectByKey is a no-op for an absent frame", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+    assert.strictEqual(fg.focusInspectByKey("does-not-exist"), false, "returns false");
+    assert.strictEqual(fg.getInspectFocus(), null, "no focus set");
+    assert.strictEqual(fg.focusInspectByKey(null), false, "null key is a no-op");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("onZoomChange fires on inspect enter and exit (URL stays in sync)", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    let calls = 0;
+    const fg = createFlamegraph(dom.makeEl(), () => { calls++; });
+    fg.setTreeDirect(sampleTree(), 15);
+
+    const before = calls;
+    fg.focusInspectByKey("mid");
+    assert.ok(calls > before, "callback fired on inspect enter");
+
+    const afterEnter = calls;
+    fg.handleEscape(); // exits inspect
+    assert.ok(calls > afterEnter, "callback fired on inspect exit");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("resetView clears zoom + inspect without firing the change callback", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    let calls = 0;
+    const fg = createFlamegraph(dom.makeEl(), () => { calls++; });
+    fg.setTreeDirect(sampleTree(), 15);
+
+    fg.zoomToPath("worker", ["a", "mid"]);
+    fg.focusInspectByKey("leaf");
+    const afterSetup = calls;
+
+    fg.resetView();
+    assert.deepStrictEqual(fg.getZoomPath().worker, [], "zoom cleared");
+    assert.strictEqual(fg.getInspectFocus(), null, "inspect cleared");
+    assert.strictEqual(calls, afterSetup, "resetView is silent (no URL churn during restore)");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("resetView makes repeated zoom restore idempotent (streaming retry safety)", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    // Simulate flamegraph.html retrying restore over several streamed snapshots:
+    // reset-then-apply each time must converge to the exact path, never append.
+    for (let i = 0; i < 3; i++) {
+      fg.resetView();
+      fg.zoomToPath("worker", ["a", "mid", "leaf"]);
+    }
+    assert.deepStrictEqual(
+      fg.getZoomPath().worker, ["a", "mid", "leaf"],
+      "path is exact after repeated reset+restore (no duplicated frames)");
+  } finally {
+    dom.restore();
+  }
+});
+
+summarize();

--- a/dial9-viewer/ui/test_flamegraph_deeplink.js
+++ b/dial9-viewer/ui/test_flamegraph_deeplink.js
@@ -273,4 +273,108 @@ test("resetView makes repeated zoom restore idempotent (streaming retry safety)"
   }
 });
 
+// --- getViewState / applyViewState: the bridge flamegraph.html uses with the
+// flamegraph_view_state.js URL codec. These pin the object shape the codec
+// reads/writes and the restore semantics (silent, full-restore, retry-safe). ---
+
+test("getViewState reports the live zoom + inspect focus in codec shape", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    assert.deepStrictEqual(fg.getViewState(), {}, "empty view → empty state");
+
+    fg.zoomToPath("worker", ["a", "mid"]);
+    fg.focusInspectByKey("leaf");
+    const st = fg.getViewState();
+    assert.deepStrictEqual(st.workerZoom, ["a", "mid"], "workerZoom captured");
+    // fullName falls back to name for aggregated trees (no symbol).
+    assert.deepStrictEqual(st.inspect, { name: "leaf", fullName: "leaf" },
+      "inspect captured as {name, fullName}");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("applyViewState restores zoom + inspect and is silent (no URL churn)", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    let calls = 0;
+    const fg = createFlamegraph(dom.makeEl(), () => { calls++; });
+    fg.setTreeDirect(sampleTree(), 15);
+
+    const before = calls;
+    fg.applyViewState({ workerZoom: ["a", "mid", "leaf"], inspect: { name: "mid", fullName: "mid" } });
+    assert.strictEqual(calls, before, "applyViewState does not fire the change callback");
+    assert.deepStrictEqual(fg.getZoomPath().worker, ["a", "mid", "leaf"], "zoom restored");
+    assert.strictEqual(fg.getInspectFocus(), "mid", "inspect restored");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("getViewState → applyViewState round-trips through the codec", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const VS = require("./flamegraph_view_state.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    fg.zoomToPath("worker", ["a", "mid"]);
+    fg.focusInspectByKey("leaf");
+
+    // Serialize to a URL and back exactly as flamegraph.html does.
+    const params = VS.writeState(new URLSearchParams(), fg.getViewState());
+
+    const fg2 = createFlamegraph(dom.makeEl());
+    fg2.setTreeDirect(sampleTree(), 15);
+    fg2.applyViewState(VS.readState(params));
+
+    assert.deepStrictEqual(fg2.getZoomPath().worker, ["a", "mid"], "zoom survived the URL round-trip");
+    assert.strictEqual(fg2.getInspectFocus(), "leaf", "inspect survived the URL round-trip");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("applyViewState is a full restore: absent fields are cleared", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    fg.applyViewState({ workerZoom: ["a", "mid"], inspect: { name: "leaf", fullName: "leaf" } });
+    // Re-apply an empty state: prior zoom/inspect must be gone, not merged.
+    fg.applyViewState({});
+    assert.deepStrictEqual(fg.getZoomPath().worker, [], "zoom cleared by empty restore");
+    assert.strictEqual(fg.getInspectFocus(), null, "inspect cleared by empty restore");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("repeated applyViewState converges (streamed-snapshot retry safety)", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    // flamegraph.html re-applies the URL state on each streamed snapshot until
+    // the focus lands; that must be idempotent (no duplicated zoom frames).
+    for (let i = 0; i < 3; i++) {
+      fg.applyViewState({ workerZoom: ["a", "mid", "leaf"] });
+    }
+    assert.deepStrictEqual(fg.getZoomPath().worker, ["a", "mid", "leaf"],
+      "zoom path exact after repeated restore");
+  } finally {
+    dom.restore();
+  }
+});
+
 summarize();

--- a/dial9-viewer/ui/test_flamegraph_diff_view_state.js
+++ b/dial9-viewer/ui/test_flamegraph_diff_view_state.js
@@ -1,0 +1,247 @@
+"use strict";
+
+// Diff-view URL state wiring: createDiffView(onChange/initialState). The diff
+// view is normally browser-only (it owns DOM + live SSE streams), so this test
+// installs a minimal DOM and stubs the SSE module to synchronously deliver one
+// tree per side. It asserts the two things flamegraph.html relies on:
+//   1. initialState { zoom, search } seeds the view (deep-link restore).
+//   2. onChange fires with { zoom, search } on user zoom / highlight (persist).
+// The zoom path is root-inclusive (element 0 is the merged root), matching the
+// flamegraph_view_state.js diff codec contract.
+
+const { assert, test, summarize } = require("./test_harness.js");
+
+// --- Stub the SSE module so each side "streams" one fixed tree, synchronously.
+const sse = require("./sse.js");
+const realOpenSse = sse.openSse;
+// tree: (all) → runtime → poll(leaf). Server JSON shape {name,count,self,children}.
+function serverTree() {
+  return {
+    name: "(all)", count: 10, self: 0,
+    children: [
+      { name: "runtime", count: 10, self: 0, children: [
+        { name: "poll", count: 10, self: 10, children: [] },
+      ]},
+    ],
+  };
+}
+// Capture each side's callbacks so a test can control WHEN data arrives. This
+// matters for the deep-link case: in the browser the merged tree is empty until
+// the first SSE snapshot lands (well after construction), so a seeded zoom must
+// survive the initial empty render and land later — not be delivered inline.
+let sides = [];
+sse.openSse = function (url, opts) {
+  sides.push(opts);
+  return Promise.resolve();
+};
+// Deliver one snapshot (+ close) to every open side, as the server would.
+function deliverSnapshot() {
+  for (const opts of sides) {
+    if (opts.onEvent) opts.onEvent({ tree: serverTree(), total_samples: 10, metadata: { hosts: 1 }, coverage: null });
+    if (opts.onClose) opts.onClose();
+  }
+}
+
+function makeCtx() {
+  return {
+    scale() {}, fillRect() {}, save() {}, restore() {}, beginPath() {},
+    rect() {}, clip() {}, fillText() {}, measureText() { return { width: 0 }; },
+    setTransform() {}, strokeRect() {}, stroke() {},
+    fillStyle: "", strokeStyle: "", lineWidth: 1, font: "", textBaseline: "", globalAlpha: 1,
+  };
+}
+
+function makeDom() {
+  function makeEl(tag) {
+    const listeners = {};
+    const el = {
+      tagName: tag || "div", _listeners: listeners, style: {}, dataset: {},
+      children: [], _className: "", value: "",
+      _rect: { left: 0, top: 0, width: 600, height: 400, right: 600, bottom: 400 },
+      classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+      get className() { return el._className; },
+      set className(v) { el._className = v; },
+      innerHTML: "", textContent: "", title: "",
+      offsetWidth: 600, offsetHeight: 400, clientWidth: 600, clientHeight: 400,
+      width: 0, height: 0,
+      // Every querySelector returns a fresh stable child so header controls exist.
+      _q: {},
+      querySelector(sel) { return (el._q[sel] = el._q[sel] || makeEl()); },
+      querySelectorAll() { return []; },
+      appendChild(c) { el.children.push(c); c.parentNode = el; c.parentElement = el; return c; },
+      removeChild(c) { return c; },
+      insertBefore(c) { return c; },
+      remove() {},
+      setAttribute() {}, removeAttribute() {}, getAttribute() { return null; },
+      contains() { return false; },
+      focus() {}, select() {}, blur() {}, click() {},
+      getContext() { return makeCtx(); },
+      getBoundingClientRect() { return el._rect; },
+      addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+      removeEventListener(type, fn) {
+        if (!listeners[type]) return;
+        listeners[type] = listeners[type].filter((f) => f !== fn);
+      },
+      dispatchEvent(ev) {
+        ev.target = ev.target || el;
+        for (const fn of (listeners[ev.type] || []).slice()) fn(ev);
+        return true;
+      },
+    };
+    el.parentElement = null; el.parentNode = null;
+    return el;
+  }
+
+  const prev = { doc: global.document, win: global.window, dpr: global.devicePixelRatio, raf: global.requestAnimationFrame };
+  const prevNav = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const doc = makeEl();
+  doc.body = makeEl();
+  doc.createElement = (tag) => makeEl(tag);
+  doc.activeElement = null;
+  const docListeners = {};
+  doc.addEventListener = (t, fn) => { (docListeners[t] = docListeners[t] || []).push(fn); };
+  doc.removeEventListener = () => {};
+  global.document = doc;
+  Object.defineProperty(globalThis, "navigator", { value: { platform: "" }, configurable: true, writable: true });
+  const winListeners = {};
+  global.window = {
+    innerWidth: 1600, innerHeight: 900, location: { origin: "http://localhost" },
+    addEventListener(t, fn) { (winListeners[t] = winListeners[t] || []).push(fn); },
+    removeEventListener() {},
+    devicePixelRatio: 1,
+  };
+  global.window._listeners = winListeners;
+  global.devicePixelRatio = 1;
+  global.requestAnimationFrame = (fn) => { fn(); return 0; };
+
+  function restore() {
+    global.document = prev.doc; global.window = prev.win;
+    global.devicePixelRatio = prev.dpr; global.requestAnimationFrame = prev.raf;
+    if (prevNav) Object.defineProperty(globalThis, "navigator", prevNav);
+    else delete globalThis.navigator;
+  }
+  return { makeEl, restore, container: makeEl() };
+}
+
+const { createDiffView } = require("./flamegraph_diff_view.js");
+
+function scopes() {
+  return { a: new URLSearchParams("service=svc-a"), b: new URLSearchParams("service=svc-b") };
+}
+
+test("seeded zoom SURVIVES the empty initial render and lands once data arrives", () => {
+  const dom = makeDom();
+  sides = [];
+  try {
+    const s = scopes();
+    const view = createDiffView(dom.container, {
+      scopeA: s.a, scopeB: s.b,
+      initialState: { zoom: ["(all)", "runtime"], search: "poll" },
+    });
+    assert.ok(view && typeof view.destroy === "function", "view constructed with initial state");
+
+    // The seeded highlight query is applied immediately (no data needed).
+    const searchInput = dom.container.children[0]._q[".fgd-search"];
+    assert.strictEqual(searchInput.value, "poll", "seeded highlight query set");
+
+    // Data has NOT arrived yet: the merged tree is empty, so the deep zoom
+    // target cannot resolve. The regression was render() clobbering the seed to
+    // root here; the breadcrumb (shown only when zoomed past root) must stay
+    // hidden but the seed must be RETAINED, not discarded.
+    const breadcrumb = dom.container.children[1];
+    assert.strictEqual(breadcrumb.style.display, "none",
+      "before data: not zoomed yet (breadcrumb hidden)");
+
+    // Now the sides stream in. render() re-tries the pending target, which now
+    // resolves against the merged tree, so the view jumps to the seeded focus.
+    deliverSnapshot();
+    assert.strictEqual(breadcrumb.style.display, "flex",
+      "after data: seeded zoom landed (breadcrumb visible)");
+    view.destroy();
+  } finally {
+    dom.restore();
+  }
+});
+
+test("onChange fires with { zoom, search } when the highlight box changes", () => {
+  const dom = makeDom();
+  sides = [];
+  try {
+    const s = scopes();
+    let last = null;
+    const view = createDiffView(dom.container, {
+      scopeA: s.a, scopeB: s.b,
+      onChange: (st) => { last = st; },
+    });
+    // The header is the first child appended to the container; the search input
+    // is its ".fgd-search" query child.
+    const header = dom.container.children[0];
+    const searchInput = header._q[".fgd-search"];
+    assert.ok(searchInput, "search input exists");
+    searchInput.value = "runtime";
+    searchInput.dispatchEvent({ type: "input" });
+    assert.ok(last, "onChange fired on highlight input");
+    assert.strictEqual(last.search, "runtime", "onChange carries the highlight query");
+    assert.deepStrictEqual(last.zoom, [], "no zoom → empty zoom array (clean URL)");
+    view.destroy();
+  } finally {
+    dom.restore();
+  }
+});
+
+test("onChange fires with a root-inclusive zoom on Escape reset", () => {
+  const dom = makeDom();
+  sides = [];
+  try {
+    const s = scopes();
+    let last = null;
+    const view = createDiffView(dom.container, {
+      scopeA: s.a, scopeB: s.b,
+      initialState: { zoom: ["(all)", "runtime"] },
+      onChange: (st) => { last = st; },
+    });
+    deliverSnapshot();
+    // Escape resets zoom to the root and persists — the window keydown listener.
+    const winListeners = global.window._listeners.keydown || [];
+    assert.ok(winListeners.length > 0, "diff view registered a keydown listener");
+    for (const fn of winListeners) fn({ key: "Escape", preventDefault() {} });
+    assert.ok(last, "onChange fired on Escape reset");
+    assert.deepStrictEqual(last.zoom, [], "reset → empty zoom array");
+    view.destroy();
+  } finally {
+    dom.restore();
+  }
+});
+
+test("a user zoom cancels a not-yet-landed pending restore", () => {
+  const dom = makeDom();
+  sides = [];
+  try {
+    const s = scopes();
+    let last = null;
+    // Seed a DEEP target that never appears in the streamed tree (only "runtime"
+    // does). Before it can land, the user resets — which must cancel the pending
+    // restore so a later snapshot can't snap the view back to the seed.
+    const view = createDiffView(dom.container, {
+      scopeA: s.a, scopeB: s.b,
+      initialState: { zoom: ["(all)", "runtime", "poll"] },
+      onChange: (st) => { last = st; },
+    });
+    // User hits Escape (reset to root) before any data arrives.
+    for (const fn of (global.window._listeners.keydown || [])) fn({ key: "Escape", preventDefault() {} });
+    assert.deepStrictEqual(last.zoom, [], "user reset persisted a root zoom");
+    // Data now arrives; the (cancelled) seed must NOT re-zoom the view.
+    deliverSnapshot();
+    const breadcrumb = dom.container.children[1];
+    assert.strictEqual(breadcrumb.style.display, "none",
+      "view stays at root — cancelled restore did not snap back");
+    view.destroy();
+  } finally {
+    dom.restore();
+  }
+});
+
+// Restore the real SSE fn so requiring this module elsewhere is side-effect free.
+sse.openSse = realOpenSse;
+
+summarize();

--- a/dial9-viewer/ui/test_flamegraph_diff_view_state.js
+++ b/dial9-viewer/ui/test_flamegraph_diff_view_state.js
@@ -189,6 +189,35 @@ test("onChange fires with { zoom, search } when the highlight box changes", () =
   }
 });
 
+test("highlight typed before a deep-link zoom lands keeps the zoom in the URL", () => {
+  const dom = makeDom();
+  sides = [];
+  try {
+    const s = scopes();
+    let last = null;
+    // Deep-link seeds a zoom target that can't resolve until data arrives.
+    const view = createDiffView(dom.container, {
+      scopeA: s.a, scopeB: s.b,
+      initialState: { zoom: ["(all)", "runtime"] },
+      onChange: (st) => { last = st; },
+    });
+    // User types a highlight BEFORE any snapshot arrives (pendingZoom still in
+    // flight, zoomPath still root-only). persistState must carry the pending
+    // target, not wipe diff_zoom — otherwise the URL loses the zoom the view
+    // will still jump to once data lands.
+    const searchInput = dom.container.children[0]._q[".fgd-search"];
+    searchInput.value = "poll";
+    searchInput.dispatchEvent({ type: "input" });
+    assert.ok(last, "onChange fired on highlight input");
+    assert.strictEqual(last.search, "poll", "highlight persisted");
+    assert.deepStrictEqual(last.zoom, ["(all)", "runtime"],
+      "pending zoom target preserved in the URL, not wiped");
+    view.destroy();
+  } finally {
+    dom.restore();
+  }
+});
+
 test("onChange fires with a root-inclusive zoom on Escape reset", () => {
   const dom = makeDom();
   sides = [];

--- a/dial9-viewer/ui/test_flamegraph_exact_view_state.js
+++ b/dial9-viewer/ui/test_flamegraph_exact_view_state.js
@@ -1,0 +1,206 @@
+"use strict";
+
+// Exact-trace view-state round-trip: search + spawn-location filter. The
+// deep-link test uses setTreeDirect (aggregated/API mode), where the spawn and
+// runtime filters are hidden and inapplicable. This test drives the OTHER path —
+// setData() with raw samples — so getViewState/applyViewState are exercised for
+// search and the spawn filter, including the ordering rule that a filter rebuilds
+// the trees BEFORE zoom/inspect restore.
+//
+// The repo has no jsdom, so — like test_flamegraph_inspect_dom.js and
+// test_flamegraph_deeplink.js — we install a minimal DOM stub.
+
+const { assert, test, summarize } = require("./test_harness.js");
+
+function makeCtx() {
+  return {
+    scale() {}, fillRect() {}, save() {}, restore() {}, beginPath() {},
+    rect() {}, clip() {}, fillText() {}, measureText() { return { width: 0 }; },
+    fillStyle: "", font: "", textBaseline: "", globalAlpha: 1,
+  };
+}
+
+function makeDom() {
+  const byClass = {};
+  function makeEl(tag) {
+    const listeners = {};
+    const el = {
+      tagName: tag || "div", _listeners: listeners, style: {}, dataset: {},
+      children: [], _className: "", options: [],
+      _rect: { left: 0, top: 0, width: 1200, height: 400, right: 1200, bottom: 400 },
+      classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+      get className() { return el._className; },
+      set className(v) {
+        el._className = v;
+        for (const cls of String(v).split(/\s+/)) {
+          if (!cls) continue;
+          (byClass[cls] = byClass[cls] || []).push(el);
+        }
+      },
+      innerHTML: "", textContent: "", title: "", value: "",
+      offsetWidth: 1200, offsetHeight: 400, clientWidth: 1200, clientHeight: 400,
+      width: 0, height: 0,
+      querySelector() { return makeEl(); },
+      querySelectorAll() { return []; },
+      appendChild(c) {
+        el.children.push(c); c.parentNode = el; c.parentElement = el;
+        // <select> tracks its <option> children so value-set can be validated.
+        if (c.tagName === "option") el.options.push(c);
+        return c;
+      },
+      removeChild(c) { return c; },
+      insertBefore(c) { return c; },
+      remove() {},
+      setAttribute() {}, removeAttribute() {}, getAttribute() { return null; },
+      contains() { return false; },
+      focus() {}, select() {}, blur() {}, click() {},
+      getContext() { return makeCtx(); },
+      getBoundingClientRect() { return el._rect; },
+      addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+      removeEventListener(type, fn) {
+        if (!listeners[type]) return;
+        listeners[type] = listeners[type].filter((f) => f !== fn);
+      },
+      dispatchEvent(ev) {
+        ev.target = ev.target || el;
+        for (const fn of (listeners[ev.type] || []).slice()) fn(ev);
+        return true;
+      },
+    };
+    el.parentElement = null; el.parentNode = null;
+    return el;
+  }
+
+  const prevDocument = global.document;
+  const prevNavigatorDesc = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const prevWindow = global.window;
+  const prevDpr = global.devicePixelRatio;
+
+  const doc = makeEl();
+  doc.body = makeEl();
+  doc.createElement = (tag) => makeEl(tag);
+  const docListeners = {};
+  doc.addEventListener = (type, fn) => { (docListeners[type] = docListeners[type] || []).push(fn); };
+  doc.removeEventListener = (type, fn) => {
+    if (docListeners[type]) docListeners[type] = docListeners[type].filter((f) => f !== fn);
+  };
+  doc._listeners = docListeners;
+  global.document = doc;
+  Object.defineProperty(globalThis, "navigator", {
+    value: { platform: "", clipboard: { writeText() { return Promise.resolve(); } } },
+    configurable: true, writable: true,
+  });
+  global.window = {
+    innerWidth: 1600, innerHeight: 900, open() { return null; },
+    addEventListener() {}, removeEventListener() {},
+  };
+  global.devicePixelRatio = 1;
+  global.requestAnimationFrame = (fn) => { fn(); return 0; };
+
+  function restore() {
+    global.document = prevDocument;
+    if (prevNavigatorDesc) Object.defineProperty(globalThis, "navigator", prevNavigatorDesc);
+    else delete globalThis.navigator;
+    global.window = prevWindow;
+    global.devicePixelRatio = prevDpr;
+  }
+  return { makeEl, restore, byClass };
+}
+
+// Two spawn locations, each with a distinct leaf, so a spawn filter changes the
+// tree observably. callframeSymbols maps addr → { symbol, location }.
+function sampleData() {
+  const symbols = new Map([
+    [1, { symbol: "root_fn", location: null }],
+    [2, { symbol: "alpha_leaf", location: null }],
+    [3, { symbol: "beta_leaf", location: null }],
+  ]);
+  // callchain is innermost-first (buildFlamegraphTree reverses it); workerId
+  // != 255 so the samples land in the worker lane.
+  const samples = [
+    { callchain: [2, 1], workerId: 0, spawnLoc: "src/a.rs:1", weight: 1 },
+    { callchain: [2, 1], workerId: 0, spawnLoc: "src/a.rs:1", weight: 1 },
+    { callchain: [3, 1], workerId: 0, spawnLoc: "src/b.rs:2", weight: 1 },
+  ];
+  return { samples, symbols };
+}
+
+test("search round-trips through getViewState/applyViewState (exact mode)", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    const { samples, symbols } = sampleData();
+    fg.setData(samples, symbols, { exportTitle: "t" });
+
+    fg.setSearch("alpha");
+    assert.strictEqual(fg.getSearch(), "alpha", "getSearch reports the live query");
+    assert.strictEqual(fg.getViewState().search, "alpha", "search in view state");
+
+    const fg2 = createFlamegraph(dom.makeEl());
+    fg2.setData(samples, symbols, { exportTitle: "t" });
+    fg2.applyViewState(fg.getViewState());
+    assert.strictEqual(fg2.getSearch(), "alpha", "search restored");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("spawn filter round-trips and rebuilds the tree before zoom restore", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    const { samples, symbols } = sampleData();
+    fg.setData(samples, symbols, { exportTitle: "t" });
+
+    // Apply a spawn filter + a zoom into the alpha subtree. applyViewState must
+    // set the filter (rebuild) FIRST, then zoom — otherwise the zoom target
+    // would resolve against the unfiltered tree.
+    const state = { spawn: "src/a.rs:1", workerZoom: ["root_fn", "alpha_leaf"] };
+    fg.applyViewState(state);
+    assert.strictEqual(fg.getSpawnFilter(), "src/a.rs:1", "spawn filter restored");
+    assert.deepStrictEqual(fg.getZoomPath().worker, ["root_fn", "alpha_leaf"],
+      "zoom restored against the filtered tree");
+
+    const st = fg.getViewState();
+    assert.strictEqual(st.spawn, "src/a.rs:1");
+    assert.deepStrictEqual(st.workerZoom, ["root_fn", "alpha_leaf"]);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("applyViewState({}) clears a previously-applied spawn filter", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    const { samples, symbols } = sampleData();
+    fg.setData(samples, symbols, { exportTitle: "t" });
+
+    fg.applyViewState({ spawn: "src/a.rs:1" });
+    assert.strictEqual(fg.getSpawnFilter(), "src/a.rs:1", "filter applied");
+    fg.applyViewState({});
+    assert.strictEqual(fg.getSpawnFilter(), "", "filter cleared by empty restore");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("a stale spawn value not present in this trace is ignored", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    const { samples, symbols } = sampleData();
+    fg.setData(samples, symbols, { exportTitle: "t" });
+
+    fg.applyViewState({ spawn: "src/nonexistent.rs:99" });
+    assert.strictEqual(fg.getSpawnFilter(), "", "unknown spawn value left unselected");
+  } finally {
+    dom.restore();
+  }
+});
+
+summarize();

--- a/dial9-viewer/ui/test_flamegraph_inspect.js
+++ b/dial9-viewer/ui/test_flamegraph_inspect.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+"use strict";
+
+// Tests for the pure inspect/butterfly (#652) and search-results (#653) tree
+// builders in flamegraph.js. These are DOM-free, so they run under plain node.
+
+const { assert, test, summarize } = require("./test_harness.js");
+const FG = require("./flamegraph.js");
+
+// Build a flamegraph-tree node in the shape trace_analysis.buildFlamegraphTree
+// produces: { name, fullName, count, self, children: Map }. Enforces the tree
+// invariant count === self + Σ(children.count): if `count` is given, `self` is
+// derived from it; otherwise `count` is derived from `self` (default 0) plus
+// the children. This keeps fixtures internally consistent for free.
+function node(name, spec) {
+  spec = spec || {};
+  const children = new Map();
+  let childSum = 0;
+  for (const c of spec.children || []) {
+    children.set(c.fullName || c.name, c);
+    childSum += c.count;
+  }
+  let count, self;
+  if (spec.count != null) {
+    count = spec.count;
+    self = spec.self != null ? spec.self : count - childSum;
+  } else {
+    self = spec.self != null ? spec.self : 0;
+    count = childSum + self;
+  }
+  return {
+    name: name,
+    fullName: spec.fullName || name,
+    location: spec.location || null,
+    docsUrl: spec.docsUrl || null,
+    count: count,
+    self: self,
+    children: children,
+  };
+}
+
+// Shared fixture:
+//   (all) 100
+//   ├── a 60 (self 10)
+//   │   ├── b 30 (self 5)  → target 25
+//   │   └── target 20
+//   └── c 40
+//       └── b 40 (self 10) → target 30
+function fixture() {
+  const targetA = node("target", { count: 25, self: 25 });
+  const targetB = node("target", { count: 20, self: 20 });
+  const targetC = node("target", { count: 30, self: 30 });
+  const bUnderA = node("b", { self: 5, children: [targetA] });
+  const bUnderC = node("b", { self: 10, children: [targetC] });
+  const a = node("a", { self: 10, children: [bUnderA, targetB] });
+  const c = node("c", { self: 0, children: [bUnderC] });
+  return node("(all)", { children: [a, c] });
+}
+
+test("buildInspect: totals and self across all occurrences", () => {
+  const root = fixture();
+  const focus = root.children.get("a").children.get("target"); // any occurrence
+  const ins = FG.buildInspect(root, focus);
+  assert.strictEqual(ins.total, 75, "inclusive total = 25+20+30");
+  assert.strictEqual(ins.self, 75, "self = 25+20+30 (all leaves)");
+  assert.strictEqual(ins.occurrences, 3, "three call sites");
+  assert.strictEqual(ins.focusName, "target");
+});
+
+test("buildInspect: callees tree merges subtrees (leaves → no children)", () => {
+  const root = fixture();
+  const focus = root.children.get("a").children.get("target");
+  const ins = FG.buildInspect(root, focus);
+  assert.strictEqual(ins.callees.count, 75, "callee root count is inclusive total");
+  assert.strictEqual(ins.callees.self, 75, "callee root self is exact self");
+  assert.strictEqual(ins.callees.children.size, 0, "target is a leaf everywhere");
+});
+
+test("buildInspect: callers tree is the inverted caller graph", () => {
+  const root = fixture();
+  const focus = root.children.get("a").children.get("target");
+  const ins = FG.buildInspect(root, focus);
+  const callers = ins.callers;
+  assert.strictEqual(callers.count, 75, "caller root = focus inclusive total");
+  // Immediate callers of target: b (25 via a→b, 30 via c→b = 55) and a (20).
+  assert.strictEqual(callers.children.size, 2, "two immediate callers: b and a");
+  const b = callers.children.get("b");
+  const aDirect = callers.children.get("a");
+  assert.ok(b && aDirect, "both b and a present as immediate callers");
+  assert.strictEqual(b.count, 55, "b calls target with 25+30 samples");
+  assert.strictEqual(aDirect.count, 20, "a directly calls target with 20 samples");
+  // b's callers: a (25) and c (30).
+  assert.strictEqual(b.children.size, 2, "b is called by a and c");
+  assert.strictEqual(b.children.get("a").count, 25, "a→b→target = 25");
+  assert.strictEqual(b.children.get("c").count, 30, "c→b→target = 30");
+});
+
+test("buildInspect: recursion is not double-counted", () => {
+  // r → rec → rec → rec(self 50)
+  const inner = node("rec", { count: 50, self: 50 });
+  const mid = node("rec", { self: 0, children: [inner] });
+  const outer = node("rec", { self: 0, children: [mid] });
+  const root = node("(all)", { children: [node("r", { children: [outer] })] });
+  const ins = FG.buildInspect(root, inner);
+  assert.strictEqual(ins.total, 50, "inclusive counted once at top-most rec");
+  assert.strictEqual(ins.self, 50, "self still summed across nested frames");
+  assert.strictEqual(ins.occurrences, 1, "only the top-most rec is a call site");
+  // Callers: only r (the caller of the top-most rec), not rec-under-rec.
+  assert.strictEqual(ins.callers.children.size, 1, "single immediate caller");
+  assert.ok(ins.callers.children.get("r"), "r is the caller");
+  // Callees: the recursive self-calls remain visible below focus.
+  assert.ok(ins.callees.children.has("rec"), "recursion visible in callees");
+});
+
+test("buildInspect: matches by fullName (aggregated trees may lack it)", () => {
+  // Aggregated/API trees have no fullName; matching must fall back to name.
+  const leaf1 = { name: "foo", count: 10, self: 10, children: new Map() };
+  const leaf2 = { name: "foo", count: 5, self: 5, children: new Map() };
+  const p = { name: "p", count: 15, self: 0, children: new Map([["foo", leaf1]]) };
+  const q = { name: "q", count: 5, self: 0, children: new Map([["foo", leaf2]]) };
+  const root = { name: "(all)", count: 20, self: 0, children: new Map([["p", p], ["q", q]]) };
+  const ins = FG.buildInspect(root, leaf1);
+  assert.strictEqual(ins.total, 15, "foo inclusive = 10+5");
+  assert.strictEqual(ins.callers.children.size, 2, "p and q both call foo");
+});
+
+test("collectSearchResults: groups by function with sizes and sites", () => {
+  const root = fixture();
+  const results = FG.collectSearchResults(root, "target");
+  assert.strictEqual(results.length, 1, "one matching function");
+  const r = results[0];
+  assert.strictEqual(r.name, "target");
+  assert.strictEqual(r.total, 75, "inclusive across all sites");
+  assert.strictEqual(r.self, 75, "self across all sites");
+  assert.strictEqual(r.sites, 3, "three call sites");
+});
+
+test("collectSearchResults: substring match spans multiple functions", () => {
+  const root = fixture();
+  const results = FG.collectSearchResults(root, "b");
+  const b = results.find((x) => x.name === "b");
+  assert.ok(b, "b matched");
+  assert.strictEqual(b.total, 70, "b inclusive = 30 (under a) + 40 (under c)");
+  assert.strictEqual(b.self, 15, "b self = 5 + 10");
+  assert.strictEqual(b.sites, 2, "two b call sites");
+});
+
+test("collectSearchResults: no matches → empty array", () => {
+  const root = fixture();
+  assert.deepStrictEqual(FG.collectSearchResults(root, "zzz"), []);
+});
+
+test("searchAggregate: inclusive coverage matches a frame's inspect total", () => {
+  const root = fixture();
+  // "target" appears in 3 places totalling 75 inclusive samples; rootTotal 100.
+  const agg = FG.searchAggregate(root, "target");
+  assert.strictEqual(agg.functions, 1, "one distinct matching function");
+  assert.strictEqual(agg.covered, 75, "inclusive union = 25+20+30");
+  assert.strictEqual(agg.rootTotal, 100);
+  // Must equal what buildInspect reports for the same frame (no self/inclusive
+  // mismatch between the summary line, the dropdown, and the focus band).
+  const focus = root.children.get("a").children.get("target");
+  const ins = FG.buildInspect(root, focus);
+  assert.strictEqual(agg.covered, ins.total, "summary coverage == inspect total");
+});
+
+test("searchAggregate: nested matches are not double-counted", () => {
+  // r → rec(inclusive 50) → rec → rec(self 50). Substring "rec" matches all
+  // three nested frames, but coverage counts the top-most once = 50.
+  const inner = node("rec", { count: 50, self: 50 });
+  const mid = node("rec", { self: 0, children: [inner] });
+  const outer = node("rec", { self: 0, children: [mid] });
+  const root = node("(all)", { children: [node("r", { children: [outer] })] });
+  const agg = FG.searchAggregate(root, "rec");
+  assert.strictEqual(agg.functions, 1, "'rec' is one distinct function");
+  assert.strictEqual(agg.covered, 50, "counted once at the top-most rec");
+});
+
+test("searchAggregate: distinct-function count matches dropdown", () => {
+  const root = fixture();
+  // "b" matches only function b; but a broad query can hit several functions.
+  const aggB = FG.searchAggregate(root, "b");
+  assert.strictEqual(aggB.functions, 1);
+  const results = FG.collectSearchResults(root, "b");
+  assert.strictEqual(aggB.functions, results.length,
+    "summary 'N frames' equals dropdown row count");
+});
+
+test("buildInspect + search span multiple roots (worker + off-worker lanes)", () => {
+  // Two independent lanes, both containing `target` under different callers.
+  const workerTarget = node("target", { count: 25, self: 25 });
+  const worker = node("(all)", {
+    children: [node("w", { children: [workerTarget] })],
+  });
+  const offTarget = node("target", { count: 15, self: 15 });
+  const offworker = node("(all)", {
+    children: [node("o", { children: [offTarget] })],
+  });
+  const ins = FG.buildInspect([worker, offworker], workerTarget);
+  assert.strictEqual(ins.total, 40, "target inclusive across both lanes = 25+15");
+  assert.strictEqual(ins.rootTotal, 40, "rootTotal sums both lane roots");
+  assert.strictEqual(ins.callers.children.size, 2, "callers w and o from both lanes");
+  assert.ok(ins.callers.children.get("w") && ins.callers.children.get("o"));
+
+  const results = FG.collectSearchResults([worker, offworker], "target");
+  assert.strictEqual(results.length, 1);
+  assert.strictEqual(results[0].total, 40, "search total spans both lanes");
+  assert.strictEqual(results[0].sites, 2, "one site per lane");
+});
+
+summarize();

--- a/dial9-viewer/ui/test_flamegraph_inspect_dom.js
+++ b/dial9-viewer/ui/test_flamegraph_inspect_dom.js
@@ -1,0 +1,256 @@
+"use strict";
+
+// DOM-level smoke test for the inspect/butterfly UI (#652) and the search
+// results dropdown (#653). The repo has no jsdom, so — like
+// test_flamegraph_setdirect_export.js — we install a minimal DOM. This stub is
+// richer: elements record event listeners and can dispatch synthetic events, so
+// the test can drive the real event handlers (right-click → context menu →
+// Inspect, plain click → re-pivot, Esc → exit) end to end through the renderer.
+
+const { assert, test, summarize } = require("./test_harness.js");
+
+function makeCtx() {
+  return {
+    scale() {}, fillRect() {}, save() {}, restore() {}, beginPath() {},
+    rect() {}, clip() {}, fillText() {}, measureText() { return { width: 0 }; },
+    fillStyle: "", font: "", textBaseline: "", globalAlpha: 1,
+  };
+}
+
+// A DOM environment where elements track class/style/children/listeners and can
+// dispatchEvent to their registered handlers. Returns { document, registry,
+// elements, restore }. `elements` collects every element by className so the
+// test can find the canvases and menu after construction.
+function makeDom() {
+  const registry = {};
+  const byClass = {};
+
+  function makeEl(tag) {
+    const listeners = {};
+    const el = {
+      tagName: tag || "div",
+      _listeners: listeners,
+      style: {},
+      dataset: {},
+      children: [],
+      _className: "",
+      _rect: { left: 0, top: 0, width: 1200, height: 400, right: 1200, bottom: 400 },
+      classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+      get className() { return el._className; },
+      set className(v) {
+        el._className = v;
+        for (const cls of String(v).split(/\s+/)) {
+          if (!cls) continue;
+          (byClass[cls] = byClass[cls] || []).push(el);
+        }
+      },
+      innerHTML: "",
+      textContent: "",
+      title: "",
+      value: "",
+      offsetWidth: 1200,
+      offsetHeight: 400,
+      clientWidth: 1200,
+      clientHeight: 400,
+      width: 0,
+      height: 0,
+      querySelector(sel) { return (registry[sel] = registry[sel] || makeEl()); },
+      querySelectorAll() { return []; },
+      appendChild(c) { el.children.push(c); c.parentNode = el; c.parentElement = el; return c; },
+      removeChild(c) { return c; },
+      insertBefore(c) { return c; },
+      remove() {},
+      setAttribute() {},
+      removeAttribute() {},
+      getAttribute() { return null; },
+      contains() { return false; },
+      focus() {}, select() {}, blur() {}, click() {},
+      getContext() { return makeCtx(); },
+      getBoundingClientRect() { return el._rect; },
+      addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+      removeEventListener(type, fn) {
+        if (!listeners[type]) return;
+        listeners[type] = listeners[type].filter((f) => f !== fn);
+      },
+      dispatchEvent(ev) {
+        ev.target = ev.target || el;
+        const fns = listeners[ev.type] || [];
+        for (const fn of fns.slice()) fn(ev);
+        return true;
+      },
+    };
+    el.parentElement = null;
+    el.parentNode = null;
+    return el;
+  }
+
+  const prevDocument = global.document;
+  const prevNavigatorDesc = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const prevWindow = global.window;
+  const prevDpr = global.devicePixelRatio;
+
+  const doc = makeEl();
+  doc.body = makeEl();
+  doc.createElement = (tag) => makeEl(tag);
+  const docListeners = {};
+  doc.addEventListener = (type, fn) => { (docListeners[type] = docListeners[type] || []).push(fn); };
+  doc.removeEventListener = (type, fn) => {
+    if (docListeners[type]) docListeners[type] = docListeners[type].filter((f) => f !== fn);
+  };
+  doc._listeners = docListeners;
+  global.document = doc;
+  Object.defineProperty(globalThis, "navigator", {
+    value: { platform: "", clipboard: { writeText() { return Promise.resolve(); } } },
+    configurable: true,
+    writable: true,
+  });
+  global.window = {
+    innerWidth: 1600, innerHeight: 900, open() { return null; },
+    addEventListener() {}, removeEventListener() {},
+  };
+  global.devicePixelRatio = 1;
+  // requestAnimationFrame is used by the hover-highlight repaint throttle.
+  global.requestAnimationFrame = (fn) => { fn(); return 0; };
+
+  function restore() {
+    global.document = prevDocument;
+    if (prevNavigatorDesc) Object.defineProperty(globalThis, "navigator", prevNavigatorDesc);
+    else delete globalThis.navigator;
+    global.window = prevWindow;
+    global.devicePixelRatio = prevDpr;
+  }
+
+  return { document: doc, registry, byClass, makeEl, restore };
+}
+
+function tree(name, count, self, children) {
+  const m = new Map();
+  for (const c of children || []) m.set(c.fullName || c.name, c);
+  return { name, fullName: name, location: null, count, self, children: m };
+}
+
+// Fixture with a shared callee so callers/callees are both non-trivial:
+//   root → a(10) → mid(10) → leaf(10 self)
+//   root → b(5)  → mid(5)  → leaf(5 self)
+function sampleTree() {
+  const leafA = tree("leaf", 10, 10, []);
+  const midA = tree("mid", 10, 0, [leafA]);
+  const a = tree("a", 10, 0, [midA]);
+  const leafB = tree("leaf", 5, 5, []);
+  const midB = tree("mid", 5, 0, [leafB]);
+  const b = tree("b", 5, 0, [midB]);
+  return tree("", 15, 0, [a, b]);
+}
+
+// Dispatch a mouse-ish event to an element's handlers.
+function fire(el, type, props) {
+  const ev = Object.assign({
+    type, target: el, clientX: 100, clientY: 100,
+    preventDefault() {}, stopPropagation() {},
+    metaKey: false, ctrlKey: false, altKey: false,
+  }, props || {});
+  el.dispatchEvent(ev);
+  return ev;
+}
+
+test("right-click → Inspect enters butterfly; Esc exits (#652)", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const container = dom.makeEl();
+    const fg = createFlamegraph(container);
+    fg.setTreeDirect(sampleTree(), 15);
+
+    // The aggregated lane is the "worker" canvas. Find it and its hit regions
+    // by right-clicking where a frame was painted. renderCanvas records regions
+    // keyed by the mid-frame's y; we synthesize a hit by right-clicking the
+    // canvas and relying on the recorded regions. Instead of guessing pixels,
+    // drive inspect through the search dropdown, which is deterministic.
+    const searchInput = dom.registry[".fg-search-input"];
+    assert.ok(searchInput, "search input exists");
+    searchInput.value = "mid";
+    fire(searchInput, "input");
+
+    const results = dom.byClass["fg-search-results"] && dom.byClass["fg-search-results"][0];
+    assert.ok(results, "search results container exists");
+    assert.notStrictEqual(results.style.display, "none", "results shown for a match");
+    // The rows are appended as children; find the row for "mid" and click it.
+    const rows = results.children.filter((c) => c.className === "fg-sr-row");
+    assert.ok(rows.length >= 1, "at least one result row rendered");
+    fire(rows[0], "click");
+
+    // Inspect view should now be visible with the focus band populated.
+    const inspectView = dom.byClass["fg-inspect"] && dom.byClass["fg-inspect"][0];
+    assert.ok(inspectView, "inspect view element exists");
+    assert.strictEqual(inspectView.style.display, "", "inspect view visible after Inspect");
+    const band = dom.byClass["fg-focus-band"][0];
+    assert.ok(band.children.some((c) => c.textContent === "mid"), "focus band names the frame");
+
+    // Esc exits inspect.
+    const consumed = fg.handleEscape();
+    assert.strictEqual(consumed, true, "Esc consumed by inspect exit");
+    assert.strictEqual(inspectView.style.display, "none", "inspect view hidden after Esc");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("search dropdown lists matches with sizes and hides when cleared (#653)", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    const searchInput = dom.registry[".fg-search-input"];
+    searchInput.value = "leaf";
+    fire(searchInput, "input");
+
+    const results = dom.byClass["fg-search-results"] && dom.byClass["fg-search-results"][0];
+    const rows = results.children.filter((c) => c.className === "fg-sr-row");
+    assert.strictEqual(rows.length, 1, "one function 'leaf' across both stacks");
+    const sizeSpan = rows[0].children.find((c) => c.className === "fg-sr-size");
+    assert.ok(sizeSpan && /100\.0%/.test(sizeSpan.textContent),
+      "leaf is 15/15 = 100% of samples: " + (sizeSpan && sizeSpan.textContent));
+
+    // Clearing the query hides the dropdown.
+    searchInput.value = "";
+    fire(searchInput, "input");
+    assert.strictEqual(results.style.display, "none", "results hidden when query empty");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("re-pivot: clicking a caller frame on the canvas while inspecting", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("./flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    fg.setTreeDirect(sampleTree(), 15);
+
+    // Enter inspect on "mid" via search.
+    const searchInput = dom.registry[".fg-search-input"];
+    searchInput.value = "mid";
+    fire(searchInput, "input");
+    const results = dom.byClass["fg-search-results"] && dom.byClass["fg-search-results"][0];
+    fire(results.children.filter((c) => c.className === "fg-sr-row")[0], "click");
+
+    // Canvases are created worker, off-worker, callees, callers — so the
+    // callers canvas is the 4th fg-canvas. Its inverted layout paints the
+    // immediate callers (a=10, b=5, sorted desc) at depth 0: a spans the left
+    // ~2/3 at y∈[4,22). Click there to re-pivot onto "a".
+    const canvases = dom.byClass["fg-canvas"];
+    assert.ok(canvases.length >= 4, "worker/off-worker/callees/callers canvases exist");
+    const callersCanvas = canvases[3];
+    fire(callersCanvas, "click", { clientX: 100, clientY: 10 });
+
+    const band = dom.byClass["fg-focus-band"][0];
+    assert.ok(band.children.some((c) => c.textContent === "a"),
+      "focus band re-pivoted to 'a' after clicking its caller frame");
+  } finally {
+    dom.restore();
+  }
+});
+
+summarize();

--- a/dial9-viewer/ui/test_flamegraph_view_state.js
+++ b/dial9-viewer/ui/test_flamegraph_view_state.js
@@ -1,0 +1,136 @@
+"use strict";
+
+// Unit tests for flamegraph_view_state.js — the URL codec that is the single
+// source of truth for serializing a flamegraph's interactive view state (zoom /
+// inspect / search / filters, and the diff view's zoom + highlight). All the
+// consuming code (flamegraph.html, the renderer's getViewState/applyViewState,
+// the diff view) goes through this module, so these tests pin the wire format:
+// exact key names, the tab separator, delete-on-absence, and the round-trip.
+
+const { assert, test, summarize } = require("./test_harness.js");
+const VS = require("./flamegraph_view_state.js");
+
+const SEP = "\t";
+
+// --- Single-flamegraph state ---
+
+test("readState: empty query yields empty state", () => {
+  assert.deepStrictEqual(VS.readState(""), {});
+  assert.deepStrictEqual(VS.readState(new URLSearchParams()), {});
+});
+
+test("writeState → readState round-trips a full state", () => {
+  const state = {
+    workerZoom: ["a", "mid", "leaf"],
+    offworkerZoom: ["park"],
+    inspect: { name: "poll", fullName: "core::poll::poll" },
+    search: "tokio",
+    spawn: "src/main.rs:10",
+    runtime: "app",
+  };
+  const p = VS.writeState(new URLSearchParams(), state);
+  // Exact wire keys.
+  assert.strictEqual(p.get("worker-zoom"), "a\tmid\tleaf");
+  assert.strictEqual(p.get("offworker-zoom"), "park");
+  assert.strictEqual(p.get("inspect"), "poll");
+  assert.strictEqual(p.get("inspect_full"), "core::poll::poll");
+  assert.strictEqual(p.get("search"), "tokio");
+  assert.strictEqual(p.get("spawn"), "src/main.rs:10");
+  assert.strictEqual(p.get("runtime"), "app");
+  // Decodes back to the same structure.
+  assert.deepStrictEqual(VS.readState(p), state);
+});
+
+test("inspect_full is omitted when it equals the display name", () => {
+  const p = VS.writeState(new URLSearchParams(), {
+    inspect: { name: "leaf", fullName: "leaf" },
+  });
+  assert.strictEqual(p.get("inspect"), "leaf");
+  assert.strictEqual(p.get("inspect_full"), null, "no redundant inspect_full");
+  // On read, fullName falls back to the display name.
+  assert.deepStrictEqual(VS.readState(p).inspect, { name: "leaf", fullName: "leaf" });
+});
+
+test("writeState deletes keys for absent fields (URL stays clean on zoom-out)", () => {
+  // Start from a URL that HAS every view key set...
+  const p = new URLSearchParams();
+  p.set("worker-zoom", "a" + SEP + "b");
+  p.set("offworker-zoom", "x");
+  p.set("inspect", "poll");
+  p.set("inspect_full", "core::poll");
+  p.set("search", "q");
+  p.set("spawn", "s");
+  p.set("runtime", "r");
+  // ...then write an empty state: every owned key must be removed.
+  VS.writeState(p, {});
+  for (const k of VS.STATE_KEYS) {
+    assert.strictEqual(p.get(k), null, `${k} deleted on absence`);
+  }
+});
+
+test("writeState preserves foreign keys it does not own", () => {
+  const p = new URLSearchParams();
+  p.set("api", "1");
+  p.set("bucket", "my-bucket");
+  VS.writeState(p, { search: "q" });
+  assert.strictEqual(p.get("api"), "1", "foreign key untouched");
+  assert.strictEqual(p.get("bucket"), "my-bucket", "foreign key untouched");
+  assert.strictEqual(p.get("search"), "q");
+});
+
+test("writeState clears inspect_full when only a name is present", () => {
+  const p = new URLSearchParams();
+  p.set("inspect_full", "stale::symbol");
+  VS.writeState(p, { inspect: { name: "leaf", fullName: "leaf" } });
+  assert.strictEqual(p.get("inspect"), "leaf");
+  assert.strictEqual(p.get("inspect_full"), null, "stale inspect_full cleared");
+});
+
+test("readState ignores empty inspect / inspect with no name", () => {
+  assert.strictEqual(VS.readState("inspect=").inspect, undefined);
+  // A name-less write produces nothing to read back.
+  const p = VS.writeState(new URLSearchParams(), { inspect: { name: "", fullName: "x" } });
+  assert.strictEqual(p.get("inspect"), null);
+});
+
+test("zoom path split filters stray empty segments (leading/trailing tab)", () => {
+  const p = new URLSearchParams();
+  p.set("worker-zoom", SEP + "a" + SEP + SEP + "b" + SEP);
+  assert.deepStrictEqual(VS.readState(p).workerZoom, ["a", "b"]);
+});
+
+test("readState accepts a raw query string or URLSearchParams", () => {
+  const fromStr = VS.readState("search=hello&worker-zoom=a" + encodeURIComponent(SEP) + "b");
+  assert.strictEqual(fromStr.search, "hello");
+  assert.deepStrictEqual(fromStr.workerZoom, ["a", "b"]);
+});
+
+// --- Diff-view state ---
+
+test("writeDiffState → readDiffState round-trips (root-inclusive zoom)", () => {
+  const state = { zoom: ["(all)", "runtime", "poll"], search: "spawn" };
+  const p = VS.writeDiffState(new URLSearchParams(), state);
+  assert.strictEqual(p.get("diff_zoom"), "(all)\truntime\tpoll");
+  assert.strictEqual(p.get("diff_search"), "spawn");
+  assert.deepStrictEqual(VS.readDiffState(p), state);
+});
+
+test("writeDiffState deletes its keys on absence", () => {
+  const p = new URLSearchParams();
+  p.set("diff_zoom", "(all)" + SEP + "x");
+  p.set("diff_search", "q");
+  VS.writeDiffState(p, {});
+  for (const k of VS.DIFF_STATE_KEYS) {
+    assert.strictEqual(p.get(k), null, `${k} deleted on absence`);
+  }
+});
+
+test("diff and single state keys are disjoint namespaces", () => {
+  const p = new URLSearchParams();
+  VS.writeState(p, { search: "single" });
+  VS.writeDiffState(p, { search: "diff" });
+  assert.strictEqual(p.get("search"), "single");
+  assert.strictEqual(p.get("diff_search"), "diff");
+});
+
+summarize();

--- a/dial9-viewer/ui/viewer.html
+++ b/dial9-viewer/ui/viewer.html
@@ -7179,6 +7179,10 @@
                 const z = fgInstance.getZoomPath();
                 if (z.worker.length > 0) base.set("worker-zoom", z.worker.join("\t"));
                 if (z.offworker.length > 0) base.set("offworker-zoom", z.offworker.join("\t"));
+                // Carry the inspect (butterfly) focus so the popped-out flamegraph
+                // reproduces the exact focus position, not just the zoom.
+                const insp = fgInstance.getInspectFocus();
+                if (insp) base.set("inspect", insp);
 
                 // Prefer carrying this viewer's own scope through to the
                 // flamegraph (short + stateless, so it can't overflow the URI

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -95,6 +95,10 @@ node dial9-viewer/ui/test_flamegraph_export.js
 echo "--- Checking flamegraph export button enablement in API mode (#625) ---"
 node dial9-viewer/ui/test_flamegraph_setdirect_export.js
 
+echo "--- Checking flamegraph inspect/butterfly + search results (#652/#653) ---"
+node dial9-viewer/ui/test_flamegraph_inspect.js
+node dial9-viewer/ui/test_flamegraph_inspect_dom.js
+
 echo "--- Checking runtime grouping (multi-runtime lanes) ---"
 node dial9-viewer/ui/test_runtime_groups.js
 

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -99,8 +99,17 @@ echo "--- Checking flamegraph inspect/butterfly + search results (#652/#653) ---
 node dial9-viewer/ui/test_flamegraph_inspect.js
 node dial9-viewer/ui/test_flamegraph_inspect_dom.js
 
+echo "--- Checking flamegraph view-state URL codec (single + diff) ---"
+node dial9-viewer/ui/test_flamegraph_view_state.js
+
 echo "--- Checking flamegraph deep-link view state (zoom + inspect focus) ---"
 node dial9-viewer/ui/test_flamegraph_deeplink.js
+
+echo "--- Checking exact-trace view-state restore (search + spawn filter) ---"
+node dial9-viewer/ui/test_flamegraph_exact_view_state.js
+
+echo "--- Checking diff-view URL state (onChange/initialState wiring) ---"
+node dial9-viewer/ui/test_flamegraph_diff_view_state.js
 
 echo "--- Checking runtime grouping (multi-runtime lanes) ---"
 node dial9-viewer/ui/test_runtime_groups.js

--- a/scripts/e2e-trace-tests.sh
+++ b/scripts/e2e-trace-tests.sh
@@ -99,6 +99,9 @@ echo "--- Checking flamegraph inspect/butterfly + search results (#652/#653) ---
 node dial9-viewer/ui/test_flamegraph_inspect.js
 node dial9-viewer/ui/test_flamegraph_inspect_dom.js
 
+echo "--- Checking flamegraph deep-link view state (zoom + inspect focus) ---"
+node dial9-viewer/ui/test_flamegraph_deeplink.js
+
 echo "--- Checking runtime grouping (multi-runtime lanes) ---"
 node dial9-viewer/ui/test_runtime_groups.js
 


### PR DESCRIPTION
This adds an "inspect" mode to the flamegraph + improves the search functionality.

Inspect shows a butterfly that allows you to focus on a frame e.g. `tracing::event::Dispatch` and see all paths into it and out of it.

<img width="876" height="899" alt="Screenshot 2026-07-13 at 11 07 29 AM" src="https://github.com/user-attachments/assets/3210f99e-e048-4a22-8c34-e0f8ccc4a9ac" />
<img width="668" height="527" alt="Screenshot 2026-07-13 at 11 07 15 AM" src="https://github.com/user-attachments/assets/973e607c-6286-454e-9a1a-8d3c6cb193e4" />

Fixes #653 
Fixes #652 
