### PR TITLE
feat(viewer): bound and instrument aggregate folding

### DIFF
--- a/dial9-viewer/src/ingest/aggregate.rs
+++ b/dial9-viewer/src/ingest/aggregate.rs
@@ -305,14 +305,25 @@ fn full_source_key(source_is_local: bool, source_bucket: &str, key: &str) -> Str
 /// still oversubscribe the box by a factor of N.
 ///
 /// The two stages are bounded independently because they bottleneck on
-/// different resources:
+/// different
+/// resources:
 ///
-/// - [`fetch`](Self::fetch): network-bound source GETs (~37–50 MB each). These
-///   spend almost all their time waiting on the network, so we run them at high
-///   concurrency (~2× available parallelism by default).
+/// - [`fetch`](Self::fetch): network-bound source GETs (~37–50 MB compressed
+///   each). Mostly waiting on the network; bounded by `inflight` in practice
+///   (a fetch can't start without an inflight permit).
 /// - [`cpu`](Self::cpu): gunzip + decode + parquet-encode, run on blocking
-///   threads. Sized to ~= available parallelism so concurrent folds don't
-///   oversubscribe the cores and inflate every fold's wall time.
+///   threads. This is the dominant memory consumer — decoding one segment
+///   expands to >1 GB of transient structures — so it is capped by a small
+///   ABSOLUTE number ([`MAX_DECODE_CONCURRENCY`]), NOT by core count. Scaling it
+///   with cores is what OOM-killed a 64-core box.
+/// - [`inflight`](Self::inflight): the total number of folds that may hold a
+///   fetched-but-not-yet-written segment buffer at once. This is the memory
+///   backstop: [`fold_one`] releases the fetch permit before acquiring the CPU
+///   permit (so network and CPU overlap), which means a decoded-slower-than-
+///   fetched work-list would otherwise let downloaded buffers pile up without
+///   bound between the two stages — thousands of them for a broad scope,
+///   OOM-killing the process. Holding one inflight permit across the *whole*
+///   fold caps the resident segment buffers regardless of work-list size.
 ///
 /// Part-file writes (small, network-bound) run ungated: they are cheap relative
 /// to the fetch and we don't want to hold a CPU permit across their I/O.
@@ -322,27 +333,58 @@ pub(crate) struct FoldLimits {
     pub fetch: Arc<Semaphore>,
     /// Bounds concurrent decode/encode work (CPU-bound).
     pub cpu: Arc<Semaphore>,
+    /// Bounds concurrently in-flight folds (memory backstop; held fetch→write).
+    pub inflight: Arc<Semaphore>,
 }
 
 impl FoldLimits {
     /// Construct with explicit permit counts. Each is clamped to at least 1 so a
-    /// zero never deadlocks the pipeline.
-    pub(crate) fn new(fetch_permits: usize, cpu_permits: usize) -> Self {
+    /// zero never deadlocks the pipeline. `inflight` bounds resident segment
+    /// buffers and must be ≥ `fetch` (a fetch can't proceed without an inflight
+    /// permit, so a smaller inflight would cap effective fetch concurrency).
+    pub(crate) fn new(fetch_permits: usize, cpu_permits: usize, inflight_permits: usize) -> Self {
         Self {
             fetch: Arc::new(Semaphore::new(fetch_permits.max(1))),
             cpu: Arc::new(Semaphore::new(cpu_permits.max(1))),
+            inflight: Arc::new(Semaphore::new(inflight_permits.max(1))),
         }
     }
 
-    /// Default sizing derived from available CPU parallelism: fetch at 2×
-    /// parallelism (network-bound, mostly waiting), CPU at 1× parallelism.
+    /// Default sizing.
+    ///
+    /// Memory — not cores — is the binding constraint on a fold, so the
+    /// memory-bound stages use small ABSOLUTE caps rather than scaling with
+    /// parallelism (an earlier core-scaled sizing OOM-killed a 64-core box:
+    /// 64 concurrent decodes × ~1.5 GB each ≈ 96 GB):
+    ///
+    /// - `cpu` (decode/encode) is the real memory lever: decoding one segment
+    ///   expands ~1.3M events to well over 1 GB of transient structures. Capped
+    ///   at [`MAX_DECODE_CONCURRENCY`] so peak decode memory is bounded to roughly
+    ///   that many segments regardless of core count, then further limited to the
+    ///   available parallelism on small boxes.
+    /// - `inflight` (whole-fold, memory backstop) bounds how many fetched
+    ///   segment buffers are resident; a small multiple of the decode cap gives
+    ///   fetch a little runway ahead of decode without unbounded pile-up.
+    /// - `fetch` (network) can safely exceed the memory caps since a GET only
+    ///   holds a compressed (~40 MB) buffer, but it never needs to exceed
+    ///   `inflight` (a fetch can't start without an inflight permit).
     pub(crate) fn from_available_parallelism() -> Self {
         let par = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(4);
-        Self::new(par * 2, par)
+        let cpu = par.min(MAX_DECODE_CONCURRENCY);
+        let inflight = cpu * 2;
+        let fetch = inflight;
+        Self::new(fetch, cpu, inflight)
     }
 }
+
+/// Hard ceiling on concurrent segment decodes. Each decode transiently holds
+/// over a gigabyte (a ~1.3M-event segment expanded in memory), so this count
+/// times ~1.5 GB is roughly the fold pipeline's peak decode memory. Deliberately
+/// small and core-independent: adding cores speeds each decode but must not
+/// multiply the memory high-water mark.
+const MAX_DECODE_CONCURRENCY: usize = 6;
 
 impl Default for FoldLimits {
     fn default() -> Self {
@@ -356,6 +398,19 @@ struct EncodedParts {
     dict_buf: Vec<u8>,
     polls_buf: Vec<u8>,
     spans_buf: Vec<u8>,
+    /// CPU-stage timing/count breakdown, threaded out to the per-file metric.
+    cpu_stats: CpuStageStats,
+}
+
+/// Timing and size breakdown of the CPU stage ([`decode_and_encode`]), surfaced
+/// to the per-file [`FoldFileMetrics`] so the fold's cost is attributable to
+/// gunzip vs. the individual decode phases vs. parquet encode.
+#[derive(Default)]
+struct CpuStageStats {
+    decompressed_bytes: u64,
+    gunzip: std::time::Duration,
+    parquet_encode: std::time::Duration,
+    decode: crate::ingest::decode::DecodeStats,
 }
 
 /// CPU-bound stage of a fold: gunzip + decode + parquet-encode over
@@ -364,12 +419,22 @@ struct EncodedParts {
 /// network-bound fetch and write stages. (The parquet encode previously ran on
 /// the async executor thread; moving it here keeps CPU work off the runtime.)
 fn decode_and_encode(bytes: &[u8], full_key: &str) -> anyhow::Result<EncodedParts> {
+    use std::time::Instant;
+    let mut cpu_stats = CpuStageStats::default();
+
+    let t_gunzip = Instant::now();
     let raw = maybe_gunzip(bytes);
-    let (samples, stacks, polls, spans) = decode::decode_samples(&raw, full_key)
-        .map_err(|e| anyhow::anyhow!("decode {full_key}: {e}"))?;
+    cpu_stats.gunzip = t_gunzip.elapsed();
+    cpu_stats.decompressed_bytes = raw.len() as u64;
+
+    let ((samples, stacks, polls, spans), decode_stats) =
+        decode::decode_samples_with_stats(&raw, full_key)
+            .map_err(|e| anyhow::anyhow!("decode {full_key}: {e}"))?;
+    cpu_stats.decode = decode_stats;
 
     // Always encode the samples part-file, even with zero rows: its existence is
     // the record that this file is folded, so it is never re-fetched.
+    let t_encode = Instant::now();
     let metadata = HashMap::new();
     let mut samples_buf = Vec::new();
     parquet_writer::write_samples(&mut samples_buf, &samples, &metadata)?;
@@ -384,12 +449,14 @@ fn decode_and_encode(bytes: &[u8], full_key: &str) -> anyhow::Result<EncodedPart
     // Write spans part-file (may be empty for files with no tracing spans).
     let mut spans_buf = Vec::new();
     parquet_writer::write_spans(&mut spans_buf, &spans)?;
+    cpu_stats.parquet_encode = t_encode.elapsed();
 
     Ok(EncodedParts {
         samples_buf,
         dict_buf,
         polls_buf,
         spans_buf,
+        cpu_stats,
     })
 }
 
@@ -446,18 +513,49 @@ pub(crate) async fn fold_one(
     raw_key: &str,
     limits: &FoldLimits,
 ) -> anyhow::Result<()> {
+    use std::time::Instant;
+    // One per-file metric per fold: assemble phase timings as we go, emit once on
+    // the way out (success or failure). See `FoldFileMetrics`.
+    let mut metric = crate::server::metrics::FoldFileMetricsBuilder::new();
+    let t_total = Instant::now();
+    // Emit-on-exit helper so every early return still publishes what we measured.
+    let emit = |mut metric: crate::server::metrics::FoldFileMetricsBuilder,
+                total: std::time::Duration,
+                failed: bool| {
+        metric.total(total).failed(failed);
+        metric.emit();
+    };
+
+    // Memory backstop — held across the WHOLE fold (fetch → decode → write), so
+    // the number of resident ~40 MB segment buffers is bounded regardless of how
+    // many files the work-list spawned. Without this, fetch (fast, network) races
+    // ahead of decode (slow, CPU) and downloaded buffers pile up between the two
+    // stages, OOM-killing the process on a broad scope. Acquired before the fetch
+    // permit so a fold doesn't occupy fetch concurrency while waiting for memory.
+    let _inflight = limits
+        .inflight
+        .acquire()
+        .await
+        .expect("inflight semaphore is never closed");
+
     // Stage 1 — fetch (network-bound). Permit held only for the duration of the GET.
+    let t_fetch = Instant::now();
     let bytes = {
         let _permit = limits
             .fetch
             .acquire()
             .await
             .expect("fetch semaphore is never closed");
-        agg.source
-            .get_object(&agg.source_bucket, raw_key)
-            .await
-            .map_err(|e| anyhow::anyhow!("fetch {raw_key}: {e}"))?
+        match agg.source.get_object(&agg.source_bucket, raw_key).await {
+            Ok(b) => b,
+            Err(e) => {
+                emit(metric, t_total.elapsed(), true);
+                return Err(anyhow::anyhow!("fetch {raw_key}: {e}"));
+            }
+        }
     };
+    metric.fetch(t_fetch.elapsed());
+    metric.source_bytes(bytes.len() as u64);
 
     // Stage 2 — decode + encode (CPU-bound) on a blocking thread, gated so
     // concurrent folds don't oversubscribe the cores.
@@ -469,20 +567,42 @@ pub(crate) async fn fold_one(
             .acquire()
             .await
             .expect("cpu semaphore is never closed");
-        tokio::task::spawn_blocking(move || decode_and_encode(&bytes, &decode_key))
-            .await
-            .map_err(|e| anyhow::anyhow!("decode task panicked: {e}"))??
+        match tokio::task::spawn_blocking(move || decode_and_encode(&bytes, &decode_key)).await {
+            Ok(Ok(encoded)) => encoded,
+            Ok(Err(e)) => {
+                emit(metric, t_total.elapsed(), true);
+                return Err(e);
+            }
+            Err(e) => {
+                emit(metric, t_total.elapsed(), true);
+                return Err(anyhow::anyhow!("decode task panicked: {e}"));
+            }
+        }
     };
+    // Fold the CPU-stage breakdown into the metric before `encoded` is consumed
+    // by the writer.
+    let cpu = &encoded.cpu_stats;
+    metric
+        .gunzip(cpu.gunzip)
+        .decompressed_bytes(cpu.decompressed_bytes)
+        .decode_phases(&cpu.decode)
+        .parquet_encode(cpu.parquet_encode);
 
     // Stage 3 — write part-files (small, network-bound). Ungated.
-    write_parts(
+    let t_write = Instant::now();
+    let write_result = write_parts(
         &*agg.output,
         &agg.output_bucket,
         &agg.output_prefix,
         &full_key,
         encoded,
     )
-    .await
+    .await;
+    metric.write_parts(t_write.elapsed());
+
+    let failed = write_result.is_err();
+    emit(metric, t_total.elapsed(), failed);
+    write_result
 }
 
 /// LIST the folded set for one source bucket: the source-file leaf hashes that
@@ -1449,7 +1569,154 @@ pub struct AggContext {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+
     use super::*;
+    use crate::storage::{BucketInfo, StorageError};
+
+    /// A source backend that records the peak number of `get_object` calls
+    /// running at once, so a test can assert the in-flight fold cap holds. Each
+    /// GET holds the "in-flight" state briefly (a yield-heavy spin) so overlap is
+    /// observable, then returns junk bytes (decode fails downstream — the test
+    /// only cares about fetch-stage concurrency).
+    #[derive(Default)]
+    struct ConcurrencyProbe {
+        in_flight: std::sync::atomic::AtomicUsize,
+        peak: std::sync::atomic::AtomicUsize,
+    }
+
+    impl StorageBackend for ConcurrencyProbe {
+        fn list_buckets(
+            &self,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>>
+        {
+            Box::pin(async { Ok(vec![]) })
+        }
+        fn list_objects(
+            &self,
+            _bucket: &str,
+            _prefix: &str,
+            _cap: usize,
+        ) -> Pin<Box<dyn Future<Output = Result<crate::storage::ListPage, StorageError>> + Send + '_>>
+        {
+            Box::pin(async { Err(StorageError::NotFound("unused".into())) })
+        }
+        fn list_objects_all(
+            &self,
+            _bucket: &str,
+            _prefix: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<ObjectInfo>, StorageError>> + Send + '_>>
+        {
+            Box::pin(async { Ok(vec![]) })
+        }
+        fn list_prefixes(
+            &self,
+            _bucket: &str,
+            _prefix: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>> {
+            Box::pin(async { Ok(vec![]) })
+        }
+        fn get_object(
+            &self,
+            _bucket: &str,
+            _key: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, StorageError>> + Send + '_>> {
+            use std::sync::atomic::Ordering;
+            Box::pin(async move {
+                let cur = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                self.peak.fetch_max(cur, Ordering::SeqCst);
+                // Hold the in-flight window open across several executor turns so
+                // concurrent folds actually overlap here.
+                for _ in 0..50 {
+                    tokio::task::yield_now().await;
+                }
+                self.in_flight.fetch_sub(1, Ordering::SeqCst);
+                // Junk bytes: fold_one's decode stage fails, but only AFTER the
+                // fetch — which is all this probe measures.
+                Ok(vec![0u8; 8])
+            })
+        }
+        fn put_object(
+            &self,
+            _bucket: &str,
+            _key: &str,
+            _data: Vec<u8>,
+        ) -> Pin<Box<dyn Future<Output = Result<(), StorageError>> + Send + '_>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    /// The in-flight cap bounds how many folds hold a fetched segment buffer at
+    /// once — the memory backstop against a broad scope OOM-killing the process.
+    /// Even with a high fetch permit count, concurrent `fold_one`s must never run
+    /// more source GETs simultaneously than `inflight` allows.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn inflight_cap_bounds_concurrent_fetches() {
+        use std::sync::atomic::Ordering;
+
+        let probe = Arc::new(ConcurrencyProbe::default());
+        let agg = AggContext {
+            source: probe.clone() as Arc<dyn StorageBackend>,
+            output: probe.clone() as Arc<dyn StorageBackend>,
+            source_bucket: "src".to_string(),
+            source_is_local: false,
+            output_bucket: "out".to_string(),
+            output_prefix: "flamegraph-data".to_string(),
+            source_prefixes: vec![],
+            segment_duration_secs: 60,
+        };
+
+        // fetch permits high (32) but inflight capped low (3): the inflight cap
+        // must be the binding constraint on concurrent fetches.
+        const INFLIGHT: usize = 3;
+        let limits = FoldLimits::new(32, 8, INFLIGHT);
+
+        let mut tasks = tokio::task::JoinSet::new();
+        for i in 0..64 {
+            let agg = agg.clone();
+            let limits = limits.clone();
+            tasks.spawn(async move {
+                // Decode fails on junk bytes; we don't care about the result,
+                // only that the fetch obeyed the in-flight cap.
+                let _ = fold_one(&agg, &format!("raw-{i}"), &limits).await;
+            });
+        }
+        while tasks.join_next().await.is_some() {}
+
+        let peak = probe.peak.load(Ordering::SeqCst);
+        assert!(peak > 0, "probe should have observed fetches");
+        assert!(
+            peak <= INFLIGHT,
+            "peak concurrent fetches {peak} exceeded the in-flight cap {INFLIGHT}"
+        );
+    }
+
+    /// Regression guard for the OOM: the default fold sizing must NOT scale the
+    /// memory-bound decode stage with core count. On a big box the decode cap has
+    /// to stay small and absolute — a 64-core machine running 64 concurrent
+    /// ~1.5 GB decodes is ~96 GB and gets OOM-killed. `cpu` is the decode gate and
+    /// must never exceed MAX_DECODE_CONCURRENCY regardless of parallelism.
+    #[test]
+    fn default_fold_limits_do_not_scale_decode_with_cores() {
+        let limits = FoldLimits::from_available_parallelism();
+        assert!(
+            limits.cpu.available_permits() <= MAX_DECODE_CONCURRENCY,
+            "decode concurrency {} must stay within the absolute cap {MAX_DECODE_CONCURRENCY}",
+            limits.cpu.available_permits()
+        );
+        // The whole-fold (memory backstop) cap is a small multiple of the decode
+        // cap, and fetch never needs to exceed inflight.
+        assert!(
+            limits.inflight.available_permits() <= MAX_DECODE_CONCURRENCY * 2,
+            "inflight {} should stay a small multiple of the decode cap",
+            limits.inflight.available_permits()
+        );
+        assert!(
+            limits.fetch.available_permits() <= limits.inflight.available_permits(),
+            "fetch must not exceed inflight (a fetch needs an inflight permit)"
+        );
+    }
 
     #[test]
     fn sample_filter_source_and_thread() {

--- a/dial9-viewer/src/ingest/decode.rs
+++ b/dial9-viewer/src/ingest/decode.rs
@@ -36,7 +36,7 @@ use spans::span_builder;
 use spans::{interval_pairing, legacy};
 
 pub(crate) use types::{
-    DecodeResult, EnclosingSpanSummary, ResolvedPoll, ResolvedSample, ResolvedSpan,
+    DecodeResult, DecodeStats, EnclosingSpanSummary, ResolvedPoll, ResolvedSample, ResolvedSpan,
 };
 
 /// Wire value of the `CpuProfile` CPU-sample source (periodic on-CPU sample).
@@ -91,6 +91,21 @@ fn is_date(s: &str) -> bool {
 /// Returns the resolved samples and a map of stack_id → frame names for the
 /// stacks dictionary.
 pub(crate) fn decode_samples(data: &[u8], source_key: &str) -> anyhow::Result<DecodeResult> {
+    decode_samples_with_stats(data, source_key).map(|(result, _stats)| result)
+}
+
+/// Like [`decode_samples`], but also returns per-phase [`DecodeStats`] so the
+/// fold pipeline can emit a per-file timing metric. The extra bookkeeping is a
+/// handful of `Instant::now()` calls and counter reads, so this is the real
+/// implementation and [`decode_samples`] delegates to it.
+pub(crate) fn decode_samples_with_stats(
+    data: &[u8],
+    source_key: &str,
+) -> anyhow::Result<(DecodeResult, DecodeStats)> {
+    use std::time::Instant;
+
+    let mut stats = DecodeStats::default();
+    let t_wire = Instant::now();
     let events::DecodedTrace {
         interner,
         mut addr_to_keys,
@@ -101,6 +116,12 @@ pub(crate) fn decode_samples(data: &[u8], source_key: &str) -> anyhow::Result<De
         legacy_exits,
         legacy_closes,
     } = events::decode_trace(data, source_key)?;
+    stats.wire_decode = t_wire.elapsed();
+    stats.span_events_decoded =
+        (legacy_enters.len() + legacy_exits.len() + legacy_closes.len()) as u64;
+    // Span events are collected separately and never enter the sorted event stream.
+    stats.events_decoded = events.len() as u64 + stats.span_events_decoded;
+
     let timestamp_bounds = events
         .iter()
         .map(TraceEvent::timestamp_ns)
@@ -129,14 +150,20 @@ pub(crate) fn decode_samples(data: &[u8], source_key: &str) -> anyhow::Result<De
     }
     tracing::info!("sorting {} events", events.len());
     // Sort events by timestamp for correct worker_id inference.
+    let t_sort = Instant::now();
     events.sort_unstable_by_key(|e| e.timestamp_ns());
 
     // Pre-sort symbol entries by inline depth.
     for entries in addr_to_keys.values_mut() {
         entries.sort_unstable_by_key(|(d, _)| *d);
     }
-    let mut poll_timeline = polls::PollTimeline::reconstruct(&events);
+    stats.sort_events = t_sort.elapsed();
 
+    let t_polls = Instant::now();
+    let mut poll_timeline = polls::PollTimeline::reconstruct(&events);
+    stats.poll_reconstruct = t_polls.elapsed();
+
+    let t_samples = Instant::now();
     let mut stacks_dict: FxHashMap<[u8; 16], Vec<String>> = FxHashMap::default();
     let mut stack_cache: FxHashMap<Vec<u64>, [u8; 16]> = FxHashMap::default();
     let mut samples = Vec::new();
@@ -219,6 +246,8 @@ pub(crate) fn decode_samples(data: &[u8], source_key: &str) -> anyhow::Result<De
 
     let resolved_polls =
         poll_timeline.resolved(clock_offset, &parsed_host, &parsed_service, &parsed_date);
+    stats.sample_resolve = t_samples.elapsed();
+
     // ── Stage 2: Reconstruct tracing spans from enter/exit/close events ──────
     //
     // Decode the authoritative boot_id from SegmentMetadata when available.
@@ -253,6 +282,7 @@ pub(crate) fn decode_samples(data: &[u8], source_key: &str) -> anyhow::Result<De
     let mut legacy_intervals: FxHashMap<u64, Vec<interval_pairing::MonoInterval>> =
         FxHashMap::default();
 
+    let t_spans = Instant::now();
     if !legacy_enters.is_empty() || !legacy_closes.is_empty() {
         let legacy_resolution = resolve_legacy_spans(
             &legacy_enters,
@@ -269,6 +299,8 @@ pub(crate) fn decode_samples(data: &[u8], source_key: &str) -> anyhow::Result<De
         legacy_intervals = legacy_resolution.instance_intervals;
         resolved_spans.extend(legacy_resolution.spans);
     }
+    stats.span_resolve = t_spans.elapsed();
+
     // ── Stage 3: Attribute samples to spans using entered intervals ──────────
     //
     // Build a flat sorted interval index for O(n log n + m log n) sweep instead
@@ -279,6 +311,7 @@ pub(crate) fn decode_samples(data: &[u8], source_key: &str) -> anyhow::Result<De
     // intervals — never to lifecycle envelopes. An async span that is exited
     // (waiting) must NOT claim samples that fire during its idle gap.
 
+    let t_attr = Instant::now();
     attribution::attribute_samples_to_spans(
         &mut samples,
         &mut resolved_spans,
@@ -286,11 +319,16 @@ pub(crate) fn decode_samples(data: &[u8], source_key: &str) -> anyhow::Result<De
         &boot_id,
         clock_offset,
     );
+    stats.sample_attribution = t_attr.elapsed();
+
     Ok((
-        samples,
-        stacks_dict.into_iter().collect(),
-        resolved_polls,
-        resolved_spans,
+        (
+            samples,
+            stacks_dict.into_iter().collect(),
+            resolved_polls,
+            resolved_spans,
+        ),
+        stats,
     ))
 }
 

--- a/dial9-viewer/src/ingest/decode/types.rs
+++ b/dial9-viewer/src/ingest/decode/types.rs
@@ -159,3 +159,31 @@ pub(crate) type DecodeResult = (
     Vec<ResolvedPoll>,
     Vec<ResolvedSpan>,
 );
+
+/// Per-phase timing and counts for one `decode_samples` call, returned by
+/// [`super::decode_samples_with_stats`]. Purely observational — used by the fold
+/// pipeline to emit a per-file metric so we can see where decode time goes
+/// (wire decode vs. poll reconstruction vs. span resolution vs. attribution)
+/// without a profiler. Durations are wall-clock for each phase, measured in
+/// sequence, so they sum (modulo rounding) to the total decode time.
+#[derive(Debug, Clone, Default)]
+pub struct DecodeStats {
+    /// Total events decoded off the wire (samples + park/unpark + poll
+    /// start/end + span enter/exit/close). The headline "how big is this file"
+    /// number.
+    pub events_decoded: u64,
+    /// Legacy span enter + exit + close events (subset of `events_decoded`).
+    pub span_events_decoded: u64,
+    /// Phase: one-pass wire decode (`decode_trace`).
+    pub wire_decode: std::time::Duration,
+    /// Phase: sort the event vector by timestamp.
+    pub sort_events: std::time::Duration,
+    /// Phase: reconstruct the poll timeline from park/unpark/poll events.
+    pub poll_reconstruct: std::time::Duration,
+    /// Phase: the sample loop (symbolication + per-sample poll attribution).
+    pub sample_resolve: std::time::Duration,
+    /// Phase: legacy span reconstruction (`resolve_legacy_spans`).
+    pub span_resolve: std::time::Duration,
+    /// Phase: sweep-line sample→span attribution.
+    pub sample_attribution: std::time::Duration,
+}

--- a/dial9-viewer/src/server/fold_stream.rs
+++ b/dial9-viewer/src/server/fold_stream.rs
@@ -411,7 +411,7 @@ mod tests {
             failed_key: full_keys[1].clone(),
         };
 
-        let events: Vec<_> = drive(agg, resolved, FoldLimits::new(1, 1), sink)
+        let events: Vec<_> = drive(agg, resolved, FoldLimits::new(1, 1, 1), sink)
             .collect()
             .await;
 

--- a/dial9-viewer/src/server/metrics.rs
+++ b/dial9-viewer/src/server/metrics.rs
@@ -11,7 +11,7 @@
 //!   `/api/browse`, `/api/object`), so you can alarm a single noisy endpoint.
 //! - `[]` (the empty set) — a service-wide aggregate across all operations.
 
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use axum::extract::{MatchedPath, Request};
 use axum::middleware::Next;
@@ -20,7 +20,7 @@ use metrique::ServiceMetrics;
 use metrique::emf::Emf;
 use metrique::local::{LocalFormat, OutputStyle};
 use metrique::timers::Timer;
-use metrique::unit::{Count, Millisecond};
+use metrique::unit::{Byte, Count, Millisecond};
 use metrique::unit_of_work::metrics;
 use metrique::writer::sink::AttachHandle;
 use metrique::writer::{AttachGlobalEntrySinkExt, FormatExt};
@@ -200,6 +200,188 @@ impl ObjectStreamMetrics {
             truncated_mid_stream: 0,
         }
         .append_on_drop(ServiceMetrics::sink_or_discard())
+    }
+}
+
+/// One entry per source file folded, carrying the per-phase timing breakdown of
+/// processing that file — emitted so we can see *where* fold time goes without a
+/// profiler. This is the metric that answers "why is the server slow": it splits
+/// a fold into fetch (S3 GET) → gunzip → the individual decode phases →
+/// parquet-encode → write (S3 PUTs), alongside the file's size and event count.
+///
+/// Standalone (not part of [`RequestMetrics`]): one HTTP request folds many
+/// files, so folding to the request entry would collapse per-file detail. Each
+/// fold appends its own entry to the global sink on drop, sharing the same empty
+/// global dimension set so per-file timings aggregate across the fleet.
+///
+/// All phase durations are wall-clock and measured in sequence, so they sum
+/// (modulo scheduling gaps) to `total`.
+#[metrics(emf::dimension_sets = [[]])]
+pub struct FoldFileMetrics {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+
+    /// Always `1`: the count of folded files (denominator for per-file rates).
+    #[metrics(unit = Count)]
+    count: u32,
+
+    /// `1` when the fold failed (fetch/decode/write error). The phase timings up
+    /// to the failure point are still emitted; later phases are zero.
+    #[metrics(unit = Count)]
+    failed: u32,
+
+    /// Compressed size of the source object as fetched from S3 (bytes).
+    #[metrics(unit = Byte)]
+    source_bytes: u64,
+
+    /// Decompressed size handed to the decoder (bytes). The ratio to
+    /// `source_bytes` is the gzip ratio.
+    #[metrics(unit = Byte)]
+    decompressed_bytes: u64,
+
+    /// Total events decoded off the wire (all event types).
+    #[metrics(unit = Count)]
+    events_decoded: u64,
+
+    /// Span enter/exit/close events (subset of `events_decoded`) — the span path
+    /// is the one under scrutiny, so it gets its own count.
+    #[metrics(unit = Count)]
+    span_events_decoded: u64,
+
+    // ── Phase timings (sum ≈ total) ──────────────────────────────────────────
+    /// S3 GET of the source object.
+    #[metrics(unit = Millisecond)]
+    fetch: Duration,
+    /// gunzip of the fetched bytes.
+    #[metrics(unit = Millisecond)]
+    gunzip: Duration,
+    /// One-pass wire decode into typed events.
+    #[metrics(unit = Millisecond)]
+    wire_decode: Duration,
+    /// Sort the event stream by timestamp.
+    #[metrics(unit = Millisecond)]
+    sort_events: Duration,
+    /// Reconstruct the poll timeline from park/unpark/poll events.
+    #[metrics(unit = Millisecond)]
+    poll_reconstruct: Duration,
+    /// Sample loop: symbolication + per-sample poll attribution.
+    #[metrics(unit = Millisecond)]
+    sample_resolve: Duration,
+    /// Legacy span reconstruction (enter/exit pairing, close segmentation).
+    #[metrics(unit = Millisecond)]
+    span_resolve: Duration,
+    /// Sweep-line sample→span attribution.
+    #[metrics(unit = Millisecond)]
+    sample_attribution: Duration,
+    /// Parquet-encode of the four part-files (samples, dict, polls, spans).
+    #[metrics(unit = Millisecond)]
+    parquet_encode: Duration,
+    /// S3 PUTs of the four part-files.
+    #[metrics(unit = Millisecond)]
+    write_parts: Duration,
+    /// Wall-clock time for the whole fold (fetch → write), including any time
+    /// spent waiting on the fold concurrency semaphores.
+    #[metrics(unit = Millisecond)]
+    total: Duration,
+}
+
+/// Builder for a [`FoldFileMetrics`] entry. The fold path fills phases in as it
+/// runs, then calls [`emit`](Self::emit) once to append the entry to the global
+/// sink. Kept separate from the metric struct so the metric's fields stay
+/// private (new phases are non-breaking).
+#[derive(Default)]
+pub struct FoldFileMetricsBuilder {
+    source_bytes: u64,
+    decompressed_bytes: u64,
+    events_decoded: u64,
+    span_events_decoded: u64,
+    fetch: Duration,
+    gunzip: Duration,
+    wire_decode: Duration,
+    sort_events: Duration,
+    poll_reconstruct: Duration,
+    sample_resolve: Duration,
+    span_resolve: Duration,
+    sample_attribution: Duration,
+    parquet_encode: Duration,
+    write_parts: Duration,
+    total: Duration,
+    failed: bool,
+}
+
+impl FoldFileMetricsBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn source_bytes(&mut self, n: u64) -> &mut Self {
+        self.source_bytes = n;
+        self
+    }
+    pub fn decompressed_bytes(&mut self, n: u64) -> &mut Self {
+        self.decompressed_bytes = n;
+        self
+    }
+    pub fn fetch(&mut self, d: Duration) -> &mut Self {
+        self.fetch = d;
+        self
+    }
+    pub fn gunzip(&mut self, d: Duration) -> &mut Self {
+        self.gunzip = d;
+        self
+    }
+    /// Set every decode sub-phase at once from the decoder's own [`DecodeStats`].
+    pub fn decode_phases(&mut self, s: &crate::ingest::decode::DecodeStats) -> &mut Self {
+        self.wire_decode = s.wire_decode;
+        self.sort_events = s.sort_events;
+        self.poll_reconstruct = s.poll_reconstruct;
+        self.sample_resolve = s.sample_resolve;
+        self.span_resolve = s.span_resolve;
+        self.sample_attribution = s.sample_attribution;
+        self.events_decoded = s.events_decoded;
+        self.span_events_decoded = s.span_events_decoded;
+        self
+    }
+    pub fn parquet_encode(&mut self, d: Duration) -> &mut Self {
+        self.parquet_encode = d;
+        self
+    }
+    pub fn write_parts(&mut self, d: Duration) -> &mut Self {
+        self.write_parts = d;
+        self
+    }
+    pub fn total(&mut self, d: Duration) -> &mut Self {
+        self.total = d;
+        self
+    }
+    pub fn failed(&mut self, failed: bool) -> &mut Self {
+        self.failed = failed;
+        self
+    }
+
+    /// Append the assembled entry to the global metrics sink. A no-op sink is
+    /// used when none is attached (tests), matching the rest of this module.
+    pub fn emit(self) {
+        FoldFileMetrics {
+            timestamp: SystemTime::now(),
+            count: 1,
+            failed: self.failed as u32,
+            source_bytes: self.source_bytes,
+            decompressed_bytes: self.decompressed_bytes,
+            events_decoded: self.events_decoded,
+            span_events_decoded: self.span_events_decoded,
+            fetch: self.fetch,
+            gunzip: self.gunzip,
+            wire_decode: self.wire_decode,
+            sort_events: self.sort_events,
+            poll_reconstruct: self.poll_reconstruct,
+            sample_resolve: self.sample_resolve,
+            span_resolve: self.span_resolve,
+            sample_attribution: self.sample_attribution,
+            parquet_encode: self.parquet_encode,
+            write_parts: self.write_parts,
+            total: self.total,
+        }
+        .append_on_drop(ServiceMetrics::sink_or_discard());
     }
 }
 
@@ -496,5 +678,53 @@ mod tests {
 
         let e = inspector.get(0);
         assert_eq!(e.metrics["truncated_mid_stream"].as_u64(), 0);
+    }
+
+    #[tokio::test]
+    async fn fold_file_metric_carries_phases_size_and_counts() {
+        let TestEntrySink { inspector, sink } = test_entry_sink();
+        let _guard = ServiceMetrics::set_test_sink_on_current_tokio_runtime(sink);
+
+        let mut b = FoldFileMetricsBuilder::new();
+        b.source_bytes(1_257_686)
+            .decompressed_bytes(2_314_769)
+            .fetch(Duration::from_millis(120))
+            .gunzip(Duration::from_millis(5))
+            .parquet_encode(Duration::from_millis(8))
+            .write_parts(Duration::from_millis(30));
+        let decode = crate::ingest::decode::DecodeStats {
+            events_decoded: 1_300_000,
+            span_events_decoded: 4_368,
+            wire_decode: Duration::from_millis(20),
+            span_resolve: Duration::from_millis(3),
+            ..Default::default()
+        };
+        b.decode_phases(&decode).total(Duration::from_millis(200));
+        b.emit();
+
+        let e = inspector.get(0);
+        assert_eq!(e.metrics["count"].as_u64(), 1);
+        assert_eq!(e.metrics["failed"].as_u64(), 0);
+        assert_eq!(e.metrics["source_bytes"].as_u64(), 1_257_686);
+        assert_eq!(e.metrics["decompressed_bytes"].as_u64(), 2_314_769);
+        assert_eq!(e.metrics["events_decoded"].as_u64(), 1_300_000);
+        assert_eq!(e.metrics["span_events_decoded"].as_u64(), 4_368);
+        // A representative phase and the total are present.
+        assert_eq!(e.metrics["wire_decode"].num_observations(), 1);
+        assert_eq!(e.metrics["span_resolve"].num_observations(), 1);
+        assert_eq!(e.metrics["total"].num_observations(), 1);
+    }
+
+    #[tokio::test]
+    async fn fold_file_metric_marks_failure() {
+        let TestEntrySink { inspector, sink } = test_entry_sink();
+        let _guard = ServiceMetrics::set_test_sink_on_current_tokio_runtime(sink);
+
+        let mut b = FoldFileMetricsBuilder::new();
+        b.failed(true).total(Duration::from_millis(50));
+        b.emit();
+
+        let e = inspector.get(0);
+        assert_eq!(e.metrics["failed"].as_u64(), 1);
     }
 }

--- a/dial9/Cargo.toml
+++ b/dial9/Cargo.toml
@@ -45,6 +45,10 @@ default = ["cli"]
 ## The `dial9` viewer/analysis binary (`dial9 serve`, `dial9 agents`).
 cli = ["dep:dial9-viewer", "dep:anyhow"]
 
+## Opt-in self-instrumentation for the `dial9` CLI.
+## Activate recording with `DIAL9_ENABLED=true`.
+self-telemetry = ["tokio", "cpu-profiling"]
+
 ## Background segment-processing pipeline (worker, processors, on-demand dumps).
 ## Pulls a Tokio runtime for the worker, but not the runtime *integration*.
 ## The `?/` forward enables perf's symbolize processor only when a perf source

--- a/dial9/src/main.rs
+++ b/dial9/src/main.rs
@@ -1,3 +1,10 @@
+#[cfg(feature = "self-telemetry")]
+#[dial9::main(config = dial9::recorder_from_env)]
+async fn main() -> anyhow::Result<()> {
+    dial9_viewer::cli::run().await
+}
+
+#[cfg(not(feature = "self-telemetry"))]
 fn main() -> anyhow::Result<()> {
     dial9_viewer::cli::run_blocking()
 }


### PR DESCRIPTION
## Summary
- bound process-wide fetch, decode, and whole-fold concurrency
- expose decode and CPU-stage accounting through per-file fold metrics
- keep observability definitions and all producers/callsites atomic
- add opt-in viewer self-telemetry wiring

## Stack
Stacked on #692. PR 5 of 7.

## Validation
- default and all-feature viewer checks
- all-target/all-feature clippy
- viewer tests: 271/271
- independent boundary review approved
