### PR TITLE
fix(viewer): autodetect regions for listed S3 buckets

### DIFF
--- a/dial9-viewer/src/server/buckets.rs
+++ b/dial9-viewer/src/server/buckets.rs
@@ -1,6 +1,5 @@
-//! Bucket-listing endpoints. `GET /api/buckets` preserves the names-only API;
-//! `GET /api/buckets/details` also returns each bucket's region for the picker.
-//! Both double as credential checks (they fail if the credentials are bad).
+//! `GET /api/buckets` lists each visible bucket and its region for the picker.
+//! It also doubles as a credential check (it fails if the credentials are bad).
 
 use axum::Json;
 use axum::extract::State;
@@ -13,22 +12,10 @@ use crate::server::error::storage_error_response;
 pub async fn list_buckets(
     State(state): State<AppState>,
     creds: MaybeCreds,
-) -> Result<Json<Vec<String>>, (StatusCode, String)> {
-    let backend = state.resolve(creds).await?;
-    let buckets = backend
-        .list_buckets()
-        .await
-        .map_err(storage_error_response)?;
-    Ok(Json(buckets))
-}
-
-pub async fn list_bucket_details(
-    State(state): State<AppState>,
-    creds: MaybeCreds,
 ) -> Result<Json<Vec<crate::storage::BucketInfo>>, (StatusCode, String)> {
     let backend = state.resolve(creds).await?;
     let buckets = backend
-        .list_bucket_details()
+        .list_buckets()
         .await
         .map_err(storage_error_response)?;
     Ok(Json(buckets))

--- a/dial9-viewer/src/server/buckets.rs
+++ b/dial9-viewer/src/server/buckets.rs
@@ -1,6 +1,6 @@
-//! `GET /api/buckets` — list the buckets the supplied credentials can see, so
-//! the viewer can offer a bucket picker instead of requiring the user to know
-//! the name. Also doubles as a credential check (it fails if the creds are bad).
+//! Bucket-listing endpoints. `GET /api/buckets` preserves the names-only API;
+//! `GET /api/buckets/details` also returns each bucket's region for the picker.
+//! Both double as credential checks (they fail if the credentials are bad).
 
 use axum::Json;
 use axum::extract::State;
@@ -17,6 +17,18 @@ pub async fn list_buckets(
     let backend = state.resolve(creds).await?;
     let buckets = backend
         .list_buckets()
+        .await
+        .map_err(storage_error_response)?;
+    Ok(Json(buckets))
+}
+
+pub async fn list_bucket_details(
+    State(state): State<AppState>,
+    creds: MaybeCreds,
+) -> Result<Json<Vec<crate::storage::BucketInfo>>, (StatusCode, String)> {
+    let backend = state.resolve(creds).await?;
+    let buckets = backend
+        .list_bucket_details()
         .await
         .map_err(storage_error_response)?;
     Ok(Json(buckets))

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -547,10 +547,6 @@ fn api_router(state: AppState) -> Router {
         .route("/config", axum::routing::get(config::get_config))
         .route("/buckets", axum::routing::get(buckets::list_buckets))
         .route(
-            "/buckets/details",
-            axum::routing::get(buckets::list_bucket_details),
-        )
-        .route(
             "/credentials/check",
             axum::routing::post(check::check_credentials),
         )

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -547,6 +547,10 @@ fn api_router(state: AppState) -> Router {
         .route("/config", axum::routing::get(config::get_config))
         .route("/buckets", axum::routing::get(buckets::list_buckets))
         .route(
+            "/buckets/details",
+            axum::routing::get(buckets::list_bucket_details),
+        )
+        .route(
             "/credentials/check",
             axum::routing::post(check::check_credentials),
         )

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -245,7 +245,16 @@ where
         // was built for, so S3 refuses with `PermanentRedirect` (the classic
         // form) or the generic `Redirect`. Surface a clear message rather than
         // the opaque "unclassified S3 error" this used to fall through to.
-        Some("PermanentRedirect" | "Redirect") => StorageError::WrongRegion,
+        //
+        // `IllegalLocationConstraintException` is the same mismatch reported
+        // differently: an opt-in region (e.g. `af-south-1`) whose bucket is
+        // addressed through a region-specific endpoint the request wasn't signed
+        // for returns this (HTTP 400) instead of the 301 `PermanentRedirect`. It
+        // is still "wrong region", so classify it alongside the others rather
+        // than letting it fall through to the `Other` arm's 500 `fault`.
+        Some("PermanentRedirect" | "Redirect" | "IllegalLocationConstraintException") => {
+            StorageError::WrongRegion
+        }
         // Missing bucket/key: the user pointed at something that does not exist
         // (typo'd bucket name, deleted object). This is a client mistake, so map
         // it to 404 rather than letting it fall through to the `Other` arm —
@@ -1268,6 +1277,35 @@ mod tests {
             .list_prefixes("my-bucket", "")
             .await
             .expect_err("a PermanentRedirect must surface as an error");
+        assert!(
+            matches!(err, StorageError::WrongRegion),
+            "expected WrongRegion, got {err:?}"
+        );
+        // The message points the user at the fix (set/detect the region).
+        assert!(err.to_string().contains("region"), "message: {err}");
+    }
+
+    /// An `IllegalLocationConstraintException` is a region mismatch reported
+    /// differently: an opt-in region (e.g. `af-south-1`) whose bucket is
+    /// addressed through an endpoint the request wasn't signed for returns this
+    /// (HTTP 400) instead of a 301 `PermanentRedirect`. It must classify to
+    /// [`StorageError::WrongRegion`] like the redirect forms, not the opaque
+    /// `Other` that produced the "unclassified S3 error" log and a 500 `fault`.
+    #[tokio::test]
+    async fn illegal_location_constraint_classifies_as_wrong_region() {
+        // The XML S3 sends for an opt-in-region bucket hit through the wrong
+        // regional endpoint (HTTP 400) — the exact shape seen in prod.
+        let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <Error>
+              <Code>IllegalLocationConstraintException</Code>
+              <Message>The af-south-1 location constraint is incompatible for the region specific endpoint this request was sent to.</Message>
+            </Error>"#;
+        let backend = replay_error_backend(400, body);
+
+        let err = backend
+            .list_prefixes("my-bucket", "")
+            .await
+            .expect_err("an IllegalLocationConstraintException must surface as an error");
         assert!(
             matches!(err, StorageError::WrongRegion),
             "expected WrongRegion, got {err:?}"

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -83,30 +83,13 @@ pub struct ObjectStream {
 
 /// Abstraction over trace storage (S3, local FS, etc.)
 pub trait StorageBackend: Send + Sync {
-    /// List the buckets the current credentials can see. Lets the viewer offer
-    /// a bucket picker instead of requiring the user to know the name. Backends
+    /// List the buckets the current credentials can see, including their AWS
+    /// regions when available. Lets the viewer offer a region-aware bucket
+    /// picker instead of requiring the user to know either value. Backends
     /// without a bucket concept (local FS) return an empty list.
     fn list_buckets(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>>;
-
-    /// List buckets with their AWS regions when available.
-    ///
-    /// The default preserves compatibility for third-party backends by
-    /// adapting [`StorageBackend::list_buckets`] and leaving the region
-    /// unknown. S3 overrides this to retain `BucketRegion` from `ListBuckets`.
-    fn list_bucket_details(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
-        Box::pin(async move {
-            Ok(self
-                .list_buckets()
-                .await?
-                .into_iter()
-                .map(|name| BucketInfo::new(name, None))
-                .collect())
-        })
-    }
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>>;
 
     /// List objects under `prefix`, paginating up to `cap` results.
     ///
@@ -511,19 +494,6 @@ pub fn build_credentialed_client(
 impl StorageBackend for S3Backend {
     fn list_buckets(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>> {
-        Box::pin(async move {
-            Ok(self
-                .fetch_bucket_details()
-                .await?
-                .into_iter()
-                .map(|bucket| bucket.name)
-                .collect())
-        })
-    }
-
-    fn list_bucket_details(
-        &self,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
         Box::pin(self.fetch_bucket_details())
     }
@@ -898,7 +868,7 @@ impl Drop for LocalBackend {
 impl StorageBackend for LocalBackend {
     fn list_buckets(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
         // Local mode has no bucket concept; the synthetic "local" bucket is
         // wired in by the caller.
         Box::pin(async { Ok(Vec::new()) })
@@ -1325,7 +1295,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_bucket_details_requests_and_preserves_regions() {
+    async fn list_buckets_requests_and_preserves_regions() {
         use aws_smithy_http_client::test_util::infallible_client_fn;
 
         let http_client = infallible_client_fn(|req: http::Request<_>| {
@@ -1367,7 +1337,7 @@ mod tests {
             .build();
         let backend = S3Backend::from_client(aws_sdk_s3::Client::from_conf(cfg));
 
-        let buckets = backend.list_bucket_details().await.unwrap();
+        let buckets = backend.list_buckets().await.unwrap();
         assert_eq!(
             buckets,
             vec![

--- a/dial9-viewer/src/storage.rs
+++ b/dial9-viewer/src/storage.rs
@@ -13,6 +13,27 @@ pub struct ObjectInfo {
     pub last_modified: Option<String>,
 }
 
+/// A bucket visible to the current credentials and its AWS region, when S3
+/// included it in the `ListBuckets` response.
+///
+/// `#[non_exhaustive]` keeps this additive response type extensible without
+/// preventing callers from reading the current fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct BucketInfo {
+    pub name: String,
+    pub region: Option<String>,
+}
+
+impl BucketInfo {
+    pub fn new(name: impl Into<String>, region: Option<String>) -> Self {
+        Self {
+            name: name.into(),
+            region,
+        }
+    }
+}
+
 /// A bounded page of object listings, plus whether the cap was reached.
 ///
 /// `truncated` is the signal the old listing path lacked: when a prefix fans
@@ -68,6 +89,24 @@ pub trait StorageBackend: Send + Sync {
     fn list_buckets(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>>;
+
+    /// List buckets with their AWS regions when available.
+    ///
+    /// The default preserves compatibility for third-party backends by
+    /// adapting [`StorageBackend::list_buckets`] and leaving the region
+    /// unknown. S3 overrides this to retain `BucketRegion` from `ListBuckets`.
+    fn list_bucket_details(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
+        Box::pin(async move {
+            Ok(self
+                .list_buckets()
+                .await?
+                .into_iter()
+                .map(|name| BucketInfo::new(name, None))
+                .collect())
+        })
+    }
 
     /// List objects under `prefix`, paginating up to `cap` results.
     ///
@@ -338,6 +377,45 @@ impl S3Backend {
         Self { client }
     }
 
+    async fn fetch_bucket_details(&self) -> Result<Vec<BucketInfo>, StorageError> {
+        const MAX_BUCKETS: usize = 200;
+
+        // S3 only includes BucketRegion when ListBuckets has at least one valid
+        // parameter. Setting the page size both enables that field and keeps
+        // pagination bounded by the viewer's existing display cap.
+        let mut pages = self
+            .client
+            .list_buckets()
+            .max_buckets(MAX_BUCKETS as i32)
+            .into_paginator()
+            .send();
+        let mut buckets = Vec::new();
+        let mut truncated = false;
+        'pages: while let Some(page) = pages.next().await {
+            let page = page.map_err(|e| classify_s3_error(&e))?;
+            for bucket in page.buckets() {
+                if let Some(name) = bucket.name() {
+                    buckets.push(BucketInfo::new(
+                        name,
+                        bucket.bucket_region().map(str::to_string),
+                    ));
+                }
+                if buckets.len() >= MAX_BUCKETS {
+                    truncated = true;
+                    break 'pages;
+                }
+            }
+        }
+        if truncated {
+            tracing::warn!(
+                max = MAX_BUCKETS,
+                "bucket listing truncated at cap; some buckets are not shown"
+            );
+        }
+        buckets.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(buckets)
+    }
+
     /// Build an ephemeral backend from user-supplied credentials.
     ///
     /// The credentials are passed as a concrete value, which acts as a *static*
@@ -435,31 +513,19 @@ impl StorageBackend for S3Backend {
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>> {
         Box::pin(async move {
-            const MAX_BUCKETS: usize = 200;
-            let mut pages = self.client.list_buckets().into_paginator().send();
-            let mut names = Vec::new();
-            let mut truncated = false;
-            'pages: while let Some(page) = pages.next().await {
-                let page = page.map_err(|e| classify_s3_error(&e))?;
-                for b in page.buckets() {
-                    if let Some(name) = b.name() {
-                        names.push(name.to_string());
-                    }
-                    if names.len() >= MAX_BUCKETS {
-                        truncated = true;
-                        break 'pages;
-                    }
-                }
-            }
-            if truncated {
-                tracing::warn!(
-                    max = MAX_BUCKETS,
-                    "bucket listing truncated at cap; some buckets are not shown"
-                );
-            }
-            names.sort();
-            Ok(names)
+            Ok(self
+                .fetch_bucket_details()
+                .await?
+                .into_iter()
+                .map(|bucket| bucket.name)
+                .collect())
         })
+    }
+
+    fn list_bucket_details(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
+        Box::pin(self.fetch_bucket_details())
     }
 
     fn list_objects(
@@ -1256,6 +1322,59 @@ mod tests {
             .http_client(http_client)
             .build();
         S3Backend::from_client(aws_sdk_s3::Client::from_conf(cfg))
+    }
+
+    #[tokio::test]
+    async fn list_bucket_details_requests_and_preserves_regions() {
+        use aws_smithy_http_client::test_util::infallible_client_fn;
+
+        let http_client = infallible_client_fn(|req: http::Request<_>| {
+            assert!(
+                req.uri()
+                    .query()
+                    .is_some_and(|query| query.contains("max-buckets=200")),
+                "ListBuckets must include a valid parameter so S3 returns BucketRegion: {}",
+                req.uri()
+            );
+            let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+                <ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <Buckets>
+                    <Bucket>
+                      <Name>dial9-cape-town</Name>
+                      <CreationDate>2026-07-21T00:00:00.000Z</CreationDate>
+                      <BucketRegion>af-south-1</BucketRegion>
+                    </Bucket>
+                    <Bucket>
+                      <Name>dial9-oregon</Name>
+                      <CreationDate>2026-07-21T00:00:00.000Z</CreationDate>
+                      <BucketRegion>us-west-2</BucketRegion>
+                    </Bucket>
+                  </Buckets>
+                </ListAllMyBucketsResult>"#;
+            http::Response::builder()
+                .status(200)
+                .header("content-type", "application/xml")
+                .body(body)
+                .unwrap()
+        });
+        let cfg = aws_sdk_s3::config::Builder::new()
+            .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
+            .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                "test", "test", None, None, "test",
+            ))
+            .region(aws_sdk_s3::config::Region::new("us-east-1"))
+            .http_client(http_client)
+            .build();
+        let backend = S3Backend::from_client(aws_sdk_s3::Client::from_conf(cfg));
+
+        let buckets = backend.list_bucket_details().await.unwrap();
+        assert_eq!(
+            buckets,
+            vec![
+                BucketInfo::new("dial9-cape-town", Some("af-south-1".to_string())),
+                BucketInfo::new("dial9-oregon", Some("us-west-2".to_string())),
+            ]
+        );
     }
 
     /// A `PermanentRedirect` (the error S3 returns when a bucket is addressed in

--- a/dial9-viewer/tests/aggregate_test.rs
+++ b/dial9-viewer/tests/aggregate_test.rs
@@ -424,7 +424,10 @@ impl dial9_viewer::storage::StorageBackend for FailingPuts {
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<
-                    Output = Result<Vec<String>, dial9_viewer::storage::StorageError>,
+                    Output = Result<
+                        Vec<dial9_viewer::storage::BucketInfo>,
+                        dial9_viewer::storage::StorageError,
+                    >,
                 > + Send
                 + '_,
         >,

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -800,6 +800,25 @@ async fn byo_credentials_list_buckets_from_headers() {
     let names: Vec<String> = resp.json().await.unwrap();
     check!(names.contains(&"byo-bucket".to_string()));
     check!(names.contains(&"dial9-traces".to_string()));
+
+    // The additive details endpoint preserves the existing names-only contract
+    // while giving the picker ListBuckets' per-bucket region when available.
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/api/buckets/details"))
+        .header(H_AKID, "test")
+        .header(H_SECRET, "test")
+        .header(H_REGION, "us-east-1")
+        .send()
+        .await
+        .unwrap();
+    check!(resp.status().as_u16() == 200);
+    let buckets: Vec<serde_json::Value> = resp.json().await.unwrap();
+    check!(buckets.iter().any(|bucket| bucket["name"] == "byo-bucket"));
+    check!(
+        buckets
+            .iter()
+            .any(|bucket| bucket["name"] == "dial9-traces")
+    );
 }
 
 #[tokio::test]

--- a/dial9-viewer/tests/server_test.rs
+++ b/dial9-viewer/tests/server_test.rs
@@ -1,7 +1,7 @@
 use assert2::check;
 use dial9_viewer::server::{AppState, UploadLimits, router};
 use dial9_viewer::storage::{
-    ListPage, LocalBackend, ObjectInfo, S3Backend, StorageBackend, StorageError,
+    BucketInfo, ListPage, LocalBackend, ObjectInfo, S3Backend, StorageBackend, StorageError,
 };
 use std::future::Future;
 use std::pin::Pin;
@@ -13,7 +13,7 @@ struct FakeBackend;
 impl StorageBackend for FakeBackend {
     fn list_buckets(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
         Box::pin(async { Ok(vec![]) })
     }
 
@@ -111,7 +111,7 @@ struct ErroringBackend;
 impl StorageBackend for ErroringBackend {
     fn list_buckets(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
         Box::pin(async { Err(StorageError::Other("default backend used".into())) })
     }
 
@@ -632,7 +632,7 @@ fn obj_info(key: &str) -> ObjectInfo {
 impl StorageBackend for ReorderingBackend {
     fn list_buckets(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
         Box::pin(async { Ok(vec![]) })
     }
 
@@ -797,28 +797,9 @@ async fn byo_credentials_list_buckets_from_headers() {
 
     let resp = client_list_buckets(&base).await;
     check!(resp.status().as_u16() == 200);
-    let names: Vec<String> = resp.json().await.unwrap();
-    check!(names.contains(&"byo-bucket".to_string()));
-    check!(names.contains(&"dial9-traces".to_string()));
-
-    // The additive details endpoint preserves the existing names-only contract
-    // while giving the picker ListBuckets' per-bucket region when available.
-    let resp = reqwest::Client::new()
-        .get(format!("{base}/api/buckets/details"))
-        .header(H_AKID, "test")
-        .header(H_SECRET, "test")
-        .header(H_REGION, "us-east-1")
-        .send()
-        .await
-        .unwrap();
-    check!(resp.status().as_u16() == 200);
-    let buckets: Vec<serde_json::Value> = resp.json().await.unwrap();
-    check!(buckets.iter().any(|bucket| bucket["name"] == "byo-bucket"));
-    check!(
-        buckets
-            .iter()
-            .any(|bucket| bucket["name"] == "dial9-traces")
-    );
+    let buckets: Vec<BucketInfo> = resp.json().await.unwrap();
+    check!(buckets.iter().any(|bucket| bucket.name == "byo-bucket"));
+    check!(buckets.iter().any(|bucket| bucket.name == "dial9-traces"));
 }
 
 #[tokio::test]
@@ -1476,8 +1457,8 @@ async fn assume_role_lists_bucket_via_assumed_creds() {
         .await
         .unwrap();
     check!(resp.status().as_u16() == 200);
-    let names: Vec<String> = resp.json().await.unwrap();
-    check!(names.contains(&"byo-bucket".to_string()));
+    let buckets: Vec<BucketInfo> = resp.json().await.unwrap();
+    check!(buckets.iter().any(|bucket| bucket.name == "byo-bucket"));
     // The exact ARN from the header reached the assumer.
     let assumed = assumed.lock().unwrap();
     check!(assumed.as_slice() == ["arn:aws:iam::123456789012:role/dial9-reader"]);
@@ -1502,8 +1483,8 @@ async fn assume_role_via_query_params_is_linkable() {
         .await
         .unwrap();
     check!(resp.status().as_u16() == 200);
-    let names: Vec<String> = resp.json().await.unwrap();
-    check!(names.contains(&"byo-bucket".to_string()));
+    let buckets: Vec<BucketInfo> = resp.json().await.unwrap();
+    check!(buckets.iter().any(|bucket| bucket.name == "byo-bucket"));
     let assumed = assumed.lock().unwrap();
     check!(assumed.as_slice() == ["arn:aws:iam::123456789012:role/dial9-reader"]);
 }

--- a/dial9-viewer/ui/creds.js
+++ b/dial9-viewer/ui/creds.js
@@ -347,6 +347,22 @@
     return await resp.json();
   }
 
+  /**
+   * List visible buckets with the region returned by S3's ListBuckets call.
+   * Unlike listBuckets(), this returns `{name, region}` objects and is used by
+   * the picker to avoid a second, wrong-region HeadBucket probe.
+   *
+   * @returns {Promise<Array<{name: string, region: string|null}>>}
+   */
+  async function listBucketDetails() {
+    const resp = await fetch("/api/buckets/details", { headers: headers() });
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`HTTP ${resp.status}${body ? ": " + body : ""}`);
+    }
+    return await resp.json();
+  }
+
   /** Clear stored credentials and notify listeners. */
   function clear() {
     storage().removeItem(STORAGE_KEY);
@@ -398,6 +414,7 @@
     parse,
     check,
     listBuckets,
+    listBucketDetails,
     clear,
     headers,
     // Test seam — inject a fake storage backend.

--- a/dial9-viewer/ui/creds.js
+++ b/dial9-viewer/ui/creds.js
@@ -332,30 +332,14 @@
   }
 
   /**
-   * List the buckets the stored credentials can see (`GET /api/buckets`), so
-   * the UI can offer a picker. Browser-only. Throws on HTTP error with the
+   * List the buckets the stored credentials can see (`GET /api/buckets`) with
+   * the region returned by S3. Browser-only. Throws on HTTP error with the
    * server's message (e.g. credentials rejected).
-   *
-   * @returns {Promise<string[]>}
-   */
-  async function listBuckets() {
-    const resp = await fetch("/api/buckets", { headers: headers() });
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "");
-      throw new Error(`HTTP ${resp.status}${body ? ": " + body : ""}`);
-    }
-    return await resp.json();
-  }
-
-  /**
-   * List visible buckets with the region returned by S3's ListBuckets call.
-   * Unlike listBuckets(), this returns `{name, region}` objects and is used by
-   * the picker to avoid a second, wrong-region HeadBucket probe.
    *
    * @returns {Promise<Array<{name: string, region: string|null}>>}
    */
-  async function listBucketDetails() {
-    const resp = await fetch("/api/buckets/details", { headers: headers() });
+  async function listBuckets() {
+    const resp = await fetch("/api/buckets", { headers: headers() });
     if (!resp.ok) {
       const body = await resp.text().catch(() => "");
       throw new Error(`HTTP ${resp.status}${body ? ": " + body : ""}`);
@@ -414,7 +398,6 @@
     parse,
     check,
     listBuckets,
-    listBucketDetails,
     clear,
     headers,
     // Test seam — inject a fake storage backend.

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -269,7 +269,7 @@
             <button id="creds-clear">Clear</button>
             <span id="creds-status" class="creds-status"></span>
         </div>
-        <!-- Bucket picker, populated from GET /api/buckets after Apply. -->
+        <!-- Bucket picker, populated from GET /api/buckets/details after Apply. -->
         <div class="creds-row" id="creds-buckets-row" style="display:none;align-items:flex-start">
             <label style="padding-top:6px">Bucket</label>
             <div id="creds-buckets" class="creds-buckets"></div>
@@ -575,25 +575,25 @@
         // trace buckets. Defaults to the filtered view; the "Show all" toggle
         // flips it. Retained across re-renders (e.g. re-listing on reload).
         let showAllBuckets = false;
-        // The last full bucket list from /api/buckets, so the toggle can
+        // The last full bucket list from /api/buckets/details, so the toggle can
         // re-render without another list call.
-        let lastBucketNames = [];
+        let lastBuckets = [];
 
         // Buckets whose name contains "dial9" are the trace buckets — surfaced
         // by default. Everything else is hidden unless "Show all" is on.
-        const isTraceBucket = (n) => n.toLowerCase().includes('dial9');
+        const isTraceBucket = (bucket) => bucket.name.toLowerCase().includes('dial9');
 
         // Render the bucket picker from the last listing. Shows the dial9 trace
         // buckets by default, or every visible bucket when "Show all" is on. A
         // toggle button lets the user switch (some deployments don't put "dial9"
         // in the bucket name, so the filtered view can hide the real bucket).
-        function renderBucketPicker(names) {
-            if (names) lastBucketNames = names;
-            names = lastBucketNames;
+        function renderBucketPicker(buckets) {
+            if (buckets) lastBuckets = buckets;
+            buckets = lastBuckets;
             bucketsBox.innerHTML = '';
             bucketsRow.style.display = '';
 
-            const all = [...names].sort((a, b) => a.localeCompare(b));
+            const all = [...buckets].sort((a, b) => a.name.localeCompare(b.name));
             const matches = all.filter(isTraceBucket);
             const shown = showAllBuckets ? all : matches;
 
@@ -614,19 +614,19 @@
             }
 
             if (!shown.length) {
-                bucketsBox.textContent = names.length
+                bucketsBox.textContent = buckets.length
                     ? 'No dial9 trace buckets visible to these credentials.'
                     : 'No buckets visible to these credentials.';
                 appendToggle();
                 return;
             }
 
-            for (const name of shown) {
+            for (const bucket of shown) {
                 const b = document.createElement('button');
-                b.textContent = name;
+                b.textContent = bucket.name;
                 // Highlight the trace buckets even within the full list.
-                if (isTraceBucket(name)) b.classList.add('match');
-                b.addEventListener('click', () => selectBucket(name, b));
+                if (isTraceBucket(bucket)) b.classList.add('match');
+                b.addEventListener('click', () => selectBucket(bucket, b));
                 bucketsBox.appendChild(b);
             }
             appendToggle();
@@ -638,13 +638,23 @@
             }
         }
 
-        // Choose a bucket: fill the bucket field, detect its region via
-        // /api/credentials/check, then run the search.
-        async function selectBucket(name, el) {
+        // Choose a bucket. ListBuckets normally supplies its region directly;
+        // fall back to /api/credentials/check for compatible S3 implementations
+        // that omit the newer BucketRegion field.
+        async function selectBucket(bucket, el) {
+            const { name } = bucket;
             [...bucketsBox.children].forEach(c => c.classList.remove('selected'));
             if (el) el.classList.add('selected');
             bucketInput.value = name;
             syncUrl();
+            if (bucket.region) {
+                region.value = bucket.region;
+                Dial9Creds.setRegion(bucket.region);
+                syncUrl();
+                setStatus(`Using ${name} · region ${bucket.region}`, 'ok');
+                discoverPrefixes().then(() => reRunCurrentSearch());
+                return;
+            }
             setStatus(`Detecting region for ${name}…`, null);
             const result = await Dial9Creds.check(name);
             if (result.ok) {
@@ -692,7 +702,7 @@
         async function loadBuckets() {
             setStatus('Listing buckets…', null);
             try {
-                const buckets = await Dial9Creds.listBuckets();
+                const buckets = await Dial9Creds.listBucketDetails();
                 setStatus(`${buckets.length} bucket(s) — pick one below`, 'ok');
                 renderBucketPicker(buckets);
             } catch (e) {

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -269,7 +269,7 @@
             <button id="creds-clear">Clear</button>
             <span id="creds-status" class="creds-status"></span>
         </div>
-        <!-- Bucket picker, populated from GET /api/buckets/details after Apply. -->
+        <!-- Bucket picker, populated from GET /api/buckets after Apply. -->
         <div class="creds-row" id="creds-buckets-row" style="display:none;align-items:flex-start">
             <label style="padding-top:6px">Bucket</label>
             <div id="creds-buckets" class="creds-buckets"></div>
@@ -575,7 +575,7 @@
         // trace buckets. Defaults to the filtered view; the "Show all" toggle
         // flips it. Retained across re-renders (e.g. re-listing on reload).
         let showAllBuckets = false;
-        // The last full bucket list from /api/buckets/details, so the toggle can
+        // The last full bucket list from /api/buckets, so the toggle can
         // re-render without another list call.
         let lastBuckets = [];
 
@@ -702,7 +702,7 @@
         async function loadBuckets() {
             setStatus('Listing buckets…', null);
             try {
-                const buckets = await Dial9Creds.listBucketDetails();
+                const buckets = await Dial9Creds.listBuckets();
                 setStatus(`${buckets.length} bucket(s) — pick one below`, 'ok');
                 renderBucketPicker(buckets);
             } catch (e) {

--- a/dial9-viewer/ui/src/lib/trace/creds.ts
+++ b/dial9-viewer/ui/src/lib/trace/creds.ts
@@ -6,6 +6,7 @@
 
 export { Dial9Creds } from "../../../creds.js";
 export type {
+  BucketInfo,
   CredentialCheckResult,
   Dial9CredsApi,
   SetCredentialsInput,

--- a/dial9-viewer/ui/src/lib/trace/index.ts
+++ b/dial9-viewer/ui/src/lib/trace/index.ts
@@ -238,6 +238,7 @@ export type {
 // x-dial9-aws-* headers.
 export { Dial9Creds } from "./creds.js";
 export type {
+  BucketInfo,
   CredentialCheckResult,
   Dial9CredsApi,
   SetCredentialsInput,

--- a/dial9-viewer/ui/src/pages/browser/creds-panel.test.ts
+++ b/dial9-viewer/ui/src/pages/browser/creds-panel.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Dial9CredsApi } from "../../lib/trace/creds.js";
+import type { BrowserActions } from "./actions.js";
+import { mountCredsPanel } from "./creds-panel.js";
+import type { BrowserEls } from "./dom.js";
+import { createBrowserStore } from "./state.js";
+
+type Listener = () => void;
+
+class FakeElement {
+  value = "";
+  style = { display: "", cssText: "" };
+  className = "";
+  children: FakeElement[] = [];
+  private text = "";
+  private readonly classes = new Set<string>();
+  private readonly listeners = new Map<string, Listener[]>();
+
+  readonly classList = {
+    add: (name: string) => this.classes.add(name),
+    remove: (name: string) => this.classes.delete(name),
+    toggle: (name: string, force?: boolean) => {
+      const enabled = force ?? !this.classes.has(name);
+      if (enabled) this.classes.add(name);
+      else this.classes.delete(name);
+      return enabled;
+    },
+    contains: (name: string) => this.classes.has(name),
+  };
+
+  get textContent(): string {
+    return this.text;
+  }
+
+  set textContent(value: string | null) {
+    this.text = value ?? "";
+    this.children = [];
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  click(): void {
+    for (const listener of this.listeners.get("click") ?? []) listener();
+  }
+}
+
+function fakeEls(): BrowserEls {
+  const el = () => new FakeElement();
+  return {
+    credsBtn: el(),
+    credsBtnLabel: el(),
+    credsPanel: el(),
+    credsClose: el(),
+    credsPaste: el(),
+    credsPasteFill: el(),
+    credsAkid: el(),
+    credsSecret: el(),
+    credsToken: el(),
+    credsRegion: el(),
+    credsApply: el(),
+    credsClear: el(),
+    credsStatus: el(),
+    credsBucketsRow: el(),
+    credsBuckets: el(),
+    bucketInput: el(),
+  } as unknown as BrowserEls;
+}
+
+async function drainMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) await Promise.resolve();
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("mountCredsPanel", () => {
+  it("uses a listed af-south-1 region without probing the bucket", async () => {
+    const setRegion = vi.fn();
+    const check = vi.fn();
+    const creds = {
+      has: vi.fn(() => false),
+      get: vi.fn(() => null),
+      set: vi.fn(async () => ({ ok: true, error: null })),
+      setRegion,
+      check,
+      listBuckets: vi.fn(async () => [
+        { name: "dial9-cape-town", region: "af-south-1" },
+      ]),
+      clear: vi.fn(),
+      parse: vi.fn(),
+    } as unknown as Dial9CredsApi;
+    vi.stubGlobal("window", {
+      Dial9Creds: creds,
+      addEventListener: vi.fn(),
+    });
+    vi.stubGlobal("document", {
+      createElement: () => new FakeElement(),
+      createTextNode: (text: string) => {
+        const node = new FakeElement();
+        node.textContent = text;
+        return node;
+      },
+    });
+
+    const discoverPrefixes = vi.fn(async () => {});
+    const reRunCurrentSearch = vi.fn();
+    const actions = {
+      syncUrl: vi.fn(),
+      discoverPrefixes,
+      reRunCurrentSearch,
+      isAutoSearched: vi.fn(() => false),
+    } as unknown as BrowserActions;
+    const els = fakeEls();
+    const panel = mountCredsPanel({
+      store: createBrowserStore(),
+      els,
+      actions,
+    });
+    panel.init();
+
+    els.credsAkid.value = "AK";
+    els.credsSecret.value = "SK";
+    els.credsApply.click();
+    await drainMicrotasks();
+
+    expect(els.bucketInput.value).toBe("dial9-cape-town");
+    expect(els.credsRegion.value).toBe("af-south-1");
+    expect(setRegion).toHaveBeenCalledWith("af-south-1");
+    expect(check).not.toHaveBeenCalled();
+    expect(discoverPrefixes).toHaveBeenCalledOnce();
+    expect(reRunCurrentSearch).toHaveBeenCalledOnce();
+  });
+});

--- a/dial9-viewer/ui/src/pages/browser/creds-panel.ts
+++ b/dial9-viewer/ui/src/pages/browser/creds-panel.ts
@@ -10,6 +10,7 @@
 // open, status line, bucket picker).
 
 import { assertInScheduledRender } from "../../store/store.js";
+import type { BucketInfo } from "../../lib/trace/creds.js";
 import { bucketMatchesFilter } from "./bucket-filter.js";
 import type { PageCtx } from "./ctx.js";
 
@@ -24,8 +25,8 @@ export function mountCredsPanel({ store, els, actions }: PageCtx): CredsPanel {
   // on. The predicate is config-driven (URL `bucket_filter=` override >
   // /api/config > "dial9" - bucket-filter.ts). An empty filter matches
   // every bucket, so filtering is effectively off and the toggle disappears.
-  const isTraceBucket = (n: string) =>
-    bucketMatchesFilter(n, store.getState().config.bucketFilter);
+  const isTraceBucket = (bucket: BucketInfo) =>
+    bucketMatchesFilter(bucket.name, store.getState().config.bucketFilter);
 
   function setStatus(msg: string | null, kind: "ok" | "error" | null): void {
     store.update("creds", { status: { text: msg || "", kind } });
@@ -54,14 +55,24 @@ export function mountCredsPanel({ store, els, actions }: PageCtx): CredsPanel {
     store.update("creds", { panelOpen: open });
   }
 
-  // Choose a bucket: fill the bucket field, detect its region via
-  // /api/credentials/check, then run the search.
-  async function selectBucket(name: string): Promise<void> {
+  // Choose a bucket. ListBuckets normally supplies its region directly;
+  // fall back to /api/credentials/check for compatible S3 implementations
+  // that omit the newer BucketRegion field.
+  async function selectBucket(bucket: BucketInfo): Promise<void> {
     const creds = window.Dial9Creds;
     if (!creds) return;
+    const { name } = bucket;
     store.update("creds", { selectedBucket: name });
     els.bucketInput.value = name;
     actions.syncUrl();
+    if (bucket.region) {
+      els.credsRegion.value = bucket.region;
+      creds.setRegion(bucket.region);
+      actions.syncUrl();
+      setStatus(`Using ${name} · region ${bucket.region}`, "ok");
+      void actions.discoverPrefixes().then(() => actions.reRunCurrentSearch());
+      return;
+    }
     setStatus(`Detecting region for ${name}…`, null);
     const result = await creds.check(name);
     if (result.ok) {
@@ -70,12 +81,7 @@ export function mountCredsPanel({ store, els, actions }: PageCtx): CredsPanel {
         // Persist the resolved region so it rides on every request, then
         // mirror it into the URL (aws_region) so a shared link reproduces
         // the cross-region bucket.
-        void creds.set({
-          accessKeyId: els.credsAkid.value,
-          secretAccessKey: els.credsSecret.value,
-          sessionToken: els.credsToken.value,
-          region: result.region,
-        });
+        creds.setRegion(result.region);
         actions.syncUrl();
       }
       setStatus(`Using ${name}${result.region ? ` · region ${result.region}` : ""}`, "ok");
@@ -91,7 +97,9 @@ export function mountCredsPanel({ store, els, actions }: PageCtx): CredsPanel {
   function autoSelectSingleMatch(): void {
     const s = store.getState().creds;
     if (s.showAll) return;
-    const matches = [...s.buckets].sort((a, b) => a.localeCompare(b)).filter(isTraceBucket);
+    const matches = [...s.buckets]
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .filter(isTraceBucket);
     if (matches.length === 1) void selectBucket(matches[0]!);
   }
 
@@ -117,14 +125,14 @@ export function mountCredsPanel({ store, els, actions }: PageCtx): CredsPanel {
   // toggle when the two lists differ. The filter name renders into the
   // messages ("dial9" by default).
   function renderPicker(
-    buckets: readonly string[],
+    buckets: readonly BucketInfo[],
     showAll: boolean,
     selectedBucket: string | null,
   ): void {
     els.credsBuckets.textContent = "";
     const filter = store.getState().config.bucketFilter;
 
-    const all = [...buckets].sort((a, b) => a.localeCompare(b));
+    const all = [...buckets].sort((a, b) => a.name.localeCompare(b.name));
     const matches = all.filter(isTraceBucket);
     const shown = showAll ? all : matches;
 
@@ -156,14 +164,15 @@ export function mountCredsPanel({ store, els, actions }: PageCtx): CredsPanel {
       return;
     }
 
-    for (const name of shown) {
+    for (const bucket of shown) {
+      const { name } = bucket;
       const b = document.createElement("button");
       b.textContent = name;
       // Highlight the trace buckets even within the full list.
-      if (isTraceBucket(name)) b.classList.add("match");
+      if (isTraceBucket(bucket)) b.classList.add("match");
       if (name === selectedBucket) b.classList.add("selected");
       b.addEventListener("click", () => {
-        void selectBucket(name);
+        void selectBucket(bucket);
       });
       els.credsBuckets.appendChild(b);
     }
@@ -175,7 +184,7 @@ export function mountCredsPanel({ store, els, actions }: PageCtx): CredsPanel {
   // predicate/messages read), so the pre-init state - hidden button, closed
   // panel - is just the initial state.
   let lastPicker: {
-    buckets: readonly string[];
+    buckets: readonly BucketInfo[];
     showAll: boolean;
     selectedBucket: string | null;
     bucketFilter: string;

--- a/dial9-viewer/ui/src/pages/browser/state.ts
+++ b/dial9-viewer/ui/src/pages/browser/state.ts
@@ -11,6 +11,7 @@
 
 import { createStore, type Store } from "../../store/store.js";
 import type { HostRow } from "../../lib/canvas/heatmap.js";
+import type { BucketInfo } from "../../lib/trace/creds.js";
 import { DEFAULT_BUCKET_FILTER } from "./bucket-filter.js";
 import type { RawSort } from "./raw-rows.js";
 
@@ -153,7 +154,7 @@ export interface CredsSlice {
   panelOpen: boolean;
   status: { text: string; kind: "ok" | "error" | null };
   /** Last /api/buckets listing. */
-  buckets: readonly string[];
+  buckets: readonly BucketInfo[];
   bucketsRowVisible: boolean;
   /** "Show all" vs filtered picker view. */
   showAll: boolean;

--- a/dial9-viewer/ui/src/types/creds.d.ts
+++ b/dial9-viewer/ui/src/types/creds.d.ts
@@ -39,6 +39,12 @@ declare module "*/creds.js" {
    */
   export type StoredCredentials = StaticCredentials | RoleCredentials;
 
+  /** One bucket returned by S3's region-bearing ListBuckets response. */
+  export interface BucketInfo {
+    name: string;
+    region: string | null;
+  }
+
   export interface SetCredentialsInput {
     accessKeyId: string;
     secretAccessKey: string;
@@ -115,10 +121,11 @@ declare module "*/creds.js" {
      */
     check(bucket?: string): Promise<CredentialCheckResult>;
     /**
-     * Buckets visible to the stored credentials (GET /api/buckets).
+     * Buckets and their AWS regions visible to the stored credentials
+     * (GET /api/buckets).
      * Throws on HTTP error with the server's message.
      */
-    listBuckets(): Promise<string[]>;
+    listBuckets(): Promise<BucketInfo[]>;
     /** Clear stored credentials and notify listeners. */
     clear(): void;
     /**

--- a/dial9-viewer/ui/src/types/probe.ts
+++ b/dial9-viewer/ui/src/types/probe.ts
@@ -428,7 +428,8 @@ export async function probeCreds(blob: string): Promise<void> {
   if (!active) Dial9Creds.clear();
   const check = await Dial9Creds.check("some-bucket");
   void check.ok;
-  const buckets: string[] = await Dial9Creds.listBuckets();
+  const buckets: { name: string; region: string | null }[] =
+    await Dial9Creds.listBuckets();
   void buckets;
   const headers: Record<string, string> = Dial9Creds.headers();
   await fetch("/api/browse", { headers });

--- a/dial9-viewer/ui/tests/core/creds.test.ts
+++ b/dial9-viewer/ui/tests/core/creds.test.ts
@@ -25,6 +25,11 @@ interface SetResult {
   error?: string | null;
 }
 
+interface BucketInfo {
+  name: string;
+  region: string | null;
+}
+
 interface StorageLike {
   getItem: (k: string) => string | null;
   setItem: (k: string, v: string) => void;
@@ -43,7 +48,7 @@ const { Dial9Creds } = require("../../creds.js") as {
     clear: () => void;
     headers: () => Record<string, string>;
     parse: (text: string) => StoredCreds;
-    listBuckets: () => Promise<string[]>;
+    listBuckets: () => Promise<BucketInfo[]>;
   };
 };
 
@@ -334,7 +339,7 @@ describe("Dial9Creds", () => {
     ).toThrow(/could not find/);
   });
 
-  it("listBuckets() sends cred headers and returns the list", async () => {
+  it("listBuckets() returns each bucket's ListBuckets region", async () => {
     freshStore();
     await Dial9Creds.set({ accessKeyId: "AK", secretAccessKey: "SK" });
     let seen: { url: string; opts: { headers: Record<string, string> } } | undefined;
@@ -346,14 +351,20 @@ describe("Dial9Creds", () => {
           ok: true,
           status: 200,
           async json() {
-            return ["a", "dial9-traces", "b"];
+            return [
+              { name: "dial9-cape-town", region: "af-south-1" },
+              { name: "dial9-legacy", region: null },
+            ];
           },
         };
       },
     );
     try {
-      const names = await Dial9Creds.listBuckets();
-      expect(names).toEqual(["a", "dial9-traces", "b"]);
+      const buckets = await Dial9Creds.listBuckets();
+      expect(buckets).toEqual([
+        { name: "dial9-cape-town", region: "af-south-1" },
+        { name: "dial9-legacy", region: null },
+      ]);
       expect(seen!.url).toBe("/api/buckets");
       expect(seen!.opts.headers[H_AKID]).toBe("AK");
       expect(seen!.opts.headers[H_SECRET]).toBe("SK");


### PR DESCRIPTION
## What

Carry each bucket region from S3 `ListBuckets` into the bucket picker so selecting a bucket does not depend on a wrong-region `HeadBucket` probe. Also classify `IllegalLocationConstraintException` as `WrongRegion` instead of returning an opaque 500.

## Why

S3 only includes `BucketRegion` when `ListBuckets` contains at least one valid parameter. The viewer sent a parameterless request and reduced each returned bucket to its name, so the picker discarded the strongest available region signal. It then called `HeadBucket` through the default endpoint. For opt-in regions such as `af-south-1`, S3 can report that mismatch as `IllegalLocationConstraintException` (HTTP 400) rather than the 301 redirect the detection path expected.

## Change

- Set a bounded `max-buckets` value so S3 includes `BucketRegion`.
- Change the existing `StorageBackend::list_buckets`, `/api/buckets`, and `Dial9Creds.listBuckets()` contracts to return `{name, region}` values directly. The frontend is the only caller and deploys in lockstep with the server.
- Use the listed region directly in the picker, with `HeadBucket` retained as a fallback when S3 omits the field.
- Classify `IllegalLocationConstraintException` alongside other wrong-region responses.
- Add Rust and JS regression coverage for the SDK request, response propagation, endpoint, and credential client.

## Verification

- Confirmed the picker works against an `af-south-1` bucket.
- Confirmed the live endpoint returns regions for real cross-region buckets with `AWS_PROFILE=rcoh`.
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run` (931 passed)
- `cargo nextest run --stress-duration 20s` (2 iterations, 931 passed each)
- `node dial9-viewer/ui/test_creds.js`