### PR TITLE
feat(viewer): Tokio Stats "Worker activity" rollup + focus deep-link

### DIFF
--- a/dial9-viewer/src/server/tokio_stats.rs
+++ b/dial9-viewer/src/server/tokio_stats.rs
@@ -132,18 +132,17 @@ pub struct WorkerStats {
     pub host: String,
     /// All polls observed on this worker (including sub-floor).
     pub total_polls: u64,
-    /// Share of total polls across all workers, as a percentage (0–100).
-    pub poll_share_pct: f64,
     /// Sum of ALL poll durations on this worker (ns).
     pub busy_ns: i64,
-    /// The worker's observed time span (ns): `max(end_ns) − min(start_ns)`.
-    /// This is the denominator for `busy_pct` — exposed so the UI can show the
-    /// breakdown for verification (busy_ns / span_ns = busy_pct).
+    /// The worker's observed active time (ns) — the denominator for `busy_pct`,
+    /// exposed so the UI can show the breakdown for verification
+    /// (busy_ns / span_ns = busy_pct). This is observed time, not the wall-clock
+    /// span; see [`WorkerAccum::observed_ns`].
     pub span_ns: i64,
     /// Busyness percentage: `busy_ns / span_ns * 100`. Approximates worker
-    /// utilization — 100% means the worker never idled during its observed
-    /// window. Measured over the worker's full observed window, including any
-    /// downtime between boots on the same host.
+    /// utilization — 100% means the worker was polling for the whole of its
+    /// observed active time. Bounded to ≤100% because a worker's polls are
+    /// sequential (non-overlapping), so `busy_ns ≤ span_ns`.
     pub busy_pct: f64,
     /// Polls above the duration floor on this worker.
     pub notable_polls: u64,
@@ -405,7 +404,7 @@ fn snapshot_event(
         bucket: ctx.source_bucket.clone(),
         by_spawn_loc,
         top_long_polls: acc.top_long_polls(),
-        worker_activity: acc.worker_activity(time_span_ns),
+        worker_activity: acc.worker_activity(),
         coverage: Some(aggregate::Coverage {
             files_matched: ctx.resolved.files_matched,
             files_folded,
@@ -470,34 +469,32 @@ impl TokioStatsAccum {
         top
     }
 
-    /// Per-worker activity ranked by busyness descending. Computes shares from
-    /// the current `total_polls` denominator and busyness from each worker's own
-    /// `busy_ns / (max_end_ns − min_start_ns)` (not the global span, which would
-    /// be meaninglessly diluted in multi-host scopes). Falls back to the global
-    /// span for the degenerate single-poll worker (where min_start == max_end
-    /// after the guard, i.e. a single instantaneous poll).
-    fn worker_activity(&self, global_time_span_ns: i64) -> Vec<WorkerStats> {
+    /// Per-worker activity ranked by busyness descending. Busyness is
+    /// `busy_ns / observed_ns` — poll time over the worker's observed active
+    /// time (the sum of its per-segment windows, NOT the gap-filled span across
+    /// segments; see [`WorkerAccum::observed_ns`]). A worker with no observed
+    /// window (e.g. a single instantaneous poll in every segment) reports 0%
+    /// rather than dividing by zero.
+    fn worker_activity(&self) -> Vec<WorkerStats> {
         if self.by_worker.is_empty() {
             return Vec::new();
         }
-        let total = self.total_polls.max(1) as f64;
-        let fallback_span = global_time_span_ns.max(1) as f64;
         let mut workers: Vec<WorkerStats> = self
             .by_worker
             .iter()
             .map(|((host, wid), wa)| {
-                let worker_span = match (wa.min_ts, wa.max_ts) {
-                    (Some(min), Some(max)) if max > min => (max - min) as f64,
-                    _ => fallback_span,
+                let busy_pct = if wa.observed_ns > 0 {
+                    (wa.busy_ns as f64 / wa.observed_ns as f64) * 100.0
+                } else {
+                    0.0
                 };
                 WorkerStats {
                     worker_id: *wid,
                     host: host.clone(),
                     total_polls: wa.total_polls,
-                    poll_share_pct: (wa.total_polls as f64 / total) * 100.0,
                     busy_ns: wa.busy_ns,
-                    span_ns: worker_span as i64,
-                    busy_pct: (wa.busy_ns as f64 / worker_span) * 100.0,
+                    span_ns: wa.observed_ns,
+                    busy_pct,
                     notable_polls: wa.notable_polls,
                     worst_poll_ns: wa.worst_poll_ns,
                     worst_exemplar: wa.worst_exemplar.clone(),
@@ -513,19 +510,23 @@ impl TokioStatsAccum {
     }
 }
 
-/// Per-worker accumulator for the worker activity rollup. Tracks total polls
-/// (for share computation), busy time (for busyness %), time span observed (for
-/// per-worker denominator), and the worst poll (for heat-coloring + deep-link).
+/// Per-worker accumulator for the worker activity rollup. Tracks total polls,
+/// busy time (for busyness %), observed active time (the busyness denominator),
+/// and the worst poll (for heat-coloring + deep-link).
 #[derive(Default)]
 struct WorkerAccum {
     total_polls: u64,
     /// Sum of all poll durations on this worker (ns), for busyness computation.
     busy_ns: i64,
-    /// Earliest poll start observed on this worker — used with `max_ts` to
-    /// compute the worker's own time span (the correct busyness denominator,
-    /// rather than the global scope span which inflates for multi-host scopes).
-    min_ts: Option<i64>,
-    max_ts: Option<i64>,
+    /// Sum of this worker's per-segment observed windows (ns): for each trace
+    /// segment (= one polls part-file), `max(end_ns) − min(start_ns)` over the
+    /// worker's polls in that segment, accumulated across segments. This is the
+    /// busyness denominator. It deliberately EXCLUDES the idle gaps between
+    /// segments: taking `max − min` across all segments would count that
+    /// unobserved downtime, making a host whose segments cluster in wall-clock
+    /// time read as far busier than one whose segments are spread out —
+    /// independent of actual work.
+    observed_ns: i64,
     notable_polls: u64,
     worst_poll_ns: i64,
     worst_exemplar: Option<PollExemplar>,
@@ -579,6 +580,11 @@ fn read_polls_part(
         4096,
     )
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Per-worker (min start_ns, max end_ns) window within this segment (one
+    // part-file = one segment), accumulated across this file's batches and
+    // folded into each worker's `observed_ns` after the loop.
+    let mut seg_windows: HashMap<(String, u32), (i64, i64)> = HashMap::new();
 
     for batch in reader {
         let batch = batch.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -635,30 +641,27 @@ fn read_polls_part(
             acc.total_polls += 1;
 
             // Worker activity: count every poll and accumulate busy_ns (before
-            // the notable floor) so share% and busyness reflect the true
-            // distribution. Keyed by (host, worker_id) so multi-host scopes
-            // don't conflate workers from different runtimes. Skip part-files
-            // that predate the worker_id column rather than fabricating a worker 0.
+            // the notable floor) so busyness reflects the true distribution.
+            // Keyed by (host, worker_id) so multi-host scopes don't conflate
+            // workers from different runtimes. Skip part-files that predate the
+            // worker_id column rather than fabricating a worker 0.
             if let Some(workers) = worker_arr {
                 let host_val = host_arr
                     .and_then(|a| if a.is_null(i) { None } else { Some(a.value(i)) })
                     .unwrap_or("");
-                let wa = acc
-                    .by_worker
-                    .entry((host_val.to_string(), workers.value(i)))
-                    .or_default();
+                let key = (host_val.to_string(), workers.value(i));
+                let wa = acc.by_worker.entry(key.clone()).or_default();
                 wa.total_polls += 1;
                 wa.busy_ns += dur;
-                if let Some(sa) = start_arr {
-                    let ts = sa.value(i);
-                    wa.min_ts = Some(wa.min_ts.map_or(ts, |m| m.min(ts)));
-                }
-                // max_ts uses end_ns (not start_ns) so the span covers the
-                // full duration of the last poll — otherwise busy_pct exceeds
-                // 100% when a worker's last poll is long relative to its span.
-                if let Some(ea) = end_arr {
-                    let ts = ea.value(i);
-                    wa.max_ts = Some(wa.max_ts.map_or(ts, |m| m.max(ts)));
+                // Extend this worker's window within this segment. The upper
+                // bound uses end_ns (not start_ns) so it covers the last poll's
+                // full duration, keeping busy_ns ≤ the window. Folded into
+                // `observed_ns` after the batch loop.
+                if let (Some(sa), Some(ea)) = (start_arr, end_arr) {
+                    let (start, end) = (sa.value(i), ea.value(i));
+                    let w = seg_windows.entry(key).or_insert((start, end));
+                    w.0 = w.0.min(start);
+                    w.1 = w.1.max(end);
                 }
             }
 
@@ -756,6 +759,15 @@ fn read_polls_part(
             }
         }
     }
+
+    // Fold this segment's per-worker windows into each worker's observed active
+    // time (summed across segments, so inter-segment gaps aren't counted).
+    for (key, (start, end)) in seg_windows {
+        if let Some(wa) = acc.by_worker.get_mut(&key) {
+            wa.observed_ns += (end - start).max(0);
+        }
+    }
+
     Ok(())
 }
 
@@ -815,23 +827,14 @@ mod tests {
             top[0].duration_ns >= DURATION_FLOOR_NS,
             "long polls must clear the notable floor"
         );
-        // Worker activity: populated, ranked by busy_pct descending, shares
-        // sum to ~100%, busyness > 0, host is set, and worst exemplar carries
-        // a source key.
-        let time_span_ns = match (acc.min_ts, acc.max_ts) {
-            (Some(min), Some(max)) => (max - min).max(1),
-            _ => 1,
-        };
-        let workers = acc.worker_activity(time_span_ns);
+        // Worker activity: populated, ranked by busy_pct descending, busyness
+        // > 0 and bounded ≤100%, host is set, and worst exemplar carries a
+        // source key.
+        let workers = acc.worker_activity();
         assert!(!workers.is_empty(), "expected at least one worker");
         assert!(
             workers.windows(2).all(|w| w[0].busy_pct >= w[1].busy_pct),
             "worker activity must be ranked descending by busyness"
-        );
-        let share_sum: f64 = workers.iter().map(|w| w.poll_share_pct).sum();
-        assert!(
-            (share_sum - 100.0).abs() < 0.1,
-            "worker shares must sum to ~100% (got {share_sum})"
         );
         assert!(
             workers.iter().all(|w| w.total_polls > 0),
@@ -844,6 +847,19 @@ mod tests {
         assert!(
             workers.iter().all(|w| w.busy_pct > 0.0),
             "every worker must have non-zero busyness"
+        );
+        // Busyness is poll time over observed active time. A worker's polls are
+        // sequential (non-overlapping), so busy_ns ≤ observed_ns ⇒ busy_pct is
+        // bounded to ≤100% (with a small epsilon for float error). This is the
+        // invariant the old gap-filled-span denominator could violate.
+        assert!(
+            workers.iter().all(|w| w.busy_pct <= 100.0 + 1e-6),
+            "busyness must be bounded to 100% (got {:?})",
+            workers.iter().map(|w| w.busy_pct).fold(0.0_f64, f64::max)
+        );
+        assert!(
+            workers.iter().all(|w| w.span_ns >= w.busy_ns),
+            "observed span must be at least the busy time for every worker"
         );
         // In real traces, host is non-empty (parsed from source key structure);
         // in the demo-trace test the source key "test-key" yields "" — which is

--- a/dial9-viewer/src/server/tokio_stats.rs
+++ b/dial9-viewer/src/server/tokio_stats.rs
@@ -68,6 +68,11 @@ pub struct TokioStatsResponse {
     /// coordinates to deep-link its trace segment. Ported from IRIS's
     /// `longPolls.top` (rust-ingest `analyze.rs`).
     pub top_long_polls: Vec<LongPoll>,
+    /// Per-worker busyness + poll distribution, ranked by busyness descending.
+    /// Ported from IRIS's `workers` rollup, extended with a busyness metric
+    /// (sum of poll durations / worker's own observed time span). Workers are
+    /// keyed per-host so multi-runtime deployments don't conflate worker IDs.
+    pub worker_activity: Vec<WorkerStats>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coverage: Option<aggregate::Coverage>,
 }
@@ -111,6 +116,42 @@ pub struct LongPoll {
     pub host: String,
     /// Source trace file key for constructing the viewer deep link.
     pub source_key: String,
+}
+
+/// Per-worker poll distribution + busyness, for the "Worker activity" card.
+/// Ported from IRIS's `workers` rollup, extended with a busyness metric (sum of
+/// poll durations / wall-clock time) as the best utilization proxy available
+/// without park/unpark events. Workers are scoped per-host so multi-runtime
+/// (multi-host) deployments don't conflate worker IDs across different runtimes.
+#[derive(Serialize, Clone)]
+pub struct WorkerStats {
+    pub worker_id: u32,
+    /// Host this worker belongs to. Workers on different hosts are distinct
+    /// runtime instances; this disambiguates worker 0 on host-A from worker 0
+    /// on host-B in multi-host scopes.
+    pub host: String,
+    /// All polls observed on this worker (including sub-floor).
+    pub total_polls: u64,
+    /// Share of total polls across all workers, as a percentage (0–100).
+    pub poll_share_pct: f64,
+    /// Sum of ALL poll durations on this worker (ns).
+    pub busy_ns: i64,
+    /// The worker's observed time span (ns): `max(end_ns) − min(start_ns)`.
+    /// This is the denominator for `busy_pct` — exposed so the UI can show the
+    /// breakdown for verification (busy_ns / span_ns = busy_pct).
+    pub span_ns: i64,
+    /// Busyness percentage: `busy_ns / span_ns * 100`. Approximates worker
+    /// utilization — 100% means the worker never idled during its observed
+    /// window. Measured over the worker's full observed window, including any
+    /// downtime between boots on the same host.
+    pub busy_pct: f64,
+    /// Polls above the duration floor on this worker.
+    pub notable_polls: u64,
+    /// Longest poll duration on this worker (for heat-coloring).
+    pub worst_poll_ns: i64,
+    /// Exemplar of the worst poll for deep-linking into the viewer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worst_exemplar: Option<PollExemplar>,
 }
 
 /// Handler for GET /api/tokio-stats — a Server-Sent Events stream.
@@ -204,7 +245,7 @@ struct StreamCtx {
 enum Phase {
     Start,
     Folding {
-        acc: TokioStatsAccum,
+        acc: Box<TokioStatsAccum>,
         folded: HashSet<String>,
         errors: FoldErrors,
     },
@@ -260,7 +301,7 @@ fn tokio_stats_stream(
                             ctx,
                             folds,
                             Phase::Folding {
-                                acc,
+                                acc: Box::new(acc),
                                 folded,
                                 errors,
                             },
@@ -364,6 +405,7 @@ fn snapshot_event(
         bucket: ctx.source_bucket.clone(),
         by_spawn_loc,
         top_long_polls: acc.top_long_polls(),
+        worker_activity: acc.worker_activity(time_span_ns),
         coverage: Some(aggregate::Coverage {
             files_matched: ctx.resolved.files_matched,
             files_folded,
@@ -397,6 +439,12 @@ struct TokioStatsAccum {
     /// Unsorted between compactions; [`TokioStatsAccum::top_long_polls`] produces
     /// the final ranked list.
     long_polls: Vec<LongPoll>,
+    /// Per-worker accumulation for the "Worker activity" rollup. Keyed by
+    /// `(host, worker_id)` so multi-host scopes (multiple runtimes) don't
+    /// conflate workers with the same ID from different hosts. Populated only
+    /// when the polls part-file includes the `worker_id` column (older files are
+    /// silently skipped, same as long polls).
+    by_worker: HashMap<(String, u32), WorkerAccum>,
 }
 
 impl TokioStatsAccum {
@@ -421,6 +469,66 @@ impl TokioStatsAccum {
         top.truncate(LONG_POLL_TOP);
         top
     }
+
+    /// Per-worker activity ranked by busyness descending. Computes shares from
+    /// the current `total_polls` denominator and busyness from each worker's own
+    /// `busy_ns / (max_end_ns − min_start_ns)` (not the global span, which would
+    /// be meaninglessly diluted in multi-host scopes). Falls back to the global
+    /// span for the degenerate single-poll worker (where min_start == max_end
+    /// after the guard, i.e. a single instantaneous poll).
+    fn worker_activity(&self, global_time_span_ns: i64) -> Vec<WorkerStats> {
+        if self.by_worker.is_empty() {
+            return Vec::new();
+        }
+        let total = self.total_polls.max(1) as f64;
+        let fallback_span = global_time_span_ns.max(1) as f64;
+        let mut workers: Vec<WorkerStats> = self
+            .by_worker
+            .iter()
+            .map(|((host, wid), wa)| {
+                let worker_span = match (wa.min_ts, wa.max_ts) {
+                    (Some(min), Some(max)) if max > min => (max - min) as f64,
+                    _ => fallback_span,
+                };
+                WorkerStats {
+                    worker_id: *wid,
+                    host: host.clone(),
+                    total_polls: wa.total_polls,
+                    poll_share_pct: (wa.total_polls as f64 / total) * 100.0,
+                    busy_ns: wa.busy_ns,
+                    span_ns: worker_span as i64,
+                    busy_pct: (wa.busy_ns as f64 / worker_span) * 100.0,
+                    notable_polls: wa.notable_polls,
+                    worst_poll_ns: wa.worst_poll_ns,
+                    worst_exemplar: wa.worst_exemplar.clone(),
+                }
+            })
+            .collect();
+        workers.sort_unstable_by(|a, b| {
+            b.busy_pct
+                .partial_cmp(&a.busy_pct)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        workers
+    }
+}
+
+/// Per-worker accumulator for the worker activity rollup. Tracks total polls
+/// (for share computation), busy time (for busyness %), time span observed (for
+/// per-worker denominator), and the worst poll (for heat-coloring + deep-link).
+#[derive(Default)]
+struct WorkerAccum {
+    total_polls: u64,
+    /// Sum of all poll durations on this worker (ns), for busyness computation.
+    busy_ns: i64,
+    /// Earliest poll start observed on this worker — used with `max_ts` to
+    /// compute the worker's own time span (the correct busyness denominator,
+    /// rather than the global scope span which inflates for multi-host scopes).
+    min_ts: Option<i64>,
+    max_ts: Option<i64>,
+    notable_polls: u64,
+    worst_poll_ns: i64,
+    worst_exemplar: Option<PollExemplar>,
 }
 
 struct LocAccum {
@@ -526,6 +634,34 @@ fn read_polls_part(
             let dur = duration_arr.value(i);
             acc.total_polls += 1;
 
+            // Worker activity: count every poll and accumulate busy_ns (before
+            // the notable floor) so share% and busyness reflect the true
+            // distribution. Keyed by (host, worker_id) so multi-host scopes
+            // don't conflate workers from different runtimes. Skip part-files
+            // that predate the worker_id column rather than fabricating a worker 0.
+            if let Some(workers) = worker_arr {
+                let host_val = host_arr
+                    .and_then(|a| if a.is_null(i) { None } else { Some(a.value(i)) })
+                    .unwrap_or("");
+                let wa = acc
+                    .by_worker
+                    .entry((host_val.to_string(), workers.value(i)))
+                    .or_default();
+                wa.total_polls += 1;
+                wa.busy_ns += dur;
+                if let Some(sa) = start_arr {
+                    let ts = sa.value(i);
+                    wa.min_ts = Some(wa.min_ts.map_or(ts, |m| m.min(ts)));
+                }
+                // max_ts uses end_ns (not start_ns) so the span covers the
+                // full duration of the last poll — otherwise busy_pct exceeds
+                // 100% when a worker's last poll is long relative to its span.
+                if let Some(ea) = end_arr {
+                    let ts = ea.value(i);
+                    wa.max_ts = Some(wa.max_ts.map_or(ts, |m| m.max(ts)));
+                }
+            }
+
             if let Some(sa) = start_arr {
                 let ts = sa.value(i);
                 acc.min_ts = Some(acc.min_ts.map_or(ts, |m| m.min(ts)));
@@ -576,6 +712,27 @@ fn read_polls_part(
                     host: host.to_string(),
                     source_key: source_key.to_string(),
                 });
+            }
+
+            // Worker activity: track notable polls + worst exemplar per worker
+            // (above the floor, so they're meaningful). Same guard as long-polls:
+            // skip old part-files lacking the worker_id column.
+            if let Some(workers) = worker_arr {
+                let wa = acc
+                    .by_worker
+                    .entry((host.to_string(), workers.value(i)))
+                    .or_default();
+                wa.notable_polls += 1;
+                if dur > wa.worst_poll_ns {
+                    wa.worst_poll_ns = dur;
+                    wa.worst_exemplar = Some(PollExemplar {
+                        start_ns: start_arr.map_or(0, |a| a.value(i)),
+                        end_ns: end_arr.map_or(0, |a| a.value(i)),
+                        duration_ns: dur,
+                        host: host.to_string(),
+                        source_key: source_key.to_string(),
+                    });
+                }
             }
 
             // Top longest polls (IRIS `longPolls.top`): a poll is only useful in
@@ -658,13 +815,72 @@ mod tests {
             top[0].duration_ns >= DURATION_FLOOR_NS,
             "long polls must clear the notable floor"
         );
+        // Worker activity: populated, ranked by busy_pct descending, shares
+        // sum to ~100%, busyness > 0, host is set, and worst exemplar carries
+        // a source key.
+        let time_span_ns = match (acc.min_ts, acc.max_ts) {
+            (Some(min), Some(max)) => (max - min).max(1),
+            _ => 1,
+        };
+        let workers = acc.worker_activity(time_span_ns);
+        assert!(!workers.is_empty(), "expected at least one worker");
+        assert!(
+            workers.windows(2).all(|w| w[0].busy_pct >= w[1].busy_pct),
+            "worker activity must be ranked descending by busyness"
+        );
+        let share_sum: f64 = workers.iter().map(|w| w.poll_share_pct).sum();
+        assert!(
+            (share_sum - 100.0).abs() < 0.1,
+            "worker shares must sum to ~100% (got {share_sum})"
+        );
+        assert!(
+            workers.iter().all(|w| w.total_polls > 0),
+            "every worker must have at least one poll"
+        );
+        assert!(
+            workers.iter().all(|w| w.busy_ns > 0),
+            "every worker must have accumulated some busy time"
+        );
+        assert!(
+            workers.iter().all(|w| w.busy_pct > 0.0),
+            "every worker must have non-zero busyness"
+        );
+        // In real traces, host is non-empty (parsed from source key structure);
+        // in the demo-trace test the source key "test-key" yields "" — which is
+        // fine: workers group by whatever host string the parquet carries. What
+        // matters is that all workers from the same runtime share the same host.
+        let hosts: HashSet<&str> = workers.iter().map(|w| w.host.as_str()).collect();
+        assert_eq!(
+            hosts.len(),
+            1,
+            "demo trace is single-host: all workers should share one host value"
+        );
+        assert!(
+            workers.iter().any(|w| w.worst_exemplar.is_some()),
+            "at least one worker should have a worst exemplar (from above-floor polls)"
+        );
+        assert!(
+            workers
+                .iter()
+                .filter_map(|w| w.worst_exemplar.as_ref())
+                .all(|ex| !ex.source_key.is_empty()),
+            "worker worst exemplars must carry a source key for deep-linking"
+        );
+        let total_worker_polls: u64 = workers.iter().map(|w| w.total_polls).sum();
+        assert_eq!(
+            total_worker_polls, acc.total_polls,
+            "sum of per-worker polls must equal total_polls"
+        );
+
         eprintln!(
-            "tokio-stats: {} total, {} above floor, {} locs with exemplars, {} long polls (worst {}ns)",
+            "tokio-stats: {} total, {} above floor, {} locs with exemplars, {} long polls (worst {}ns), {} workers (busiest {:.1}%)",
             acc.total_polls,
             notable,
             with_exemplar,
             top.len(),
             top[0].duration_ns,
+            workers.len(),
+            workers[0].busy_pct,
         );
     }
 }

--- a/dial9-viewer/ui/test_tokio_stats_api.js
+++ b/dial9-viewer/ui/test_tokio_stats_api.js
@@ -10,9 +10,9 @@ const {
   exemplarViewerUrl,
   formatTokioCoverage,
   latencyHeat,
-  workerShareHeat,
   busynessHeat,
   hostBusyPct,
+  hostWorkerCounts,
   canRefineMore,
 } = require("./tokio_stats_api.js");
 
@@ -181,17 +181,6 @@ assertEq(latencyHeat(2_500_000), "#d29922", "1–3ms poll is amber");
 assertEq(latencyHeat(3_000_000), "#f85149", "3ms poll is red");
 assertEq(latencyHeat(50_000_000), "#f85149", "50ms poll is red");
 
-// ── workerShareHeat ──
-// With 4 workers, ideal = 25%. >50% (2×) is red, >37.5% (1.5×) amber, else green.
-assertEq(workerShareHeat(20, 4), "#3fb950", "4 workers: 20% share is green (balanced)");
-assertEq(workerShareHeat(25, 4), "#3fb950", "4 workers: exactly ideal share is green");
-assertEq(workerShareHeat(38, 4), "#d29922", "4 workers: 38% share is amber (>1.5× ideal)");
-assertEq(workerShareHeat(55, 4), "#f85149", "4 workers: 55% share is red (>2× ideal, hot worker)");
-// Edge case: single worker always gets 100% which is exactly ideal (not hot).
-assertEq(workerShareHeat(100, 1), "#3fb950", "1 worker: 100% is just ideal, green");
-// Edge case: no workers (guard).
-assertEq(workerShareHeat(50, 0), "#3fb950", "0 workers: fallback green");
-
 // ── busynessHeat ──
 // Busyness = poll time / wall-clock. ≥80% red (saturated), ≥50% amber, else green.
 assertEq(busynessHeat(30), "#3fb950", "30% busy is green (has headroom)");
@@ -202,34 +191,79 @@ assertEq(busynessHeat(80), "#f85149", "80% busy is red (near-saturated)");
 assertEq(busynessHeat(99), "#f85149", "99% busy is red");
 
 // ── hostBusyPct ──
-// A host's busyness is the MEAN of its workers' busy_pct, not Σ busy_ns over a
-// single span. It must stay bounded and match the average of the per-worker
-// rows shown on expand.
+// A host's busyness is the POOLED ratio Σ busy_ns / Σ span_ns — total poll time
+// over total observed worker-time — NOT a mean of per-worker ratios (which
+// over-weights sparse-window workers and reads backwards).
 assertClose(
-  hostBusyPct([{ busy_pct: 40 }, { busy_pct: 60 }]),
+  hostBusyPct([{ busy_ns: 40, span_ns: 100 }, { busy_ns: 60, span_ns: 100 }]),
   50,
-  "two workers -> mean of their busy_pct",
+  "two equal-span workers -> pooled ratio equals their mean",
 );
-assertClose(hostBusyPct([{ busy_pct: 73.25 }]), 73.25, "single worker -> its own busy_pct");
-// rcoh's case: 64 workers each 1/64 saturated must read ~1.56%, NOT 100%.
+assertClose(
+  hostBusyPct([{ busy_ns: 7325, span_ns: 10000 }]),
+  73.25,
+  "single worker -> busy_ns / span_ns",
+);
+// Pooling weights by observed time, so it is NOT the mean of per-worker
+// percentages: a 90%-busy worker observed briefly plus a 10%-busy worker
+// observed 9× longer pools to 18%, not the naive 50% average. This is the
+// bias that made the old mean read backwards.
+assertClose(
+  hostBusyPct([{ busy_ns: 90, span_ns: 100 }, { busy_ns: 90, span_ns: 900 }]),
+  (90 + 90) / (100 + 900) * 100,
+  "pooled ratio weights by observed time (18%), not the 50% naive mean",
+);
+// rcoh's case: 64 workers each 1/64 saturated -> host reads ~1.56%, not 100%.
 {
-  const workers = Array.from({ length: 64 }, () => ({ busy_pct: 100 / 64 }));
+  const workers = Array.from({ length: 64 }, () => ({ busy_ns: 1, span_ns: 64 }));
   assertClose(hostBusyPct(workers), 100 / 64, "64 workers each 1/64 busy -> ~1.56%, not 100%");
 }
-// The mean can never exceed the workers' own (bounded) busyness, so a host of
-// fully-saturated workers is 100% — never over.
+// Fully-saturated workers pool to 100% and never exceed it (Σbusy ≤ Σspan).
 {
-  const workers = Array.from({ length: 8 }, () => ({ busy_pct: 100 }));
+  const workers = Array.from({ length: 8 }, () => ({ busy_ns: 100, span_ns: 100 }));
   assertClose(hostBusyPct(workers), 100, "all workers 100% busy -> host 100% (never over)");
 }
 // Degenerate / defensive inputs.
 assertEq(hostBusyPct([]), 0, "no workers -> 0 (no NaN)");
 assertEq(hostBusyPct(undefined), 0, "undefined workers -> 0");
-assertClose(
-  hostBusyPct([{ busy_pct: 50 }, {}]),
-  25,
-  "missing busy_pct counts as 0 in the mean (not NaN)",
+assertEq(
+  hostBusyPct([{ busy_ns: 5, span_ns: 0 }]),
+  0,
+  "zero observed time -> 0 (no divide-by-zero)",
 );
+
+// ── hostWorkerCounts ──
+// active = observed workers; total = configured (max worker_id + 1, since Tokio
+// numbers workers 0..N-1). total ≥ active always.
+{
+  const c = hostWorkerCounts([{ worker_id: 0 }, { worker_id: 1 }, { worker_id: 2 }]);
+  assertEq(c.active, 3, "contiguous 0..2 -> active 3");
+  assertEq(c.total, 3, "contiguous 0..2 -> total 3 (fully observed)");
+}
+// rcoh's case: only 23 workers polled, but ids run up to 63 -> "23 / 64".
+{
+  const ids = [0, 1, 2, 5, 10, 63]; // 6 observed, highest id 63
+  const c = hostWorkerCounts(ids.map((id) => ({ worker_id: id })));
+  assertEq(c.active, 6, "sparse ids -> active is observed count");
+  assertEq(c.total, 64, "sparse ids -> total is max id + 1 (undercount closed)");
+}
+// Missing worker_id (older part-files): fall back to active, never below it.
+{
+  const c = hostWorkerCounts([{}, {}]);
+  assertEq(c.active, 2, "no worker_id -> active from row count");
+  assertEq(c.total, 2, "no worker_id -> total falls back to active");
+}
+// A single worker 0 -> 1 / 1.
+{
+  const c = hostWorkerCounts([{ worker_id: 0 }]);
+  assertEq(c.total, 1, "worker 0 alone -> total 1");
+}
+// No workers.
+{
+  const c = hostWorkerCounts([]);
+  assertEq(c.active, 0, "no workers -> active 0");
+  assertEq(c.total, 0, "no workers -> total 0");
+}
 
 // ── canRefineMore ──
 assertEq(canRefineMore({ files_matched: 480, files_folded: 24 }), true, "folded < matched -> more");

--- a/dial9-viewer/ui/test_tokio_stats_api.js
+++ b/dial9-viewer/ui/test_tokio_stats_api.js
@@ -12,6 +12,7 @@ const {
   latencyHeat,
   workerShareHeat,
   busynessHeat,
+  hostBusyPct,
   canRefineMore,
 } = require("./tokio_stats_api.js");
 
@@ -25,6 +26,19 @@ function assertEq(actual, expected, desc) {
   } else {
     console.log(
       `✗ ${desc}\n    expected: ${JSON.stringify(expected)}\n    actual:   ${JSON.stringify(actual)}`,
+    );
+    failed++;
+  }
+}
+
+// Float-tolerant variant for computed percentages.
+function assertClose(actual, expected, desc, eps = 1e-9) {
+  if (Math.abs(actual - expected) <= eps) {
+    console.log(`✓ ${desc}`);
+    passed++;
+  } else {
+    console.log(
+      `✗ ${desc}\n    expected: ~${JSON.stringify(expected)}\n    actual:   ${JSON.stringify(actual)}`,
     );
     failed++;
   }
@@ -186,6 +200,36 @@ assertEq(busynessHeat(50), "#d29922", "50% busy is amber (moderately loaded)");
 assertEq(busynessHeat(75), "#d29922", "75% busy is amber");
 assertEq(busynessHeat(80), "#f85149", "80% busy is red (near-saturated)");
 assertEq(busynessHeat(99), "#f85149", "99% busy is red");
+
+// ── hostBusyPct ──
+// A host's busyness is the MEAN of its workers' busy_pct, not Σ busy_ns over a
+// single span. It must stay bounded and match the average of the per-worker
+// rows shown on expand.
+assertClose(
+  hostBusyPct([{ busy_pct: 40 }, { busy_pct: 60 }]),
+  50,
+  "two workers -> mean of their busy_pct",
+);
+assertClose(hostBusyPct([{ busy_pct: 73.25 }]), 73.25, "single worker -> its own busy_pct");
+// rcoh's case: 64 workers each 1/64 saturated must read ~1.56%, NOT 100%.
+{
+  const workers = Array.from({ length: 64 }, () => ({ busy_pct: 100 / 64 }));
+  assertClose(hostBusyPct(workers), 100 / 64, "64 workers each 1/64 busy -> ~1.56%, not 100%");
+}
+// The mean can never exceed the workers' own (bounded) busyness, so a host of
+// fully-saturated workers is 100% — never over.
+{
+  const workers = Array.from({ length: 8 }, () => ({ busy_pct: 100 }));
+  assertClose(hostBusyPct(workers), 100, "all workers 100% busy -> host 100% (never over)");
+}
+// Degenerate / defensive inputs.
+assertEq(hostBusyPct([]), 0, "no workers -> 0 (no NaN)");
+assertEq(hostBusyPct(undefined), 0, "undefined workers -> 0");
+assertClose(
+  hostBusyPct([{ busy_pct: 50 }, {}]),
+  25,
+  "missing busy_pct counts as 0 in the mean (not NaN)",
+);
 
 // ── canRefineMore ──
 assertEq(canRefineMore({ files_matched: 480, files_folded: 24 }), true, "folded < matched -> more");

--- a/dial9-viewer/ui/test_tokio_stats_api.js
+++ b/dial9-viewer/ui/test_tokio_stats_api.js
@@ -10,6 +10,8 @@ const {
   exemplarViewerUrl,
   formatTokioCoverage,
   latencyHeat,
+  workerShareHeat,
+  busynessHeat,
   canRefineMore,
 } = require("./tokio_stats_api.js");
 
@@ -164,6 +166,26 @@ assertEq(latencyHeat(1_000_000), "#d29922", "1ms poll is amber");
 assertEq(latencyHeat(2_500_000), "#d29922", "1–3ms poll is amber");
 assertEq(latencyHeat(3_000_000), "#f85149", "3ms poll is red");
 assertEq(latencyHeat(50_000_000), "#f85149", "50ms poll is red");
+
+// ── workerShareHeat ──
+// With 4 workers, ideal = 25%. >50% (2×) is red, >37.5% (1.5×) amber, else green.
+assertEq(workerShareHeat(20, 4), "#3fb950", "4 workers: 20% share is green (balanced)");
+assertEq(workerShareHeat(25, 4), "#3fb950", "4 workers: exactly ideal share is green");
+assertEq(workerShareHeat(38, 4), "#d29922", "4 workers: 38% share is amber (>1.5× ideal)");
+assertEq(workerShareHeat(55, 4), "#f85149", "4 workers: 55% share is red (>2× ideal, hot worker)");
+// Edge case: single worker always gets 100% which is exactly ideal (not hot).
+assertEq(workerShareHeat(100, 1), "#3fb950", "1 worker: 100% is just ideal, green");
+// Edge case: no workers (guard).
+assertEq(workerShareHeat(50, 0), "#3fb950", "0 workers: fallback green");
+
+// ── busynessHeat ──
+// Busyness = poll time / wall-clock. ≥80% red (saturated), ≥50% amber, else green.
+assertEq(busynessHeat(30), "#3fb950", "30% busy is green (has headroom)");
+assertEq(busynessHeat(49.9), "#3fb950", "just under 50% is still green");
+assertEq(busynessHeat(50), "#d29922", "50% busy is amber (moderately loaded)");
+assertEq(busynessHeat(75), "#d29922", "75% busy is amber");
+assertEq(busynessHeat(80), "#f85149", "80% busy is red (near-saturated)");
+assertEq(busynessHeat(99), "#f85149", "99% busy is red");
 
 // ── canRefineMore ──
 assertEq(canRefineMore({ files_matched: 480, files_folded: 24 }), true, "folded < matched -> more");

--- a/dial9-viewer/ui/tokio_stats.html
+++ b/dial9-viewer/ui/tokio_stats.html
@@ -422,9 +422,12 @@
   }
 
   // "Worker activity": per-host busyness summary with expandable per-worker
-  // detail. Busyness = sum(poll durations) / worker's observed time span.
-  // One row per host (runtime), click to expand individual workers. Each worker
-  // row shows a verification breakdown: busy_ns / span_ns = busy_pct.
+  // detail. Per-worker busyness = sum(poll durations) / worker's observed time
+  // span; a host's busyness is the mean of its workers' busyness (bounded, and
+  // equal to the average of the per-worker rows shown on expand — see
+  // hostBusyPct). One row per host (runtime), click to expand individual
+  // workers. Each worker row shows a verification breakdown: busy_ns / span_ns
+  // = busy_pct.
   let workerSortKey = "busy_pct"; // sort key for host rows
   let workerSortDesc = true;
   let expandedHosts = new Set(); // hosts whose worker details are visible
@@ -441,17 +444,17 @@
       hostMap[h].push(w);
     }
 
-    // Compute per-host aggregates.
+    // Compute per-host aggregates. Busyness is the MEAN of the workers'
+    // individual busy_pct (see hostBusyPct) — NOT Σ busy_ns / max(span), which
+    // is unbounded and would show a 64-worker runtime that is 1/64 saturated
+    // per worker as "100% saturated".
     const hostRows = Object.entries(hostMap).map(([host, ws]) => {
       const totalPolls = ws.reduce((s, w) => s + w.total_polls, 0);
-      const busyNs = ws.reduce((s, w) => s + w.busy_ns, 0);
       const notablePolls = ws.reduce((s, w) => s + w.notable_polls, 0);
-      const maxSpanNs = Math.max(...ws.map(w => w.span_ns || 0));
-      const busyPct = maxSpanNs > 0 ? (busyNs / maxSpanNs) * 100 : 0;
+      const busyPct = hostBusyPct(ws);
       const worstPollNs = Math.max(...ws.map(w => w.worst_poll_ns || 0));
-      const worstWorker = ws.reduce((best, w) => w.worst_poll_ns > (best.worst_poll_ns || 0) ? w : best, ws[0]);
       const pollSharePct = ws.reduce((s, w) => s + w.poll_share_pct, 0);
-      return { host, workers: ws, totalPolls, busyNs, notablePolls, maxSpanNs, busyPct, worstPollNs, worstWorker, pollSharePct, numWorkers: ws.length };
+      return { host, workers: ws, totalPolls, notablePolls, busyPct, worstPollNs, pollSharePct, numWorkers: ws.length };
     });
 
     // Sort host rows.
@@ -467,7 +470,7 @@
     const th = (label, key) => `<th style="cursor:pointer" onclick="sortWorkers('${key}')">${label}${sortInd(key)}</th>`;
 
     let html = `<h3 style="margin:20px 0 8px">⚙️ Worker activity</h3>
-      <p style="font-size:0.8em;color:#8b949e;margin-bottom:6px">${totalWorkers} workers across ${numHosts} host${numHosts > 1 ? "s" : ""} — busyness = Σ poll durations / observed span. Click a host row to expand individual workers.</p>
+      <p style="font-size:0.8em;color:#8b949e;margin-bottom:6px">${totalWorkers} workers across ${numHosts} host${numHosts > 1 ? "s" : ""} — per-worker busyness = Σ poll durations / observed span; a host's busyness is the mean across its workers. Click a host row to expand individual workers.</p>
       <table><thead><tr>
         ${th("Host", "host")}${th("Workers", "numWorkers")}${th("Busy", "busyPct")}<th>Bar</th>${th("Polls", "totalPolls")}${th("Share", "pollSharePct")}${th("Notable", "notablePolls")}${th("Worst poll", "worstPollNs")}
       </tr></thead><tbody>`;
@@ -483,9 +486,14 @@
       const worstDur = hr.worstPollNs > 0
         ? `<span style="color:${latencyHeat(hr.worstPollNs)};font-weight:600">${formatDuration(hr.worstPollNs)}</span>`
         : "—";
+      // Pass the host through a data-attribute (read back via this.dataset.host),
+      // never interpolated into the inline handler's JS: a host containing a
+      // quote would break `toggleWorkerHost('…')`. escapeHtml is the right (and
+      // sufficient) escaping for both the attribute value and the cell text —
+      // same pattern as openExemplar's data-url.
       const hostLabel = escapeHtml(hr.host);
 
-      html += `<tr style="cursor:pointer;font-weight:600" onclick="toggleWorkerHost('${hostLabel}')">
+      html += `<tr style="cursor:pointer;font-weight:600" data-host="${hostLabel}" onclick="toggleWorkerHost(this.dataset.host)">
         <td>${toggle} ${hostLabel}</td>
         <td>${hr.numWorkers}</td>
         <td><span style="color:${busyColor}">${busyFmt}</span></td>

--- a/dial9-viewer/ui/tokio_stats.html
+++ b/dial9-viewer/ui/tokio_stats.html
@@ -416,9 +416,136 @@
       </tr>`;
     }
     html += "</tbody></table>";
+    html += renderWorkerActivity(data, threshNs);
     html += renderLongPolls(data, threshNs);
     tableEl.innerHTML = html;
   }
+
+  // "Worker activity": per-host busyness summary with expandable per-worker
+  // detail. Busyness = sum(poll durations) / worker's observed time span.
+  // One row per host (runtime), click to expand individual workers. Each worker
+  // row shows a verification breakdown: busy_ns / span_ns = busy_pct.
+  let workerSortKey = "busy_pct"; // sort key for host rows
+  let workerSortDesc = true;
+  let expandedHosts = new Set(); // hosts whose worker details are visible
+
+  function renderWorkerActivity(data, threshNs) {
+    const workers = (data && data.worker_activity) || [];
+    if (!workers.length) return "";
+
+    // Group workers by host.
+    const hostMap = {};
+    for (const w of workers) {
+      const h = w.host || "(unknown)";
+      if (!hostMap[h]) hostMap[h] = [];
+      hostMap[h].push(w);
+    }
+
+    // Compute per-host aggregates.
+    const hostRows = Object.entries(hostMap).map(([host, ws]) => {
+      const totalPolls = ws.reduce((s, w) => s + w.total_polls, 0);
+      const busyNs = ws.reduce((s, w) => s + w.busy_ns, 0);
+      const notablePolls = ws.reduce((s, w) => s + w.notable_polls, 0);
+      const maxSpanNs = Math.max(...ws.map(w => w.span_ns || 0));
+      const busyPct = maxSpanNs > 0 ? (busyNs / maxSpanNs) * 100 : 0;
+      const worstPollNs = Math.max(...ws.map(w => w.worst_poll_ns || 0));
+      const worstWorker = ws.reduce((best, w) => w.worst_poll_ns > (best.worst_poll_ns || 0) ? w : best, ws[0]);
+      const pollSharePct = ws.reduce((s, w) => s + w.poll_share_pct, 0);
+      return { host, workers: ws, totalPolls, busyNs, notablePolls, maxSpanNs, busyPct, worstPollNs, worstWorker, pollSharePct, numWorkers: ws.length };
+    });
+
+    // Sort host rows.
+    hostRows.sort((a, b) => {
+      const av = a[workerSortKey] ?? a.busyPct, bv = b[workerSortKey] ?? b.busyPct;
+      const cmp = typeof av === "string" ? av.localeCompare(bv) : av - bv;
+      return workerSortDesc ? -cmp : cmp;
+    });
+
+    const totalWorkers = workers.length;
+    const numHosts = hostRows.length;
+    const sortInd = (key) => workerSortKey === key ? (workerSortDesc ? " ▼" : " ▲") : "";
+    const th = (label, key) => `<th style="cursor:pointer" onclick="sortWorkers('${key}')">${label}${sortInd(key)}</th>`;
+
+    let html = `<h3 style="margin:20px 0 8px">⚙️ Worker activity</h3>
+      <p style="font-size:0.8em;color:#8b949e;margin-bottom:6px">${totalWorkers} workers across ${numHosts} host${numHosts > 1 ? "s" : ""} — busyness = Σ poll durations / observed span. Click a host row to expand individual workers.</p>
+      <table><thead><tr>
+        ${th("Host", "host")}${th("Workers", "numWorkers")}${th("Busy", "busyPct")}<th>Bar</th>${th("Polls", "totalPolls")}${th("Share", "pollSharePct")}${th("Notable", "notablePolls")}${th("Worst poll", "worstPollNs")}
+      </tr></thead><tbody>`;
+
+    for (const hr of hostRows) {
+      const expanded = expandedHosts.has(hr.host);
+      const toggle = expanded ? "▾" : "▸";
+      const busyFmt = hr.busyPct.toFixed(3) + "%";
+      const busyColor = busynessHeat(hr.busyPct);
+      const barWidth = Math.min(hr.busyPct, 100);
+      const barHtml = `<div style="background:${busyColor}33;border-radius:2px;height:14px;width:${barWidth}%"></div>`;
+      const shareFmt = hr.pollSharePct.toFixed(1) + "%";
+      const worstDur = hr.worstPollNs > 0
+        ? `<span style="color:${latencyHeat(hr.worstPollNs)};font-weight:600">${formatDuration(hr.worstPollNs)}</span>`
+        : "—";
+      const hostLabel = escapeHtml(hr.host);
+
+      html += `<tr style="cursor:pointer;font-weight:600" onclick="toggleWorkerHost('${hostLabel}')">
+        <td>${toggle} ${hostLabel}</td>
+        <td>${hr.numWorkers}</td>
+        <td><span style="color:${busyColor}">${busyFmt}</span></td>
+        <td style="width:120px">${barHtml}</td>
+        <td>${hr.totalPolls.toLocaleString()}</td>
+        <td>${shareFmt}</td>
+        <td>${hr.notablePolls.toLocaleString()}</td>
+        <td>${worstDur}</td>
+      </tr>`;
+
+      if (expanded) {
+        const sortedWorkers = hr.workers.slice().sort((a, b) => b.busy_pct - a.busy_pct);
+        for (const w of sortedWorkers) {
+          const url = w.worst_exemplar ? exemplarLink(w.worst_exemplar, data) : "";
+          const wBusyFmt = w.busy_pct.toFixed(3) + "%";
+          const wBusyColor = busynessHeat(w.busy_pct);
+          const wBarWidth = Math.min(w.busy_pct, 100);
+          const wBarHtml = `<div style="background:${wBusyColor}33;border-radius:2px;height:14px;width:${wBarWidth}%"></div>`;
+          const wShareFmt = w.poll_share_pct.toFixed(1) + "%";
+          const wShareColor = workerShareHeat(w.poll_share_pct, totalWorkers);
+          const wWorstDur = w.worst_poll_ns > 0
+            ? `<span style="color:${latencyHeat(w.worst_poll_ns)};font-weight:600">${formatDuration(w.worst_poll_ns)}</span>`
+            : "—";
+          // Verification tooltip: busy_ns / span_ns = busy_pct
+          const spanFmt = w.span_ns ? formatDuration(w.span_ns) : "?";
+          const busyNsFmt = formatDuration(w.busy_ns);
+          const verifyTitle = `${busyNsFmt} busy / ${spanFmt} span = ${wBusyFmt}`;
+          const cells = `<td style="padding-left:28px;font-weight:normal">w${w.worker_id}</td>
+            <td></td>
+            <td title="${verifyTitle}"><span style="color:${wBusyColor}">${wBusyFmt}</span></td>
+            <td style="width:120px">${wBarHtml}</td>
+            <td>${w.total_polls.toLocaleString()}</td>
+            <td><span style="color:${wShareColor}">${wShareFmt}</span></td>
+            <td>${w.notable_polls.toLocaleString()}</td>
+            <td>${wWorstDur}</td>`;
+          html += url
+            ? `<tr style="cursor:pointer;background:#1a1f26" onclick="openExemplar(this)" data-url="${url.replace(/"/g, "&quot;")}">${cells}</tr>`
+            : `<tr style="background:#1a1f26">${cells}</tr>`;
+        }
+      }
+    }
+    html += "</tbody></table>";
+    return html;
+  }
+
+  window.toggleWorkerHost = function(host) {
+    if (expandedHosts.has(host)) expandedHosts.delete(host);
+    else expandedHosts.add(host);
+    renderFromCache();
+  };
+
+  window.sortWorkers = function(key) {
+    if (workerSortKey === key) {
+      workerSortDesc = !workerSortDesc;
+    } else {
+      workerSortKey = key;
+      workerSortDesc = true;
+    }
+    renderFromCache();
+  };
 
   // "Longest polls": the single futures that held a worker thread longest in one
   // poll — long polls starve every other task on that worker. Ported from IRIS's

--- a/dial9-viewer/ui/tokio_stats.html
+++ b/dial9-viewer/ui/tokio_stats.html
@@ -422,12 +422,11 @@
   }
 
   // "Worker activity": per-host busyness summary with expandable per-worker
-  // detail. Per-worker busyness = sum(poll durations) / worker's observed time
-  // span; a host's busyness is the mean of its workers' busyness (bounded, and
-  // equal to the average of the per-worker rows shown on expand — see
-  // hostBusyPct). One row per host (runtime), click to expand individual
-  // workers. Each worker row shows a verification breakdown: busy_ns / span_ns
-  // = busy_pct.
+  // detail. Per-worker busyness = busy_ns / observed active time (span_ns); a
+  // host's busyness pools its workers (Σ busy_ns / Σ span_ns — see hostBusyPct),
+  // which is bounded ≤100% and weights each worker by observed time. One row per
+  // host (runtime), click to expand individual workers. Each worker row shows a
+  // verification breakdown: busy_ns / span_ns = busy_pct.
   let workerSortKey = "busy_pct"; // sort key for host rows
   let workerSortDesc = true;
   let expandedHosts = new Set(); // hosts whose worker details are visible
@@ -444,17 +443,19 @@
       hostMap[h].push(w);
     }
 
-    // Compute per-host aggregates. Busyness is the MEAN of the workers'
-    // individual busy_pct (see hostBusyPct) — NOT Σ busy_ns / max(span), which
-    // is unbounded and would show a 64-worker runtime that is 1/64 saturated
-    // per worker as "100% saturated".
+    // Compute per-host aggregates. Busyness is the POOLED ratio Σ busy_ns /
+    // Σ span_ns (see hostBusyPct) — weighting workers by observed time so a
+    // host with sparse sampling doesn't read as spuriously busier than one
+    // doing more work.
     const hostRows = Object.entries(hostMap).map(([host, ws]) => {
       const totalPolls = ws.reduce((s, w) => s + w.total_polls, 0);
       const notablePolls = ws.reduce((s, w) => s + w.notable_polls, 0);
       const busyPct = hostBusyPct(ws);
       const worstPollNs = Math.max(...ws.map(w => w.worst_poll_ns || 0));
-      const pollSharePct = ws.reduce((s, w) => s + w.poll_share_pct, 0);
-      return { host, workers: ws, totalPolls, notablePolls, busyPct, worstPollNs, pollSharePct, numWorkers: ws.length };
+      // "active / total" workers: active = observed, total = configured (Tokio
+      // numbers workers 0..N-1, so max id + 1). Sort by total (numWorkers).
+      const { active: activeWorkers, total: numWorkers } = hostWorkerCounts(ws);
+      return { host, workers: ws, totalPolls, notablePolls, busyPct, worstPollNs, activeWorkers, numWorkers };
     });
 
     // Sort host rows.
@@ -470,9 +471,9 @@
     const th = (label, key) => `<th style="cursor:pointer" onclick="sortWorkers('${key}')">${label}${sortInd(key)}</th>`;
 
     let html = `<h3 style="margin:20px 0 8px">⚙️ Worker activity</h3>
-      <p style="font-size:0.8em;color:#8b949e;margin-bottom:6px">${totalWorkers} workers across ${numHosts} host${numHosts > 1 ? "s" : ""} — per-worker busyness = Σ poll durations / observed span; a host's busyness is the mean across its workers. Click a host row to expand individual workers.</p>
+      <p style="font-size:0.8em;color:#8b949e;margin-bottom:6px">${totalWorkers} workers across ${numHosts} host${numHosts > 1 ? "s" : ""} — busyness = poll time / observed active time; a host's busyness pools its workers (Σ busy / Σ observed). Click a host row to expand individual workers.</p>
       <table><thead><tr>
-        ${th("Host", "host")}${th("Workers", "numWorkers")}${th("Busy", "busyPct")}<th>Bar</th>${th("Polls", "totalPolls")}${th("Share", "pollSharePct")}${th("Notable", "notablePolls")}${th("Worst poll", "worstPollNs")}
+        ${th("Host", "host")}${th("Workers<br><span style='font-weight:normal;color:#8b949e'>active / total</span>", "numWorkers")}${th("Busy", "busyPct")}<th>Bar</th>${th("Polls", "totalPolls")}${th("Notable", "notablePolls")}${th("Worst poll", "worstPollNs")}
       </tr></thead><tbody>`;
 
     for (const hr of hostRows) {
@@ -482,7 +483,6 @@
       const busyColor = busynessHeat(hr.busyPct);
       const barWidth = Math.min(hr.busyPct, 100);
       const barHtml = `<div style="background:${busyColor}33;border-radius:2px;height:14px;width:${barWidth}%"></div>`;
-      const shareFmt = hr.pollSharePct.toFixed(1) + "%";
       const worstDur = hr.worstPollNs > 0
         ? `<span style="color:${latencyHeat(hr.worstPollNs)};font-weight:600">${formatDuration(hr.worstPollNs)}</span>`
         : "—";
@@ -495,11 +495,10 @@
 
       html += `<tr style="cursor:pointer;font-weight:600" data-host="${hostLabel}" onclick="toggleWorkerHost(this.dataset.host)">
         <td>${toggle} ${hostLabel}</td>
-        <td>${hr.numWorkers}</td>
+        <td>${hr.activeWorkers} / ${hr.numWorkers}</td>
         <td><span style="color:${busyColor}">${busyFmt}</span></td>
         <td style="width:120px">${barHtml}</td>
         <td>${hr.totalPolls.toLocaleString()}</td>
-        <td>${shareFmt}</td>
         <td>${hr.notablePolls.toLocaleString()}</td>
         <td>${worstDur}</td>
       </tr>`;
@@ -512,8 +511,6 @@
           const wBusyColor = busynessHeat(w.busy_pct);
           const wBarWidth = Math.min(w.busy_pct, 100);
           const wBarHtml = `<div style="background:${wBusyColor}33;border-radius:2px;height:14px;width:${wBarWidth}%"></div>`;
-          const wShareFmt = w.poll_share_pct.toFixed(1) + "%";
-          const wShareColor = workerShareHeat(w.poll_share_pct, totalWorkers);
           const wWorstDur = w.worst_poll_ns > 0
             ? `<span style="color:${latencyHeat(w.worst_poll_ns)};font-weight:600">${formatDuration(w.worst_poll_ns)}</span>`
             : "—";
@@ -526,7 +523,6 @@
             <td title="${verifyTitle}"><span style="color:${wBusyColor}">${wBusyFmt}</span></td>
             <td style="width:120px">${wBarHtml}</td>
             <td>${w.total_polls.toLocaleString()}</td>
-            <td><span style="color:${wShareColor}">${wShareFmt}</span></td>
             <td>${w.notable_polls.toLocaleString()}</td>
             <td>${wWorstDur}</td>`;
           html += url

--- a/dial9-viewer/ui/tokio_stats_api.js
+++ b/dial9-viewer/ui/tokio_stats_api.js
@@ -92,17 +92,6 @@ function latencyHeat(ns) {
   return "#3fb950"; // green — sub-millisecond
 }
 
-// Map a worker's poll share to a severity color relative to the ideal balanced
-// share (100 / numWorkers). >2× ideal is red (hot worker), >1.5× amber, else
-// green. Used by the "Worker activity" card.
-function workerShareHeat(sharePct, numWorkers) {
-  if (!numWorkers || numWorkers < 1) return "#3fb950";
-  const ideal = 100 / numWorkers;
-  if (sharePct > ideal * 2) return "#f85149"; // red — hot worker
-  if (sharePct > ideal * 1.5) return "#d29922"; // amber — somewhat concentrated
-  return "#3fb950"; // green — balanced
-}
-
 // Map a worker's busyness percentage to a severity color. Busyness = time spent
 // in poll() / wall-clock time. ≥80% is red (near-saturated), ≥50% amber
 // (moderately loaded), else green. Thresholds are intentionally higher than
@@ -114,24 +103,47 @@ function busynessHeat(busyPct) {
   return "#3fb950"; // green — has headroom
 }
 
-// Aggregate a host's busyness from its workers' individual `busy_pct` values.
+// A host's busyness as a POOLED ratio: Σ busy_ns / Σ span_ns (span_ns =
+// observed active time; see worker_activity in tokio_stats.rs) — total poll
+// time over total observed worker-time, i.e. the runtime's mean utilization.
 //
-// A runtime's busyness is the MEAN of its workers' busyness, not Σ busy_ns over
-// any single span. Two reasons the naive form is wrong:
-//   - Different denominators: each worker's busy_pct uses that worker's OWN
-//     observed span (see worker_activity in tokio_stats.rs), so summing the
-//     numerators over one worker's span is a category error.
-//   - Unbounded / misleading: Σ busy_ns / max(span) can exceed 100%, and a
-//     64-worker runtime where each worker is 1/64 saturated would read as
-//     "100% saturated" — the opposite of the truth. The mean reads ~1.6%.
-// The mean is bounded by the per-worker values (each ≤ ~100%) and equals the
-// average of the per-worker rows shown when the host is expanded, so the number
-// stays verifiable by eye. Returns 0 for a host with no workers.
+// NOT the mean of per-worker busy_pct: a mean-of-ratios over-weights workers
+// with a tiny observed window (a few polls clustered in time read as spuriously
+// "busy"), so a host sampled more sparsely looks busier than one doing more
+// work. Pooling weights each worker by its observed time, so those can't
+// dominate.
+//
+// Bounded to ≤100% (per-worker busy_ns ≤ span_ns, so Σ busy_ns ≤ Σ span_ns).
+// Returns 0 for a host with no workers or no observed time.
 function hostBusyPct(workers) {
   const ws = workers || [];
-  if (!ws.length) return 0;
-  const sum = ws.reduce((s, w) => s + (Number(w.busy_pct) || 0), 0);
-  return sum / ws.length;
+  let busy = 0, span = 0;
+  for (const w of ws) {
+    busy += Number(w.busy_ns) || 0;
+    span += Number(w.span_ns) || 0;
+  }
+  return span > 0 ? (busy / span) * 100 : 0;
+}
+
+// A host's worker count as { active, total }, rendered "active / total".
+//
+//   - active = workers actually observed polling (the rows we have).
+//   - total  = the runtime's configured worker count. Tokio numbers workers
+//     contiguously 0..N-1, so max observed worker_id + 1 recovers it. When some
+//     workers never polled in the window, active < total (e.g. "23 / 64"),
+//     surfacing idle-but-available capacity that `active` alone would hide.
+//
+// total ≥ active always (falls back to active when no worker_id is present).
+function hostWorkerCounts(workers) {
+  const ws = workers || [];
+  const active = ws.length;
+  let maxId = -1;
+  for (const w of ws) {
+    const id = Number(w.worker_id);
+    if (Number.isFinite(id) && id > maxId) maxId = id;
+  }
+  const total = maxId >= 0 ? Math.max(maxId + 1, active) : active;
+  return { active, total };
 }
 
 // Whether a coverage block still has matched files left to fold (so "Load more"
@@ -148,9 +160,9 @@ if (typeof module !== "undefined" && module.exports) {
     exemplarViewerUrl,
     formatTokioCoverage,
     latencyHeat,
-    workerShareHeat,
     busynessHeat,
     hostBusyPct,
+    hostWorkerCounts,
     canRefineMore,
   };
 }

--- a/dial9-viewer/ui/tokio_stats_api.js
+++ b/dial9-viewer/ui/tokio_stats_api.js
@@ -114,6 +114,26 @@ function busynessHeat(busyPct) {
   return "#3fb950"; // green — has headroom
 }
 
+// Aggregate a host's busyness from its workers' individual `busy_pct` values.
+//
+// A runtime's busyness is the MEAN of its workers' busyness, not Σ busy_ns over
+// any single span. Two reasons the naive form is wrong:
+//   - Different denominators: each worker's busy_pct uses that worker's OWN
+//     observed span (see worker_activity in tokio_stats.rs), so summing the
+//     numerators over one worker's span is a category error.
+//   - Unbounded / misleading: Σ busy_ns / max(span) can exceed 100%, and a
+//     64-worker runtime where each worker is 1/64 saturated would read as
+//     "100% saturated" — the opposite of the truth. The mean reads ~1.6%.
+// The mean is bounded by the per-worker values (each ≤ ~100%) and equals the
+// average of the per-worker rows shown when the host is expanded, so the number
+// stays verifiable by eye. Returns 0 for a host with no workers.
+function hostBusyPct(workers) {
+  const ws = workers || [];
+  if (!ws.length) return 0;
+  const sum = ws.reduce((s, w) => s + (Number(w.busy_pct) || 0), 0);
+  return sum / ws.length;
+}
+
 // Whether a coverage block still has matched files left to fold (so "Load more"
 // can deepen the sample). False when fully folded or coverage is absent.
 function canRefineMore(coverage) {
@@ -130,6 +150,7 @@ if (typeof module !== "undefined" && module.exports) {
     latencyHeat,
     workerShareHeat,
     busynessHeat,
+    hostBusyPct,
     canRefineMore,
   };
 }

--- a/dial9-viewer/ui/tokio_stats_api.js
+++ b/dial9-viewer/ui/tokio_stats_api.js
@@ -92,6 +92,28 @@ function latencyHeat(ns) {
   return "#3fb950"; // green — sub-millisecond
 }
 
+// Map a worker's poll share to a severity color relative to the ideal balanced
+// share (100 / numWorkers). >2× ideal is red (hot worker), >1.5× amber, else
+// green. Used by the "Worker activity" card.
+function workerShareHeat(sharePct, numWorkers) {
+  if (!numWorkers || numWorkers < 1) return "#3fb950";
+  const ideal = 100 / numWorkers;
+  if (sharePct > ideal * 2) return "#f85149"; // red — hot worker
+  if (sharePct > ideal * 1.5) return "#d29922"; // amber — somewhat concentrated
+  return "#3fb950"; // green — balanced
+}
+
+// Map a worker's busyness percentage to a severity color. Busyness = time spent
+// in poll() / wall-clock time. ≥80% is red (near-saturated), ≥50% amber
+// (moderately loaded), else green. Thresholds are intentionally higher than
+// latencyHeat — a worker spending 50% of time polling is busy but not
+// necessarily problematic (unlike a single 3ms poll which directly starves).
+function busynessHeat(busyPct) {
+  if (busyPct >= 80) return "#f85149"; // red — near-saturated
+  if (busyPct >= 50) return "#d29922"; // amber — moderately loaded
+  return "#3fb950"; // green — has headroom
+}
+
 // Whether a coverage block still has matched files left to fold (so "Load more"
 // can deepen the sample). False when fully folded or coverage is absent.
 function canRefineMore(coverage) {
@@ -106,6 +128,8 @@ if (typeof module !== "undefined" && module.exports) {
     exemplarViewerUrl,
     formatTokioCoverage,
     latencyHeat,
+    workerShareHeat,
+    busynessHeat,
     canRefineMore,
   };
 }


### PR DESCRIPTION
Added`workers` rollup (fallback path: poll counts + share%) into the Tokio Stats aggregate page. Shows per-worker poll distribution to surface work imbalance across the runtime's thread pool.

Server: `worker_activity: Vec<WorkerStats>` on TokioStatsResponse, accumulated via `by_worker: HashMap<u32, WorkerAccum>` — counts ALL polls (before the 100µs floor) for accurate share%, then tracks notable polls + worst exemplar for above-floor rows. Old part-files without worker_id column silently skipped (same guard as long-polls).

UI: `renderWorkerActivity` card with worker/total/share/bar/notable/ worst-poll columns; rows deep-link to the worst poll's trace segment. `workerShareHeat(sharePct, numWorkers)` helper colors imbalance (>2× ideal red, >1.5× amber, else green). Each worker can be clicked upon as well, taking the user to the instance of the longest poll on that worker.

<img width="1902" height="366" alt="Screenshot 2026-07-16 at 11 50 21 AM" src="https://github.com/user-attachments/assets/077a4596-f047-45d9-8b76-e45e9b4a739b" />
