### PR TITLE
viewer: split serve() into build_app() so embedders own binding

### DIFF
--- a/dial9-viewer/examples/embedded_viewer.rs
+++ b/dial9-viewer/examples/embedded_viewer.rs
@@ -2,48 +2,65 @@
 //!
 //! Shows how a downstream consumer (e.g. an internal tool) can reuse the
 //! viewer's built-in routes while adding its own endpoints and wrapping the
-//! whole thing with middleware.
+//! whole thing with middleware such as auth.
 //!
-//! The extension point is [`dial9_viewer::server::router`] — it returns an
-//! [`axum::Router`] that you can `.merge()`, `.layer()`, or `.nest_service()`
-//! before binding to a listener.
+//! The extension point is [`dial9_viewer::build_app`]: describe the viewer in
+//! code with a [`dial9_viewer::ViewerConfig`], get back a fully-assembled
+//! [`axum::Router`] (which is also a `tower::Service`), then `.merge()` /
+//! `.layer()` it and bind it yourself. Binding, logging, and the per-request
+//! metrics sink are all the embedder's to own — see
+//! [`dial9_viewer::init_tracing`], [`dial9_viewer::attach_request_metrics`],
+//! and [`dial9_viewer::shutdown_signal`].
 //!
 //! ```text
 //! cargo run --example embedded_viewer -- my-trace-bucket
 //! ```
 
 use axum::http::{HeaderName, HeaderValue};
-use dial9_viewer::server::{AppState, router};
+use dial9_viewer::{
+    ViewerConfig, attach_request_metrics, build_app, init_tracing, shutdown_signal,
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
-
     let bucket = std::env::args()
         .nth(1)
         .expect("usage: embedded_viewer <bucket>");
 
-    // 1. Build AppState from an S3 bucket (handles region detection,
-    //    BYO-credentials, and the assume-role path automatically).
-    let state = AppState::from_bucket(&bucket, None).await;
+    // Logging and per-request metrics are process-global concerns the embedder
+    // owns; `build_app` deliberately does not touch them. `local = true` gives
+    // human-readable logs + metrique's local metrics format (nice for a dev
+    // example); pass `false` for JSON logs + EMF in a deployed service. Hold
+    // the metrics guard for the life of the server.
+    init_tracing(true);
+    let _metrics = attach_request_metrics(true);
 
-    // 2. Get the base router with all built-in routes.
-    let app = router(state);
+    // 1. Describe the viewer in code: serve from an S3 bucket (region detection,
+    //    BYO-credentials and the assume-role path are wired up automatically),
+    //    with demand-driven aggregation enabled. Everything else is defaulted.
+    let config = ViewerConfig {
+        bucket: Some(bucket),
+        agg: true,
+        ..Default::default()
+    };
 
-    // 3. Merge custom routes — e.g. a feedback endpoint.
+    // 2. Assemble the fully-configured app (built-in routes + state +
+    //    aggregation). `build_app` RETURNS the router rather than binding it.
+    let app = build_app(config).await?;
+
+    // 3. Merge custom routes — e.g. a first-party feedback endpoint.
     let app =
         app.merge(axum::Router::new().route("/api/feedback", axum::routing::post(handle_feedback)));
 
-    // 4. Layer middleware — e.g. inject a response header for every request.
+    // 4. Wrap the WHOLE app (built-in + custom routes) with middleware — this is
+    //    where you'd put auth; here it just injects a response header.
     let app = app.layer(axum::middleware::from_fn(add_server_header));
 
-    // 5. Bind and serve.
+    // 5. Bind and serve — the embedder owns the listener/port/TLS.
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
     tracing::info!("embedded viewer listening on http://localhost:3000");
     axum::serve(listener, app)
-        .with_graceful_shutdown(async {
-            tokio::signal::ctrl_c().await.ok();
-        })
+        .with_graceful_shutdown(shutdown_signal())
         .await?;
 
     Ok(())

--- a/dial9-viewer/src/cli.rs
+++ b/dial9-viewer/src/cli.rs
@@ -193,13 +193,19 @@ pub async fn run() -> anyhow::Result<()> {
             agg_segment_secs,
             enable_upload,
         } => {
-            return crate::serve(crate::ServeConfig {
-                port,
+            // Logging and per-request metrics are process-global concerns owned
+            // by the binary, not by app assembly (see `crate::build_app`).
+            // `--local` selects human-readable logs + metrique's local metrics
+            // format; the default (deployed) is JSON logs + EMF. Hold the
+            // metrics handle for the life of the server.
+            crate::init_tracing(local);
+            let _metrics = crate::attach_request_metrics(local);
+
+            let app = crate::build_app(crate::ViewerConfig {
                 bucket,
                 prefix,
                 local_dir,
                 dev,
-                local,
                 agg,
                 agg_source_dir,
                 agg_output_dir,
@@ -208,7 +214,15 @@ pub async fn run() -> anyhow::Result<()> {
                 agg_segment_secs,
                 enable_upload,
             })
-            .await;
+            .await?;
+
+            let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
+            tracing::info!(port, "dial9-viewer listening");
+            println!("\n  → http://localhost:{port}\n");
+            axum::serve(listener, app)
+                .with_graceful_shutdown(crate::shutdown_signal())
+                .await?;
+            return Ok(());
         }
         Commands::Report { action } => match action {
             ReportAction::Serve { path, port } => {

--- a/dial9-viewer/src/lib.rs
+++ b/dial9-viewer/src/lib.rs
@@ -6,6 +6,11 @@ pub mod storage;
 
 pub use report_serve::report_serve_router;
 
+// Expose the standard per-request metrics sink so a caller embedding
+// `build_app` can attach it — or supply their own metrique sink instead.
+// Metrics are a process-global concern the caller owns, like logging.
+pub use server::metrics::attach_request_metrics;
+
 use std::path::PathBuf;
 
 async fn detect_bucket_region(bucket: &str) -> Option<String> {
@@ -14,17 +19,21 @@ async fn detect_bucket_region(bucket: &str) -> Option<String> {
     server::region_from_head_bucket(&client, bucket).await
 }
 
-/// Configuration for the `serve` subcommand, assembled from CLI args.
-pub(crate) struct ServeConfig {
-    pub port: u16,
+/// Configuration for [`build_app`]. Construct it directly in code, or map it
+/// from CLI args (see [`cli::run`]).
+///
+/// Deliberately excluded, because they are the caller's concern rather than
+/// part of app assembly:
+///   - the listen **port** — binding is the caller's job (see [`build_app`]);
+///   - **logging** and the per-request **metrics** format — see [`init_tracing`]
+///     and [`attach_request_metrics`], which the caller drives (often from a
+///     `--local`/deployed flag).
+#[derive(Debug, Clone)]
+pub struct ViewerConfig {
     pub bucket: Option<String>,
     pub prefix: Option<String>,
     pub local_dir: Option<PathBuf>,
     pub dev: bool,
-    /// Local mode: render logs human-readably (not JSON) and per-request
-    /// metrics in metrique's local format (not EMF). Defaults to off, i.e. the
-    /// deployed shape — JSON logs and EMF metrics to stdout.
-    pub local: bool,
     /// Enable demand-driven aggregation against the S3 `bucket`/`prefix` source.
     pub agg: bool,
     /// When set, enable demand-driven aggregation reading raw segments from
@@ -44,6 +53,24 @@ pub(crate) struct ServeConfig {
     pub enable_upload: bool,
 }
 
+impl Default for ViewerConfig {
+    fn default() -> Self {
+        Self {
+            bucket: None,
+            prefix: None,
+            local_dir: None,
+            dev: false,
+            agg: false,
+            agg_source_dir: None,
+            agg_output_dir: None,
+            agg_output_bucket: None,
+            agg_output_prefix: "flamegraph-data".to_string(),
+            agg_segment_secs: crate::ingest::aggregate::DEFAULT_SEGMENT_DURATION_SECS,
+            enable_upload: false,
+        }
+    }
+}
+
 /// Build an [`S3Backend`] for `bucket`, pinned to the bucket's region when it
 /// can be detected (so cross-region buckets work), else the default chain.
 pub(crate) async fn s3_backend_for(bucket: &str) -> storage::S3Backend {
@@ -60,25 +87,11 @@ pub(crate) async fn s3_backend_for(bucket: &str) -> storage::S3Backend {
     }
 }
 
-pub(crate) async fn serve(
-    ServeConfig {
-        port,
-        bucket,
-        prefix,
-        local_dir,
-        dev,
-        local,
-        agg,
-        agg_source_dir,
-        agg_output_dir,
-        agg_output_bucket,
-        agg_output_prefix,
-        agg_segment_secs,
-        enable_upload,
-    }: ServeConfig,
-) -> anyhow::Result<()> {
-    // Logs: JSON by default (so they render cleanly in CloudWatch), human
-    // format under `--local`. Metrics follow the same split (EMF vs. local).
+/// Initialize the process-global tracing subscriber: JSON logs by default (so
+/// they render cleanly in CloudWatch), human-readable under `local`. Call once,
+/// before serving. Logging is the binary's concern, so it is separate from
+/// [`build_app`].
+pub fn init_tracing(local: bool) {
     let env_filter = || {
         tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| "dial9_viewer=info".parse().unwrap())
@@ -93,11 +106,35 @@ pub(crate) async fn serve(
             .with_env_filter(env_filter())
             .init();
     }
+}
 
-    // Attach the process-global request-metrics sink for the life of the
-    // server. Held until `serve` returns; dropping flushes and detaches it.
-    let _metrics_handle = server::metrics::attach_request_metrics(local);
-
+/// Assemble the fully-configured viewer application — routes, storage backend,
+/// and optional demand-driven aggregation — and return it as an [`axum::Router`],
+/// which is also a `tower::Service`.
+///
+/// Binding is the caller's responsibility: add routes with [`axum::Router::merge`],
+/// wrap middleware such as auth with [`axum::Router::layer`], pick a
+/// server/listener/TLS, then serve. Two other process-global concerns are the
+/// caller's as well, so they compose freely and can be swapped:
+///   - **logging** — call [`init_tracing`] once beforehand;
+///   - **per-request metrics** — attach a sink with [`attach_request_metrics`]
+///     (the standard EMF/local sink) or supply your own metrique sink, and hold
+///     the returned handle for the life of the server.
+pub async fn build_app(
+    ViewerConfig {
+        bucket,
+        prefix,
+        local_dir,
+        dev,
+        agg,
+        agg_source_dir,
+        agg_output_dir,
+        agg_output_bucket,
+        agg_output_prefix,
+        agg_segment_secs,
+        enable_upload,
+    }: ViewerConfig,
+) -> anyhow::Result<axum::Router> {
     // Build the demand-driven aggregation context if requested. Two sources:
     //   - `agg_source_dir` (local): source + output are LocalBackends.
     //   - `agg` + `bucket` (S3): source is the served bucket/prefix; output is a
@@ -270,24 +307,13 @@ pub(crate) async fn serve(
     }
 
     let app = server::router(app_state);
-
-    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
-    tracing::info!(port, dev, "dial9-viewer listening");
-    println!("\n  → http://localhost:{}\n", port);
-    if let Some(dir) = &local_dir {
-        tracing::info!(path = %dir.display(), "local directory mode");
-    } else if let Some(bucket) = &bucket {
-        tracing::info!(%bucket, "default bucket");
-    }
-
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
-
-    Ok(())
+    Ok(app)
 }
 
-async fn shutdown_signal() {
+/// Wait for a shutdown signal (Ctrl-C), then resolve. Pass this to
+/// `axum::serve(...).with_graceful_shutdown(...)` when binding a router from
+/// [`build_app`].
+pub async fn shutdown_signal() {
     tokio::signal::ctrl_c()
         .await
         .expect("failed to install CTRL+C handler");

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -30,7 +30,7 @@ use credentials::{CredError, CredSource, MaybeCreds};
 /// success and the `x-amz-bucket-region` response header on the redirect error
 /// that S3 returns when the client's region doesn't match the bucket's.
 ///
-/// Shared by startup region detection ([`crate::serve`]) and the
+/// Shared by startup region detection ([`crate::build_app`]) and the
 /// `/api/credentials/check` endpoint.
 pub(crate) async fn region_from_head_bucket(
     client: &aws_sdk_s3::Client,


### PR DESCRIPTION
## Summary

`serve()` both assembled the axum app AND bound the listener, so an embedder could not add routes or wrap middleware (e.g. auth) around the whole app without duplicating the ~200-line assembly.

Split it into:
- **`pub build_app(ViewerConfig) -> axum::Router`** — assembles routes/state/aggregation and RETURNS the router (which is a `tower::Service`)
- Caller-owned binding in `cli::run` (standalone binary behavior is unchanged)

### Changes
- `ServeConfig` → `pub ViewerConfig` (+`Default`); drop `port` (a binding concern) and `local` (a logging/metrics concern)
- Logging + per-request metrics become caller-owned process concerns: `pub init_tracing(local)`, `pub shutdown_signal()`, and a re-exported `pub attach_request_metrics(local)` (callers can also supply their own metrique sink)

### Why

This unblocks embedders adding first-party routes (`.merge`) and auth middleware (`.layer`) around the whole app without forking `serve()`. Embedders can now:

```rust
let app = build_app(cfg).await?;
let app = app.merge(my_routes).layer(my_auth);
let listener = TcpListener::bind(addr).await?;
axum::serve(listener, app).await?;
```