### PR TITLE
Add local mode for aggregation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,29 @@ Unguarded logging in loops causes log spam that degrades observability and can i
 
 ## Testing
 
+### Local viewer server
+
+For local server testing, run the viewer from the repository root with:
+
+```bash
+cargo run -p dial9-viewer -- serve --port 3003 --local --dev
+```
+
+When testing on-demand aggregation, prefer a release build so Parquet encoding
+and trace decoding behave at representative speed:
+
+```bash
+cargo run --release -p dial9-viewer -- serve --port 3003 --local --dev
+```
+
+This is the recommended workflow: `--local` enables readable workstation logs,
+`--dev` serves UI assets directly from `dial9-viewer/ui`, and omitting
+`--agg-output-bucket` keeps on-demand S3/BYOC aggregate rollups in a
+process-local temporary directory. Source credentials therefore need only read
+access, and the temporary rollups are removed when the server exits. Open
+`http://127.0.0.1:3003/`; use `/tmp/dial9-viewer-3003.log` when running it in the
+background during agent-driven testing.
+
 - Behavior changes should include focused tests that fail without the change; if tests are not practical, state why.
 - For Rust behavior changes, run `cargo nextest run`.
 - For final verification of Rust changes, run `cargo nextest run --stress-duration 20s`. The package is expected to have no flaky tests; report any apparent flake instead of ignoring it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/dial9-viewer/Cargo.toml
+++ b/dial9-viewer/Cargo.toml
@@ -83,3 +83,6 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "decode_bench"
 harness = false
+
+[target."cfg(windows)".dependencies]
+windows-sys = { version = "=0.61.2", features = ["Win32_Storage_FileSystem"] }

--- a/dial9-viewer/src/cli.rs
+++ b/dial9-viewer/src/cli.rs
@@ -72,8 +72,9 @@ enum Commands {
         #[arg(long)]
         agg_output_dir: Option<PathBuf>,
 
-        /// Output S3 bucket for the aggregator's Parquet part-files. Defaults to
-        /// the source `--bucket`. May target a different bucket/account/region.
+        /// Optional S3 bucket for persistent aggregator Parquet part-files. For
+        /// S3/BYOC aggregation, leaving this unset uses a process-local temporary
+        /// directory and never writes to the source bucket.
         #[arg(long)]
         agg_output_bucket: Option<String>,
 

--- a/dial9-viewer/src/lib.rs
+++ b/dial9-viewer/src/lib.rs
@@ -136,32 +136,27 @@ pub async fn build_app(
         enable_upload,
     }: ViewerConfig,
 ) -> anyhow::Result<axum::Router> {
-    // Build one aggregate-output backend shared by the configured aggregation
-    // context and all BYOC requests. An explicit output bucket retains the
-    // persistent S3 behavior; otherwise output uses a process-local temporary
-    // directory that is removed when the server drops it.
+    // Build one aggregate-output destination shared by the configured
+    // aggregation context and all BYOC requests. An explicit output bucket
+    // retains the persistent S3 behavior; otherwise output uses a process-local
+    // temporary directory that is removed when the server drops it.
     use crate::ingest::aggregate::AggContext;
-    let agg_output_backend: std::sync::Arc<dyn storage::StorageBackend> =
-        if let Some(out_bucket) = &agg_output_bucket {
-            tracing::info!(
-                %out_bucket,
-                "aggregation output bucket configured (writes go here, not the source)"
-            );
-            std::sync::Arc::new(s3_backend_for(out_bucket).await)
-        } else {
-            let backend = storage::LocalBackend::new_temporary_aggregate();
-            tracing::info!(
-                output = %backend.root().display(),
-                "no aggregation output bucket configured; using temporary local directory"
-            );
-            std::sync::Arc::new(backend)
-        };
+    use crate::server::AggOutput;
+    let agg_output = if let Some(out_bucket) = &agg_output_bucket {
+        let backend = std::sync::Arc::new(s3_backend_for(out_bucket).await);
+        AggOutput::s3(out_bucket.clone(), backend).with_prefix(agg_output_prefix.clone())
+    } else {
+        AggOutput::temporary().with_prefix(agg_output_prefix.clone())
+    };
+    tracing::info!(
+        output = %agg_output.location(),
+        "aggregate output destination (writes go here, never the source)"
+    );
 
     // Build the demand-driven aggregation context if requested. Two sources:
     //   - `agg_source_dir` (local): source + output are LocalBackends.
     //   - `agg` + `bucket` (S3): source is the served bucket/prefix; output is
     //     the configured S3 bucket or a process-local temporary directory.
-    let agg_output_prefix_for_state = agg_output_prefix.clone();
     let agg = if let Some(src_dir) = &agg_source_dir {
         let src_dir = std::fs::canonicalize(src_dir)?;
         let out_dir = agg_output_dir.unwrap_or_else(|| src_dir.join("flamegraph-data"));
@@ -186,26 +181,20 @@ pub async fn build_app(
         let Some(src_bucket) = bucket.clone() else {
             anyhow::bail!("--agg requires --bucket (the S3 source of raw traces)");
         };
-        let out_bucket = agg_output_bucket
-            .clone()
-            .unwrap_or_else(|| src_bucket.clone());
         let source = std::sync::Arc::new(s3_backend_for(&src_bucket).await);
-        let output = std::sync::Arc::clone(&agg_output_backend);
         tracing::info!(
             source_bucket = %src_bucket,
-            output = agg_output_bucket
-                .as_deref()
-                .unwrap_or("temporary local directory"),
-            output_prefix = %agg_output_prefix,
+            output = %agg_output.location(),
+            output_prefix = %agg_output.prefix(),
             "demand-driven aggregation enabled (S3 source)"
         );
         Some(AggContext {
             source,
-            output,
+            output: agg_output.backend(),
+            output_bucket: agg_output.output_bucket_for(&src_bucket),
             source_bucket: src_bucket,
             source_is_local: false,
-            output_bucket: out_bucket,
-            output_prefix: agg_output_prefix,
+            output_prefix: agg_output.prefix().to_string(),
             // The served `prefix` (if any) scopes the raw-segment listing.
             source_prefixes: vec![prefix.clone().unwrap_or_default()],
             segment_duration_secs: agg_segment_secs,
@@ -286,14 +275,13 @@ pub async fn build_app(
         (state, true)
     };
 
-    // Hand the same output backend to BYOC aggregation. With an explicit
+    // Hand the same output destination to BYOC aggregation. With an explicit
     // bucket this is the region-aware S3 client built above; otherwise it is
     // the process-local temporary directory. In neither mode do aggregate
     // writes use the source backend or the caller's read credentials.
     app_state = app_state
         .with_byo_creds(source_is_s3)
-        .with_agg_output_prefix(agg_output_prefix_for_state)
-        .with_agg_output_bucket(agg_output_bucket, Some(agg_output_backend))
+        .with_agg_output(agg_output)
         .with_agg_segment_secs(agg_segment_secs);
     // For an S3 source, also offer the assume-role path: a request may name a
     // role ARN and the viewer assumes it with its own (ambient) identity via

--- a/dial9-viewer/src/lib.rs
+++ b/dial9-viewer/src/lib.rs
@@ -42,7 +42,8 @@ pub struct ViewerConfig {
     /// Where the on-demand aggregator writes its Parquet output (local).
     /// Defaults to `<agg_source_dir>/flamegraph-data`.
     pub agg_output_dir: Option<PathBuf>,
-    /// Output S3 bucket for aggregator part-files. Defaults to the source bucket.
+    /// Optional persistent S3 destination for aggregator part-files. When unset,
+    /// S3/BYOC aggregate output uses a process-local temporary directory.
     pub agg_output_bucket: Option<String>,
     /// Output S3 key prefix for aggregator part-files.
     pub agg_output_prefix: String,
@@ -135,11 +136,31 @@ pub async fn build_app(
         enable_upload,
     }: ViewerConfig,
 ) -> anyhow::Result<axum::Router> {
+    // Build one aggregate-output backend shared by the configured aggregation
+    // context and all BYOC requests. An explicit output bucket retains the
+    // persistent S3 behavior; otherwise output uses a process-local temporary
+    // directory that is removed when the server drops it.
+    use crate::ingest::aggregate::AggContext;
+    let agg_output_backend: std::sync::Arc<dyn storage::StorageBackend> =
+        if let Some(out_bucket) = &agg_output_bucket {
+            tracing::info!(
+                %out_bucket,
+                "aggregation output bucket configured (writes go here, not the source)"
+            );
+            std::sync::Arc::new(s3_backend_for(out_bucket).await)
+        } else {
+            let backend = storage::LocalBackend::new_temporary_aggregate();
+            tracing::info!(
+                output = %backend.root().display(),
+                "no aggregation output bucket configured; using temporary local directory"
+            );
+            std::sync::Arc::new(backend)
+        };
+
     // Build the demand-driven aggregation context if requested. Two sources:
     //   - `agg_source_dir` (local): source + output are LocalBackends.
-    //   - `agg` + `bucket` (S3): source is the served bucket/prefix; output is a
-    //     (possibly different) bucket. Both go through region-aware S3 clients.
-    use crate::ingest::aggregate::AggContext;
+    //   - `agg` + `bucket` (S3): source is the served bucket/prefix; output is
+    //     the configured S3 bucket or a process-local temporary directory.
     let agg_output_prefix_for_state = agg_output_prefix.clone();
     let agg = if let Some(src_dir) = &agg_source_dir {
         let src_dir = std::fs::canonicalize(src_dir)?;
@@ -169,13 +190,14 @@ pub async fn build_app(
             .clone()
             .unwrap_or_else(|| src_bucket.clone());
         let source = std::sync::Arc::new(s3_backend_for(&src_bucket).await);
-        // Output may be a different bucket/account/region → its own client.
-        let output = std::sync::Arc::new(s3_backend_for(&out_bucket).await);
+        let output = std::sync::Arc::clone(&agg_output_backend);
         tracing::info!(
             source_bucket = %src_bucket,
-            output_bucket = %out_bucket,
+            output = agg_output_bucket
+                .as_deref()
+                .unwrap_or("temporary local directory"),
             output_prefix = %agg_output_prefix,
-            "demand-driven aggregation enabled (S3)"
+            "demand-driven aggregation enabled (S3 source)"
         );
         Some(AggContext {
             source,
@@ -264,28 +286,14 @@ pub async fn build_app(
         (state, true)
     };
 
-    // When an output bucket is configured, build its region-aware backend once
-    // (ambient identity — the operator owns this bucket) and hand both to the
-    // state. The `/api/flamegraph` BYOC path writes aggregated part-files here
-    // instead of back into the (often read-only) source bucket. Without this,
-    // aggregation against a read-only source fails with S3 AccessDenied on the
-    // first PutObject.
-    let agg_output_backend: Option<std::sync::Arc<dyn storage::StorageBackend>> =
-        match &agg_output_bucket {
-            Some(out_bucket) => {
-                tracing::info!(
-                    %out_bucket,
-                    "aggregation output bucket configured (writes go here, not the source)"
-                );
-                Some(std::sync::Arc::new(s3_backend_for(out_bucket).await))
-            }
-            None => None,
-        };
-
+    // Hand the same output backend to BYOC aggregation. With an explicit
+    // bucket this is the region-aware S3 client built above; otherwise it is
+    // the process-local temporary directory. In neither mode do aggregate
+    // writes use the source backend or the caller's read credentials.
     app_state = app_state
         .with_byo_creds(source_is_s3)
         .with_agg_output_prefix(agg_output_prefix_for_state)
-        .with_agg_output_bucket(agg_output_bucket, agg_output_backend)
+        .with_agg_output_bucket(agg_output_bucket, Some(agg_output_backend))
         .with_agg_segment_secs(agg_segment_secs);
     // For an S3 source, also offer the assume-role path: a request may name a
     // role ARN and the viewer assumes it with its own (ambient) identity via

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -1,4 +1,4 @@
-use crate::storage::{EphemeralS3Config, S3Backend, StorageBackend};
+use crate::storage::{EphemeralS3Config, LocalBackend, S3Backend, StorageBackend};
 use axum::Router;
 use axum::body::Body;
 use axum::extract::DefaultBodyLimit;
@@ -82,17 +82,14 @@ pub struct AppState {
     pub role_assumer: Option<Arc<dyn credentials::RoleAssumer>>,
     /// Output prefix for BYOC aggregation. Defaults to "flamegraph-data".
     pub agg_output_prefix: String,
-    /// Output bucket for BYOC aggregation. `None` means write the aggregated
-    /// part-files back into the source bucket (the query-param `bucket`). Set it
-    /// (via `--agg-output-bucket`) when the source bucket is read-only, so the
-    /// output lands in a separate writable bucket.
+    /// Output bucket for BYOC aggregation. When set, aggregate part-files are
+    /// persisted to this S3 bucket. When unset, they stay in a process-local
+    /// temporary directory that is removed when the server exits.
     pub agg_output_bucket: Option<String>,
-    /// Region-aware backend for [`Self::agg_output_bucket`], built once at
-    /// startup (the output bucket name is known then, so no per-request region
-    /// detection). Writes to the output bucket use the server's ambient identity
-    /// — the operator controls that bucket via `--agg-output-bucket`. `None`
-    /// when no output bucket override is configured; the BYOC path then writes
-    /// to the source bucket through the request's own (BYOC or ambient) backend.
+    /// Backend for BYOC aggregate output. This is a process-local temporary
+    /// directory by default, replaced by a region-aware S3 backend when
+    /// `--agg-output-bucket` is configured. The temporary backend is shared by
+    /// all requests handled by this server process.
     pub agg_output_backend: Option<Arc<dyn StorageBackend>>,
     /// Segment duration (seconds) for BYOC aggregation scope padding.
     pub agg_segment_secs: i64,
@@ -120,7 +117,7 @@ impl AppState {
             role_assumer: None,
             agg_output_prefix: "flamegraph-data".to_string(),
             agg_output_bucket: None,
-            agg_output_backend: None,
+            agg_output_backend: Some(Arc::new(LocalBackend::new_temporary_aggregate())),
             agg_segment_secs: crate::ingest::aggregate::DEFAULT_SEGMENT_DURATION_SECS,
             fold_limits: crate::ingest::aggregate::FoldLimits::default(),
         }
@@ -203,16 +200,17 @@ impl AppState {
         self
     }
 
-    /// Set the output bucket for BYOC aggregation, paired with the region-aware
-    /// backend that writes to it. Pass `None` to keep the default of writing
-    /// back into the source bucket through the request's own backend.
+    /// Set an S3 output bucket and its backend for BYOC aggregation. Passing no
+    /// backend restores a fresh process-local temporary directory; in either
+    /// case the source backend is never used for aggregate writes.
     pub fn with_agg_output_bucket(
         mut self,
         bucket: Option<String>,
         backend: Option<Arc<dyn StorageBackend>>,
     ) -> Self {
         self.agg_output_bucket = bucket;
-        self.agg_output_backend = backend;
+        self.agg_output_backend =
+            Some(backend.unwrap_or_else(|| Arc::new(LocalBackend::new_temporary_aggregate())));
         self
     }
 
@@ -227,9 +225,10 @@ impl AppState {
     /// When `bucket` is `Some`, the request targets the user's own bucket:
     /// resolve a backend from any supplied credentials, scope the source listing
     /// to `prefix` (falling back to the server default), and route output to the
-    /// configured `--agg-output-bucket` (through its own region-aware backend) or
-    /// else back into the source bucket. When `bucket` is `None`, fall back to
-    /// the server's `--agg` context if one is configured.
+    /// configured `--agg-output-bucket` or the shared process-local temporary
+    /// directory. The request's source backend is never used for aggregate
+    /// writes. When `bucket` is `None`, fall back to the server's `--agg`
+    /// context if one is configured.
     ///
     /// Returns `None` only when no `bucket` is given *and* the server has no
     /// `--agg` context — the caller maps that to 404. This is the single place
@@ -250,17 +249,19 @@ impl AppState {
                 .map(str::to_string)
                 .or_else(|| self.default_prefix.clone())
                 .unwrap_or_default();
-            // Output may target a different, writable bucket than the (often
-            // read-only) source. When `--agg-output-bucket` is configured we
-            // write there through its own region-aware backend; otherwise we
-            // write back into the source bucket through the request's backend.
-            let (output_bucket, output) = match (&self.agg_output_bucket, &self.agg_output_backend)
-            {
-                (Some(out_bucket), Some(out_backend)) => {
-                    (out_bucket.clone(), Arc::clone(out_backend))
-                }
-                _ => (bucket.to_string(), Arc::clone(&backend)),
-            };
+            // Output goes through a backend owned by the server, never through
+            // the request's source credentials: either the configured S3 output
+            // bucket or the process-local temporary directory.
+            let output_bucket = self
+                .agg_output_bucket
+                .clone()
+                .unwrap_or_else(|| bucket.to_string());
+            let output = self.agg_output_backend.clone().unwrap_or_else(|| {
+                // Public AppState fields can be constructed manually; preserve
+                // the no-source-writes guarantee even if an embedder cleared
+                // the backend after construction.
+                Arc::new(LocalBackend::new_temporary_aggregate())
+            });
             tracing::info!(
                 %bucket,
                 %output_bucket,

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -50,6 +50,95 @@ pub(crate) async fn region_from_head_bucket(
 #[folder = "ui/"]
 struct UiAssets;
 
+/// Default output key prefix for aggregate part-files.
+const DEFAULT_AGG_OUTPUT_PREFIX: &str = "flamegraph-data";
+
+/// Destination for the aggregate part-files produced by demand-driven folding.
+///
+/// This is always a **server-owned** backend — never the request's source
+/// backend or the caller's bring-your-own credentials. That is the invariant
+/// that lets aggregation run against a read-only source bucket without failing
+/// on the first `PutObject`, and guarantees a caller's keys are never used for
+/// writes. There are two shapes:
+///   - [`AggOutput::s3`] persists parts to an operator-owned S3 bucket, so
+///     rollups survive restarts. Built from `--agg-output-bucket`.
+///   - [`AggOutput::temporary`] writes to a fresh process-local temporary
+///     directory that is removed at shutdown; rollups are recomputed after a
+///     restart. This is the default when no output bucket is configured.
+///
+/// The backend, bucket, and prefix always travel together, so they are one
+/// value rather than three independently-optional fields on [`AppState`].
+#[derive(Clone)]
+pub struct AggOutput {
+    /// Backend all aggregate writes go through.
+    backend: Arc<dyn StorageBackend>,
+    /// The S3 output bucket, or `None` for the process-local temporary
+    /// directory (whose [`LocalBackend`] ignores the bucket argument, so the
+    /// per-request source bucket rides along as an inert placeholder).
+    bucket: Option<String>,
+    /// Output key prefix (default [`DEFAULT_AGG_OUTPUT_PREFIX`]).
+    prefix: String,
+    /// Human-readable destination, captured at construction for startup logging
+    /// (the temp path is only reachable on the concrete backend, not `dyn`).
+    location: String,
+}
+
+impl AggOutput {
+    /// Persist aggregate parts to the operator-owned S3 `bucket` via `backend`
+    /// (built once at startup with the server's ambient identity, region-aware).
+    pub fn s3(bucket: impl Into<String>, backend: Arc<dyn StorageBackend>) -> Self {
+        let bucket = bucket.into();
+        let location = format!("s3://{bucket}");
+        Self {
+            backend,
+            bucket: Some(bucket),
+            prefix: DEFAULT_AGG_OUTPUT_PREFIX.to_string(),
+            location,
+        }
+    }
+
+    /// Write aggregate parts to a fresh process-local temporary directory,
+    /// removed when this value's last clone drops at server shutdown.
+    pub fn temporary() -> Self {
+        let backend = LocalBackend::new_temporary_aggregate();
+        let location = format!("temporary local directory ({})", backend.root().display());
+        Self {
+            backend: Arc::new(backend),
+            bucket: None,
+            prefix: DEFAULT_AGG_OUTPUT_PREFIX.to_string(),
+            location,
+        }
+    }
+
+    /// Override the output key prefix (default `flamegraph-data`).
+    pub fn with_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = prefix.into();
+        self
+    }
+
+    pub(crate) fn backend(&self) -> Arc<dyn StorageBackend> {
+        Arc::clone(&self.backend)
+    }
+
+    pub(crate) fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    /// The bucket argument for writes: the configured S3 output bucket, or the
+    /// request's `source_bucket` as an inert placeholder for the local
+    /// temporary backend (which ignores it).
+    pub(crate) fn output_bucket_for(&self, source_bucket: &str) -> String {
+        self.bucket
+            .clone()
+            .unwrap_or_else(|| source_bucket.to_string())
+    }
+
+    /// Human-readable destination, for startup logging.
+    pub(crate) fn location(&self) -> &str {
+        &self.location
+    }
+}
+
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct AppState {
@@ -80,17 +169,11 @@ pub struct AppState {
     /// fake. Independent of `allow_byo_creds` so a deployment can offer one path,
     /// both, or neither.
     pub role_assumer: Option<Arc<dyn credentials::RoleAssumer>>,
-    /// Output prefix for BYOC aggregation. Defaults to "flamegraph-data".
-    pub agg_output_prefix: String,
-    /// Output bucket for BYOC aggregation. When set, aggregate part-files are
-    /// persisted to this S3 bucket. When unset, they stay in a process-local
-    /// temporary directory that is removed when the server exits.
-    pub agg_output_bucket: Option<String>,
-    /// Backend for BYOC aggregate output. This is a process-local temporary
-    /// directory by default, replaced by a region-aware S3 backend when
-    /// `--agg-output-bucket` is configured. The temporary backend is shared by
-    /// all requests handled by this server process.
-    pub agg_output_backend: Option<Arc<dyn StorageBackend>>,
+    /// Destination for BYOC aggregate part-files: an operator-owned S3 bucket
+    /// (persistent) or a process-local temporary directory (the default,
+    /// removed at shutdown). Always a server-owned backend — aggregate writes
+    /// never use the request's source credentials. See [`AggOutput`].
+    pub agg_output: AggOutput,
     /// Segment duration (seconds) for BYOC aggregation scope padding.
     pub agg_segment_secs: i64,
     /// Process-global concurrency limits for the demand-driven fold pipeline,
@@ -115,9 +198,7 @@ impl AppState {
             allow_byo_creds: false,
             ephemeral_s3: None,
             role_assumer: None,
-            agg_output_prefix: "flamegraph-data".to_string(),
-            agg_output_bucket: None,
-            agg_output_backend: Some(Arc::new(LocalBackend::new_temporary_aggregate())),
+            agg_output: AggOutput::temporary(),
             agg_segment_secs: crate::ingest::aggregate::DEFAULT_SEGMENT_DURATION_SECS,
             fold_limits: crate::ingest::aggregate::FoldLimits::default(),
         }
@@ -195,22 +276,12 @@ impl AppState {
         self
     }
 
-    pub fn with_agg_output_prefix(mut self, prefix: String) -> Self {
-        self.agg_output_prefix = prefix;
-        self
-    }
-
-    /// Set an S3 output bucket and its backend for BYOC aggregation. Passing no
-    /// backend restores a fresh process-local temporary directory; in either
-    /// case the source backend is never used for aggregate writes.
-    pub fn with_agg_output_bucket(
-        mut self,
-        bucket: Option<String>,
-        backend: Option<Arc<dyn StorageBackend>>,
-    ) -> Self {
-        self.agg_output_bucket = bucket;
-        self.agg_output_backend =
-            Some(backend.unwrap_or_else(|| Arc::new(LocalBackend::new_temporary_aggregate())));
+    /// Set the destination for BYOC aggregate part-files. Defaults to a
+    /// process-local temporary directory ([`AggOutput::temporary`]); pass
+    /// [`AggOutput::s3`] to persist to an operator-owned bucket. In every case
+    /// the source backend is never used for aggregate writes.
+    pub fn with_agg_output(mut self, output: AggOutput) -> Self {
+        self.agg_output = output;
         self
     }
 
@@ -249,33 +320,24 @@ impl AppState {
                 .map(str::to_string)
                 .or_else(|| self.default_prefix.clone())
                 .unwrap_or_default();
-            // Output goes through a backend owned by the server, never through
-            // the request's source credentials: either the configured S3 output
+            // Output goes through the server-owned backend, never through the
+            // request's source credentials: either the configured S3 output
             // bucket or the process-local temporary directory.
-            let output_bucket = self
-                .agg_output_bucket
-                .clone()
-                .unwrap_or_else(|| bucket.to_string());
-            let output = self.agg_output_backend.clone().unwrap_or_else(|| {
-                // Public AppState fields can be constructed manually; preserve
-                // the no-source-writes guarantee even if an embedder cleared
-                // the backend after construction.
-                Arc::new(LocalBackend::new_temporary_aggregate())
-            });
+            let output_bucket = self.agg_output.output_bucket_for(bucket);
             tracing::info!(
                 %bucket,
                 %output_bucket,
                 resolved_source_prefix = %source_prefix,
-                output_prefix = %self.agg_output_prefix,
+                output_prefix = %self.agg_output.prefix(),
                 "agg: BYOC context"
             );
             Ok(Some(AggContext {
                 source: backend,
-                output,
+                output: self.agg_output.backend(),
                 source_bucket: bucket.to_string(),
                 source_is_local: false,
                 output_bucket,
-                output_prefix: self.agg_output_prefix.clone(),
+                output_prefix: self.agg_output.prefix().to_string(),
                 source_prefixes: vec![source_prefix],
                 segment_duration_secs: self.agg_segment_secs,
             }))
@@ -487,4 +549,34 @@ fn api_router(state: AppState) -> Router {
         // static-asset fetches. Publishes to the global `ServiceMetrics` sink.
         .layer(axum::middleware::from_fn(metrics::record_request_metrics))
         .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The temporary output uses the request's source bucket as the (ignored)
+    /// bucket argument, while an S3 output always writes to its own bucket
+    /// regardless of the source. This is the routing that keeps aggregate
+    /// writes off the caller's (possibly read-only) source bucket.
+    #[test]
+    fn output_bucket_for_routes_temp_to_source_and_s3_to_configured() {
+        let temp = AggOutput::temporary();
+        assert_eq!(temp.output_bucket_for("caller-source"), "caller-source");
+
+        let backend: Arc<dyn StorageBackend> = Arc::new(LocalBackend::new_temporary_aggregate());
+        let s3 = AggOutput::s3("operator-owned", backend);
+        assert_eq!(s3.output_bucket_for("caller-source"), "operator-owned");
+    }
+
+    /// The default output prefix is applied and overridable, and the default
+    /// matches the CLI's `--agg-output-prefix` default.
+    #[test]
+    fn agg_output_prefix_defaults_and_overrides() {
+        assert_eq!(AggOutput::temporary().prefix(), DEFAULT_AGG_OUTPUT_PREFIX);
+        assert_eq!(
+            AggOutput::temporary().with_prefix("custom").prefix(),
+            "custom"
+        );
+    }
 }

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -710,12 +710,55 @@ impl StorageBackend for S3Backend {
     }
 }
 
+#[cfg(unix)]
+fn make_temporary_root_private(root: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(root, std::fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn make_temporary_root_private(_root: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_file_atomically(source: &Path, destination: &Path) -> std::io::Result<()> {
+    std::fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn replace_file_atomically(source: &Path, destination: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let source: Vec<u16> = source.as_os_str().encode_wide().chain([0]).collect();
+    let destination: Vec<u16> = destination.as_os_str().encode_wide().chain([0]).collect();
+    // SAFETY: both arguments are valid NUL-terminated UTF-16 paths. The source
+    // and destination are sibling files, so MoveFileExW performs one atomic
+    // same-volume replacement and cannot expose a partial destination.
+    let result = unsafe {
+        MoveFileExW(
+            source.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
 /// Local filesystem storage backend. Serves trace files from a directory.
 ///
 /// The `bucket` parameter is ignored — all operations are relative to `root`.
 /// Keys are relative paths from `root`.
 pub struct LocalBackend {
     root: PathBuf,
+    remove_on_drop: bool,
 }
 
 impl LocalBackend {
@@ -724,7 +767,56 @@ impl LocalBackend {
         // Canonicalize root so that symlink resolution in child paths
         // (e.g. macOS /tmp → /private/tmp) matches the root prefix.
         let root = root.canonicalize().unwrap_or(root);
-        Self { root }
+        Self {
+            root,
+            remove_on_drop: false,
+        }
+    }
+
+    /// Create a process-local aggregate store under the system temporary
+    /// directory. The path is unique per backend and removed when the last
+    /// owning `Arc` drops at server shutdown.
+    pub(crate) fn new_temporary_aggregate() -> Self {
+        Self::new_temporary_aggregate_in(std::env::temp_dir())
+    }
+
+    fn new_temporary_aggregate_in(base: impl AsRef<Path>) -> Self {
+        // Resolve platform aliases before appending the not-yet-created unique
+        // directory (notably macOS /tmp -> /private/tmp). Child canonicalization
+        // in put_object can then be compared against this stable root.
+        let base = base.as_ref();
+        let base = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
+        let root = base.join(format!(
+            "dial9-aggregate-{}",
+            uuid::Uuid::new_v4().as_hyphenated()
+        ));
+        Self {
+            root,
+            remove_on_drop: true,
+        }
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for LocalBackend {
+    fn drop(&mut self) {
+        if !self.remove_on_drop {
+            return;
+        }
+        match std::fs::remove_dir_all(&self.root) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::warn!(
+                    path = %self.root.display(),
+                    error = %e,
+                    "failed to remove temporary aggregate directory"
+                );
+            }
+        }
     }
 }
 
@@ -874,6 +966,7 @@ impl StorageBackend for LocalBackend {
         data: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), StorageError>> + Send + '_>> {
         let root = self.root.clone();
+        let private_temporary_root = self.remove_on_drop;
         let key = key.to_string();
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
@@ -887,21 +980,44 @@ impl StorageBackend for LocalBackend {
                         "key contains path traversal".to_string(),
                     ));
                 }
-                // Reject keys that escape the root once their parent dirs are
-                // resolved (mirrors the safety check used elsewhere here).
-                if let Some(parent) = path.parent() {
-                    std::fs::create_dir_all(parent)
+                let parent = path.parent().ok_or_else(|| {
+                    StorageError::Other("object path has no parent directory".to_string())
+                })?;
+                std::fs::create_dir_all(parent).map_err(|e| StorageError::Other(e.to_string()))?;
+                if private_temporary_root {
+                    make_temporary_root_private(&root)
                         .map_err(|e| StorageError::Other(e.to_string()))?;
-                    let canonical_parent = parent
-                        .canonicalize()
-                        .map_err(|e| StorageError::Other(e.to_string()))?;
-                    if !canonical_parent.starts_with(&root) {
-                        return Err(StorageError::Other(
-                            "path escapes root directory".to_string(),
-                        ));
-                    }
                 }
-                std::fs::write(&path, data).map_err(|e| StorageError::Other(e.to_string()))?;
+                let canonical_parent = parent
+                    .canonicalize()
+                    .map_err(|e| StorageError::Other(e.to_string()))?;
+                if !canonical_parent.starts_with(&root) {
+                    return Err(StorageError::Other(
+                        "path escapes root directory".to_string(),
+                    ));
+                }
+
+                // Publish through a hidden same-directory temporary file. A
+                // direct write to `path` would expose a truncated final object
+                // to concurrent aggregate readers; rename gives local storage
+                // the same all-at-once visibility that an S3 PutObject has.
+                let temp_path = canonical_parent.join(format!(
+                    ".dial9-write-{}",
+                    uuid::Uuid::new_v4().as_hyphenated()
+                ));
+                std::fs::write(&temp_path, data).map_err(|e| StorageError::Other(e.to_string()))?;
+                if let Err(rename_error) = replace_file_atomically(&temp_path, &path) {
+                    if let Err(cleanup_error) = std::fs::remove_file(&temp_path)
+                        && cleanup_error.kind() != std::io::ErrorKind::NotFound
+                    {
+                        tracing::warn!(
+                            path = %temp_path.display(),
+                            error = %cleanup_error,
+                            "failed to clean up temporary object write"
+                        );
+                    }
+                    return Err(StorageError::Other(rename_error.to_string()));
+                }
                 Ok(())
             })
             .await
@@ -1291,6 +1407,92 @@ mod tests {
         let written = dir.path().join("a/b/c.bin");
         assert!(written.exists(), "expected file at {}", written.display());
         assert_eq!(std::fs::read(&written).unwrap(), b"hi");
+    }
+
+    /// Concurrent overwrites of one object must never expose a truncated body.
+    /// Aggregate folds use deterministic keys, so overlapping requests can hit
+    /// this exact pattern.
+    #[tokio::test]
+    async fn concurrent_put_object_readers_see_only_complete_versions() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = std::sync::Arc::new(LocalBackend::new(dir.path()));
+        let key = "samples/part.parquet";
+        let body_len = 1024 * 1024;
+        backend
+            .put_object("local", key, vec![0; body_len])
+            .await
+            .unwrap();
+
+        let mut writers = Vec::new();
+        for byte in 1..=8u8 {
+            let backend = std::sync::Arc::clone(&backend);
+            writers.push(tokio::spawn(async move {
+                backend
+                    .put_object("local", key, vec![byte; body_len])
+                    .await
+                    .unwrap();
+            }));
+        }
+
+        for _ in 0..64 {
+            let body = backend.get_object("local", key).await.unwrap();
+            assert_eq!(body.len(), body_len, "reader observed a truncated object");
+            assert!(
+                body.iter().all(|byte| *byte == body[0]),
+                "reader observed bytes from multiple object versions"
+            );
+            tokio::task::yield_now().await;
+        }
+        for writer in writers {
+            writer.await.unwrap();
+        }
+    }
+
+    /// A temporary aggregate backend removes its whole cache tree when dropped.
+    #[tokio::test]
+    async fn temporary_aggregate_backend_cleans_up_on_drop() {
+        let backend = LocalBackend::new_temporary_aggregate();
+        let root = backend.root.clone();
+        backend
+            .put_object("cache", "a/b/c.parquet", b"cached".to_vec())
+            .await
+            .unwrap();
+        assert!(root.join("a/b/c.parquet").exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "temporary cache root must be owner-only");
+        }
+
+        drop(backend);
+        assert!(!root.exists(), "temporary aggregate directory leaked");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn temporary_aggregate_backend_resolves_symlinked_temp_base() {
+        use std::os::unix::fs::symlink;
+
+        let outer = tempfile::tempdir().unwrap();
+        let real_base = outer.path().join("real-temp");
+        let linked_base = outer.path().join("temp-link");
+        std::fs::create_dir(&real_base).unwrap();
+        symlink(&real_base, &linked_base).unwrap();
+
+        let backend = LocalBackend::new_temporary_aggregate_in(&linked_base);
+        assert!(backend.root.starts_with(real_base.canonicalize().unwrap()));
+        backend
+            .put_object("cache", "samples/part.parquet", b"complete".to_vec())
+            .await
+            .unwrap();
+        assert_eq!(
+            backend
+                .get_object("cache", "samples/part.parquet")
+                .await
+                .unwrap(),
+            b"complete"
+        );
     }
 
     /// Build a backend that replays a single response with an explicit status

--- a/dial9-viewer/tests/aggregate_test.rs
+++ b/dial9-viewer/tests/aggregate_test.rs
@@ -523,20 +523,34 @@ impl dial9_viewer::storage::StorageBackend for FailingPuts {
 }
 
 /// Start a server WITHOUT a server-side `AggContext`, exercising the
-/// bring-your-own-credentials `/api/flamegraph?bucket=…` path instead. The
-/// output bucket is configured separately (as `--agg-output-bucket` does), so
-/// aggregated part-files are written there rather than back into the (possibly
-/// read-only) source bucket. Returns the base URL.
+/// bring-your-own-credentials `/api/flamegraph?bucket=…` path instead. With an
+/// output bucket, aggregate parts persist there; without one, they use the
+/// server's temporary local directory. Returns the base URL.
 async fn start_byoc_server(
     fs_root: &std::path::Path,
     source_bucket: &str,
     output_bucket: Option<&str>,
     segment_secs: i64,
 ) -> String {
-    // The request backend (no BYOC headers in the test → server's ambient
-    // identity, which here is the fake S3 client). This both lists the source
-    // and, when no output override is set, writes the output.
-    let request_backend = Arc::new(S3Backend::from_client(fake_s3_client(fs_root)));
+    let request_backend: Arc<dyn dial9_viewer::storage::StorageBackend> =
+        Arc::new(S3Backend::from_client(fake_s3_client(fs_root)));
+    start_byoc_server_with_backend(
+        fs_root,
+        source_bucket,
+        output_bucket,
+        segment_secs,
+        request_backend,
+    )
+    .await
+}
+
+async fn start_byoc_server_with_backend(
+    fs_root: &std::path::Path,
+    source_bucket: &str,
+    output_bucket: Option<&str>,
+    segment_secs: i64,
+    request_backend: Arc<dyn dial9_viewer::storage::StorageBackend>,
+) -> String {
     let mut state = AppState::new(request_backend, Some(source_bucket.into()), None)
         .with_byo_creds(true)
         .with_agg_segment_secs(segment_secs);
@@ -1393,11 +1407,11 @@ async fn byoc_writes_output_to_configured_bucket_not_source() {
     );
 }
 
-/// When NO output bucket is configured, BYOC aggregation falls back to writing
-/// into the source bucket (the historical behavior, valid when the source is
-/// writable). Guards the fallback branch of the output-bucket routing.
+/// With no output bucket, BYOC aggregation must use the server-local cache and
+/// never attempt to write through source credentials. The injected source
+/// backend rejects every PUT, matching a caller-provided read-only bucket.
 #[tokio::test]
-async fn byoc_without_output_bucket_writes_to_source() {
+async fn byoc_without_output_bucket_uses_temporary_cache_for_read_only_source() {
     let fs = tempfile::tempdir().unwrap();
     std::fs::create_dir(fs.path().join("src-bucket")).unwrap();
 
@@ -1405,17 +1419,31 @@ async fn byoc_without_output_bucket_writes_to_source() {
     let body = mini_trace_gz();
     seed_fleet(&uploader, "src-bucket", &body).await;
 
-    let base = start_byoc_server(fs.path(), "src-bucket", None, 60).await;
+    let readable: Arc<dyn dial9_viewer::storage::StorageBackend> =
+        Arc::new(S3Backend::from_client(fake_s3_client(fs.path())));
+    let read_only: Arc<dyn dial9_viewer::storage::StorageBackend> = Arc::new(FailingPuts {
+        inner: readable,
+        fail_substr: "",
+    });
+    let base = start_byoc_server_with_backend(fs.path(), "src-bucket", None, 60, read_only).await;
     let http = reqwest::Client::new();
+    let query = "bucket=src-bucket&service=shale&host=host-a";
 
-    let r = stream_final(&http, &base, "bucket=src-bucket&service=shale&host=host-a").await;
-    assert!(r.total_samples > 0);
+    let first = stream(&http, &base, query).await;
+    let final_response = first.last().unwrap();
+    assert!(final_response.total_samples > 0);
+    assert_eq!(final_response.coverage.as_ref().unwrap().fold_errors, 0);
+
+    // A second request starts from the already-folded temporary cache rather
+    // than recomputing, proving the cache is shared across requests.
+    let second = stream(&http, &base, query).await;
+    assert!(
+        second[0].coverage.as_ref().unwrap().files_folded > 0,
+        "second request should observe aggregate parts cached by the first"
+    );
 
     let src_n = count_objects(&uploader, "src-bucket", "flamegraph-data/").await;
-    assert!(
-        src_n > 0,
-        "with no output override, output falls back to the source bucket"
-    );
+    assert_eq!(src_n, 0, "source bucket must remain unmodified");
 }
 
 /// The `/api/tokio-stats` SSE endpoint streams the same refinement machinery as

--- a/dial9-viewer/tests/aggregate_test.rs
+++ b/dial9-viewer/tests/aggregate_test.rs
@@ -557,7 +557,7 @@ async fn start_byoc_server_with_backend(
     if let Some(out) = output_bucket {
         let out_backend: Arc<dyn dial9_viewer::storage::StorageBackend> =
             Arc::new(S3Backend::from_client(fake_s3_client(fs_root)));
-        state = state.with_agg_output_bucket(Some(out.to_string()), Some(out_backend));
+        state = state.with_agg_output(dial9_viewer::server::AggOutput::s3(out, out_backend));
     }
     let app = router(state);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/docs/aggregation-feature.md
+++ b/docs/aggregation-feature.md
@@ -179,6 +179,12 @@ dial9 serve --bucket <raw-traces> --agg \
   [--agg-output-bucket <bucket>] [--agg-output-prefix flamegraph-data]
 ```
 
+For S3/BYOC aggregation, omitting `--agg-output-bucket` stores aggregate
+part-files in a process-local temporary directory. Source credentials only need
+read access, the source bucket is never modified, and rollups are recomputed
+after server restart. The temporary directory is removed when the server exits.
+Set `--agg-output-bucket` to retain the existing persistent S3-backed cache.
+
 `--agg-segment-secs` (default 60) sets the segment-duration pad for the time
 filter.
 


### PR DESCRIPTION
When running aggregation locally, its convenient to avoid needing to persist the aggregates to S3. This adds a default mode so that aggregates go to a tempdir instead.

I cleaned up some other arguments while I was there