### PR TITLE
fix(taskdump): propagate Ready from the capture re-poll

### DIFF
--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -155,7 +155,13 @@ impl<F: Future> Future for TaskDumped<F> {
                 if *this.just_captured {
                     *this.just_captured = false;
                 } else {
-                    this.frames.capture(this.inner.as_mut(), cx);
+                    let repoll_result = this.frames.capture(this.inner.as_mut(), cx);
+                    // In rare circumstances, repoll will now be ready.
+                    if repoll_result.is_ready() {
+                        this.frames.clear();
+                        *this.pending_capture_ts = None;
+                        return repoll_result;
+                    }
                     *this.just_captured = true;
                     let poll_end = crate::telemetry::recorder::poll_start_ts_monotonic();
                     *this.pending_capture_ts = NonZeroU64::new(poll_end);
@@ -236,8 +242,11 @@ impl FrameBuf {
     }
 
     /// Capture backtraces at yield points by re-polling `inner` under the
-    /// real waker inside `trace_with`.
-    fn capture<F: Future>(&mut self, inner: Pin<&mut F>, cx: &mut Context<'_>) {
+    /// real waker inside `trace_with`, returning that re-poll's result.
+    ///
+    /// The re-poll can complete `inner`; that `Ready` is returned so the caller
+    /// can adopt it.
+    fn capture<F: Future>(&mut self, inner: Pin<&mut F>, cx: &mut Context<'_>) -> Poll<F::Output> {
         if self.ips.capacity() == 0 {
             self.ips.reserve(FRAME_BUF_INITIAL_CAPACITY);
         }
@@ -248,9 +257,10 @@ impl FrameBuf {
 
         // `trace_with`'s outer closure is `FnOnce`; `Option::take` moves the
         // pinned reference in without requiring a `Copy` bound or unsafe.
+        let mut result = Poll::Pending;
         tokio::runtime::dump::trace_with(
             || {
-                let _ = inner.poll(cx);
+                result = inner.poll(cx);
             },
             |meta| {
                 let ip_start = ips.len();
@@ -266,6 +276,7 @@ impl FrameBuf {
                 });
             },
         );
+        result
     }
 }
 

--- a/dial9-tokio-telemetry/tests/task_dump.rs
+++ b/dial9-tokio-telemetry/tests/task_dump.rs
@@ -3,6 +3,9 @@
 mod common;
 
 use dial9_tokio_telemetry::telemetry::{TaskDumpConfig, TelemetryEvent, TracedRuntime};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::task::JoinSet;
 
@@ -188,5 +191,60 @@ fn spawn_with_joinset_emits_task_dump() {
             .iter()
             .map(std::mem::discriminant)
             .collect::<Vec<_>>()
+    );
+}
+
+/// A contract-abiding future that completes on its **second** poll, used to
+/// reproduce the race condition in the regression test below.
+struct CompletesOnSecondPoll {
+    polls: u32,
+}
+
+impl Future for CompletesOnSecondPoll {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        self.polls += 1;
+        match self.polls {
+            // Park and arm the waker, as a future waiting on an external
+            // resource does; this pending wake reschedules the task.
+            1 => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            // The capture re-poll completes the future.
+            2 => Poll::Ready(()),
+            // Any further poll is a poll-after-`Ready` contract violation.
+            n => panic!("future polled again after it returned Ready (poll #{n})"),
+        }
+    }
+}
+
+/// Regression: the task-dump capture re-poll must not complete a future and
+/// then let it be polled again. Before the fix this panicked with a
+/// poll-after-`Ready` (surfacing as a `JoinError`); the task must instead
+/// complete cleanly.
+#[test]
+fn task_dump_capture_repoll_does_not_cause_poll_after_ready() {
+    let (writer, _events) = common::CapturingWriter::new();
+
+    let mut builder = tokio::runtime::Builder::new_current_thread();
+    builder.enable_all();
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .with_task_dumps(TaskDumpConfig::builder().rng_seed(42).build())
+        .build_and_start(builder, writer)
+        .unwrap();
+
+    let handle = guard.handle();
+    let result = runtime.block_on(async { handle.spawn(CompletesOnSecondPoll { polls: 0 }).await });
+
+    drop(runtime);
+    let _ = guard.graceful_shutdown(Duration::from_secs(1));
+
+    assert!(
+        result.is_ok(),
+        "spawned future was polled after it returned Ready \
+         (TaskDumped re-polled a completed future): {result:?}"
     );
 }


### PR DESCRIPTION
To sample a task-dump backtrace, TaskDumped polls the inner future a second time and discarded the result. On a multi-threaded runtime that re-poll can legitimately return Ready (a resource the future is parked on is readied by another thread between the primary poll and the capture re-poll). The completion was dropped and Pending returned to the caller; the pending wake then reschedules the task and the completed future is polled again — a poll-after-Ready contract violation. It panics (e.g. "async fn resumed after completion", or "Map must not be polled after it returned Poll::Ready") and, under panic=abort, aborts the process.

just_captured (#375) guards the capture, not the primary poll, so it does not prevent this.

Make FrameBuf::capture return the re-poll's Poll, and have TaskDumped::poll adopt a Ready (running the same cleanup as the Ready arm and returning it) so the future is never polled after completion.

Adds a regression test that spawns a future which completes on its second poll (the capture re-poll); it panicked before this fix and passes now.


(cherry picked from commit d913c630769d413d4fde9e28f5d85aef2e737ead)