### PR TITLE
docs: define the diff-first unified analysis view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,51 @@ rate_limited!(Duration::from_secs(60), {
 ```
 Unguarded logging in loops causes log spam that degrades observability and can itself become a performance problem. One-time paths (startup, shutdown, per-thread init) are exempt.
 
+## Viewer deep links (`/api/object` and `source_key`)
+
+When building a viewer/flamegraph deep link in the UI that loads a specific
+trace file, the `trace=/api/object?bucket=…&key=…` component's `key` must be a
+**bucket-relative** key (e.g. `2026-07-15/1715/svc/host/boot/epoch-seg.bin.gz`),
+NOT a fully-qualified `s3://{bucket}/{key}` URI. `/api/object` treats the `key`
+verbatim, so passing an `s3://…` URI yields a **404**.
+
+Beware: the folded backend stores a span/sample's `source_key` as the
+fully-qualified `s3://{bucket}/{key}` form (that is the `full_key`
+`decode_samples` was handed). So any UI code that turns a `source_key` into an
+`/api/object` link must split off the `s3://{bucket}/` prefix first (parse the
+bucket from the URI, keep the remainder as the key). See
+`exemplarViewerUrl` in `dial9-viewer/ui/span_explorer.js`.
+
+Diagnosing a broken deep link: a **404 is almost always a wrong key/endpoint**,
+not missing credentials. Credentials (BYOC) live in `sessionStorage`, which the
+browser copies to a tab opened via a normal same-origin link or `window.open`,
+so a new viewer tab inherits them. Before blaming creds, print the exact
+`/api/object?bucket=&key=` the link produces and `curl` it against the running
+server — compare the `s3://…` key vs the bucket-relative key.
+
+## Query-param bools: send `true`/`false`, not `1`/`0`
+
+The server parses query strings with `serde` (via `serde_urlencoded`), and its
+bool deserializer accepts ONLY the literal strings `true` and `false`. A UI that
+sends `?flag=1` yields a **400** with body `Failed to deserialize query string:
+<field>: provided string was not 'true' or 'false'` — the request is rejected
+during param parsing (fast, ~50µs) before any handler work runs. This has bitten
+us repeatedly (e.g. `exemplars_only`).
+
+Rules when adding a `bool` query param to any `#[derive(Deserialize)]` params
+struct (`SpanStatsParams`, flamegraph params, etc.):
+
+- **In the UI, set the value to `"true"` / `"false"`** — never `"1"`/`"0"`.
+  Grep for the param name after wiring it to confirm no `=1` literal slipped in.
+- If a param must accept `1`/`0`/`yes`/absent (e.g. an external caller you don't
+  control), don't type it as `bool`. Deserialize it as `Option<String>` and
+  interpret it yourself, or add a lenient `#[serde(deserialize_with = …)]`.
+- **Diagnosing:** a **400 within microseconds** on an endpoint that otherwise
+  streams is almost always a query-string deserialize failure, not a logic bug.
+  `curl` the exact URL the UI builds and read the response body — it names the
+  offending field. Verify the fix with `curl` (expect the param to parse: you
+  may then get a legitimate 404/200, just not the 400).
+
 ## Testing
 
 ### Local viewer server

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,16 +49,19 @@ job). The old tree is abandoned and GC'd out-of-band.
 **Refinement loop**:
 The query control flow, realized as a **single held-open SSE stream** per
 request. The server *resolves* the scope once (list → [[order-key]] sort →
-take the first [[sampling-cap]] files → list the folded set), emits the
-already-folded snapshot immediately, then folds the not-yet-folded
-[[source-file]]s (in order) concurrently and pushes a fresh tree +
-[[coverage]] block as each file lands, closing the stream at the cap. The
+retain the matched set + take the first [[sampling-cap]] files as the new-work
+prefix → list the folded set), streams every folded matching part in bounded
+cumulative snapshots, then folds missing prefix [[source-file]]s (in order)
+concurrently and pushes a fresh tree + [[coverage]] block as each file lands,
+closing when the work-list drains. The cap bounds new source folding; reusable
+cache from overlapping scopes can make coverage exceed it. The
 endpoint merges each folded file into an in-memory accumulator incrementally
 (one merge per file), rather than re-scanning the whole folded set per event.
 No background tasks and no coordination — folding runs only while the request
 is open (the fold `JoinSet` is dropped, cancelling in-flight folds, when the
 client disconnects), and re-folding is safe by idempotency. Coverage climbs
-monotonically until the server closes the stream at the cap.
+monotonically until cached reconstruction and the bounded work-list drain; it may
+exceed the cap because the cap limits new source folding, not reusable cache.
 (Deferred optimization: memoize each file's immutable `{stack_id→count}`
 histogram *across requests* so a reopened stream sums cached per-file maps.)
 _Avoid_: client re-polling, `refine=` request flag, job handle, background
@@ -106,11 +109,12 @@ The point at which the [[refinement-loop]] stops folding a scope's tail:
 backend-configurable. The percentage keeps small scopes sensible; the
 absolute ceiling stops a fleet-day scope from chasing 5% of tens of
 thousands of files (which would re-create the batch job). The
-[[refinement-loop]] closes the stream once it reaches the cap. A user-facing
-"fetch more" reopens the stream with a raised ceiling for that scope on
-demand. Folding also stops early if the client disconnects
-(refine-while-watched).
-_Avoid_: completion target (we deliberately never reach 100%).
+[[refinement-loop]] closes the stream once cached reconstruction and its missing
+in-prefix work drain. A user-facing "fetch more" reopens the stream with a
+raised new-work ceiling for that scope on demand. Folding also stops early if the
+client disconnects (refine-while-watched). The cap is not a coverage ceiling:
+matching reusable cache may take coverage beyond it, including to 100%.
+_Avoid_: completion target for new folding (the cap bounds work, not coverage).
 
 **Scope**:
 A query's selection: a time range (minute precision), a service, and a
@@ -126,6 +130,343 @@ browser's 🔥 button builds a scope from the heatmap selection's hosts +
 `[t0,t1]` and drives the [[refinement-loop]] when the server advertises
 `aggregation_enabled` via `/api/config`.
 _Avoid_: query (use "scope" for the selection, "query" for the request).
+
+## Unified diff-first view
+
+**Diffability**:
+The design principle that every analysis surface is built to compare two
+[[selection]]s, A and B. A single-slice view is the special case where one
+side is empty (a diff against "a perfect world where everything was
+infinitely fast/cheap"). We strive for a **single-view** experience: one
+page, one renderer per lens, that always speaks in terms of A vs B. Legacy
+single-slice pages are not deleted on day one, but new work is designed
+diff-first.
+_Avoid_: comparison mode (it is not a mode; it is the paradigm).
+
+**One renderer, two layout modes**:
+"B = ∅" is the *conceptual* unification (same data model, same renderer code,
+B's filter set merely empty) — **not** a literal always-two-panels UI. The
+one-sided case ([[baseline]] Inspect) renders as a **single full-width panel**
+with all rich features; **Compare** transitions it into the **split** two-panel
+layout by revealing the B panel. An always-present empty/ghost B panel is
+rejected — it would waste the viewport the UX audit already flags as too empty
+on cold open. One renderer, one [[selection]] model, two layouts (full-width
+when B empty, split when B populated).
+
+**Renderer direction**:
+The diff capability is folded **into** the feature-rich flamegraph renderer
+(search, inspect/butterfly, zoom history), not built on top of the minimal
+two-sided diff renderer. The layout is **two synced rich panels** — A left,
+B right, each the *full* renderer (zoom, search, inspect all work per side),
+kept in sync: zoom in one zooms the other to the same frame path, search
+highlights matches in both, inspect/butterfly roots both at the same frame.
+That synchronization is what makes it "one view of two things" rather than two
+independent flamegraphs. Each existing feature grows a side-by-side variant:
+e.g. flamegraph search shows the matched field in *each* selection with each
+side's representative percentage. The color encoding is **user-selectable**
+(not a fixed hotness scale). Alongside the panels is a **listing table** of
+the biggest differences — ranked both by **percentage** delta and by
+**absolute sample-count** delta — the flamegraph view's instance of
+[[significant-difference]]. A single merged delta-colored tree is a possible
+later toggle, not the primary layout (self-normalized side-by-side widths are
+more legible than delta-color on one tree).
+
+**Diff vocabulary**:
+Every quantity shown is one of a few **diffable types**, and each type has one
+canonical A-vs-B rendering, reused across all [[view]]s so a p99 diff looks and
+behaves the same in the spans table, a flamegraph tooltip, and the
+[[significant-difference]] rail:
+
+| Diffable type | Examples | Canonical diff rendering |
+|---|---|---|
+| **Scalar** | p50/p95/p99, count, mean poll, `db_time` metric | **Dumbbell** — A-dot ● and B-dot ● on one shared (log) axis, joined by a colored bar; length+direction = the change |
+| **Distribution** | a span type's duration histogram | **Overlaid/mirrored histograms** or a per-bucket **difference histogram** (B−A, diverging) — the whole shift, not 3 percentiles |
+| **Set membership** | which span types / frames exist | **new / gone** badges |
+| **Tree** | call graph; nested time-attribution | **delta-colored flame/icicle** |
+
+Consequence: a spans/tokio [[view]] is **not two tables** (here-is-A,
+here-is-B); it is **one aligned table** — one row per identity (union of A and
+B), each cell rendering its quantity's diff primitive. The row *is* the diff.
+Sorting by change-magnitude merges the table with the
+[[significant-difference]] rail for tabular views.
+_Avoid_: side-by-side A/B tables (that is "show both", not "show the
+difference" — the failure mode this vocabulary exists to kill).
+
+**Time-attribution is a metric bag, not necessarily a tree**:
+"Where did a span's elapsed time go" generalizes beyond the fixed five-way
+breakdown (on-cpu / sync-block / async-wait / sched-delay / unknown). The
+right conception: a span carries a **bag of measured quantities**; the subset
+that are *durations* (`db_time`, `on_cpu`, a child span's contribution) are
+what "composition" is made of. A `db_time` **metric attached to the span** is
+the easy, always-available case (→ scalar dumbbell diff); a nested
+parent/child **tree** is the richer case when containment exists (→ delta-tree
+diff). The diff engine does not distinguish them — it diffs numbers grouped by
+identity; the tree is a *rendering* choice for when the numbers nest, not a
+separate diffable type. So the fixed five-way bar folds into this: it is just
+the shallowest projection. This lets "my p99 is slow *because* db.query is
+slow" read straight out of the A-vs-B diff, since B is already the p99 tail.
+
+Two honesty/scope constraints:
+- **Mandatory `unknown`.** Any duration decomposition is
+  [[source-file]]-bounded (no global span-graph reconstruction). It must
+  always carry an explicit `unknown` node and never be fabricated to sum to
+  100%. The on-cpu portion falls out of the enriched sample scan
+  (`enclosing_spans` depth 0–2); the by-child *wall-time* split is the bounded
+  part.
+- **Aggregate diff ≠ per-instance correlation.** The A-vs-B diff gives the
+  *aggregate* claim ("the slow bucket spends proportionally more time in
+  db.query"), which needs no new machinery because B = the tail. Genuine
+  *per-instance* correlation ("elapsed correlates with db_time span-by-span")
+  is a **separate, deferred** capability — it needs per-span joins that fight
+  the source-file-bounded model. Not a v1 blocker.
+
+**Unsymbolized frames excluded from diff**:
+Frames whose addresses did not resolve to a symbol are **excluded** from the
+diff coloring and the [[significant-difference]] listing. Unsymbolized frames
+will essentially always differ between A and B (different raw addresses), so
+including them would flood the ranking with noise that is not a real
+behavioral difference.
+
+**Selection**:
+One of the two things being compared: **A** or **B**. A selection is a
+**shared filter set** — a predicate over the trace data — applied uniformly
+across every [[view]]. It would make no sense to change the filter criteria
+for just one view. The filter set is the *union* across views: a single
+selection can carry a `span_type_uid`, a duration band, a `thread_class`, and
+an attribute-equality filter all at once, and each view uses the subset it
+understands. A single-slice display is the special case B = ∅.
+_Avoid_: pane, side (use A/B), scope (scope is the coarse S3-prune subset of
+a selection's filters — see the Aggregation glossary).
+
+**View**:
+One way of presenting a [[selection]] pair: the **flamegraph** view, the
+**span-stats** view, the **tokio** view. Switching views re-runs the same A/B
+[[selection]] against a different endpoint; the selection is unchanged.
+_Avoid_: lens (too close to "filter/predicate"), drawer, tab, page.
+
+**Derived-statistic filter**:
+A pop-out predicate defined over a *computed aggregate* rather than a single
+row — e.g. ">p99 duration". Unlike a row-level predicate (`region = Bar`,
+stable as [[coverage]] grows), a percentile is coverage-dependent: computed
+over whatever is folded so far. On pop-out it is **frozen to a concrete,
+editable row predicate** (`duration_ns > 340ms` — the p99 value at that
+moment) so it behaves like every other filter (single-pass scan,
+[[coverage-symmetry]] gating, `NOT P` complement all just work). But the chip
+**tracks its provenance** — "derived: p99 @ coverage 12/480" — so a
+**refresh** recomputes the threshold against all currently-folded data. Frozen
+for stability by default; re-derivable on demand.
+_Avoid_: live percentile filter (the membership churns as files land, fighting
+coverage-symmetry and jittering the [[significant-difference]] ranking).
+
+**Semantic focus vs navigation state**:
+The rule for what carries when switching [[view]]s. **Semantic** state — any
+filter, a focused span type, a time sub-range — is *just a filter*, lives in
+the [[selection]], and therefore carries across views automatically (selecting
+span `auth` in span-stats and switching to the flamegraph scopes the
+flamegraph to `auth` — this falls out of the selection model, it is not a
+special cross-view rule). **Navigation** state — flamegraph zoom rectangle,
+butterfly/inspect root, exact search string, histogram brush geometry — is
+purely mechanical, stays **per-view**, and is *remembered per-view* so
+switching away and back restores your place. Both serialize into the
+shareable URL (selection + per-view nav state).
+
+**"Everything" (B) is never literally 100%**:
+The customer's canonical "selection B is everything" is **always a
+cap-bounded, representative sample**, never every file — nothing in this system
+is ever literally 100% of the data (the [[sampling-cap]] and [[order-key]]
+guarantee a uniform spread, and the [[coverage]] badge tells the truth,
+e.g. "100 / 45,000 files, 0.2%"). In the [[compare]] pop-out flow, "everything"
+means A's **coarse scope minus the popped predicate** (the `NOT P` complement
+within A's time/service window) — bounded by construction and the more useful
+comparison (it controls for time-of-day, deploy version, etc.; comparing
+against the literal all-time fleet would confound). A genuinely fleet-wide B is
+an explicit, cap-bounded, clearly-labeled choice, not the default.
+
+**Predicate / Consequent**:
+Two roles the *same* set of fields plays. As a **predicate**, a field filters
+(`service = Foo`, `region = Bar`, duration `> X`). As a **consequent**, the
+same field (now a superset) is a computed result of the selection ("given
+that predicate, p99 is now X", "mean poll duration is now X"). The diff
+highlights how a consequent changed between A and B.
+
+**View-local filter**:
+A [[view]] may *add* filter criteria on top of the shared [[selection]]
+predicate, expressed in that view's own terms — e.g. right-clicking a stack
+frame in the flamegraph to keep only samples that passed through that code
+path. This narrows within a view without redefining the cross-view
+[[selection]]. A view-local filter can target **A only, B only, or both** —
+all three are legitimate (both = keep the sides honestly comparable; one
+side = ask a lopsided question). When a filter targets only one side, A and
+B are no longer defined by the same predicate, and the UI must make that
+asymmetry visible rather than silent. View-local filters are undoable via a
+breadcrumb/zoom history.
+
+**Significant difference**:
+A ranked, surfaced change in a [[consequent]] between [[selection]]s A and B
+— the "pull out the most significant differences" feature. Ranked
+**per-[[view]]** in that view's own units (flamegraph: |Δ self-fraction| of a
+frame, including frames present on only one side; span-stats: |Δ p99| /
+|Δ mean| of a span type; tokio: |Δ mean poll| of a spawn location). A unified
+**cross-view** ranking — one "what changed" summary drawing the globally most
+significant deltas from every view — is the aspiration but is deferred: it
+needs a common significance metric to compare heterogeneous deltas
+(Δp99-of-a-span vs Δself-fraction-of-a-frame), which is unsolved. Ship
+per-view first, learn what "significant" means, then attempt the summary.
+_Avoid_: root cause (the customer's own hedge is "auto-(not-quite-)root-cause"
+— we surface differences, we do not assert causation).
+
+**Server-side diff**:
+The diff and the ranked [[significant-difference]] list are computed
+**server-side**, not in the browser. One endpoint (or a `compare=` mode on the
+existing per-[[view]] endpoints) resolves both A and B [[selection]]s and
+**schedules** fold work across both to keep their [[coverage]] *comparable*
+(not rigid lockstep — the sides may drift within a tolerance), and streams
+(1) the two sides already merged into a diff
+structure and (2) the bounded ranked differences (by % and by absolute
+sample-count, [[unsymbolized-frames-excluded]]). The **client** renders the
+two synced panels + listing table and owns only interactive navigation
+(zoom/search/inspect) over the shipped structure. Rationale: the server
+already holds the data in the right shape; the design bounds output rather
+than shipping every instance; per-node confidence intervals need server-side
+per-file statistics; and one Rust diff+rank implementation over the
+kind-agnostic span accumulator ([[span-kind-unification]]) serves every view,
+versus re-implementing merge+rank per view in JS. See ADR-0004.
+_Avoid_: client-side merge (the legacy `flamegraph_diff.js` two-stream merge
+is superseded; at most a thin fallback).
+
+**Coverage symmetry**:
+The rule that A/B differences are only trustworthy when both [[selection]]s
+have folded a *comparable* fraction of their [[matched-set]]. Comparing a
+5%-folded A against a 90%-folded B produces an illusion — B appears to "have"
+frames A is merely missing. The unified view drives both sides toward
+comparable [[sampling-cap]]s and **suppresses/grays the
+[[significant-difference]] ranking** until both sides clear a minimum
+[[coverage]], showing an explicit "still folding — differences preliminary"
+state instead. The [[server-side-diff]] endpoint schedules fold work across
+both sides to keep coverage comparable, so gating rarely trips for long. This
+is the v1 guard. The honest end-state is per-difference
+**confidence intervals** (the planned per-node CIs that tighten as files fold,
+already anticipated by [[coverage]]) — rank by statistical significance, not
+raw magnitude, so a frame seen once in A and zero times in B sinks rather than
+headlines. Raw-magnitude ranking with only a coverage badge is explicitly
+rejected: an auto-surfaced "top difference" that is sampling noise destroys
+trust on first use.
+
+**Span kind unification**:
+Polls (`PollStart`/`PollEnd`), worker parks (`WorkerUnpark`/`WorkerPark`), and
+tracing spans are all analyzed as **spans**. The unification is at the level of
+*in-code representation and analysis machinery*, not storage and not
+presentation:
+
+- **Storage stays separate.** The physical `polls/` projection and the
+  `spans/` table remain distinct — polls are the highest-volume event class,
+  and folding every poll into a full span row is a deferred storage cost (see
+  the generalized-span design). The worker-active interval is a further span
+  *kind*.
+- **In-code representation is uniform.** After leaving Parquet, every kind
+  deserializes into one span type. Kind-specific metadata (e.g. tokio spawn
+  location) rides as typed fields — special-cased decoding
+  (`derive(Deserialize)`-style), not a separate code path. `kind ∈ {tracing,
+  tokio_poll, worker_park}`.
+- **Analysis machinery is shared.** Anything computing span lengths,
+  frequencies, percentiles, or composition runs over any kind. This is the
+  point: if poll times for one spawn location are far longer than its peers,
+  that is *interesting* and it is found by the *same code* that ranks tracing
+  spans — a [[significant-difference]] across kinds.
+- **Worker-active span** = the `[WorkerUnpark, WorkerPark)` interval during
+  which a worker is **busy** (running tasks), *not* idle. Same polarity as a
+  poll: more of them, or longer ones, means the runtime is churning through
+  more work (busier). This is the interval CONTEXT's Worker attribution
+  section calls the "active span" for CPU-time ratios.
+  _Avoid_: park duration = idle time (the *span* is the busy interval between
+  an unpark and the next park).
+- **Presentation stays separate.** It does not make sense to list tracing
+  spans and tokio tasks in the same [[view]] table. The [[view]] groups by
+  kind; the shared machinery is what makes cross-kind observations possible.
+
+**Group-by-attribute**:
+A span type is *not* subdivided by its metadata: all polls are one type
+(`kind = tokio_poll`), not "`tokio.poll` + spawn location" (this **departs**
+from the generalized-span design §1.1, which baked spawn location into the
+type UID). Instead, spawn location is typed metadata and the span machinery
+has a first-class **group-by-attribute** capability — the tokio view is "spans
+of kind `tokio_poll`, grouped by spawn location". This generalizes: tracing
+spans can be grouped by any attribute too (e.g. `handle_request` grouped by
+`route`). Grouping is a generic operation over metadata, not baked identity —
+consistent with spawn location being just a `derive(Deserialize)` field on the
+one uniform span type. The tokio view's on-cpu/off-cpu classification maps onto
+the five-way composition; its top-N "longest polls" list is the span view's
+slow-exemplars.
+_Avoid_: spawn-location-as-span-type (grouping is a runtime operation, not
+identity).
+
+**Baseline (selection A)**:
+The starting [[selection]], built in the viewer/S3 browser by quick-click
+buttons ("whole service", "whole host" — new; do not exist today) or today's
+drag-select. From the baseline you can **Inspect** (one-sided mode: today's
+viewer — flamegraph looks like a flamegraph, span table like today's, no diff
+ceremony) or **Compare**.
+_Avoid_: selection A when discussing construction (it *is* [[selection]] A;
+"baseline" names its role as the thing B is measured against).
+
+**Compare (pop-out)**:
+The action that creates [[selection]] B from the [[baseline]]. Any selection
+criterion you could otherwise apply to narrow the current view is instead
+"popped out as compare": rather than narrowing in place, it **splits** into
+A vs B where **B gets the popped predicate `P`**. By **default** the two
+sides are **disjoint** (no overlap): B = baseline ∩ `P`, and A gets a visible
+`NOT P` filter chip auto-added so A = baseline ∖ `P` — "the matching subset vs
+the rest", which maximizes the [[significant-difference]] signal (comparing a
+tail against a population that *includes* it dilutes the contrast). The
+`NOT P` chip is **not a hidden mode**: it is an ordinary filter on A, shown
+like any other, and clicking it away reverts to "B vs the whole baseline"
+(A ⊇ B). So B is normally a *refinement* of A's predicate, expressed entirely
+in the one uniform filter model — no special "compare-against" toggle
+machinery. The general filter-builder (arbitrary independent A and B) still
+exists and is primary, but pop-out-refinement is the common path and the
+[[capture-tray]]/derive-B presets are accelerators that populate it.
+
+**Comparison permalink**:
+The whole comparison is a **shareable, self-contained URL** — required to not
+regress the UX audit's task-blocking S3 finding ("view state lives only in
+memory"). Encoding: **A is encoded fully; B is encoded as a *delta* from A**
+(the popped predicate(s) + any auto-added `NOT P`), because B is normally a
+[[compare]] refinement of A. This keeps URLs compact as the arbitrary-filter
+set grows and makes "B is a refinement of A" explicit in the URL structure.
+A fully-independent B (rare) falls back to a full encode. Per-[[view]]
+navigation state, the active view, the color encoding, and
+[[derived-statistic-filter]] provenance ride as additional URL params. No
+server-side saved-selection storage — the model stays URL-self-contained
+(creds in sessionStorage, everything else in the URL).
+
+**Capture tray**:
+The existing "Add to diff" A/B accelerator (today in `flamegraph_diff.js`):
+analyze a scope, click "Add to diff" → fills A, then B. In the unified view it
+is demoted to one of several accelerators that *populate* the [[selection]]
+filter-builder (alongside the derive-B presets: same-scope-different-host,
+time-shifted), not a separate diff-construction mechanism.
+
+**Migration path**:
+The unified view is grown by **forking/copying the current span explorer
+page** as the host shell, then *adding* to it — not a greenfield rewrite and
+not flamegraph-first. The span explorer is the surface already closest to the
+destination: it hits `/api/span-stats`, already has the catalog →
+select-span-type → drill-into-flamegraph flow, already computes the
+percentiles/composition/exemplars that are the raw material for
+[[significant-difference]], and already owns the span→flamegraph deep-link.
+Forking protects the live page while building. Growth order:
+1. Add the A/B [[selection]] model + [[compare]] pop-out to the fork.
+2. Diff the span catalog it already renders (its [[significant-difference]]
+   instance).
+3. Embed the **rich flamegraph renderer as a [[view]] inside the shell** (the
+   [[renderer-direction]] two-synced-panels work) — the flamegraph stops being
+   a separate `window.open` page you deep-link out to and becomes a view
+   *inside* the unified shell.
+The three existing pages (flamegraph, span_explorer, tokio_stats) stay alive
+and **un-deprecated** until the unified view reaches per-[[view]] feature
+parity; a page is deleted only when its unified equivalent is strictly better.
+Span/tokio diff, [[group-by-attribute]], and the cross-view
+[[significant-difference]] summary are deferred beyond the first slice.
 
 ## Worker attribution
 

--- a/aggregator.md
+++ b/aggregator.md
@@ -28,11 +28,12 @@ few samples.** You don't need to aggregate every minute of every hour — a smal
    — deterministic, but uniform across host and time, so the first few files are
    a representative spread rather than one host's earliest minutes.
 3. **One request streams the refinement** over Server-Sent Events. The server
-   emits the already-folded snapshot immediately (stamped with *coverage* —
-   "4 / 480 files"), then folds the not-yet-folded files up to the *sampling cap*
-   (default 5% of matched, ceiling 100 files), pushing a fresh full tree as each
-   file lands, and closes the stream at the cap. It deliberately never folds the
-   whole window. "Fetch more" reopens the stream with a higher cap.
+   merges every already-folded matching part in bounded batches and emits
+   cumulative snapshots (stamped with *coverage* — "40 / 480 files"), then
+   folds missing files inside the *sampling-cap prefix* (default 5% of matched,
+   ceiling 100 files), pushing a fresh full tree as each file lands. It never
+   decodes the whole window merely to answer one request; "Fetch more" reopens
+   the stream with a larger new-work prefix.
 4. **You drill into the tree** — filter by host, source, thread class, or spawn
    location (the toolbar is driven by the *facets* the response advertises) and
    the tree recomputes over the folded set.
@@ -174,11 +175,13 @@ clicked node) are **not yet a server endpoint** — see [Deferred](#deferred).
 ## API Endpoints
 
 Both endpoints are **Server-Sent Event streams** (`Content-Type:
-text/event-stream`). A single request holds the connection open: the server
-emits the already-folded snapshot first, then folds the not-yet-folded files up
-to the sampling cap and pushes a fresh full snapshot (one `data:` JSON object per
-SSE event) as each file lands, closing the stream at the cap. The client
-re-renders on every event — there is no client-driven polling.
+text/event-stream`). A single request holds the connection open. Generic aggregate
+streams (`/api/flamegraph` and `/api/span-stats`) emit cumulative snapshots after
+bounded batches of every matching cached part, then fold missing files only in
+the sampling-cap prefix and close when that bounded work-list drains. The custom
+`/api/tokio-stats` stream retains capped-prefix reconstruction. Each newly folded
+file produces a fresh full snapshot (one `data:` JSON object per SSE event); there
+is no client-driven polling.
 
 Because bring-your-own-credentials rides on `x-dial9-aws-*` request headers, the
 client reads the stream via `fetch` (the native `EventSource` can't set request
@@ -211,6 +214,7 @@ the UI renders the toolbar from that array.
   "coverage": {
     "files_matched": 480,
     "files_folded": 24,
+    "fold_work_cap": 24,
     "samples_folded": 163029,
     "total_bytes": 1788000000
   },
@@ -229,8 +233,9 @@ the UI renders the toolbar from that array.
 }
 ```
 
-`files_folded` climbs monotonically across events until it reaches the cap, at
-which point the server closes the stream.
+`files_folded` climbs monotonically across events until cached reconstruction and
+the bounded new-work list drain. It can start or finish above `fold_work_cap`
+because every successfully merged matching cached part contributes to coverage.
 
 ### `GET /api/tokio-stats`
 
@@ -248,9 +253,10 @@ drift apart:
 
 - **`resolve`** (once per request): list the source scope, filter to the
   [scope]'s service/host/time (interval-overlap on the filename `epoch`, padded
-  by the segment duration), sort by the *order key*, take the first *cap* files
-  as the capped prefix, and list the folded set (the output `samples/` tree —
-  the record of what's already folded; **no manifest**).
+  by the segment duration), sort by the *order key*, retain the full matched set
+  for cached reads, take the first *cap* files as the bounded new-work prefix,
+  and list the folded set (the output `samples/` tree — the record of what's
+  already folded; **no manifest**).
 - **`fold_stream`** (drives the SSE stream): fold the not-yet-folded capped files
   concurrently under the process-global `FoldLimits`, yielding each file as it
   lands. A *fold* is: fetch + gunzip → decode with `dial9-trace-format::Decoder`
@@ -259,17 +265,22 @@ drift apart:
   part-file, and a polls part-file, all named `{blake3(source_key)}`.
 
 The *endpoint* consumes the fold stream, incrementally merging each folded file's
-part-files into an accumulator and emitting one SSE event per file:
-`/api/flamegraph` merges `samples/` into a tree, `/api/tokio-stats` merges
-`polls/` into poll stats. Both attach the same `coverage` block. It emits the
-already-folded snapshot first (instant), then a refined snapshot per fold.
+part-files into an accumulator and emitting SSE events: `/api/flamegraph` merges
+`samples/` into a tree, `/api/span-stats` merges `spans/` into a catalog, and
+`/api/tokio-stats` merges `polls/` into poll stats. All attach the same `coverage`
+shape. Generic fold streams count every successfully merged matching part and
+first merge all such cached parts in the matched scope,
+emitting cumulative snapshots after bounded cached batches, then emit a refined
+snapshot per newly folded capped-prefix file. Thus cache warmed by an overlapping
+query automatically improves the view; the cap bounds new work, not reusable
+cached data.
 
 Stream-driven and idempotent: folding runs only while the request is open (the
 fold `JoinSet` is dropped — cancelling in-flight folds — when the client
 disconnects), and re-folding a file writes the same keys. The `coverage` block
 (`files_matched`, `files_folded`, `samples_folded`, `total_bytes`) tells the user
-how complete the view is; it climbs monotonically until the server closes the
-stream at the cap.
+how complete the view is; it climbs monotonically until cached reconstruction and
+the bounded work-list drain.
 
 [scope]: ./CONTEXT.md
 
@@ -278,7 +289,8 @@ stream at the cap.
 `./scripts/demo-aggregation.sh` seeds a local directory with synthetic segments
 across several hosts/minutes, starts the viewer in demand-driven mode
 (`serve --agg-source-dir …`), and polls the endpoint to show coverage climbing
-from the baseline to the cap. Add `--serve` to explore it in the browser.
+through all matching cache plus the bounded new-work prefix. Add `--serve` to
+explore it in the browser.
 
 ---
 
@@ -336,9 +348,11 @@ rustc-hash = "2"    # FxHash for hot maps
 | Fleet-hourly fold (sampled, not whole window) | bounded by the sampling cap |
 | Dict size (fleet-wide, shared stacks) | ~50-100MB |
 
-The sampling cap means a query never reads the whole window: it folds a
-representative subset (default 5% of matched files, ceiling 100) and reports
-coverage, so cost scales with the cap, not the scope size.
+The sampling cap means a query never decodes the whole source window: new folding
+is limited to a representative prefix (default 5% of matched files, ceiling 100).
+Cached reconstruction still reads every applicable matching part, so source decode
+and write cost scale with the cap while reusable-cache read cost scales with the
+matching cached set.
 
 ---
 

--- a/docs/adr/0004-diff-is-computed-server-side.md
+++ b/docs/adr/0004-diff-is-computed-server-side.md
@@ -1,0 +1,40 @@
+# A/B diff and significant-difference ranking are computed server-side
+
+**Status:** accepted
+
+The unified diff-first view compares two selections (A and B) across every
+view (flamegraph, span-stats, tokio). We compute the merge and the ranked
+"significant differences" **server-side** — one endpoint resolves both
+selections, schedules fold work across both to keep coverage comparable, and
+streams an already-merged diff
+structure plus a bounded ranked-difference list — rather than shipping both
+full structures to the browser and merging in JS (as today's flamegraph-only
+`flamegraph_diff.js` does).
+
+## Why
+
+- The server already holds the folded data in the right shape (the fold
+  accumulators are resident over DuckDB/Parquet). Diffing there is a diff over
+  existing structures; client-side means shipping both full structures and
+  rebuilding the merge in JS.
+- The generalized-span design deliberately **bounds** returned output ("do not
+  return every instance for fleet scopes"). Client-side ranking can only rank
+  what was shipped, reintroducing a sampling bias the server does not have.
+- The honest end-state for significance — per-node/per-type confidence
+  intervals that tighten as files fold — requires per-file sample statistics
+  that live server-side.
+- The endpoint **schedules** fold work across both sides to keep their coverage
+  comparable (not rigid lockstep — they may drift within a tolerance), which is
+  what makes the difference ranking trustworthy under demand-driven partial
+  folds.
+- One Rust diff+rank implementation over the kind-agnostic span accumulator
+  serves every view, versus re-implementing merge+rank per view in JS.
+
+## Consequences
+
+- A new server endpoint (or a `compare=` mode on the existing per-view
+  endpoints) owns both scopes.
+- The client renders the two synced panels + listing table and owns only
+  interactive navigation (zoom/search/inspect) over the shipped structure.
+- The existing unit-tested `flamegraph_diff.js` client merge is superseded —
+  kept, if at all, as a thin fallback.

--- a/docs/adr/0005-span-type-identity-excludes-metadata.md
+++ b/docs/adr/0005-span-type-identity-excludes-metadata.md
@@ -1,0 +1,35 @@
+# Span type identity excludes metadata; grouping is a runtime operation
+
+**Status:** accepted
+
+A span type is identified by kind + callsite semantics only. Metadata such as a
+poll's spawn location is **not** part of the type identity; instead the span
+analysis machinery has a first-class **group-by-attribute** capability, and the
+tokio view is "spans of kind `tokio_poll`, grouped by spawn location."
+
+## Why
+
+This **departs from the generalized-span design** (`docs/design/generalized-span-flamegraphs.md`
+§1.1), which specifies the poll span type as "`tokio.poll` + spawn location" —
+i.e. spawn location baked into `span_type_uid`. We chose runtime grouping
+instead because:
+
+- It generalizes: tracing spans can be grouped by any attribute (e.g.
+  `handle_request` by `route`), not just polls by spawn location. Baking one
+  attribute into identity does not.
+- It matches the uniform in-code span model (ADR-forthcoming / CONTEXT "Span
+  kind unification"): spawn location is a typed `derive(Deserialize)` field on
+  the one span type, and grouping is a generic operation over metadata rather
+  than baked identity.
+- It keeps "a poll is a poll" — one `tokio_poll` type — so cross-kind analysis
+  machinery (percentiles, histograms, composition, diff) treats every kind the
+  same.
+
+## Consequences
+
+- `span_type_uid` for a poll is derived from kind + callsite, NOT spawn
+  location. Code and any folded schema following §1.1's baked-in identity must
+  be reconciled with this before the tokio view collapses into the span
+  machinery.
+- The span-stats query path needs a group-by-attribute capability it does not
+  have today.

--- a/docs/aggregation-feature.md
+++ b/docs/aggregation-feature.md
@@ -30,8 +30,8 @@ sampling**, driven by the query itself:
 | | Batch (original design) | Demand-driven (shipped) |
 |---|---|---|
 | When aggregation happens | Ahead of time, whole window | At query time, streamed file-by-file |
-| How much | Everything | A representative sample, capped (~5%) |
-| First result | After the whole batch | The already-folded snapshot, immediately |
+| How much | Everything | All matching cache plus a capped representative prefix of new folds |
+| First result | After the whole batch | After the first bounded cached batch; remaining cached state streams cumulatively |
 | Completeness signal | None | `coverage` on every SSE event |
 | `samples` table | Same schema — one row per CPU sample, drilled into at query time. Now populated *incrementally and partially* instead of batch-filled. |
 
@@ -67,35 +67,40 @@ Each `GET /api/flamegraph` request (a Server-Sent Events stream):
 
 1. **Resolve** (once) — lists the source scope, filters to the [scope]'s
    service / host-set / time (interval-overlap on the filename `epoch`, padded
-   by the segment duration), sorts by the order key, takes the first *sampling
-   cap* files, and lists the output `samples/` tree (the record of what's already
-   folded).
-2. **Prime + emit** — reads the already-folded part-files into an in-memory
-   accumulator and emits the first SSE event (the instant snapshot).
-3. **Fold + stream** — folds the not-yet-folded capped files concurrently under
-   the process-global `FoldLimits`; as each file lands, merges its part-file into
+   by the segment duration), sorts by the order key, retains the full matched set
+   for cached reads, takes the first *sampling cap* files as the bounded new-work
+   prefix, and lists the output `samples/` tree.
+2. **Prime + emit** — reads every already-folded matching part-file in bounded
+   batches into an in-memory accumulator and emits a cumulative SSE snapshot
+   after each batch.
+3. **Fold + stream** — folds missing files inside the capped prefix concurrently
+   under the process-global `FoldLimits`; as each file lands, merges its part-file into
    the accumulator (sum `stack_id` counts, merge dicts) and emits a fresh
-   flamegraph tree + `coverage` block. Closes the stream at the cap.
+   flamegraph tree + `coverage` block. The stream closes after cached
+   reconstruction and the bounded new-work list both drain.
 
 Folding runs only while the request is open — the fold `JoinSet` is dropped
 (cancelling in-flight folds) when the client disconnects — there is no background
 task or coordination, and re-folding is safe by idempotency. `coverage` climbs
-monotonically until the server closes the stream at the cap.
+monotonically until the work-list drains; matching cache can make it start or
+finish above the new-work cap.
 
 ### 4. Coverage & the cap
 Every demand-driven response carries:
 
 ```json
-"coverage": { "files_matched": 480, "files_folded": 12, "samples_folded": 41203, "total_bytes": 1788000000, "hosts_matched": 40, "hosts_folded": 8 }
+"coverage": { "files_matched": 480, "files_folded": 12, "fold_work_cap": 24, "samples_folded": 41203, "total_bytes": 1788000000, "hosts_matched": 40, "hosts_folded": 8 }
 ```
 
 rendered as e.g. `12 / 480 files (2.5%) · 8 / 40 hosts · 41,203 samples` (the
 host fraction shows how much of the scope's fleet breadth the sample spans, and
-is dropped for single-host scopes). Folding plateaus at
-the **sampling cap** = `min(max(5% × files_matched, baseline 4), 100 files)` —
-the fraction keeps small scopes sensible; the absolute ceiling (100) stops a
-fleet-day scope from chasing 5% of tens of thousands of files. A "Fetch more"
-button raises the ceiling for a scope on demand (`max_files`).
+is dropped for single-host scopes). Every matching cached part contributes to
+coverage, so a warm overlapping scope may start above the request's sampling
+cap. New folding is bounded to the deterministic prefix of
+`min(max(5% × files_matched, baseline 4), 100 files)` — the fraction keeps small
+scopes sensible; the absolute ceiling (100) bounds source decode and write work.
+A "Fetch more" button raises that new-work prefix for a scope on demand
+(`max_files`).
 
 Coverage v1 is *file coverage*. Per-node statistical confidence intervals (the
 literal "how accurate is this sample") are a planned later addition.
@@ -118,7 +123,7 @@ Two independent version knobs, deliberately in opposite places:
 - **`ORDER_VERSION`** (= 1) lives *only* in the order-key hash input. Bump it to
   change the fetch-order permutation; persisted samples are order-independent
   and survive untouched.
-- **`SAMPLES_FORMAT_VERSION`** (= 3) lives *only* in the output path. Bump it
+- **`SAMPLES_FORMAT_VERSION`** (= 5) lives *only* in the output path. Bump it
   when changing *what* we persist; reads/writes then target a fresh empty tree
   that repopulates lazily on demand — no backfill job. The old tree is abandoned
   and GC'd out-of-band.
@@ -160,8 +165,9 @@ The S3 browser's 🔥 **Flamegraph** button:
 - **Demand-driven mode** (`aggregation_enabled`): builds a scope from the
   heatmap selection's host set + `[t0, t1]` and opens `flamegraph.html?api=1&…`,
   which opens the `/api/flamegraph` SSE stream, renders the coverage badge,
-  refines in place on each event, marks the view "refined" when the server closes
-  the stream at the cap, and offers "Fetch more" (reopens with a higher cap).
+  refines in place on each event, marks the view "refined" when cached reconstruction
+  and the bounded work-list drain, and offers "Fetch more" (reopens with a higher
+  new-work cap).
 - **Exact mode** (no aggregation): the original path — streams the selected raw
   traces and decodes them client-side. This path is preserved and still backs
   the trace-viewer pop-out (which flamegraphs a specific already-loaded trace).
@@ -189,8 +195,9 @@ Set `--agg-output-bucket` to retain the existing persistent S3-backed cache.
 filter.
 
 **Demo:** `./scripts/demo-aggregation.sh` seeds synthetic segments across hosts
-and minutes, starts the server in demand-driven mode, and prints coverage
-climbing from the baseline to the cap. `--serve` leaves it up for the browser.
+and minutes, starts the server in demand-driven mode, and prints cached coverage
+plus progress through the bounded new-work prefix. `--serve` leaves it up for the
+browser.
 *(Currently untracked — a working demonstration, not yet committed.)*
 
 ## Where the code lives
@@ -215,10 +222,10 @@ dial9-viewer/tests/aggregate_test.rs   ← end-to-end SSE flow over simulated S3
 
 `tests/aggregate_test.rs` drives the real HTTP SSE endpoints against a simulated
 S3 (s3s), proving:
-- one stream emits an already-folded snapshot first, then a real tree, folding to
-  the baseline K=4;
-- coverage climbs monotonically across SSE events and **stops at the cap below
-  100%**;
+- cached state arrives in bounded cumulative snapshots before newly folded files,
+  then folding reaches the baseline K=4;
+- matching cached coverage can exceed the new-work cap while new source folding
+  remains bounded to the deterministic prefix;
 - re-folding is idempotent (no duplicate part-files; stable counts);
 - "Fetch more" raises the cap;
 - scope filtering by host and time selects the right files;

--- a/docs/design/diff-first-delivery.md
+++ b/docs/design/diff-first-delivery.md
@@ -1,0 +1,256 @@
+# Diff-first delivery plan — vertical slices
+
+Companion to [diff-first-unified-view.md](./diff-first-unified-view.md) (the
+PRD). This is the sequencing: how we get from today (three separate pages, a
+client-only flamegraph diff) to the diff-first unified view.
+
+Each slice below is stated as a **vertical slice** — it cuts through data →
+API → UI and ends at a **demoable** capability — except **S0**, which is
+foundational infra the user explicitly chose to build first (see
+[§ Fold scheduler](#s0--fold-scheduler-foundational)).
+
+## Principles
+
+- **Demoable end state per slice.** Every slice (S1+) ends with something a
+  user can drive in the viewer, not an internal-only change.
+- **No regression to the three existing pages** until the unified view reaches
+  per-view parity. They stay live and un-deprecated.
+- **`b = ∅` is the compatibility contract.** Every API change keeps the
+  single-selection response byte-for-byte unchanged when `b` is absent (PRD
+  §8.2), so existing callers never break.
+- **Reuse before invention.** Compare composes the existing `Scope`,
+  `resolve()`, `fold_stream`, `Coverage`, and per-view response types (PRD
+  §8.1). New code is confined to the scheduler (S0), the merge+rank (S1/S4),
+  and the UI shell.
+
+---
+
+## S0 — Fold scheduler (foundational)
+
+**Why first.** Today every request independently calls `resolve()` +
+`fold_stream::drive`. Two overlapping folds (two tabs, two users, or the two
+sides of a diff) duplicate S3 GETs and Parquet decodes, and nothing balances
+their progress. A **general fold scheduler that knows all currently-desired
+folds** dedupes in-flight work, caps total concurrent S3/decode, and — as a
+side effect — makes coverage-symmetry balancing a scheduling policy rather than
+bespoke diff code. The user chose to build this first so coverage symmetry is
+correct from the *very first* diff and dedup benefits land immediately,
+accepting that S0 has no standalone user-visible capability. ADR-0003's
+idempotent, listing-as-folded-set model already makes folds cacheable, so the
+seam is clean.
+
+**Scope.**
+- A process-wide scheduler owning fold execution: callers submit **fold
+  intents** (a set of source keys to fold into a given output context) and
+  receive a stream of completions.
+- **Dedup:** an in-flight fold of a given `(source_key → output)` is shared by
+  all callers that want it, rather than re-fetched/re-decoded.
+- **Concurrency cap:** one global limit on concurrent S3 GET + decode, replacing
+  the current per-request behavior.
+- **Fairness / balancing policy:** the hook coverage symmetry will later use to
+  keep two (or N) related work-lists progressing at comparable rates.
+- **`fold_stream::drive` is refactored to consume the scheduler** instead of
+  folding files itself; the two `Phase`s (Seeding, Folding) and the
+  snapshot-per-step cadence are preserved.
+
+**Data / API / UI.**
+- Data: no schema change. Pure execution-path infra.
+- API: **no visible change.** All three endpoints route through the scheduler
+  and must return identical responses and SSE cadence.
+- UI: none.
+
+**Demo / exit criteria.** Not a user demo. Exit = the three existing endpoints
+pass their current tests unchanged through the scheduler, plus new tests for
+dedup (two overlapping requests fold each shared file once) and the global
+concurrency cap. Run the stress suite — this touches the hot fold path.
+
+**Risk.** Highest-risk slice (reworks the shared fold engine with no new
+feature to justify it if it slips). Mitigated by the `b = ∅` / no-visible-change
+contract: it is a pure refactor gated on the existing endpoints' test suites.
+
+---
+
+## S1 — Load-test window comparison (spans p99), end-to-end
+
+**The demo.** Compare the **beginning of a load test vs the end**: same service
+and hosts, two different time windows (`start_ns`/`end_ns`). The spans view
+shows one aligned table ranked by p99 shift — "as load ramped, `db.query` p99
+went 12ms → 340ms." This is the first true diff and a real diagnostic.
+
+**Why this is the ideal S1.** Both selections differ **only in scope**
+(`start_ns`/`end_ns`) — no new filter plumbing, no pop-out UX yet, no derived
+statistics. It exercises S0 with two overlapping-but-distinct file sets
+(the scheduler folds the union, balances the two windows) and proves the whole
+data→API→UI path on the simplest possible B.
+
+**Data.** None new — `spans/` already carries `end_ns - start_ns` and
+percentiles are already computed.
+
+**API.** Add the `b=<base64url(SpanStatsParams)>` **compare mode** to
+`/api/span-stats` (PRD §8.2):
+- `b` absent → today's `SpanStatsResponse`, unchanged.
+- `b` present → resolve both selections (two `Scope`s differing only in the time
+  window), submit **both** fold intents to the S0 scheduler, and stream a
+  `DiffSnapshot<SpanStatsResponse>` (PRD §8.4): `{ a, b, diff, ranked,
+  coverage_a, coverage_b, comparable }`.
+- `ranked`: `Difference` rows for span types, sorted by |Δ p99|, with
+  `membership` (Both / OnlyA / OnlyB). Bounded top-N.
+- `comparable`: the coverage-symmetry gate, driven by the scheduler's balanced
+  progress (S0).
+
+**UI.** Fork `span_explorer.html` → the unified shell (first appearance). The
+shell has three regions: a **collapsible time-navigation pane** (top or side),
+the aligned diff table, and the significant-difference rail.
+
+- **Collapsible time pane = the embedded S3-browser heatmap.** This is how you
+  pick A and B and how you stay oriented in time. It is the existing
+  time × (service/host) **density heatmap** (X = wall-clock, rows = hosts, cells
+  = bytes/time) — *not* a new widget. **Drag window A, drag window B**; each
+  drag produces the `{keys, t0, t1}` selection the browser already computes,
+  which `encodeAggregationParams()` already turns into `start_ns`/`end_ns`.
+  A and B render as two labeled brushed bands (teal / coral) on the same axis.
+  The pane collapses so the table can take the full height once the windows
+  are set.
+  - **Prerequisite inside this slice:** extract the ~350 lines of heatmap
+    renderer + interaction currently inlined in `index.html`
+    (`renderHeatmap` / `drawHeatmapCanvas` / `drawHeatmapAxis` /
+    `setupHeatmapInteraction`, hardcoded to element IDs and module-globals) into
+    a **container-scoped component**. The pure `heatmap.js` core (density,
+    grouping, ticks, gaps, boot transitions) is reused **unchanged**. `index.html`
+    then consumes the same component, so the browser and the unified pane do not
+    diverge.
+- **Exemplar overlay on the time axis (the second reason for the pane).** Each
+  span type's `Exemplar` rows already carry `start_ns` + `host` (epoch ns; no
+  backend change). Overlay them as markers on the heatmap: `start_ns / 1e9` →
+  the existing `timeToX()`, row matched by `host`. This is an additive canvas
+  pass (same shape as the existing boot-transition dividers). Clicking a marker
+  deep-links to that exact span (`focus_start`/`focus_end`), and — because the
+  markers sit on the A/B bands — you *see* that the slow exemplars cluster in
+  window B, not A. Selecting a span-type row highlights its exemplars in the
+  pane.
+- One **aligned diff table**: one row per span type, the **p99 distribution
+  overlay** column (A/B histograms + p50/p99/p999 markers), occurrences A→B.
+- The **significant-difference rail**, ranked by p99 shift, derived from
+  `ranked`.
+- Per-side **coverage badges** and the **"differences preliminary"** gate while
+  `comparable` is false.
+
+**Demo / exit criteria.** On a real load-test trace: open the fork; in the time
+pane, drag window A over the first minutes and window B over the last minutes;
+see the aligned table + ranked rail flip from "preliminary" to live as the
+scheduler balances coverage; see the slow `db.query` exemplars light up under
+window B on the time axis. Collapse the pane to read the table full-height. The
+three existing pages are untouched.
+
+---
+
+## S2 — Compare / pop-out UX
+
+**The demo.** From a single baseline (Inspect), click **Compare → pop out
+> p99** (or "pop out this span type") and watch it split into A vs B with the
+`NOT P` complement auto-added to A.
+
+**Builds on S1's endpoint — no new server capability.**
+
+**API.** None (S1's `b=` mode already accepts arbitrary B params). Possibly a
+tiny helper to compute the frozen p99 threshold, but that can be client-side off
+the current snapshot.
+
+**UI.**
+- **Pop-out**: any narrowing criterion splits into A vs B; B = baseline ∩ P;
+  A gets a visible, removable `NOT P` chip (PRD §2.3).
+- **Derived-statistic freezing**: "> p99" freezes to an editable
+  `duration_ns > X` chip with provenance ("derived: p99 @ cov …") and a refresh
+  (PRD §2.4).
+- **Inspect ⇄ Compare** layout transition (single full-width ↔ split).
+- **Shareable-URL codec**: A encoded fully, B as a delta from A (PRD §9).
+
+**Demo / exit criteria.** Pop out ">p99" from a baseline; copy the comparison
+link; reload it and land on the same diff. Remove the `NOT P` chip → B vs whole
+baseline.
+
+---
+
+## S3 — Full spans diff vocabulary
+
+**The demo.** The rich spans diff: composition **reallocation** ("on-cpu −37pp,
+async-wait +24pp"), inline segment times, new/gone badges — the whole aligned
+table from the mock.
+
+**API.** Minor — the `DiffSnapshot` `diff`/`ranked` already carry composition
+and membership; this slice surfaces per-category composition deltas in the
+envelope if not already present.
+
+**UI.** The composition cell (A-over-B stacked bars, inline-labeled with time),
+new/gone row badges, rank-by-share vs rank-by-Δ% toggle. Completes the spans
+view to the mock's fidelity.
+
+**Demo / exit criteria.** The spans diff matches the
+`concept-diff-first.html` mock.
+
+---
+
+## S4 — Flamegraph view diff (server-side merge)
+
+**The demo.** Two synced rich flamegraph panels *inside* the unified shell (no
+`window.open`), delta-colored, with the flamegraph significant-difference
+listing table.
+
+**API.** Add the `b=` compare mode to `/api/flamegraph`, streaming
+`DiffSnapshot<FlamegraphResponse>`. The tree **merge moves from
+`flamegraph_diff.js` into Rust** (PRD §8.3), over the kind-agnostic accumulator.
+Both sides fold via the S0 scheduler.
+
+**UI.** Embed the feature-rich flamegraph renderer as a **view inside the
+shell**, two synced panels (zoom/search/inspect mirrored), user-selectable
+coloring, the differences listing table. The legacy `?diff=1` client merge is
+kept only as a fallback for the old page until retired.
+
+**Demo / exit criteria.** Compare two windows on the flamegraph view; zoom in
+one, the other follows; unsymbolized frames excluded from the ranking.
+
+---
+
+## S5 — Tokio view via group-by-attribute
+
+**The demo.** Tokio poll diff in the unified shell: `kind = tokio_poll` grouped
+by spawn location, poll-duration distribution + on/off-cpu reallocation per
+spawn location, A vs B.
+
+**API.** Add `group_by=<attribute-key>` to `/api/span-stats` (PRD §8.5,
+query-side of ADR-0005). `group_by=spawn_location` over `tokio_poll` spans is
+the tokio view. Retain the `polls/` projection until measured evidence supports
+collapsing it into `spans/`.
+
+**UI.** The tokio view as a grouping preset of the spans view; the group-by
+control exposes other attributes (route, host, …). The old `/api/tokio-stats`
+page stays live until parity.
+
+**Demo / exit criteria.** Load-test window diff, tokio view: see which spawn
+location's polls got slower and how their on/off-cpu split reallocated.
+
+---
+
+## Deferred beyond these slices
+
+- **Cross-view significant-difference summary** (one ranked "what changed"
+  across all views) — needs a common significance metric (PRD §6).
+- **Per-difference confidence intervals** — the honest end-state for ranking
+  (PRD §7.2).
+- **Per-instance correlation** ("elapsed correlates with `db_time`
+  span-by-span") — needs per-span joins (PRD §3.1).
+- **Collapsing `polls/` into `spans/`** — storage decision gated on measurement.
+- **Retiring the three legacy pages** — only once the unified view is strictly
+  better per view.
+
+## Dependency order
+
+```
+S0 (scheduler) ──► S1 (spans window diff) ──► S2 (pop-out UX) ──► S3 (spans vocabulary)
+                        │
+                        ├──► S4 (flamegraph diff)      [needs S0 + the shell from S1]
+                        └──► S5 (tokio via group-by)   [needs S1's spans endpoint]
+```
+
+S1 establishes the shell and the `DiffSnapshot` contract; S2–S5 extend it. S4
+and S5 depend on S1's shell but not on each other.

--- a/docs/design/diff-first-unified-view.md
+++ b/docs/design/diff-first-unified-view.md
@@ -1,0 +1,652 @@
+# Diff-first unified view
+
+## Overview
+
+Today the dial9 viewer has three separate analysis surfaces — the flamegraph,
+the span explorer (`/api/span-stats`), and tokio stats (`/api/tokio-stats`) —
+on three pages linked only by URL query strings, with one-directional deep
+links between them. A minimal two-sided differential flamegraph exists
+(`?diff=1` in `flamegraph.html`), but diffing lives only there.
+
+This design makes **comparison the primary paradigm**. Every analysis surface
+is built to compare two *selections*, **A** (the baseline) and **B** (the focus
+/ anomaly). Looking at a single slice of data is the special case where **B is
+empty** — a diff against "a perfect world where everything was infinitely
+fast/cheap." The three surfaces stop being separate pages and become **views**
+over one shared selection: switching from the flamegraph view to the spans view
+re-runs the *same* A/B selection against a different endpoint.
+
+The headline capability is to **pull out the most significant differences**
+between A and B — "p99 of `db.query` went 12ms → 340ms", "this frame didn't
+exist in A but dominates B", "on-cpu time drained into lock contention" — and
+to do so honestly under demand-driven partial folds.
+
+This is the presentation/analysis layer built on top of
+[generalized-span-flamegraphs.md](./generalized-span-flamegraphs.md) (the data
+layer: producer events, folded Parquet schema, wall-clock attribution, and the
+`/api/span-stats` query interface). Domain vocabulary is defined in
+[`CONTEXT.md`](../../CONTEXT.md) ("Unified diff-first view" section); this doc
+is the narrative spec. Key decisions are recorded in
+[ADR-0004](../adr/0004-diff-is-computed-server-side.md) and
+[ADR-0005](../adr/0005-span-type-identity-excludes-metadata.md). A clickable
+mock lives at `docs/ui-inventory/mocks/concept-diff-first.html`.
+
+## Goals
+
+- Make **comparison the default paradigm**: one page, one renderer per view,
+  always speaking in terms of A vs B; a single slice is B = ∅.
+- Let a user build A and B as **arbitrary shared filter sets**, and refine B
+  from A with a single "Compare" action ("pop out > p99", "pop out this span").
+- **Surface the most significant differences** per view, ranked and legible.
+- Show the *difference*, not "here is A / here is B": every quantity renders
+  through a small, reused **diff vocabulary**.
+- Be **honest under partial folds**: suppress rankings until A and B reach
+  comparable coverage; never present sampling noise as a headline finding.
+- Analyze polls, worker-active intervals, and tracing spans through **one
+  uniform in-code span model** and one set of analysis machinery.
+- Keep the whole comparison a **shareable, self-contained URL**.
+- Grow incrementally from the existing span explorer without deleting the
+  current pages before parity.
+
+## Non-goals
+
+- A literal always-two-panels UI (the one-sided case is a single full-width
+  panel; "B = ∅" is a conceptual unification, not a permanent empty pane).
+- A unified cross-view "what changed" ranking in v1 (deferred — needs a common
+  significance metric across heterogeneous deltas).
+- Genuine per-instance correlation ("elapsed correlates with `db_time`
+  span-by-span") in v1 (deferred — needs per-span joins that fight the
+  source-file-bounded model).
+- Global cross-file span reconstruction (inherited non-goal from the
+  generalized-span design; duration decomposition stays source-file-bounded).
+- Merging tracing spans and tokio tasks into one on-disk table or one on-screen
+  table.
+- Asserting causation. We surface differences ("auto-(not-quite-)root-cause"),
+  we do not claim root cause.
+
+---
+
+## 1. The paradigm
+
+### 1.1 Diffability
+
+Every view compares two **selections**, A and B. A single-slice view is the
+special case B = ∅. We strive for a **single-view** experience: one page, one
+renderer per view, always in terms of A vs B. Legacy single-slice pages are not
+deleted on day one, but new work is designed diff-first.
+
+"Comparison" is **not a mode** — it is the paradigm. Avoid calling it a
+comparison mode.
+
+### 1.2 One renderer, two layout modes
+
+"B = ∅" is the *conceptual* unification (same data model, same renderer code,
+B's filter set merely empty) — **not** a literal always-two-panels UI:
+
+- **Inspect** (B = ∅) renders a **single full-width panel** with all rich
+  features.
+- **Compare** transitions it into the **split** two-panel layout by revealing
+  the B panel.
+
+An always-present empty/ghost B panel is rejected — it would waste the viewport
+the UX audit already flags as too empty on cold open. One renderer, one
+selection model, two layouts.
+
+---
+
+## 2. Selection model
+
+### 2.1 Selection
+
+A **selection** (A or B) is a **shared filter set** — a predicate over the
+trace data — applied uniformly across every view. It would make no sense to
+change the filter criteria for just one view. The filter set is the *union*
+across views: one selection can carry a `span_type_uid`, a duration band, a
+`thread_class`, and an attribute-equality filter at once, and each view uses the
+subset it understands.
+
+The same set of fields plays two roles. As a **predicate** a field filters
+(`service = Foo`, duration `> X`). As a **consequent** the same field is a
+computed result of the selection ("given that predicate, p99 is now X"). The
+diff highlights how a consequent changed between A and B.
+
+### 2.2 Building A: the baseline
+
+The **baseline** (selection A) is built in the viewer / S3 browser by
+quick-click buttons — "whole service", "whole host" (new; these do not exist
+today) — or today's drag-select. From the baseline you can **Inspect**
+(one-sided) or **Compare**.
+
+### 2.3 Building B: Compare (pop-out)
+
+**Compare** creates selection B from the baseline. Any criterion you could
+otherwise apply to narrow the current view is instead "popped out": rather than
+narrowing in place, it **splits** into A vs B, where **B gets the popped
+predicate `P`**.
+
+By default the two sides are **disjoint**: B = baseline ∩ `P`, and A gets a
+visible `NOT P` filter chip auto-added so A = baseline ∖ `P` — "the matching
+subset vs the rest." This maximizes the significant-difference signal (comparing
+a tail against a population that *includes* it dilutes the contrast). The
+`NOT P` chip is **not a hidden mode**: it is an ordinary filter on A, shown like
+any other; clicking it away reverts to "B vs the whole baseline" (A ⊇ B).
+
+So B is normally a *refinement* of A's predicate, expressed entirely in the one
+uniform filter model. A general filter-builder (arbitrary independent A and B)
+still exists and is primary; pop-out is the common path. The existing "Add to
+diff" capture tray and the derive-B presets (same-scope-different-host,
+time-shifted) are demoted to accelerators that *populate* the builder.
+
+### 2.4 Derived-statistic filters (e.g. "> p99")
+
+A pop-out predicate over a *computed aggregate* (a percentile) is
+coverage-dependent — it is computed over whatever is folded so far, unlike a
+row-level predicate (`region = Bar`) which is stable as coverage grows.
+
+On pop-out it is **frozen to a concrete, editable row predicate**
+(`duration_ns > 340ms`, the p99 at that moment) so it behaves like every other
+filter — single-pass scan, coverage-symmetry gating, and the `NOT P` complement
+all just work. The chip **tracks its provenance** ("derived: p99 @ cov 12/480")
+so a **refresh** recomputes the threshold against all currently-folded data.
+Frozen for stability by default; re-derivable on demand. A *live* percentile
+filter is rejected — its membership would churn as files land, fighting
+coverage-symmetry and jittering the ranking.
+
+### 2.5 "Everything" is never literally 100%
+
+The canonical "B is everything" is **always a cap-bounded, representative
+sample** — nothing in the system is ever literally 100% of the data (the
+sampling cap and order key guarantee a uniform spread; the coverage badge tells
+the truth, e.g. "100 / 45,000 files, 0.2%"). In the pop-out flow, "everything"
+means A's **coarse scope minus the popped predicate** (the `NOT P` complement
+within A's time/service window) — bounded by construction and the more useful
+comparison (it controls for time-of-day and deploy version; the literal
+all-time fleet would confound). A genuinely fleet-wide B is an explicit,
+clearly-labeled choice, not the default.
+
+### 2.6 What carries when switching views
+
+- **Semantic** state — any filter, a focused span type, a time sub-range — is
+  *just a filter*, lives in the selection, and carries across views
+  automatically. Selecting span `auth` in the spans view and switching to the
+  flamegraph scopes the flamegraph to `auth`; this falls out of the selection
+  model, it is not a special cross-view rule.
+- **Navigation** state — flamegraph zoom rectangle, butterfly/inspect root,
+  exact search string, histogram brush geometry — is purely mechanical, stays
+  **per-view**, and is remembered per-view so switching away and back restores
+  your place.
+
+### 2.7 View-local filters
+
+A view may *add* filter criteria on top of the shared selection, in that view's
+own terms — e.g. right-clicking a flamegraph frame to keep only samples through
+that code path. A view-local filter can target **A only, B only, or both** —
+all three are legitimate (both = keep the sides honestly comparable; one side =
+ask a lopsided question). When a filter targets only one side, A and B are no
+longer defined by the same predicate, and the UI **must make that asymmetry
+visible rather than silent**. View-local filters are undoable via a
+breadcrumb/zoom history.
+
+---
+
+## 3. The diff vocabulary
+
+Showing "here is A" beside "here is B" is not showing the difference — it makes
+the reader compute the diff by eye. Instead, every quantity is one of a few
+**diffable types**, and each type has **one canonical A-vs-B rendering**, reused
+across all views so a p99 diff looks and behaves the same in the spans table, a
+flamegraph tooltip, and the significant-difference rail.
+
+| Diffable type | Examples | Canonical diff rendering |
+|---|---|---|
+| **Scalar** | p50/p95/p99, count, mean poll, a `db_time` metric | **Dumbbell** — A-dot and B-dot on one shared (log) axis joined by a colored bar; length + direction = the change |
+| **Distribution** | a span type's duration histogram | **Overlaid histograms** on a shared log axis, with **p50 / p99 / p999 markers** that move with the distribution (line-style encodes the percentile: solid p50, dashed p99, dotted p999; color encodes the side). Shows the whole shift, not three numbers |
+| **Composition (reallocation)** | the five-way time breakdown; nested child-span time | Two stacked bars, **A over B**, segments labeled inline with category **and the time they represent** (pct × that side's p99 elapsed); a one-line note names the biggest mover |
+| **Set membership** | which span types / frames exist | **new / gone** badges |
+| **Tree** | call graph; nested time-attribution | **delta-colored flame / icicle** |
+
+**Consequence for tabular views:** a spans or tokio view is **not two tables**.
+It is **one aligned table** — one row per identity (union of A and B), each cell
+rendering its quantity's diff primitive. **The row is the diff.** Sorting by
+change-magnitude merges the aligned table with the significant-difference rail.
+The rail derives from the same numbers as the table, so they never disagree.
+
+Avoid side-by-side A/B tables — that is "show both", the failure mode this
+vocabulary exists to kill.
+
+### 3.1 Time-attribution is a metric bag, not necessarily a tree
+
+"Where did a span's elapsed time go" generalizes beyond the fixed five-way
+breakdown (on-cpu / sync-block / async-wait / sched-delay / unknown). A span
+carries a **bag of measured quantities**; the subset that are *durations*
+(`db_time`, `on_cpu`, a child span's contribution) are what "composition" is
+made of.
+
+- A `db_time` **metric attached to the span** is the easy, always-available
+  case → scalar dumbbell diff.
+- A nested parent/child **tree** is the richer case when containment exists →
+  delta-tree diff.
+
+The diff engine does not distinguish them — it diffs numbers grouped by
+identity; the tree is a *rendering* choice for when the numbers nest, not a
+separate diffable type. So the fixed five-way bar is just the shallowest
+projection. This lets "my p99 is slow *because* `db.query` is slow" read
+straight out of the A-vs-B diff, since B is already the p99 tail.
+
+Two honesty/scope constraints:
+
+- **Mandatory `unknown`.** Any duration decomposition is source-file-bounded
+  (no global span-graph reconstruction). It must always carry an explicit
+  `unknown` node and never be fabricated to sum to 100%. The on-cpu portion
+  falls out of the enriched sample scan (`enclosing_spans` depth 0–2); the
+  by-child *wall-time* split is the bounded part.
+- **Aggregate diff ≠ per-instance correlation.** The A-vs-B diff gives the
+  aggregate claim ("the slow bucket spends proportionally more time in
+  `db.query`"), which needs no new machinery because B = the tail. Genuine
+  per-instance correlation is a separate, deferred capability.
+
+### 3.2 Unsymbolized frames excluded from diff
+
+Frames whose addresses did not resolve to a symbol are **excluded** from diff
+coloring and the significant-difference listing. Unsymbolized frames will
+essentially always differ between A and B (different raw addresses), so
+including them would flood the ranking with noise that is not a real behavioral
+difference.
+
+---
+
+## 4. Views
+
+A **view** is one way of presenting a selection pair. Switching views re-runs
+the same A/B selection against a different endpoint; the selection is unchanged.
+Avoid calling views "lenses" (too close to "filter/predicate").
+
+### 4.0 The time-navigation pane (shared shell chrome)
+
+The unified shell embeds a **collapsible time-navigation pane** — a version of
+the S3 browser's density heatmap — as shared chrome above/beside the views. It
+serves two jobs that no other part of the UI does:
+
+1. **It is where A and B are picked, and where you stay oriented in time.** The
+   pane is the existing time × (service/host) density heatmap (X = wall-clock,
+   rows = hosts, cells = bytes/time). You **drag window A, drag window B**; each
+   drag is the selection the browser already computes and encodes as
+   `start_ns`/`end_ns`. A and B show as two labeled brushed bands on the same
+   axis. Without this, a selection is an abstract filter set with no "where am I
+   in time" anchor; with it, the load-test-window comparison (start vs end) is a
+   direct gesture. The pane collapses once the windows are set.
+2. **It is where exemplars land back.** Each span type's slow `Exemplar`s carry
+   `start_ns` + `host`; overlaying them as markers on the heatmap's time axis
+   (row matched by host) shows *when and where* the anomalies happen — and,
+   because they sit on the A/B bands, that the slow tail clusters in B, not A.
+   Selecting a span-type row highlights its exemplars in the pane; clicking a
+   marker deep-links to that exact span.
+
+The pane reuses the pure `heatmap.js` core unchanged; the renderer/interaction
+(currently inlined in `index.html`) is extracted into a container-scoped
+component so the browser and the pane share one implementation. No backend
+change is needed for the exemplar overlay — the time/host fields already exist
+on `Exemplar`.
+
+### 4.1 Flamegraph view
+
+The diff capability is folded **into** the feature-rich flamegraph renderer
+(search, inspect/butterfly, zoom history) — not built on top of the minimal
+two-sided diff renderer. Layout is **two synced rich panels**: A left, B right,
+each the full renderer, kept in sync — zoom in one zooms the other to the same
+frame path, search highlights matches in both, inspect/butterfly roots both at
+the same frame. That synchronization is what makes it "one view of two things"
+rather than two independent flamegraphs.
+
+Each existing feature grows a side-by-side variant: e.g. search shows the
+matched field in *each* selection with each side's representative percentage.
+The color encoding is **user-selectable** (delta / hotness / by-module), not a
+fixed hotness scale; in the B = ∅ case the delta coloring and the "A heavier ↔
+B heavier" ramp are meaningless and are replaced by a neutral single-selection
+coloring. Alongside the panels is a **listing table** of the biggest
+differences, ranked by both **percentage** delta and **absolute sample-count**
+delta — the flamegraph view's instance of the significant-difference feature.
+
+A single merged delta-colored tree is a possible later toggle, not the primary
+layout (self-normalized side-by-side widths are more legible than delta-color on
+one tree).
+
+### 4.2 Spans view
+
+One aligned diff table (§3), one row per span type (union of A and B). Cells:
+occurrences (A→B), duration **distribution** (overlaid histograms + p50/p99/p999
+markers), and **composition** (A-over-B stacked bars, inline-labeled with time),
+plus new/gone membership badges. The catalog groups by span type but can group
+by any attribute (§4.4).
+
+### 4.3 Tokio view
+
+The tokio view is the spans view of `kind = tokio_poll` **grouped by spawn
+location** — the old tokio-stats shape, produced by the same machinery. Poll
+durations render with the same distribution + composition primitives;
+on-cpu/off-cpu is the five-way composition; the old top-N "longest polls" list
+is the span view's slow-exemplars.
+
+### 4.4 Group-by-attribute
+
+A span type is **not** subdivided by its metadata: all polls are one type
+(`kind = tokio_poll`). Instead, spawn location is typed metadata and the span
+machinery has a first-class **group-by-attribute** capability — the tokio view
+is "spans of kind `tokio_poll`, grouped by spawn location." This generalizes:
+tracing spans can group by any attribute (e.g. `handle_request` by `route`).
+Grouping is a runtime operation over metadata, not baked identity. This
+**departs from** generalized-span §1.1 (which baked spawn location into the type
+UID); see [ADR-0005](../adr/0005-span-type-identity-excludes-metadata.md).
+
+---
+
+## 5. Span-kind unification
+
+Polls (`PollStart`/`PollEnd`), worker-active intervals
+(`WorkerUnpark`/`WorkerPark`), and tracing spans are all analyzed as **spans**.
+The unification is at the level of *in-code representation and analysis
+machinery*, not storage and not presentation:
+
+- **Storage stays separate.** The physical `polls/` projection and the `spans/`
+  table remain distinct — polls are the highest-volume event class, and folding
+  every poll into a full span row is a deferred storage cost (see the
+  generalized-span design). The worker-active interval is a further span *kind*.
+- **In-code representation is uniform.** After leaving Parquet, every kind
+  deserializes into one span type. Kind-specific metadata (e.g. tokio spawn
+  location) rides as typed fields — special-cased decoding
+  (`derive(Deserialize)`-style), not a separate code path.
+  `kind ∈ {tracing, tokio_poll, worker_park}`.
+- **Analysis machinery is shared.** Anything computing span lengths,
+  frequencies, percentiles, or composition runs over any kind. If poll times for
+  one spawn location are far longer than their peers, that is *interesting* and
+  it is found by the *same code* that ranks tracing spans.
+- **Worker-active span** = the `[WorkerUnpark, WorkerPark)` interval during
+  which a worker is **busy** (running tasks), *not* idle. Same polarity as a
+  poll: more of them, or longer ones, means the runtime is busier. (This is the
+  interval CONTEXT's Worker attribution section calls the "active span".)
+- **Presentation stays separate.** It does not make sense to list tracing spans
+  and tokio tasks in the same view table. The view groups by kind; the shared
+  machinery is what makes cross-kind observations possible.
+
+---
+
+## 6. Significant differences
+
+The "pull out the most significant differences" feature is ranked
+**per-view**, in that view's own units:
+
+- flamegraph: |Δ self-fraction| of a frame, including frames present on only one
+  side;
+- spans: |Δ p99| / |Δ mean| of a span type;
+- tokio: |Δ mean poll| / |Δ p99| of a spawn location.
+
+A unified **cross-view** ranking — one "what changed" summary drawing the
+globally most significant deltas from every view — is the aspiration but is
+**deferred**: it needs a common significance metric to compare heterogeneous
+deltas (Δp99-of-a-span vs Δself-fraction-of-a-frame), which is unsolved. Ship
+per-view first, learn what "significant" means empirically, then attempt the
+summary.
+
+We surface differences; we do not assert causation.
+
+---
+
+## 7. Honesty under partial folds
+
+### 7.1 Coverage symmetry
+
+A/B differences are only trustworthy when both selections have folded a
+*comparable* fraction of their matched set. Comparing a 5%-folded A against a
+90%-folded B produces an illusion — B appears to "have" frames A is merely
+missing.
+
+The unified view drives both sides toward comparable sampling caps and
+**suppresses / grays the significant-difference ranking** until both sides
+clear a minimum coverage, showing an explicit "still folding — differences
+preliminary" state instead. This is the v1 guard.
+
+Raw-magnitude ranking with only a coverage badge is explicitly **rejected**: an
+auto-surfaced "top difference" that is sampling noise destroys trust on first
+use.
+
+### 7.2 Confidence intervals (end-state)
+
+The honest end-state is **per-difference confidence intervals** — the planned
+per-node CIs that tighten as files fold. Rank by statistical significance, not
+raw magnitude, so a frame seen once in A and zero times in B sinks rather than
+headlines. This is a substantial statistics effort and is not a v1 blocker.
+
+---
+
+## 8. API design
+
+The diff and the ranked significant-difference list are computed
+**server-side**, not in the browser
+([ADR-0004](../adr/0004-diff-is-computed-server-side.md)). The overriding
+design constraint is that **the current three endpoints already share almost
+everything the compare mode needs** — so compare is mostly *reuse* plus a thin
+envelope, not a new subsystem.
+
+### 8.1 What matches today's APIs (reused unchanged)
+
+The three GET SSE endpoints today are `/api/flamegraph`, `/api/span-stats`,
+`/api/tokio-stats`. They already share:
+
+| Shared piece | Today | In compare |
+|---|---|---|
+| **`Scope`** (`start_ns`, `end_ns`, `service`, `hosts[]`) — `ingest/aggregate.rs` | one per request | one **per side**; a selection's scope subset maps 1:1 |
+| **`AggContext`** (`bucket`/`prefix`/`aws_region`) | resolved from params | unchanged — both sides share one context |
+| **`resolve(agg, scope, RefineOpts{max_files}) → Resolved`** — `ingest/refine.rs` | called once | called **once per side**; each side's `Resolved.folded` + `files_matched` is exactly the coverage-symmetry input |
+| **`fold_stream::drive`** unfold driver — `server/fold_stream.rs` | drives one sink | drives **two** sinks (see §8.3) |
+| **`Coverage`** block (incl. `folded_set_id` = blake3 of the folded-leaf set) | one per snapshot | one **per side**; `folded_set_id` is the symmetry signal |
+| **Per-view filter params** (`thread_class`, `source`, `phase`, `spawn_location`, `span_type_uid`, `min_span_ns`/`max_span_ns`, `min_poll_ns`/`max_poll_ns`, `attr[]`, …) | on the request struct | **unchanged**; each side carries its own set |
+| **Per-view response types** (`FlamegraphResponse`, `SpanStatsResponse`, `TokioStatsResponse`) | the SSE payload | reused verbatim as the `a` and `b` fields of the diff envelope (§8.4) |
+
+The compare mode adds **no new scope/filter/resolve/coverage machinery** — it
+composes the existing pieces.
+
+### 8.2 The request shape: `compare` is a mode, not a new endpoint
+
+Compare is a **mode on each existing endpoint**, keyed by a single new param
+carrying selection B:
+
+```
+GET /api/span-stats?<A's params…>&b=<base64url(B's params)>
+```
+
+- **`b` absent → today's response, byte-for-byte unchanged.** This *is* the
+  "B = ∅ is the special case" principle expressed in the API: the current
+  single-selection endpoint is the compare endpoint with B omitted. No
+  migration of existing callers.
+- **`b` present →** B's params are the *same param struct* as the endpoint's own
+  (`SpanStatsParams`, etc.), base64url-encoded — mirroring the existing client
+  diff's `a=`/`b=` codec (`flamegraph_diff.js`). The **client** expands B's
+  permalink-delta (§9: "B encoded as a delta from A") into a full param set
+  before the call, so the **server stays dumb about the "B refines A"
+  relationship** — it just resolves two independent selections. The `NOT P`
+  complement on A is likewise just an ordinary filter already present in A's
+  params.
+
+Rejected alternative: a separate `/api/compare` route. It would duplicate every
+endpoint's param parsing and validation and force the client to special-case
+which endpoint's compare to call. A per-endpoint `b=` mode keeps validation and
+the response-type family co-located with the single-selection handler.
+
+### 8.3 The two genuinely new server behaviors
+
+Everything else is composition; these two are new code:
+
+1. **Coordinated fold scheduling.** Instead of two independent streams racing
+   (what the client does today — the direct cause of coverage asymmetry), one
+   driver interleaves both sides' fold work to keep
+   `files_folded / files_matched` comparable within a tolerance (not rigid
+   lockstep). Mechanically this is the existing `fold_stream::drive` unfold
+   generalized to alternate between two `Resolved` work-lists / two sinks,
+   emitting a combined snapshot after each step. Because A and B usually share
+   most of their matched files (B refines A's predicate over the same coarse
+   scope), the same folded part often feeds both sides — so a row-level B
+   predicate can be evaluated by **partitioning one fold**, not double-folding.
+2. **Server-side merge + rank.** The tree merge that lives in
+   `flamegraph_diff.js` today moves into Rust, over the kind-agnostic span
+   accumulator ([span-kind unification](#5-span-kind-unification)), producing
+   the merged `diff` structure and the bounded `ranked` list. One
+   implementation serves all three views.
+
+### 8.4 The response envelope: `DiffSnapshot<T>`
+
+Each SSE snapshot wraps the view's **existing** response type, adding the merge,
+the ranking, and per-side coverage:
+
+```rust
+struct DiffSnapshot<T> {          // T = FlamegraphResponse | SpanStatsResponse | TokioStatsResponse
+    a: T,                         // side A — the current response type, unchanged
+    b: T,                         // side B — same type
+    diff: T::Diff,                // merged structure (flamegraph: tree w/ per-node a/b counts;
+                                  //   tabular: rows aligned by identity w/ a/b values)
+    ranked: Vec<Difference>,      // bounded, sorted; the significant-difference list
+    coverage_a: Coverage,         // reused Coverage struct, per side
+    coverage_b: Coverage,
+    comparable: bool,             // coverage-symmetry gate: are the two folded fractions close enough
+                                  //   to trust `ranked`? Client grays the ranking until true.
+}
+
+struct Difference {
+    id: String,                   // frame name / span_type_uid / spawn_loc
+    kind: DiffKind,               // Frame | SpanType | SpawnLoc
+    a_value: f64, b_value: f64,   // the compared consequent (self-fraction, p99, mean poll…)
+    delta_pct: f64,               // relative change  (∞ / −100% encode new / gone)
+    delta_abs: f64,               // absolute change (e.g. sample-count delta)
+    membership: Membership,       // Both | OnlyA | OnlyB
+}
+```
+
+- `a` and `b` are the **unchanged** per-view response types, so a client can
+  render either panel with today's rendering code — the single-selection
+  renderer *is* the per-panel renderer.
+- `diff` is the merged form the two synced panels / the aligned table read from.
+- `ranked` is bounded (top-N, unsymbolized frames excluded) and drives the
+  significant-difference rail; it is derived from the same numbers as `diff`, so
+  they never disagree.
+- `comparable` is the coverage-symmetry gate (§7.1): the client shows the
+  "still folding — differences preliminary" state while it is false.
+
+### 8.5 Group-by-attribute (extends span-stats §5)
+
+Independent of compare, the span-stats query gains a `group_by=<attribute-key>`
+param (default: span-type identity). It regroups the same folded rows by any
+metadata key (e.g. `group_by=spawn_location` is the tokio view;
+`group_by=route` groups `handle_request` by route). This is the query-side of
+[ADR-0005](../adr/0005-span-type-identity-excludes-metadata.md) — grouping is a
+runtime operation, not baked into `span_type_uid`.
+
+### 8.6 What the client keeps
+
+The **client** renders the two synced panels + aligned table + rail, and owns
+only interactive navigation (zoom / search / inspect) over the shipped
+structure. The legacy `flamegraph_diff.js` client merge is superseded (kept, if
+at all, as a thin fallback for the old `?diff=1` page until it is retired).
+
+This section extends the query interface in generalized-span §5 with (a) the
+group-by-attribute capability and (b) the compare mode + `DiffSnapshot`
+envelope.
+
+---
+
+## 9. Shareable state
+
+The whole comparison is a **shareable, self-contained URL** — required to not
+regress the UX audit's task-blocking finding that view state lives only in
+memory. Encoding:
+
+- **A is encoded fully; B is encoded as a *delta* from A** (the popped
+  predicate(s) + any auto-added `NOT P`), because B is normally a refinement of
+  A. This keeps URLs compact as the filter set grows and makes "B is a
+  refinement of A" explicit in the URL structure. A fully-independent B (rare)
+  falls back to a full encode.
+- Per-view navigation state, the active view, the color encoding, and
+  derived-statistic-filter provenance ride as additional URL params.
+- No server-side saved-selection storage — the model stays URL-self-contained
+  (credentials in `sessionStorage`, everything else in the URL).
+
+---
+
+## 10. Delivery plan
+
+The vertical slices are specified in
+[diff-first-delivery.md](./diff-first-delivery.md). Summary: a **general fold
+scheduler is built first (S0)** — foundational infra so coverage symmetry is
+correct from the first diff — then the diff capability lands as vertical slices
+that each cut data → API → UI and end demoable: **S1** load-test window
+comparison (spans p99), **S2** Compare/pop-out UX, **S3** full spans vocabulary,
+**S4** flamegraph view diff, **S5** tokio via group-by-attribute.
+
+The unified view is grown by **forking the current span explorer page** as the
+host shell, then *adding* to it — not a greenfield rewrite and not
+flamegraph-first. The span explorer is already closest to the destination: it
+hits `/api/span-stats`, has the catalog → select → drill-into-flamegraph flow,
+computes the percentiles/composition/exemplars that are the raw material for the
+significant-difference feature, and owns the span→flamegraph deep link. Forking
+protects the live page while building.
+
+1. **Selection shell.** Add the A/B selection model + Compare pop-out (with the
+   `NOT P` complement and derived-statistic freezing) to the fork; wire the
+   shareable-URL codec.
+2. **Spans diff.** Diff the span catalog the fork already renders — the aligned
+   table (§3) and the spans-view significant-difference rail. Add
+   group-by-attribute and the server-side compare mode (§8).
+3. **Embed the flamegraph view.** Fold the rich flamegraph renderer in as a view
+   *inside* the shell (two synced panels), so the flamegraph stops being a
+   separate `window.open` page.
+4. **Tokio view.** Group `tokio_poll` spans by spawn location; retain the
+   `polls/` projection until measured evidence supports collapsing it.
+5. **Coverage honesty.** Coverage-symmetry gating and the "differences
+   preliminary" state; per-difference confidence intervals later.
+
+The three existing pages (flamegraph, span_explorer, tokio_stats) stay alive and
+**un-deprecated** until the unified view reaches per-view feature parity; a page
+is deleted only when its unified equivalent is strictly better. The cross-view
+significant-difference summary and per-instance correlation are deferred beyond
+the first slices.
+
+## Alternatives considered
+
+### Literal single-renderer (diff-against-empty always)
+
+Rejected as the *implementation*, kept as the *mental model*. Routing a plain
+single flamegraph through the two-sided merge/color code would regress the
+working single-view rendering, make "heavier in A vs B" coloring meaningless
+against an empty side, and leave the significant-difference ranking undefined.
+Instead: one renderer and one selection model, with two layout modes (§1.2).
+
+### Client-side diff (extend `flamegraph_diff.js`)
+
+Rejected for the general case (ADR-0004). Client-side ranking can only rank what
+was shipped, reintroducing a sampling bias the server does not have, and would
+require re-implementing merge+rank per view in JS.
+
+### A separate `/api/compare` endpoint
+
+Rejected (§8.2). It would duplicate every endpoint's param parsing and
+validation and force the client to special-case which view's compare to call. A
+per-endpoint `b=<base64>` **mode** keeps validation and the response-type family
+co-located with the single-selection handler, and makes "B = ∅ → today's
+response, unchanged" fall out for free (compare is the current endpoint with B
+omitted). It also preserves backward compatibility: existing single-selection
+callers are untouched.
+
+### Spawn-location baked into the poll span-type identity
+
+Rejected (ADR-0005). Baking one attribute into `span_type_uid` does not
+generalize; a runtime group-by-attribute capability serves polls-by-spawn-loc
+and tracing-spans-by-route with the same mechanism.
+
+### Side-by-side A/B tables
+
+Rejected (§3). Two tables make the reader compute the diff by eye; the diff
+vocabulary renders the difference directly, with the row as the unit of diff.
+
+### Unified cross-view significance ranking in v1
+
+Deferred (§6). Comparing Δp99-of-a-span against Δself-fraction-of-a-frame needs
+a common significance metric that does not yet exist; per-view ranking ships
+first.

--- a/docs/design/generalized-span-flamegraphs.md
+++ b/docs/design/generalized-span-flamegraphs.md
@@ -1,0 +1,561 @@
+# Generalized span flamegraphs
+
+## Overview
+
+Generalize dial9's poll-duration flamegraphs so any recorded span type can be
+used as the unit of latency analysis. A Tokio `PollStart` → `PollEnd` interval is
+one built-in span type; tracing spans provide application-defined types such as
+`handle_request`, `query_database`, or `serialize_response`.
+
+The aggregation pipeline remains demand-driven and source-file-bounded. It does
+not attempt to reconstruct a globally complete span graph from a randomly
+sampled, non-contiguous set of trace files. Instead, the producer emits a
+self-contained summary when a tracing span closes. Folding one source file then
+produces:
+
+- one `spans/` row for every close summary in that file, including spans that
+  began before the file;
+- CPU and scheduler sample rows enriched with the locally-known enclosing span
+  summaries, normally zero, one, or two memberships per sample;
+- exact elapsed duration for every closed span, with an explicit indication of
+  how much detailed execution data was available in that source file.
+
+This deliberately accepts the trace rotation period `R` as the practical upper
+bound for complete per-span flamegraph and wall-time detail. A span longer than
+`R` still appears with its correct elapsed duration and final metadata when its
+close event is sampled, but CPU/wait details from source files that were not
+folded are reported as unknown rather than reconstructed heuristically.
+
+## Goals
+
+- Make polls one span type rather than a flamegraph-specific special case.
+- Discover available span types and show occurrence-weighted duration
+  histograms and percentiles.
+- Brush a span-duration range and build flamegraphs from CPU samples enclosed by
+  matching spans.
+- Break elapsed time into estimated on-CPU, estimated synchronous blocking,
+  async wait, Tokio scheduling delay, and unknown time.
+- Keep queries simple: span flamegraphs read enriched sample rows without a
+  temporal join or a globally materialized span graph.
+- Include spans that have no CPU samples in discovery, histograms, percentiles,
+  and wall-time summaries.
+- Preserve demand-driven folding, deterministic per-source output, coverage,
+  and samples-part completion semantics.
+- Read old traces and tolerate old folded output through a format-version bump.
+
+## Non-goals
+
+- Joining arbitrary spans across non-contiguous source files.
+- Recovering complete CPU or wait detail for spans longer than the folded source
+  file.
+- Treating missing CPU samples as exact proof of blocking.
+- Inferring contextual parentage that the tracing layer did not record.
+- Returning every span instance to the browser for fleet-sized scopes.
+- Automatically exposing high-cardinality attributes such as request IDs as UI
+  facets.
+- Replacing the raw trace as the source of truth. Derived attribution may be
+  recomputed by bumping the folded format version.
+
+---
+
+## 1. Span semantics
+
+### 1.1 Span instance and span type
+
+A **span instance** is one occurrence of an operation. A **span type** groups
+instances with the same producer and callsite semantics.
+
+Examples:
+
+| Kind | Span type | Instance |
+|---|---|---|
+| Tokio | `tokio_poll` (kind + callsite) | One task poll |
+| Tracing | target + name + file + line | One tracing span lifecycle |
+
+> **Superseded by [ADR-0005](../adr/0005-span-type-identity-excludes-metadata.md).**
+> This table originally identified the poll span type as "`tokio.poll` +
+> spawn location", baking spawn location into `span_type_uid`. The diff-first
+> design reverses that: span-type identity is **kind + callsite only**, and
+> spawn location is metadata you **group by** at query time (a first-class
+> group-by-attribute capability that also lets tracing spans group by any
+> attribute, e.g. `handle_request` by `route`). See
+> [diff-first-unified-view.md](./diff-first-unified-view.md).
+
+Every interval is half-open: `[start_ns, end_ns)`.
+
+A poll has one execution interval and
+`elapsed_ns == active_wall_ns == PollEnd - PollStart`.
+
+A tracing span has a logical lifecycle and zero or more entered execution
+intervals. An async instrumented operation can enter and exit once per poll and
+can migrate workers. The following terms are intentionally distinct:
+
+- **Elapsed time:** lifecycle close minus lifecycle start.
+- **Active wall time:** wall-clock union of entered intervals observed in the
+  folded source file.
+- **Active thread time:** sum of entered intervals. This may exceed active wall
+  time if the span is entered concurrently.
+- **Detail coverage:** observed active/gap detail compared with elapsed time.
+
+### 1.2 Source-file-bounded completeness
+
+A close summary in source file `F` creates the authoritative span row for that
+fold. Its elapsed duration is complete because the close event carries the
+start timestamp. Its detailed attribution is complete only if all required
+enter/exit, poll, wake, and profiler events are present in `F`.
+
+The row records:
+
+- `details_complete`: the lifecycle and all classified intervals fit within the
+  source file;
+- `detail_coverage_ns`: elapsed time for which the fold had sufficient local
+  structural information;
+- `unknown_ns`: all remaining elapsed time, including unsampled source-file
+  history.
+
+A span that starts in one source file and closes in another therefore appears
+when the close file is folded. It has the true elapsed duration, but the missing
+part is unknown. No neighboring source file is fetched implicitly.
+
+### 1.3 Stable identity
+
+`tracing::span::Id` values may be recycled. `Dial9TracingLayer` assigns each new
+span a process-local monotonically increasing `span_instance_id`. The process
+boot ID from the source path namespaces it across processes. Folded rows use:
+
+```text
+span_uid = BLAKE3(boot_id || span_instance_id)[0..16]
+span_type_uid = BLAKE3(kind || target || name || file || line)[0..16]
+```
+
+The existing tracing ID remains on the wire for old viewer reconstruction, but
+is not the durable folded identity. Explicit parent references use the stable
+instance ID when available. A missing parent is represented as unknown, not as
+an asserted root.
+
+---
+
+## 2. Producer events
+
+### 2.1 Self-contained close summary
+
+Extend `SpanCloseEvent` additively. Old traces omit the new fields; current
+viewers ignore fields they do not use.
+
+Required fields:
+
+```text
+timestamp_ns                 // close timestamp; existing event timestamp
+span_id                      // existing tracing wire ID
+span_instance_id
+start_timestamp_ns           // lifecycle creation/start timestamp
+first_enter_timestamp_ns?    // absent if never entered
+active_ns                    // accumulated enter→exit thread time
+span_name
+target
+file?
+line?
+parent_span_instance_id?
+attributes: MAP<STRING, STRING>
+```
+
+The summary must be sufficient to write a useful `spans/` row even if no enter
+event for that instance is present in the same source file.
+
+The producer tracks `start_timestamp_ns` at `on_new_span`. It accumulates
+`active_ns` across balanced enters/exits. Concurrent or re-entrant entries are
+paired per thread; any unbalanced entries at close set a summary quality flag
+rather than fabricating a duration.
+
+Enter and exit events retain their existing schema for raw timeline rendering.
+They additionally carry `span_instance_id` and `tid`, allowing the folder to
+correlate local execution intervals without relying on worker identity during
+`block_in_place` handoffs.
+
+### 2.2 Effective profiler metadata
+
+The fold needs the effective configuration, not an assumed default. Segment
+metadata records at least:
+
+```text
+cpu.profile.enabled
+cpu.profile.frequency_hz
+cpu.profile.backend
+cpu.profile.event_source
+sched.profile.enabled
+sched.profile.sample_interval
+```
+
+Relevant profiler or recorder drop counts must also be available. Attribution
+is unknown when the effective configuration or loss state is unavailable.
+
+---
+
+## 3. Folded Parquet schema
+
+Changing persisted content increments `SAMPLES_FORMAT_VERSION`. The first
+implementation writes a new versioned tree and lazily refolds source files.
+`ORDER_VERSION` does not change.
+
+### 3.1 Spans table
+
+Path:
+
+```text
+spans/service={service}/date={YYYY-MM-DD}/host={host}/{source_hash}.parquet
+```
+
+One row per span close summary in the source file, plus built-in poll rows when
+the generalized endpoint requests the poll adapter. The existing `polls/`
+projection remains initially for `/api/tokio-stats`; duplicating all polls into
+`spans/` is deferred until storage measurements justify replacing it.
+
+| Column | Type | Nullable | Meaning |
+|---|---|---:|---|
+| `span_uid` | `FIXED_BINARY(16)` | no | Stable instance identity |
+| `span_type_uid` | `FIXED_BINARY(16)` | no | Grouping identity |
+| `kind` | `STRING` | no | `tracing` or `tokio_poll` |
+| `name` | `STRING` | no | Display name |
+| `target` | `STRING` | yes | Tracing target |
+| `callsite_file` | `STRING` | yes | Source file |
+| `callsite_line` | `UINT32` | yes | Source line |
+| `start_ns` | `INT64` | no | Lifecycle start |
+| `end_ns` | `INT64` | no | Lifecycle close |
+| `elapsed_ns` | `INT64` | no | `end_ns - start_ns` |
+| `active_ns` | `INT64` | yes | Producer-accumulated active thread time |
+| `observed_active_wall_ns` | `INT64` | no | Union of local entered intervals |
+| `detail_coverage_ns` | `INT64` | no | Locally classifiable elapsed time |
+| `details_complete` | `BOOL` | no | Complete detail fits in this fold |
+| `concurrent` | `BOOL` | no | Concurrent/re-entrant execution observed |
+| `parent_span_uid` | `FIXED_BINARY(16)` | yes | Explicit stable parent |
+| `attributes` | `MAP<STRING,STRING>` | no | Final close-time attributes |
+| `on_cpu_ns_est` | `INT64` | yes | Sampling estimate |
+| `blocked_ns_est` | `INT64` | yes | Sampling residual estimate |
+| `async_wait_ns` | `INT64` | yes | Not-ready time when task-scoped |
+| `scheduler_delay_ns` | `INT64` | yes | Ready-to-next-poll time |
+| `unknown_ns` | `INT64` | no | Unclassified elapsed time |
+| `cpu_sample_count` | `UINT32` | no | Raw local CPU samples |
+| `sched_sample_count` | `UINT32` | no | Raw local sched samples |
+| `attribution_version` | `UINT16` | no | Derivation algorithm |
+| `attribution_flags` | `UINT32` | no | Missing/lost/ambiguous inputs |
+| `source_key` | `STRING` | no | Origin source file |
+| `host/service/date` | `STRING` | no | Scope columns |
+
+The five time categories plus `unknown_ns` are top-level fields for simple
+aggregation. They are derived caches; raw trace events remain authoritative.
+
+### 3.2 OpenTelemetry Arrow alignment
+
+The folded schema should align with the current OpenTelemetry Arrow Protocol
+(OTAP) where the domain semantics match, without claiming byte-for-byte OTAP
+conformance. OTAP is an experimental Arrow IPC transport and in-memory model;
+dial9 stores a source-file-bounded Parquet analysis cache with additional
+profiling facts.
+
+OTAP represents traces as a normalized star schema: `SPANS`, `SPAN_ATTRS`,
+`SPAN_EVENTS`, `SPAN_LINKS`, and their attribute tables. It deliberately avoids
+putting a complete span hierarchy in a nested `List<Struct>` so each relation can
+be sorted, compressed, projected, and joined independently. Dial9 follows these
+principles:
+
+- use OTLP/OTAP field names and widths when the producer has those semantics:
+  `trace_id` (`FIXED_BINARY(16)`), `span_id` (`FIXED_BINARY(8)`),
+  `parent_span_id` (`FIXED_BINARY(8)`), `trace_state`, `name`, `kind`, start
+  timestamp, duration, status, and dropped counts;
+- keep `span_uid` and `span_type_uid` as explicitly dial9-local identities rather
+  than pretending process-local tracing spans are distributed OTLP traces;
+- reserve nullable OTLP identity/status columns so an OpenTelemetry-integrated
+  producer can populate them without another schema redesign;
+- keep dial9 profiling columns (`on_cpu_ns_est`, `async_wait_ns`, coverage,
+  attribution flags, and so on) in the main span analysis table with a clear
+  `dial9` meaning;
+- preserve current tracing field fidelity as `MAP<STRING,STRING>` initially.
+  OTAP's typed attribute relation (`key`, type tag, and nullable
+  string/integer/double/bool/bytes/serialized value columns) is the evolution
+  path when the producer preserves native field types or OTAP export is added.
+
+The design does not adopt OTAP's batch-local `u16` row IDs as durable span
+identity, nor its stateful IPC dictionary protocol. Parquet dictionary encoding
+and dial9's stable source-file keys serve different purposes.
+
+Authoritative references:
+
+- <https://github.com/open-telemetry/otel-arrow/blob/main/docs/data_model.md>
+- <https://github.com/open-telemetry/otel-arrow/blob/main/docs/otap_basics.md>
+- <https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0156-columnar-encoding.md>
+
+### 3.3 Enriched samples table
+
+Keep all existing sample columns and add only a compact relationship:
+
+```text
+enclosing_spans: LIST<STRUCT<
+    span_uid: FIXED_BINARY(16),
+    span_type_uid: FIXED_BINARY(16),
+    elapsed_ns: INT64,
+    details_complete: BOOL
+>>
+```
+
+Expected membership depth is zero, one, or two for most samples. Full names,
+attributes, wall-time composition, and quality live only in `spans/`; they are
+not duplicated into every sample. The small `elapsed_ns` and completeness cache
+keeps the common type-plus-duration flamegraph filter to one sample scan.
+Attribute and quality flamegraph filters are **deferred** (see §5.2); when
+implemented they will select matching `span_uid`s from the spans part and then
+test the compact membership list.
+
+Only memberships proven by locally observed entered execution intervals are
+attached. Lifecycle containment is not execution containment: samples while an
+async span is exited/waiting must not be attached. A long span may have a
+complete close-summary row in `spans/` but partial or absent memberships for
+samples from other source files. This limitation is explicit in
+`details_complete` and coverage.
+
+For a sample enclosed by multiple selected spans, the flamegraph counts the raw
+sample once. Inclusive per-span summaries may count that sample once for each
+span instance; the UI labels such values inclusive.
+
+### 3.4 Fold commit ordering
+
+Write dictionaries, `polls/`, and `spans/` before `samples/`. Write `samples/`
+last, including an empty part for a source file with no CPU samples. Its presence
+remains the sole folded-set/completion record required by ADR-0003.
+
+---
+
+## 4. Wall-clock attribution
+
+Attribution partitions elapsed time without silently converting uncertainty to
+zero.
+
+### 4.1 Active intervals
+
+For locally observed entered intervals:
+
+```text
+sample_period_ns = 1_000_000_000 / effective_frequency_hz
+on_cpu_ns_est = cpu_sample_count * sample_period_ns
+expected_samples = observed_active_wall_ns * frequency_hz / 1_000_000_000
+```
+
+Clamp display estimates to the observed interval while retaining raw counts.
+When profiler metadata is missing, drops are detected, worker/tid attribution is
+ambiguous, or the interval is too short for useful inference, put the residual
+in `unknown_ns`.
+
+A starting confidence rule is three expected samples. With zero observed samples
+and three expected samples, a continuously on-CPU interval would produce zero
+with probability approximately `e^-3`, or 5%. This remains an estimate and is
+shown as such.
+
+Scheduler samples identify blocking stacks but do not measure blocked duration.
+`blocked_ns_est` is the estimated active-wall residual, not scheduler sample
+count multiplied by a period.
+
+### 4.2 Inactive gaps
+
+Split a gap between entered intervals only when all intervals correlate
+unambiguously to one Tokio task and align with that task's polls:
+
+```text
+previous exit ── async wait ── effective wake ── scheduling delay ── next poll
+```
+
+- `async_wait_ns`: task returned `Pending` and was not ready.
+- `scheduler_delay_ns`: task was ready but not being polled.
+- missing/ambiguous wake or task correlation: unknown.
+
+For generic nested or manually entered spans, inactivity may simply mean the
+surrounding code ran outside the span. It is unknown, not async wait.
+
+The UI label is **Async wait (not ready)** rather than merely **Idle**, avoiding
+confusion with an idle Tokio worker.
+
+### 4.3 Accounting invariant
+
+For every span row:
+
+```text
+elapsed_ns = on_cpu_ns_est
+           + blocked_ns_est
+           + async_wait_ns
+           + scheduler_delay_ns
+           + unknown_ns
+```
+
+Nullable estimates contribute zero only when the corresponding quality flag
+says the category was evaluated and absent. Otherwise their time remains in
+`unknown_ns`.
+
+---
+
+## 5. Backend and query interface
+
+> **Extended by the diff-first design.** This section specifies the
+> single-selection query surface. The diff-first unified view adds two things
+> on top: (1) a **group-by-attribute** capability (group `span-stats` results by
+> any metadata key, e.g. poll spawn location — see the ADR-0005 note in §1.1),
+> and (2) a **server-side A/B compare** mode that resolves two selections,
+> schedules folding to keep their coverage comparable, and returns an
+> already-merged diff plus a ranked significant-differences list
+> ([ADR-0004](../adr/0004-diff-is-computed-server-side.md)). See
+> [diff-first-unified-view.md](./diff-first-unified-view.md).
+
+### 5.1 Span statistics
+
+Add `GET /api/span-stats` as an SSE refinement stream using the existing scope,
+order key, sampling cap, fold limits, and coverage model.
+
+Return bounded summaries grouped by `span_type_uid`:
+
+- kind, name, and callsite;
+- occurrence count;
+- fixed log-duration histogram;
+- p50/p95/p99/max;
+- summed five-way wall-time composition;
+- bounded low-cardinality attribute facets;
+- partial/quality counts;
+- bounded slow exemplars with viewer deep links.
+
+Do not return every instance for fleet scopes. Attribute values become automatic
+facets only below a configured cardinality cap; high-cardinality keys permit an
+exact-value filter without listing all values.
+
+### 5.2 Span-filtered flamegraphs
+
+Extend `/api/flamegraph` with:
+
+```text
+span_type_uid
+min_span_ns
+max_span_ns
+phase=on_cpu|blocking
+```
+
+> **Not yet implemented:** `span_attribute.<key>=<value>` filtering is designed
+> but not yet supported by the backend. The query parameter is not accepted;
+> passing it will be silently ignored by the URL parser (it is not a declared
+> field in `FlamegraphParams`). Attribute-based flamegraph filtering requires a
+> two-pass pipeline: first select matching `span_uid`s from the `spans/` table,
+> then test the compact membership list in `samples/`. This will be added in a
+> future iteration when the span explorer UI needs attribute drill-down.
+
+The accumulator scans `samples/` and tests each row's short
+`enclosing_spans` list. A row matches when any membership satisfies the type
+and duration filters. The sample contributes once even
+if multiple memberships match. Completeness (`details_complete`) filtering is
+**deferred** alongside attribute filtering above.
+
+`min_poll_ns` and `max_poll_ns` remain a compatibility adapter for the built-in
+`tokio.poll` type until the existing poll UI migrates.
+
+---
+
+## 6. Span Explorer UI
+
+> **Superseded as the terminal UI by the diff-first design.** The
+> single-selection Span Explorer described here is the v0 surface and the
+> starting point: the diff-first unified view is grown by forking this page and
+> making every surface compare two selections (A vs B), with the flamegraph,
+> span-stats, and tokio views becoming lenses over one shared selection. The
+> catalog below remains accurate for the B = ∅ (single-selection) case. See
+> [diff-first-unified-view.md](./diff-first-unified-view.md).
+
+Add a Span Explorer that uses `/api/span-stats` for discovery and the existing
+flamegraph renderer for selected samples.
+
+### 6.1 Catalog
+
+One bounded row per available span type:
+
+```text
+Span | Kind | Instances | p50 | p95 | p99 | Time composition | Quality
+```
+
+Polls appear as the built-in `tokio.poll` type, optionally grouped by spawn
+location. Tracing rows use name plus callsite to distinguish equal names.
+
+### 6.2 Histogram and selection
+
+The default histogram is occurrence-weighted: each span instance contributes
+once. A toggle exposes CPU-sample weighting to preserve the current poll
+minimap's meaning. Brushing sets the span-duration band and updates the selected
+count, percentiles, wall-time composition, flamegraphs, and exemplars.
+
+### 6.3 Detail tabs
+
+- **On CPU:** source-0 samples in matching memberships.
+- **Blocking:** scheduler/context-switch stacks in matching active intervals.
+- **Time breakdown:** five-way composition by duration bucket.
+- **Exemplars:** slow spans with host/time/source-file links.
+
+Async wait and scheduling delay are durations, not CPU flamegraphs. Their detail
+views show wake/task context when available. Partial and low-confidence data use
+an explicit gray/hatched Unknown category; absent data is never rendered as a
+plausible zero.
+
+---
+
+## 7. Compatibility and failure behavior
+
+- Adding fields to self-describing trace events is wire-compatible. JavaScript
+  access to new fields must tolerate `undefined` for old traces.
+- Old traces without close summaries do not produce generalized tracing-span
+  rows in the folded backend; exact client-side span rendering continues to use
+  existing enter/exit reconstruction.
+- Increment `SAMPLES_FORMAT_VERSION` so previously folded v3 source files are
+  lazily refolded. Do not add side tables under v3: existing `samples/` leaves
+  would incorrectly mark those sources complete.
+- Malformed span events are counted and skipped with rate-limited logging. A
+  failure to write `spans/` prevents the final `samples/` commit marker.
+- Block-in-place gaps and unknown worker/tid attribution remain unknown per
+  ADR-0002.
+- A source file with no spans writes an empty `spans/` part and still commits its
+  `samples/` part.
+
+---
+
+## 8. Delivery plan
+
+1. **Producer summary:** stable instance IDs, self-contained close summaries,
+   local active-time accumulation, tid on enter/exit, profiler metadata, and
+   focused trace-format compatibility tests.
+2. **Folded schema:** decode summaries and local segments, write `spans/`, enrich
+   samples, preserve samples-last commit ordering, and bump the format version.
+3. **Backend analysis:** span statistics SSE, occurrence histograms, bounded
+   facets/exemplars, and generalized sample filtering.
+4. **Span Explorer:** catalog, histogram brushing, five-way breakdown, on-CPU
+   and blocking views, coverage, and deep links.
+5. **Migration:** adapt poll-duration controls to `tokio.poll`; retain `polls/`
+   until measured evidence supports removing it.
+6. **Validation:** regenerate the demo trace, run focused Rust/JS tests, full
+   nextest, stress nextest, formatting, and clippy.
+
+## Alternatives considered
+
+### Global cross-file span reconstruction
+
+Rejected. The demand-driven order intentionally samples non-contiguous source
+files. Fetching neighbors or maintaining mutable global span state would make a
+fold no longer an independent, deterministic operation.
+
+### Span table plus temporal interval joins
+
+Correct but not chosen initially. A normalized segment table would retain every
+entered interval and avoid persisting sample membership. Every flamegraph query
+would then read and temporally join another dataset. The compact membership list
+keeps the hot sample filter simple without duplicating full spans, while the raw
+trace permits a future format version to revisit this choice.
+
+### Samples table only
+
+Rejected. Spans with no CPU samples would disappear, occurrence histograms would
+be biased toward CPU-heavy spans, and close-time duration/metadata would have no
+canonical row.
+
+### Four time columns without Unknown
+
+Rejected. CPU sampling is statistical, scheduler samples do not encode duration,
+and source-file-bounded analysis intentionally lacks some history. Forcing all
+elapsed time into four confident categories would manufacture precision.

--- a/docs/design/span-wire-contract.md
+++ b/docs/design/span-wire-contract.md
@@ -1,0 +1,669 @@
+# Span wire contract — the spec for spans
+
+> **Status:** normative. This document specifies the rules dial9 uses to *read*
+> spans from a trace. It is the contract a producer must satisfy so that spans
+> decode correctly, independent of *how* they were emitted (the built-in
+> `Dial9TracingLayer`, a hand-written `#[derive(TraceEvent)]` struct, or a future
+> bridge from another instrumentation system).
+>
+> Companion to [`generalized-span-flamegraphs.md`](generalized-span-flamegraphs.md),
+> which motivates the feature and defines the folded Parquet schema. This
+> document is narrower: it pins down the on-wire → decoded-span mapping so a
+> producer other than the tracing layer can conform.
+
+## Audience and scope
+
+Read this if you are:
+
+- writing a producer that emits spans **without** the tracing layer (custom
+  `TraceEvent` structs, an OTel/other bridge, a manual instrument);
+- modifying dial9's span decoder and need the invariants it must preserve;
+- reasoning about why a span decoded the way it did.
+
+The decoder has two independent implementations that this contract binds:
+
+1. **The folder** (Rust, `dial9-viewer/src/ingest/decode/`) — produces the
+   authoritative `spans/` Parquet rows (`ResolvedSpan`) and enriches samples.
+2. **The viewer** (JS, `dial9-viewer/ui/trace_analysis.js::buildSpanData`) —
+   reconstructs raw span timelines for the interactive trace view.
+
+Where the two diverge it is called out explicitly. A conforming producer must
+satisfy both.
+
+---
+
+## 1. The span model dial9 reads
+
+dial9 does not read a span as a single record. It reads **three event kinds**
+and reconstructs a span from them:
+
+| Event kind | Emitted | Purpose to the decoder |
+|---|---|---|
+| **Span enter** | Every time the span becomes on-CPU (guard taken / poll begins inside it) | Marks the start of one *entered execution interval*. |
+| **Span exit** | Every time the span leaves CPU (guard released / poll yields) | Closes the most recent entered interval. |
+| **Span close** | Once, at lifecycle end (the span is dropped/finished) | The authoritative summary row: identity, lifecycle bounds, final attributes, quality. |
+
+A span therefore has:
+
+- **one lifecycle**: `[start_ns, close_ns)` — carried by the close event;
+- **zero or more entered intervals**: `[enter_ts, exit_ts)` pairs — carried by
+  enter/exit events. Every interval is **half-open**.
+
+This split is deliberate. An async span holds its guard across `.await` points,
+so it enters and exits once per poll and may migrate worker threads between
+polls. The lifecycle spans the whole operation; the entered intervals are only
+the slices during which it was actually on CPU. Only the close event is required
+for a span to produce a row; enter/exit events add local execution detail.
+
+> **Key consequence for producers:** dial9 attributes CPU/scheduler samples
+> **only to entered intervals, never to the lifecycle envelope**
+> (`decode/attribution.rs`). A span that is exited (waiting) must not claim
+> samples that fire during its idle gap. If you emit only a close event with no
+> enter/exit pairs, the span appears with correct elapsed time but no on-CPU
+> detail — all elapsed time is reported as `unknown_ns`.
+
+---
+
+## 2. Event recognition — how the decoder classifies an event
+
+Events are classified **by their schema name prefix**, then by field content.
+The folder's dispatch (`events.rs::decode_trace`) is the normative rule:
+
+### 2.1 Name prefixes
+
+| Prefix / exact name | Classified as |
+|---|---|
+| `SpanClose__…` or exact `SpanCloseEvent` | span close |
+| `SpanEnter:…` or `SpanEnter__…` | span enter |
+| `SpanExit:…` or `SpanExit__…` | span exit |
+
+Two naming conventions exist because two producers exist:
+
+- **Colon form** (`SpanEnter:{target}::{name}:{file}:{line}`) — the *dynamic*
+  schema name the tracing layer builds per callsite
+  (`tracing_layer.rs::build_callsite_schemas`).
+- **Double-underscore form** (`SpanEnter__{Type}`) — a hand-written
+  `#[derive(TraceEvent)]` struct's wire name is its Rust identifier, and a Rust
+  identifier **cannot contain `:`**. So struct-derived producers use `__`
+  instead. The suffix after `SpanEnter__` is a schema discriminator only; it does
+  not affect classification.
+
+The exact names `SpanCloseEvent` (folder) and `SpanEnterEvent`/`SpanExitEvent`
+(JS viewer only) are accepted for the built-in producer's own struct names.
+
+> **Rule P1 (naming):** A custom producer must name its structs
+> `SpanEnter__{Type}`, `SpanExit__{Type}`, `SpanClose__{Type}`, using the **same
+> `{Type}` suffix** for all three of one logical span type. `{Type}` must be a
+> valid Rust identifier (no `:`; `__` is legal in identifiers).
+
+### 2.2 Dialect selection — modern vs legacy
+
+Within each event kind, the decoder picks a **dialect** by field content, not by
+name:
+
+- **Modern**: the event carries `span_instance_id > 0`. Decoded as
+  `SpanEnterEvent` / `SpanExitEvent` / `SpanCloseSummary`.
+- **Legacy**: `span_instance_id` is absent or `0`, but `span_id > 0`. Decoded as
+  `LegacySpanEnterEvent` / `LegacySpanExitEvent` / `LegacySpanCloseEvent`.
+
+The decision cascade for each event (from `decode_trace`):
+
+```text
+try modern struct
+  ├─ span_instance_id > 0  → MODERN
+  ├─ deserialized but id==0 → fall through to legacy (span_id > 0)
+  └─ deserialize error       → try legacy struct (span_id > 0)
+```
+
+`span_instance_id == 0` is reserved as a sentinel ("telemetry was disabled at
+span creation", or an old-producer event that only has `span_id`). A modern
+producer **must never** emit `span_instance_id == 0` for a live span.
+
+Modern and legacy spans may coexist in one file (e.g. a library using the old
+format alongside a service on the new format); they are resolved independently.
+
+> **New producers should always emit the modern dialect.** The legacy dialect is
+> a read-compatibility path for traces from old producers; it is documented here
+> (§5) only so the contract is complete.
+
+---
+
+## 3. Modern dialect — field contract
+
+### 3.1 Span enter / span exit
+
+The decoder reads only what it needs to pair intervals. From
+`events.rs::SpanEnterEvent` / `SpanExitEvent`:
+
+| Field | Type | Required by folder | Meaning |
+|---|---|---|---|
+| `timestamp_ns` | varint (monotonic ns) | **yes** | When the interval boundary occurred. |
+| `span_instance_id` | varint | **yes** (`> 0`) | Stable instance identity; the pairing lane. |
+| `tid` | varint | **yes** | OS thread id; part of the pairing key. |
+
+The tracing layer *also* writes `worker_id`, `span_id`, `parent_span_id`, and
+`span_name` plus user fields on enter/exit. Of these, `worker_id` is read
+indirectly: it is the lane used to infer the span's owning task from the poll
+timeline (§4.7). The rest exist for the JS viewer's raw-timeline reconstruction
+and human inspection. A minimal folder-only producer may omit them, but emitting
+`worker_id` (for task association) and `span_name` (for the viewer) is
+recommended.
+
+> **Rule P2 (pairing key):** enter/exit are paired by the composite key
+> `(span_instance_id, tid)`. An enter and its matching exit **must carry the same
+> `span_instance_id` and the same `tid`**. If execution moves to another thread,
+> emit an exit on the old `tid` first and a fresh enter on the new `tid`. Do not
+> emit an enter on one `tid` and its exit on another.
+
+### 3.2 Span close (the authoritative summary)
+
+From `events.rs::SpanCloseSummary`. This event alone must be sufficient to write
+a useful `spans/` row even if **no enter/exit for the instance appears in the
+same source file** (the span may have started in an earlier, un-folded file).
+
+| Field | Type | Required | Meaning / rule |
+|---|---|---|---|
+| `timestamp_ns` | u64 mono | **yes** | Lifecycle **close** time. |
+| `span_instance_id` | u64 | **yes** (`> 0`) | Stable instance identity. See §4.1. |
+| `start_timestamp_ns` | u64 mono | **yes** | Lifecycle **start** (creation) time. `elapsed_ns = close − start`. |
+| `first_enter_timestamp_ns` | `Option<u64>` | no | Absent if never entered. |
+| `active_ns` | u64 | recommended | Producer-accumulated active **thread** time (sum of balanced enter→exit intervals). `0` = not reported; the folder then falls back to locally computed thread time. |
+| `span_name` | String | **yes** | Display/runtime name. Participates in `span_type_uid`. |
+| `target` | String | recommended | Module/target. Participates in `span_type_uid`. |
+| `file` | `Option<String>` | recommended | Callsite file. Participates in `span_type_uid`. |
+| `line` | `Option<u32>` | recommended | Callsite line. Participates in `span_type_uid`. |
+| `parent_span_instance_id` | `Option<u64>` | no | Explicit stable parent **instance id** (not the wire id). `None` for a root — never fabricated. Folder computes `parent_span_uid` from it. See §4.6. |
+| `attributes` | `Vec<(String,String)>` | no | Final close-time key/value attributes. This dedicated field is the **only** attribute channel the folder reads — see §6.5. |
+| `unbalanced_enters` | u32 | no (default 0) | Producer's own count of unbalanced enter/exit at close. The decoder **independently** detects local imbalance from the actual events and adds this on top; report it only for imbalance the decoder cannot see (enters/exits in an earlier file). See §6.4. |
+
+> **Removed flags.** Earlier drafts carried three more close flags —
+> `concurrent`, `saturated`, and `loss_observable`. They are **not** part of this
+> contract (§6.4 explains why). `concurrent` survives only as a *derived output*
+> (the decoder infers it from thread-time vs. wall-time); a producer does not
+> emit it.
+
+All fields below `span_name` are `#[serde(default)]`: a producer that omits them
+emits an event that decodes with zeros/empties. A clean producer emitting
+balanced enter/exit pairs sets **no** quality flag at all.
+
+The close struct in the tracing layer is marked `#[traceevent(wire_slot)]` (an
+encoder fast-path opt-in); this is an encoding optimization, not part of the
+read contract.
+
+> **Rule P3 (close is authoritative):** emit exactly one close event per span
+> instance, at lifecycle end, carrying at minimum `timestamp_ns`,
+> `span_instance_id`, `start_timestamp_ns`, and `span_name`. `unbalanced_enters`
+> defaults to 0; set it only when you know about cross-file imbalance (§6.4).
+> Never inflate `active_ns`.
+
+---
+
+## 4. Derived semantics (what the decoder computes from your events)
+
+These are the rules the folder applies in `span_builder.rs::SpanCandidate::finalize`
+and `interval_pairing.rs`. A producer does not emit these values but must
+understand them to emit events that decode sensibly.
+
+### 4.1 Identity
+
+```text
+span_uid      = BLAKE3(boot_id ‖ span_instance_id_le)[0..16]
+span_type_uid = BLAKE3(kind ‖ 0 ‖ target ‖ 0 ‖ name ‖ 0 ‖ file ‖ 0 ‖ line
+                       [ ‖ "\0dial9:schema-name\0" ‖ len ‖ schema_name ])[0..16]
+```
+
+- **`span_instance_id`** must be **process-local, monotonically increasing, and
+  never recycled**. The tracing layer allocates from a global `AtomicU64`
+  starting at 1 (0 is the disabled sentinel; §2.2). `tracing::span::Id` values
+  *are* recycled and must **not** be used as the instance id.
+- **`boot_id`** namespaces instance ids across processes so `span_uid` is stable
+  across a process's segments. The folder resolves it, not the producer:
+  - `SegmentMetadata` entry `boot_id` present → `identity_quality = "metadata"`
+    (authoritative);
+  - else parsed from a namespaced source-key path
+    `…/{date}/{HHMM}/{service}/{host}/{boot_id}/{file}` where `boot_id` matches
+    `{4-alpha}-{digits}` → `identity_quality = "path"` (authoritative);
+  - else → `identity_quality = "flat"` (cannot claim cross-file stability).
+- **`span_type_uid`** groups instances of the same type. The runtime `name`
+  always participates. For struct-derived (`SpanEnter__{Type}`) schemas the
+  `{Type}` suffix is folded in as an extra discriminator so two struct types
+  that share a runtime `name` stay distinct.
+
+> **Rule P4 (identity):** allocate a nonzero, never-recycled `span_instance_id`
+> per span instance. To get `identity_quality` better than `"flat"`, either
+> write a `boot_id` entry into segment metadata, or write segments under the
+> namespaced path layout. Keep `name`/`target`/`file`/`line` **stable across
+> instances of the same type** so they group.
+
+### 4.2 Interval pairing
+
+`interval_pairing.rs::pair_intervals`:
+
+1. All enter/exit events (across all keys) are sorted by
+   `(timestamp_ns, decode_sequence)`. `decode_sequence` is the wire-decode order,
+   assigned by the decoder — it breaks ties for events at the same timestamp.
+2. Per key (`(instance_id, tid)` modern; `span_id` legacy), a **LIFO stack**:
+   enter pushes, exit pops the most recent enter.
+3. An exit matches only if `exit_ts >= enter_ts`; it produces the half-open
+   interval `[enter_ts, exit_ts)`. A zero-duration interval (`enter_ts ==
+   exit_ts`) is valid.
+4. Unmatched exits (no enter on the stack) and unmatched enters (still on the
+   stack at end) are counted and surface as `unbalanced_exits` /
+   `unbalanced_enters`.
+
+> **Consequence:** an exit encoded *before* an enter at the same timestamp stays
+> unmatched. Emit enter before exit. Nesting/re-entry on the same key is fine and
+> pairs LIFO.
+
+### 4.3 Time accounting and the five-way invariant
+
+For every resolved span:
+
+```text
+elapsed_ns = on_cpu_ns_est + blocked_ns_est + async_wait_ns
+           + scheduler_delay_ns + unknown_ns
+```
+
+(nullable estimates contribute zero when null). The decoder **enforces** this: if
+the classified categories overflow or exceed `elapsed_ns`, the whole
+classification is discarded, `unknown_ns = elapsed_ns`, and attribution flag
+bit 1 is set. dial9 never converts uncertainty into a plausible zero.
+
+Derived time fields:
+
+- `elapsed_ns` = close − start (wall clock, via `ClockSync` offset; raw mono if
+  no offset).
+- `observed_active_wall_ns` = union of entered intervals in this file.
+- active **thread** time = sum of intervals (may exceed wall if concurrent).
+- `active_ns` = producer `active_ns` if `> 0`, else local thread time, else
+  `None`.
+- `concurrent` (**derived output**) = thread time > wall time + 1. The producer
+  does not emit this; the decoder infers it from the intervals it sees.
+
+`details_complete` is `true` only when **all** hold: entered locally (has
+intervals) · no unbalanced enters/exits · lifecycle start ≥ file boundary (first
+`ClockSync` mono in the file) · `identity_quality ∈ {metadata, path}`. Legacy
+spans are therefore never `details_complete`.
+
+### 4.4 Attribution flags (bitfield)
+
+| Bit | Meaning |
+|---|---|
+| 0 | profiler metadata missing |
+| 1 | sample drops detected **or** attribution accounting invalid |
+| 2 | worker/tid attribution ambiguous |
+| 3 | wake classification unavailable |
+
+### 4.5 Sample attribution
+
+`attribution.rs` sweeps CPU/sched samples against **entered intervals only**
+(mapped to wall clock), never the lifecycle envelope. A sample inside multiple
+selected spans is counted once per span for inclusive per-span counts, but once
+overall in a flamegraph. This is why balanced, tight enter/exit pairs matter:
+they are the only thing that earns a span its on-CPU flamegraph.
+
+### 4.6 Parentage
+
+dial9 distinguishes **two relationships that must not be conflated**:
+
+- **Lifecycle parent** (this section): a *recorded* child→parent pointer set at
+  span creation. This is parentage.
+- **Runtime enclosure** (§4.5): interval containment used for sample
+  attribution, per-worker. A span that encloses another on CPU is **not**
+  necessarily its parent, and a parent need not enclose its child on CPU.
+
+**Only explicitly recorded parentage is represented.** The tracing layer
+resolves the parent from `attrs.parent()` alone (`span!(parent: &x, …)`), never
+the contextual current-span, because contextual parenting is unreliable across
+async tasks sharing a worker thread (`tracing_layer.rs::on_enter`). dial9 does
+**not** infer a lifecycle parent from timestamp containment or nesting. A missing
+parent is *unknown* — never an asserted root.
+
+**Two different parent fields carry two different ids:**
+
+| Field | Event | Value | Consumer |
+|---|---|---|---|
+| `parent_span_instance_id: Option<u64>` | **close** | parent's **stable instance id** | the folder → `parent_span_uid` |
+| `parent_span_id: Option<u64>` | **enter** | parent's **recycled tracing wire id** | JS viewer only (interactive nesting / depth) |
+
+The durable link is computed by the folder:
+
+```text
+parent_span_uid = BLAKE3(boot_id ‖ parent_span_instance_id_le)[0..16]
+```
+
+This is a **content-addressed pointer**. The parent's row need **not** be in the
+same source file; the link resolves whenever the parent's own close event
+computes the same `span_uid` (same `boot_id` + instance id). A dangling pointer
+(parent lives in an un-folded file) is expected and harmless — the folder stores
+the pointer, it does not materialize a tree. Cross-file stability of the pointer
+requires authoritative `identity_quality` (`metadata`/`path`) for **both** parent
+and child (§4.1); under `flat` identity the uid is still computed but is not
+cross-file stable.
+
+The enter event's `parent_span_id` is a *separate*, recycled value used only by
+the JS viewer to build interactive nesting (`buildSpanData`'s
+`childrenByParent`, `getDepth`, `selectSpanRenderSet` — all cycle-safe). The
+folder ignores it.
+
+**Legacy parentage is weaker.** The legacy path rebuilds the parent uid from the
+enter's `parent_span_id` plus the parent's *first-enter timestamp*
+(`legacy.rs`): `synthetic_instance_id(parent_span_id, parent_first_enter_ts)`.
+If the parent is not present in the same file, that timestamp defaults to 0 and
+the synthesized uid will not match the parent's real row — so legacy cross-file
+parentage is unreliable. This is another reason new producers should emit the
+modern dialect.
+
+**Persistence vs. use.** `parent_span_uid` is written to the `spans/` Parquet as
+a nullable column (`parquet_writer.rs`), but `/api/span-stats` groups by
+`span_type_uid` and does **not** reconstruct parent trees today. Tree/nesting
+reconstruction is currently a viewer-side feature over raw enter/exit. Setting
+parentage correctly is therefore about interactive-viewer fidelity and future
+tree analysis, not about the current aggregation flamegraph.
+
+**Computing the parent (task-keyed).** The current tracing layer records a parent
+only from an *explicit* `attrs.parent()`, so in practice `parent_span_instance_id`
+is almost always `None`. Computing it correctly is possible — but **not from
+thread state**. The parent of a span is "the span logically active *in the same
+task* when the child was created," and in an async runtime the OS thread
+interleaves tasks and tasks migrate workers, so "what span is entered on this
+thread right now" bleeds across tasks. That is why inferring a contextual parent
+from a thread-local (or from `tracing`'s thread-scoped current-span) is
+unreliable.
+
+The fix is to key the current-span stack by **task**, not thread. Tokio exposes
+the current task anywhere inside a poll via `tokio::task::try_id()` (dial9 already
+uses it for the wake graph, `traced.rs`). A producer maintains a per-task stack —
+`HashMap<TaskId, Vec<span_instance_id>>`, or a `tokio::task_local!` stack —
+pushing on enter, popping on exit, and at creation sets the parent to the top of
+the *creating task's* stack. This is correct where a thread-local is not:
+
+- **Interleaving:** task B's new spans consult B's stack, never A's, even on the
+  same worker.
+- **Worker migration:** the key is the (stable) task id, so a push on one worker
+  and pop on another still balance.
+- **A guard held across `.await`:** the held span stays in A's stack; when B runs
+  (`try_id() == B`) it is unaffected. This is precisely the case the current
+  layer's comment flags as unreliable — keying by task removes the hazard.
+
+Two residual gaps remain in *any* implementation:
+
+- **Off-runtime spans** (`try_id() == None`): no task, hence no async parent —
+  genuinely unknown, and correctly left `None`.
+- **Cross-`spawn` causal parentage:** a spawned task is a *new* task with an
+  empty stack, so a span created inside the child's first poll has no parent to
+  find. Task-locals do **not** inherit across `spawn`; the parent must be
+  captured at spawn time and propagated. dial9 has a backstop others lack — the
+  recorded spawn/wake graph (`waker_task_id`) can bridge task→task when the span
+  stack cannot.
+
+The tracing layer can adopt this with **no wire-format change** — only the source
+of `parent_span_instance_id` changes (from `attrs.parent()` to the task-keyed
+stack top). A purpose-built span system can go further: a task-local stack plus
+`spawn` that propagates the current span **and** a `trace_id`/`root_span_uid`,
+which is what turns a "compare sub-spans across request types" analysis from a
+cross-file inference into a `GROUP BY trace_id` (the design reserves the nullable
+OTLP `trace_id`/`parent_span_id` columns for exactly this).
+
+> **Rule P8 (parentage):** On the close event, set `parent_span_instance_id` to
+> the parent's stable instance id when a parent exists; leave it `None` for a
+> root (never fabricate a parent). Compute the parent from a **task-keyed**
+> current-span stack (`tokio::task::try_id()`), not a thread-local. Optionally
+> set the enter event's
+> `parent_span_id` to the parent's wire/span id for interactive-viewer nesting.
+> Do not rely on dial9 to infer parentage from containment. Avoid self-parent
+> and cycles.
+
+### 4.7 Task association (`task_id` is inferred, never written)
+
+A span carries **no `task_id` field**. The owning Tokio task is *inferred* from
+the poll timeline: `task_id` lives only on `PollStart` events (`polls.rs`), and
+`resolve_span_task(worker_polls, enter_ts)` binary-searches the **enter
+worker's** polls for the one whose `[start, end)` covers the span's **enter
+timestamp**, taking that poll's `task_id` (`legacy.rs`; the JS viewer's
+`resolveSpanTask` does the same from `(segment.worker_id, segment.start)`).
+
+This is why the enter event's `worker_id` is **not cosmetic**: it selects which
+worker's poll lane to search. Without it — or when the enter does not fall inside
+any poll (e.g. a span entered on a non-runtime thread) — the span resolves to
+*no task*, and on-CPU/async-wait cannot be split (they stay `unknown_ns`, per
+ADR-0002).
+
+Reader state, as of this writing:
+
+- **JS viewer** and the **legacy Rust folder path** both perform this
+  poll-overlap inference — to split on-CPU vs. async-wait and to reconstruct
+  per-poll active segments.
+- The **modern Rust folder path** currently **defers** task-based attribution:
+  `modern.rs` leaves `on_cpu_ns_est`/`async_wait_ns` as `None` (all elapsed falls
+  into `unknown_ns`). It still attributes CPU/sched samples to entered intervals
+  in stage 3 (§4.5). Task-based time splitting for modern spans is a future
+  stage; when added it will reuse the same poll-overlap inference and therefore
+  the same enter-`worker_id` requirement.
+
+> **Rule P9 (task association):** Do not put `task_id` on span events. To make a
+> span attributable to its task, emit its enter events with the correct
+> `worker_id` and ensure enter/exit bracket on-CPU execution **inside a poll**
+> (i.e. instrument work running on the runtime, not detached threads).
+
+---
+
+## 5. Legacy dialect (read-only compatibility)
+
+Old producers emit:
+
+- `SpanEnter:{target}::{name}:{file}:{line}` with fields `worker_id`, `span_id`,
+  `parent_span_id`, `span_name` (no `span_instance_id`, no `tid`);
+- `SpanExit:{…}` similarly;
+- `SpanCloseEvent` with only `span_id`.
+
+Reconstruction rules (`spans/legacy.rs`), documented so the contract is complete
+— **do not target this format in new producers**:
+
+- Pair enter/exit by **`span_id` alone**, *not* `(span_id, worker_id)`: async
+  tasks migrate workers across `.await`, and worker-keyed pairing dropped ~44% of
+  fully-captured spans on a measured beta trace.
+- Synthesize a deterministic instance id: `BLAKE3("legacy_instance" ‖ span_id ‖
+  first_enter_ts)[0..8]`. Same-`span_id` events within one segment are merged
+  into one instance (ids are recycled per process, but rarely within a ~60s
+  segment).
+- Parse `target`/`name`/`file`/`line` from the schema name
+  (`events.rs::parse_legacy_span_schema_name`). The `SpanEnter__{Type}`
+  struct-derived form yields only the `{Type}` suffix (no target/file/line).
+- Lifecycle start = first observed enter (conservative); `identity_quality =
+  "legacy"`; `details_complete = false`.
+- On-CPU vs async-wait for a legacy span is *estimated* by resolving the owning
+  Tokio task (the poll on the enter worker covering the enter timestamp) and
+  intersecting entered intervals with that task's polls.
+
+---
+
+## 6. Producing spans without the tracing layer
+
+### 6.1 The genuinely minimal case
+
+The smallest thing that produces a span row is **one close event with four
+fields**. No enter/exit, no flags, no attributes:
+
+```rust,ignore
+use dial9_trace_format::TraceEvent;
+use dial9_tokio_telemetry::telemetry::{clock_monotonic_ns, Dial9Handle};
+
+#[derive(TraceEvent)]
+struct SpanClose__MyOp {
+    #[traceevent(timestamp)] timestamp_ns: u64, // close time
+    span_instance_id: u64,                       // > 0, never recycled
+    start_timestamp_ns: u64,                     // lifecycle start
+    span_name: String,
+}
+
+# fn emit(handle: &Dial9Handle, id: u64, start_ns: u64) {
+handle.record_event(SpanClose__MyOp {
+    timestamp_ns: clock_monotonic_ns(),
+    span_instance_id: id,
+    start_timestamp_ns: start_ns,
+    span_name: "my_op".into(),
+});
+# }
+```
+
+That yields a span with correct `elapsed_ns` and identity, but **no execution
+detail**: no entered intervals, so no CPU samples attach and all elapsed time is
+`unknown_ns`. `target`/`file`/`line` are empty (weaker `span_type_uid`
+grouping), and it's never `details_complete`. This is enough for "show me this
+operation's duration"; it is not enough for a flamegraph.
+
+### 6.2 Adding on-CPU detail
+
+To earn on-CPU attribution, bracket the on-CPU work with a balanced enter/exit
+pair on the same `(span_instance_id, tid)`, and give the enter a `worker_id` for
+task inference (§4.7):
+
+```rust,ignore
+use dial9_tokio_telemetry::telemetry::{clock_monotonic_ns, current_worker_id, Dial9Handle};
+// `tid` is dial9's per-thread id; the public function is
+// `dial9_core::thread::current_tid()`.
+use dial9_core::thread::current_tid;
+
+#[derive(TraceEvent)]
+struct SpanEnter__MyOp {
+    #[traceevent(timestamp)] timestamp_ns: u64,
+    span_instance_id: u64,   // the pairing lane
+    tid: u64,                // must match the exit on this thread
+    worker_id: u64,          // enables task inference; see §4.7
+}
+
+#[derive(TraceEvent)]
+struct SpanExit__MyOp {
+    #[traceevent(timestamp)] timestamp_ns: u64,
+    span_instance_id: u64,
+    tid: u64,
+}
+```
+
+Emit `SpanEnter__MyOp` when the operation goes on CPU and `SpanExit__MyOp` when
+it yields, once per on-CPU stretch, then the close from §6.1 at the end. That is
+the complete conforming producer. `span_instance_id` comes from a process-local
+`AtomicU64` starting at 1 (0 is the disabled sentinel); allocate one per
+instance and never recycle it.
+
+### 6.3 Optional richer close fields
+
+Everything below `span_name` on the close is `#[serde(default)]` — add a field
+only when you have something real to say:
+
+- `target` / `file` / `line` — sharpen `span_type_uid` grouping and give the UI
+  a callsite. Recommended; keep them stable per span type (P5).
+- `active_ns` — producer-accumulated active **thread** time. Omit (0) and the
+  folder computes it from the local intervals. Only report it if you track it
+  yourself (e.g. the span's enter/exit span multiple files).
+- `parent_span_instance_id` — the parent's stable instance id (§4.6).
+- `attributes: Vec<(String, String)>` — see §6.5.
+- `unbalanced_enters` — see §6.4.
+
+### 6.4 The one quality flag: `unbalanced_enters`
+
+It defaults to `0` ("balanced / nothing to report"). A producer that emits
+balanced enter/exit pairs never sets it.
+
+**`unbalanced_enters`** is the producer's own count of enter/exit imbalance
+observed for this instance at close (in the tracing layer: enters still open plus
+exits that never matched an enter). It is a *quality flag*, not a requirement:
+the decoder independently detects imbalance from the actual enter/exit events it
+sees in the file and **adds** your number to its own (`modern.rs`). You only need
+to report it for imbalance the decoder cannot see — e.g. enters/exits that
+happened in an earlier, un-folded file. Non-zero degrades `details_complete`.
+
+**Why `concurrent`, `saturated`, and `loss_observable` are not producer flags.**
+Earlier drafts had four flags; three were dropped because a producer either
+cannot honestly set them or the decoder already knows:
+
+- **`loss_observable`** required the producer to know whether any of the span's
+  enter/exit events were *dropped* from the buffer. On the thread-local buffer
+  path there is no such signal — `record_event` is fire-and-forget, and nothing
+  reports a per-stream drop. Observing drops would need per-thread sequence
+  numbers (decoder spots a gap) or a buffer drop counter surfaced in segment
+  metadata; neither exists for spans. So the flag was always `0`, and because
+  `details_complete` *required* it, it was permanently forcing spans to
+  incomplete. Removing it lets `details_complete` actually be reached.
+- **`concurrent`** is fully derivable by the decoder (summed thread-time exceeds
+  wall-time), so a producer-emitted flag was redundant. It remains as a *derived
+  output* only (§4.3).
+- **`saturated`** flagged a `u64`-nanosecond overflow of `active_ns` — roughly
+  584 years of accumulated active time. It could never realistically be set and
+  only mattered if the producer reported `active_ns` at all.
+
+### 6.5 Attributes: the `attributes` Vec vs. top-level fields
+
+**Today, the folder reads span attributes only from the dedicated
+`attributes: Vec<(String, String)>` field on the close event.** Extra *top-level*
+fields you add to a `SpanClose__` struct are **silently ignored** by the folder:
+serde deserializes `SpanCloseSummary` by named field and drops unknown ones, so a
+top-level `status_code: u32` never reaches `ResolvedSpan.attributes` or the
+`/api/span-stats` facets. If you want an attribute to appear in span stats, it
+must go in the `attributes` Vec.
+
+This is asymmetric with enter/exit, and worth understanding:
+
+- On **enter/exit**, the tracing layer emits user fields as **top-level**
+  pooled-string fields, and the **JS viewer** collects everything outside the
+  base field set (`BASE_ENTER_FIELDS`) as the span's `fields`. But the **Rust
+  folder ignores enter/exit user fields entirely** (it reads only
+  `timestamp`/`instance_id`/`tid`). So top-level enter/exit fields reach the
+  interactive viewer, not the aggregation.
+- On **close**, attributes are the folder's channel, and they must be the Vec.
+
+So the honest answer to "couldn't attributes be top-level fields?": for the
+interactive viewer, enter/exit already work that way. For the aggregation folder
+(the thing that powers span-stats and facets), **not currently** — the close
+decoder is keyed on the `attributes` field. Making the close decoder collect
+unknown top-level fields as attributes (mirroring the JS viewer's enter/exit
+convention) would let struct-derived producers use typed top-level fields and
+keep native types; it is a reasonable decoder change but is **not implemented
+today**. Until then, use the Vec.
+
+### 6.6 Clock requirements
+
+Timestamps must come from `clock_monotonic_ns()` (the same clock as poll/wake
+events). The trace must also contain `ClockSync` events (dial9 emits these
+automatically) so the folder can convert to wall clock and establish the file
+boundary; without a clock offset the monotonic values are used raw.
+
+---
+
+## 7. Rules checklist
+
+A producer conforms if all of the following hold:
+
+- **P1** Struct names are `SpanEnter__{Type}` / `SpanExit__{Type}` /
+  `SpanClose__{Type}`, sharing one `{Type}` per logical span type.
+- **P2** Enter and its matching exit carry the **same** `span_instance_id` and
+  `tid`; enter is emitted before exit; thread migration is modeled as exit-then-enter.
+- **P3** Exactly one close event per instance at lifecycle end, with
+  `timestamp_ns`, `span_instance_id (>0)`, `start_timestamp_ns`, `span_name`, and
+  truthful quality flags.
+- **P4** `span_instance_id` is process-local, monotonic, never recycled, nonzero.
+- **P5** `name`/`target`/`file`/`line` are stable across instances of a type
+  (so `span_type_uid` groups them).
+- **P6** Timestamps are `clock_monotonic_ns`; `ClockSync` events are present.
+- **P7** `unbalanced_enters` defaults to 0; set it only for cross-file imbalance
+  the decoder cannot see (§6.4). Never inflate `active_ns`.
+- **P8** Set `parent_span_instance_id` on the close to the parent's stable
+  instance id when a parent exists; `None` for roots; never infer or fabricate.
+  See §4.6.
+- **P9** Do not write `task_id` on span events — it is inferred from the poll
+  timeline via the enter's `worker_id`. Emit enter events with the correct
+  `worker_id` and bracket on-CPU execution inside a poll. See §4.7.
+
+## 8. Compatibility rules
+
+- Adding fields to any span event is wire-compatible (self-describing schema).
+  Old traces omit new fields; the folder's serde structs default them, and the JS
+  viewer must tolerate `undefined` (see repo `AGENTS.md`).
+- Removing a non-optional field is **not** safe for old-trace reads.
+- Changing folded/derived output increments `SAMPLES_FORMAT_VERSION`, forcing a
+  lazy refold; the wire contract itself is unversioned and additive.
+- Malformed span events are counted and skipped with rate-limited logging; they
+  never abort a fold.
+</content>
+</invoke>

--- a/docs/ui-inventory/mocks/concept-diff-first.html
+++ b/docs/ui-inventory/mocks/concept-diff-first.html
@@ -1,0 +1,800 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Diff-first unified view</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Sans+Condensed:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#0d111c; --bg2:#111725; --panel:#141b2b; --panel2:#1a2233;
+  --line:#242e46; --line2:#2f3b58;
+  --ink:#e4eaf6; --dim:#93a0bd; --faint:#5e6b88;
+  --A:#31c9c0;         /* selection A — cool teal */
+  --A-dim:#1c6b68;
+  --B:#ff6a5f;         /* selection B — warm coral */
+  --B-dim:#8a3630;
+  --neutral:#3b475f;   /* parity */
+  --gold:#f2b53a;      /* derived / attention */
+  --cyan:#63d2ff;      /* interactive accent */
+  --ok:#5ad19a;
+  --mono:"IBM Plex Mono",ui-monospace,monospace;
+  --sans:"IBM Plex Sans",-apple-system,system-ui,sans-serif;
+  --cond:"IBM Plex Sans Condensed",var(--sans);
+}
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{height:100%}
+body{
+  background:
+    radial-gradient(1200px 600px at 78% -8%, rgba(255,106,95,.06), transparent 60%),
+    radial-gradient(1000px 600px at 8% -6%, rgba(49,201,192,.06), transparent 55%),
+    var(--bg);
+  color:var(--ink); font-family:var(--sans); font-size:13px; line-height:1.35;
+  display:flex; flex-direction:column; overflow:hidden;
+  -webkit-font-smoothing:antialiased;
+}
+button{font-family:inherit; cursor:pointer}
+::selection{background:rgba(99,210,255,.25)}
+
+/* ---- concept ribbon ---- */
+.ribbon{display:flex; align-items:center; gap:14px; padding:7px 16px;
+  background:linear-gradient(90deg,rgba(49,201,192,.10),rgba(255,106,95,.10));
+  border-bottom:1px solid var(--line); flex-shrink:0; font-size:11.5px; color:var(--dim)}
+.ribbon .tag{font-family:var(--cond); font-weight:600; letter-spacing:.14em; text-transform:uppercase;
+  font-size:10.5px; color:var(--ink); background:rgba(255,255,255,.05);
+  border:1px solid var(--line2); padding:2px 9px; border-radius:20px}
+.ribbon b{color:var(--A)}
+.ribbon i{color:var(--B); font-style:normal}
+.ribbon .sp{margin-left:auto; display:flex; gap:14px}
+.ribbon a{color:var(--faint); text-decoration:none}
+.ribbon a:hover{color:var(--cyan)}
+
+/* ---- header ---- */
+.head{display:flex; align-items:center; gap:16px; padding:11px 18px 10px;
+  border-bottom:1px solid var(--line); flex-shrink:0}
+.scope-title{display:flex; flex-direction:column; gap:1px}
+.scope-title .svc{font-family:var(--cond); font-size:18px; font-weight:600; letter-spacing:.01em}
+.scope-title .svc small{color:var(--faint); font-weight:500; font-size:12px; margin-left:6px}
+.scope-title .sub{font-size:11px; color:var(--faint)}
+
+.tabs{display:flex; gap:2px; margin-left:8px; background:var(--bg2);
+  border:1px solid var(--line); border-radius:9px; padding:3px}
+.tab{padding:6px 15px; border-radius:6px; font-size:12.5px; font-weight:500; color:var(--dim);
+  background:none; border:none; letter-spacing:.02em; transition:.15s}
+.tab:hover{color:var(--ink)}
+.tab.on{background:var(--panel2); color:var(--ink); box-shadow:inset 0 0 0 1px var(--line2)}
+
+.head .grow{flex:1}
+.cmp-btn{display:flex; align-items:center; gap:9px; padding:8px 15px; border-radius:9px;
+  font-size:12.5px; font-weight:600; color:#fff; border:1px solid var(--B-dim);
+  background:linear-gradient(180deg,rgba(255,106,95,.28),rgba(255,106,95,.14));
+  box-shadow:0 1px 0 rgba(255,255,255,.06) inset, 0 4px 16px rgba(255,106,95,.16)}
+.cmp-btn:hover{filter:brightness(1.12)}
+.cmp-btn .glyph{font-size:15px; line-height:1}
+.cmp-btn small{font-weight:500; color:rgba(255,255,255,.72)}
+.back-btn{padding:7px 13px; border-radius:8px; font-size:12px; color:var(--dim);
+  background:var(--panel); border:1px solid var(--line)}
+.back-btn:hover{color:var(--ink); border-color:var(--line2)}
+
+/* ---- selection bar ---- */
+.selbar{display:flex; align-items:stretch; gap:0; padding:10px 18px; border-bottom:1px solid var(--line);
+  background:var(--bg2); flex-shrink:0; position:relative}
+.side{display:flex; align-items:center; gap:8px; flex:1; min-width:0}
+.side.b{opacity:0; transform:translateX(-10px); pointer-events:none; transition:.28s ease}
+body.compare .side.b{opacity:1; transform:none; pointer-events:auto}
+.badge{display:inline-flex; align-items:center; justify-content:center; width:22px; height:22px; border-radius:6px;
+  font-family:var(--mono); font-weight:600; font-size:12px; flex-shrink:0}
+.badge.a{background:rgba(49,201,192,.16); color:var(--A); box-shadow:inset 0 0 0 1px var(--A-dim)}
+.badge.b{background:rgba(255,106,95,.16); color:var(--B); box-shadow:inset 0 0 0 1px var(--B-dim)}
+.side .lbl{font-family:var(--cond); font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:var(--faint); flex-shrink:0}
+
+.chips{display:flex; align-items:center; gap:6px; flex-wrap:wrap; min-width:0}
+.chip{display:inline-flex; align-items:center; gap:6px; padding:3px 9px; border-radius:7px;
+  font-family:var(--mono); font-size:11.5px; color:var(--ink);
+  background:var(--panel2); border:1px solid var(--line2); white-space:nowrap}
+.chip .kk{color:var(--faint)}
+.chip.all{color:var(--faint); font-style:italic; background:transparent; border-style:dashed}
+.chip.not{color:var(--A); border-color:var(--A-dim); background:rgba(49,201,192,.08)}
+.chip.derived{color:var(--gold); border-color:#5a4a1e; background:rgba(242,181,58,.08)}
+.chip.derived .prov{color:#8a7a48; font-family:var(--sans); font-style:italic; font-size:10.5px}
+.chip .x{color:var(--faint); cursor:pointer; font-size:13px; line-height:1; margin-left:1px}
+.chip .x:hover{color:var(--B)}
+.chip .rf{color:var(--gold); cursor:pointer; font-size:12px}
+.chip .rf:hover{filter:brightness(1.3)}
+.arrow{align-self:center; color:var(--faint); font-size:15px; padding:0 14px; flex-shrink:0}
+body:not(.compare) .arrow, body:not(.compare) .cov.b{display:none}
+
+.cov{display:flex; flex-direction:column; align-items:flex-end; gap:3px; flex-shrink:0; margin-left:10px}
+.cov .num{font-family:var(--mono); font-size:11px; color:var(--dim)}
+.cov .num b{color:var(--ink); font-weight:600}
+.cov .bar{width:88px; height:4px; border-radius:3px; background:var(--line); overflow:hidden}
+.cov .fill{height:100%; border-radius:3px; transition:width .5s ease}
+.cov.a .fill{background:var(--A)}
+.cov.b .fill{background:var(--B)}
+
+/* ---- view-local row ---- */
+.vlocal{display:none; align-items:center; gap:9px; padding:6px 18px; border-bottom:1px solid var(--line);
+  background:repeating-linear-gradient(45deg,rgba(242,181,58,.03) 0 8px,transparent 8px 16px)}
+body.compare.view-flame .vlocal{display:flex}
+.vlocal .lbl{font-family:var(--cond); font-size:10.5px; letter-spacing:.09em; text-transform:uppercase; color:#8a7a48}
+.chip.vl{border-style:dashed; border-color:#6b5a2a; background:rgba(242,181,58,.07); color:#f0d79a}
+.chip.vl .side-tag{font-family:var(--sans); font-size:10px; font-weight:600; padding:0 5px; border-radius:4px; letter-spacing:.03em}
+.chip.vl .side-tag.b{background:rgba(255,106,95,.2); color:var(--B)}
+.vlocal .note{font-size:10.5px; color:var(--faint); font-style:italic}
+
+/* ---- main ---- */
+.main{flex:1; display:flex; min-height:0; overflow:hidden}
+.views{flex:1; display:flex; min-width:0; gap:1px; background:var(--line)}
+.panel{flex:1; min-width:0; display:flex; flex-direction:column; background:var(--panel);
+  transition:flex-basis .28s ease}
+body:not(.compare) .panel.pb{flex:0 0 0; min-width:0; overflow:hidden; opacity:0}
+.panel-head{display:flex; align-items:center; gap:9px; padding:8px 13px; border-bottom:1px solid var(--line);
+  flex-shrink:0; background:linear-gradient(180deg,var(--panel2),var(--panel))}
+.panel-head .pb-badge{width:20px;height:20px;border-radius:5px;font-family:var(--mono);font-weight:600;font-size:11px;
+  display:inline-flex;align-items:center;justify-content:center}
+.pa .pb-badge{background:rgba(49,201,192,.16);color:var(--A);box-shadow:inset 0 0 0 1px var(--A-dim)}
+.pb .pb-badge{background:rgba(255,106,95,.16);color:var(--B);box-shadow:inset 0 0 0 1px var(--B-dim)}
+.panel-head .ptitle{font-family:var(--cond); font-size:13px; font-weight:600}
+.panel-head .psub{font-size:11px; color:var(--faint)}
+.panel-head .sync{font-size:10.5px; color:var(--faint); font-style:italic; display:flex; align-items:center; gap:4px}
+.panel-head .grow{flex:1}
+.selwrap{display:flex; align-items:center; gap:6px; font-size:11px; color:var(--dim)}
+.mini-sel{background:var(--bg2); color:var(--dim); border:1px solid var(--line2); border-radius:6px;
+  padding:4px 7px; font-size:11px; font-family:var(--mono)}
+.mini-sel:hover{color:var(--ink)}
+
+.panel-body{flex:1; overflow:hidden; position:relative}
+canvas{display:block; width:100%; height:100%}
+.fg-legend{position:absolute; left:12px; bottom:10px; display:flex; align-items:center; gap:8px;
+  font-size:10.5px; color:var(--faint); background:rgba(13,17,28,.72); backdrop-filter:blur(3px);
+  padding:4px 9px; border-radius:7px; border:1px solid var(--line)}
+.fg-legend .ramp{width:88px; height:8px; border-radius:4px;
+  background:linear-gradient(90deg,var(--A),var(--neutral) 50%,var(--B))}
+
+.tip{position:fixed; z-index:60; pointer-events:none; display:none; max-width:340px;
+  background:var(--bg); border:1px solid var(--line2); border-radius:9px; padding:9px 11px;
+  box-shadow:0 12px 34px rgba(0,0,0,.5); font-size:12px}
+.tip .fn{font-family:var(--mono); font-weight:600; color:var(--ink); word-break:break-all; margin-bottom:6px}
+.tip .row{display:flex; justify-content:space-between; gap:20px; font-family:var(--mono); font-size:11.5px; padding:1px 0}
+.tip .row .k{color:var(--faint)}
+.tip .row.a .v{color:var(--A)} .tip .row.b .v{color:var(--B)}
+.tip .delta{margin-top:6px; padding-top:6px; border-top:1px solid var(--line); font-weight:600}
+
+/* context menu */
+.ctx{position:fixed; z-index:70; display:none; background:var(--bg); border:1px solid var(--line2);
+  border-radius:10px; padding:5px; box-shadow:0 16px 40px rgba(0,0,0,.55); min-width:210px}
+.ctx .title{font-size:10.5px; letter-spacing:.08em; text-transform:uppercase; color:var(--faint);
+  padding:6px 9px 4px; font-family:var(--cond)}
+.ctx .item{display:flex; align-items:center; gap:9px; padding:7px 9px; border-radius:7px; font-size:12px; color:var(--ink)}
+.ctx .item:hover{background:var(--panel2)}
+.ctx .item .st{font-family:var(--mono); font-size:10px; font-weight:600; padding:1px 6px; border-radius:5px}
+.st.a{background:rgba(49,201,192,.16); color:var(--A)}
+.st.b{background:rgba(255,106,95,.16); color:var(--B)}
+.st.ab{background:rgba(99,210,255,.14); color:var(--cyan)}
+.ctx .illu{font-size:10px; color:var(--faint); font-style:italic; padding:3px 9px 5px}
+
+/* ---- differences rail ---- */
+.rail{flex:0 0 400px; display:flex; flex-direction:column; background:var(--bg2);
+  border-left:1px solid var(--line); min-width:0}
+body:not(.compare) .rail{flex-basis:0; overflow:hidden; border:none}
+.rail-head{padding:13px 16px 10px; border-bottom:1px solid var(--line)}
+.rail-head .t{display:flex; align-items:center; gap:9px}
+.rail-head .t h3{font-family:var(--cond); font-size:15px; font-weight:600; letter-spacing:.01em}
+.rail-head .t .spark{width:5px; height:16px; border-radius:2px; background:linear-gradient(var(--A),var(--B))}
+.rail-head .t .grow{flex:1}
+.seg{display:inline-flex; background:var(--bg); border:1px solid var(--line2); border-radius:7px; padding:2px}
+.seg button{padding:4px 9px; border-radius:5px; font-size:10.5px; font-weight:600; color:var(--faint);
+  background:none; border:none; letter-spacing:.02em}
+.seg button.on{background:var(--panel2); color:var(--ink)}
+.rail-head .cap{font-size:11px; color:var(--faint); margin-top:6px}
+
+.gate{margin:12px 14px 0; padding:11px 12px; border-radius:10px; border:1px solid #5a4a1e;
+  background:repeating-linear-gradient(45deg,rgba(242,181,58,.06) 0 9px,transparent 9px 18px);
+  display:flex; flex-direction:column; gap:9px}
+.gate .msg{font-size:12px; color:#f0d79a; line-height:1.45}
+.gate .msg b{color:var(--gold)}
+.gate button{align-self:flex-start; padding:6px 12px; border-radius:7px; font-size:11.5px; font-weight:600;
+  color:#1a1200; background:var(--gold); border:none}
+.gate button:hover{filter:brightness(1.08)}
+body.folded .gate{display:none}
+
+.difflist{flex:1; overflow:auto; padding:8px 10px 14px}
+body:not(.folded) .difflist{opacity:.32; filter:grayscale(.6); pointer-events:none}
+.diffrow{display:grid; grid-template-columns:1fr auto; gap:2px 10px; padding:9px 10px; border-radius:9px;
+  align-items:center; transition:background .12s}
+.diffrow:hover{background:var(--panel)}
+.diffrow + .diffrow{border-top:1px solid var(--line)}
+.diffrow .name{font-family:var(--mono); font-size:12px; font-weight:500; color:var(--ink);
+  display:flex; align-items:center; gap:7px; min-width:0}
+.diffrow .name .n{overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+.flag{font-family:var(--cond); font-size:9.5px; font-weight:600; letter-spacing:.05em; text-transform:uppercase;
+  padding:1px 6px; border-radius:5px; flex-shrink:0}
+.flag.new{background:rgba(255,106,95,.16); color:var(--B)}
+.flag.gone{background:rgba(49,201,192,.16); color:var(--A)}
+.diffrow .delta{font-family:var(--mono); font-size:14px; font-weight:600; text-align:right; grid-row:1/3; align-self:center}
+.diffrow .delta.up{color:var(--B)} .diffrow .delta.down{color:var(--A)}
+.diffrow .delta small{display:block; font-size:10px; font-weight:500; color:var(--faint); margin-top:1px}
+.cmpbar{grid-column:1; display:flex; align-items:center; gap:7px; margin-top:2px}
+.cmpbar .track{flex:1; height:9px; border-radius:5px; background:var(--line); position:relative; overflow:hidden}
+.cmpbar .va{position:absolute; left:0; top:0; bottom:0; background:var(--A); opacity:.85}
+.cmpbar .vb{position:absolute; left:0; top:0; bottom:0; background:var(--B); opacity:.9; mix-blend-mode:screen}
+.cmpbar .vals{font-family:var(--mono); font-size:10px; color:var(--faint); white-space:nowrap}
+.cmpbar .vals .xa{color:var(--A)} .cmpbar .vals .xb{color:var(--B)}
+.difflist .foot{font-size:10.5px; color:var(--faint); font-style:italic; padding:12px 10px 0; line-height:1.5}
+
+/* ---- span / tokio tables ---- */
+.tblpanel{flex:1; min-width:0; display:flex; flex-direction:column; background:var(--panel)}
+.tbl-view{flex:1; overflow:auto; padding:14px 16px}
+.tbl-head{display:flex; align-items:center; gap:10px; margin-bottom:12px; flex-wrap:wrap}
+.tbl-head .kindpill{font-family:var(--mono); font-size:11px; color:var(--dim);
+  background:var(--panel2); border:1px solid var(--line2); padding:3px 9px; border-radius:7px}
+.tbl-head .kindpill b{color:var(--ink)}
+.tbl-head label{font-size:11px; color:var(--faint)}
+.tbl-head select{background:var(--bg); color:var(--ink); border:1px solid var(--line2); border-radius:7px;
+  padding:5px 9px; font-family:var(--mono); font-size:11.5px}
+table{width:100%; border-collapse:collapse; font-size:12px}
+th{text-align:left; font-family:var(--cond); font-weight:600; letter-spacing:.05em; text-transform:uppercase;
+  font-size:10px; color:var(--faint); padding:6px 10px; border-bottom:1px solid var(--line2); position:sticky; top:0;
+  background:var(--panel)}
+th.num,td.num{text-align:right; font-family:var(--mono)}
+td{padding:8px 10px; border-bottom:1px solid var(--line); font-family:var(--mono); font-size:12px}
+tr:hover td{background:var(--panel2)}
+td.name{font-weight:500; color:var(--ink)}
+.comp{display:inline-flex; height:11px; width:150px; border-radius:4px; overflow:hidden; vertical-align:middle;
+  border:1px solid var(--line)}
+.comp span{height:100%}
+.split{display:inline-flex; height:11px; width:120px; border-radius:4px; overflow:hidden; border:1px solid var(--line); vertical-align:middle}
+.split .on{background:var(--A)} .split .off{background:var(--B-dim)}
+
+.legendrow{display:flex; gap:14px; align-items:center; font-size:10.5px; color:var(--faint); margin-bottom:10px; flex-wrap:wrap}
+.legendrow i{width:10px;height:10px;border-radius:3px;display:inline-block;margin-right:4px;vertical-align:middle}
+
+/* ---- unified diff table (single, aligned; the row IS the diff) ---- */
+.unified{flex:1; min-width:0; display:flex; flex-direction:column; background:var(--panel)}
+.unified .panel-head .aName{color:var(--A)} .unified .panel-head .bName{color:var(--B)}
+.dtbl{width:100%; border-collapse:separate; border-spacing:0; font-size:12px}
+.dtbl th{text-align:left; font-family:var(--cond); font-weight:600; letter-spacing:.05em; text-transform:uppercase;
+  font-size:10px; color:var(--faint); padding:8px 12px; border-bottom:1px solid var(--line2); position:sticky; top:0; background:var(--panel); z-index:2}
+.dtbl th .ab{font-family:var(--mono); text-transform:none; letter-spacing:0; font-size:10px}
+.dtbl th .ab .a{color:var(--A)} .dtbl th .ab .b{color:var(--B)}
+.dtbl td{padding:11px 12px; border-bottom:1px solid var(--line); vertical-align:middle}
+.dtbl tr:hover td{background:var(--panel2)}
+.dtbl td.nm{font-family:var(--mono); font-weight:500; color:var(--ink); white-space:nowrap}
+.rowbadge{font-family:var(--cond); font-size:9.5px; font-weight:600; letter-spacing:.05em; text-transform:uppercase;
+  padding:1px 6px; border-radius:5px; margin-left:8px}
+.rowbadge.new{background:rgba(255,106,95,.16); color:var(--B)}
+.rowbadge.gone{background:rgba(49,201,192,.16); color:var(--A)}
+
+/* shared latency/A-B text colors */
+.ta{color:var(--A)} .tb{color:var(--B)}
+.occ{font-family:var(--mono); font-size:12px; white-space:nowrap}
+
+/* DURATION = overlaid A/B histogram + moving p50/p99/p999 markers */
+.dist{min-width:260px}
+.hsvg{width:100%; height:40px; display:block; overflow:visible}
+.hsvg .gl{stroke:var(--line); stroke-width:.4}
+.hsvg .ha{fill:rgba(49,201,192,.20); stroke:var(--A); stroke-width:1; vector-effect:non-scaling-stroke}
+.hsvg .hb{fill:rgba(255,106,95,.20); stroke:var(--B); stroke-width:1; vector-effect:non-scaling-stroke}
+.hsvg .mk{vector-effect:non-scaling-stroke}
+.hsvg .mk.a{stroke:var(--A); opacity:.9} .hsvg .mk.b{stroke:var(--B); opacity:.9}
+/* percentile key: line-style swatches (solid/dashed/dotted) */
+.pkey{display:inline-flex; gap:10px; margin-left:8px; font-family:var(--mono); font-size:9.5px; color:var(--faint); text-transform:none; letter-spacing:0}
+.pkey b{display:inline-flex; align-items:center; gap:4px; font-weight:400}
+.pkey .sw{width:16px; height:0; border-top:2px solid var(--dim)}
+.pkey .sw.d{border-top-style:dashed} .pkey .sw.t{border-top-style:dotted}
+.dist .axis{position:relative; height:12px; margin-top:1px}
+.dist .axis span{position:absolute; transform:translateX(-50%); font-family:var(--mono); font-size:8.5px; color:var(--faint)}
+.dist .read{font-family:var(--mono); font-size:10.5px; color:var(--dim); margin-top:3px}
+.dist .read b{font-weight:600}
+
+/* COMPOSITION = two plain stacked bars A over B */
+.comp2{min-width:300px}
+.comp2 .crow{display:flex; align-items:center; gap:7px; margin:2px 0}
+.comp2 .cl{font-family:var(--mono); font-size:10px; color:var(--faint); width:10px}
+.cbar{display:inline-flex; height:18px; flex:1; border-radius:3px; overflow:hidden; border:1px solid var(--line)}
+.cbar span{height:100%; display:inline-flex; align-items:center; overflow:hidden}
+.cbar em{font-style:normal; font-family:var(--mono); font-size:9.5px; color:rgba(255,255,255,.92); padding:0 4px; white-space:nowrap; text-shadow:0 1px 1px rgba(0,0,0,.4)}
+.cbar span.dk em{color:rgba(16,20,30,.9); text-shadow:none}
+.comp2 .cnote{font-family:var(--mono); font-size:10px; color:var(--dim); margin-top:4px; margin-left:17px}
+.tblfoot{font-size:10.5px; color:var(--faint); font-style:italic; padding:12px 14px; line-height:1.5}
+
+/* ---- status ---- */
+.status{display:flex; align-items:center; gap:20px; padding:7px 18px; border-top:1px solid var(--line);
+  background:var(--bg2); flex-shrink:0; font-size:11px; color:var(--dim)}
+.status .mode{font-family:var(--cond); letter-spacing:.05em; color:var(--ink)}
+.status .grow{flex:1}
+.status .link{color:var(--cyan); cursor:pointer; display:flex; align-items:center; gap:5px}
+.status .link:hover{filter:brightness(1.2)}
+.status .pill{font-family:var(--mono); font-size:10px; background:var(--panel2); border:1px solid var(--line2);
+  padding:2px 7px; border-radius:5px; color:var(--dim)}
+.status em{color:var(--faint); font-style:italic}
+.illu{color:var(--faint); font-style:italic}
+</style>
+</head>
+<body class="view-flame">
+
+<div class="ribbon">
+  <span class="tag">Diff-first</span>
+  <span>Every view compares two selections — <b>A baseline</b> vs <i>B focus</i>. A lone flamegraph is just the <b>B&nbsp;=&nbsp;∅</b> case.</span>
+  <span class="sp">
+    <a href="index.html">gallery</a><a href="concept-1.html">c1</a><a href="concept-2.html">c2</a><a href="concept-3.html">c3</a>
+  </span>
+</div>
+
+<div class="head">
+  <div class="scope-title">
+    <div class="svc">checkout <small>us-east-1 · 2026-07-17 14:00–14:15</small></div>
+    <div class="sub">quick-built from S3 browser — “whole service, 15-min window”</div>
+  </div>
+  <div class="tabs" id="tabs">
+    <button class="tab on" data-view="flame">Flamegraph</button>
+    <button class="tab" data-view="spans">Spans</button>
+    <button class="tab" data-view="tokio">Tokio</button>
+  </div>
+  <div class="grow"></div>
+  <button class="cmp-btn" id="cmpBtn"><span class="glyph">⋔</span><span>Compare<br><small>pop out &gt; p99 latency</small></span></button>
+  <button class="back-btn" id="backBtn" style="display:none">← back to Inspect</button>
+</div>
+
+<div class="selbar">
+  <div class="side a">
+    <span class="badge a">A</span><span class="lbl">baseline</span>
+    <div class="chips" id="chipsA">
+      <span class="chip"><span class="kk">service</span>=checkout</span>
+      <span class="chip all">host = ∗ (all)</span>
+      <span class="chip"><span class="kk">time</span>=14:00–14:15</span>
+      <span class="chip not" id="notChip"><span class="kk">NOT</span> dur&gt;340ms <span class="x" id="notx" title="drop the complement — compare B vs the whole baseline">✕</span></span>
+    </div>
+    <div class="cov a"><div class="num"><b id="covAf">47</b>/480 files · <span id="covAp">9.8%</span></div><div class="bar"><div class="fill" id="covAfill" style="width:9.8%"></div></div></div>
+  </div>
+  <div class="arrow">→</div>
+  <div class="side b">
+    <span class="badge b">B</span><span class="lbl">focus</span>
+    <div class="chips" id="chipsB">
+      <span class="chip"><span class="kk">service</span>=checkout</span>
+      <span class="chip derived" id="derivedChip">
+        <span class="kk">dur</span>&gt;340ms
+        <span class="rf" id="refreshBtn" title="re-derive against all folded data">↻</span>
+        <span class="prov" id="prov">derived: p99 @ cov 12/480</span>
+      </span>
+    </div>
+    <div class="cov b"><div class="num"><b id="covBf">12</b>/480 files · <span id="covBp">2.5%</span></div><div class="bar"><div class="fill" id="covBfill" style="width:2.5%"></div></div></div>
+  </div>
+</div>
+
+<div class="vlocal">
+  <span class="lbl">view-local · flamegraph</span>
+  <span class="chip vl"><span class="kk">path ⊃</span> db::query <span class="side-tag b">B only</span> <span class="x" id="vlx">✕</span></span>
+  <span class="note">one-sided filter → A and B no longer share a predicate; the asymmetry is shown here, never silent.</span>
+</div>
+
+<div class="main">
+  <div class="views" id="views">
+    <!-- FLAMEGRAPH VIEW -->
+    <div class="panel pa" id="flameA">
+      <div class="panel-head">
+        <span class="pb-badge">A</span>
+        <div><div class="ptitle" id="paTitle">baseline</div></div>
+        <span class="psub" id="paSub">— all requests</span>
+        <div class="grow"></div>
+        <div class="selwrap">colour <select class="mini-sel" id="colorA"><option value="mod">by module</option><option value="delta">A/B delta</option><option value="hot">hotness</option></select></div>
+      </div>
+      <div class="panel-body"><canvas id="cvA"></canvas>
+        <div class="fg-legend" id="rampLegend" style="display:none"><span>A heavier</span><span class="ramp"></span><span>B heavier</span></div>
+      </div>
+    </div>
+    <div class="panel pb" id="flameB">
+      <div class="panel-head">
+        <span class="pb-badge">B</span>
+        <div><div class="ptitle">focus: dur&gt;340ms</div></div>
+        <span class="psub">— the slow p99 tail</span>
+        <span class="sync">⇄ synced to A · zoom / search / inspect mirror</span>
+        <div class="grow"></div>
+        <div class="selwrap">colour <select class="mini-sel" id="colorB"><option value="delta">A/B delta</option><option value="hot">hotness</option><option value="mod">by module</option></select></div>
+      </div>
+      <div class="panel-body"><canvas id="cvB"></canvas></div>
+    </div>
+  </div>
+
+  <div class="rail" id="rail">
+    <div class="rail-head">
+      <div class="t"><span class="spark"></span><h3>Most significant differences</h3><span class="grow"></span>
+        <span class="seg" id="rankSeg"><button class="on" data-rank="share">by share</button><button data-rank="rel">by Δ%</button></span>
+      </div>
+      <div class="cap" id="railCap">Ranked frames whose self-time shifted most between A and B · unsymbolised excluded.</div>
+    </div>
+    <div class="gate">
+      <div class="msg">⚠ Coverage asymmetric — <b>A 9.8%</b> vs <b>B 2.5%</b>. Differences are <b>preliminary</b> until both sides fold a comparable share.</div>
+      <button id="foldBtn">▶ simulate fold complete</button>
+    </div>
+    <div class="difflist" id="difflist"></div>
+  </div>
+</div>
+
+<div class="status">
+  <span class="mode" id="modeLbl">Inspect · B = ∅ · single full-width panel</span>
+  <span class="grow"></span>
+  <span>view: <b id="viewLbl" style="font-family:var(--mono);color:var(--cyan)">flamegraph</b></span>
+  <span><em>nav state (zoom/search) remembered per-view</em></span>
+  <span class="link" id="permalink">🔗 copy comparison link <span class="pill">A + B-as-Δ in URL</span></span>
+</div>
+
+<div class="tip" id="tip"></div>
+<div class="ctx" id="ctx">
+  <div class="title">filter to this path…</div>
+  <div class="item">keep only samples through <b style="font-family:var(--mono);margin:0 3px">db::query</b></div>
+  <div class="item">apply to <span class="st a">A only</span></div>
+  <div class="item">apply to <span class="st b">B only</span></div>
+  <div class="item">apply to <span class="st ab">both</span> · keeps sides comparable</div>
+  <div class="illu">illustrative — the “B only” result is the view-local chip above</div>
+</div>
+
+<script>
+"use strict";
+/* ------------------------------------------------------------------ *
+ * Hand-authored realistic call tree for a tokio checkout service.
+ * N(name, aSelf, bSelf, ...children). self = samples landing directly
+ * in this frame. `b` tells the story of the slow tail: db::query +
+ * pool lock_wait explode, cache_hit_path vanishes, retry::backoff
+ * appears. U(...) marks an unsymbolised frame (excluded from diff).
+ * ------------------------------------------------------------------ */
+function N(name,a,b,...kids){return{name,a,b,self_a:a,self_b:b,kids,opt:{}};}
+function U(name,a,b,...kids){const n=N(name,a,b,...kids);n.opt.unsym=true;return n;}
+
+const TREE = N("all",0,0,
+  N("tokio::runtime::worker::run_task",0,0,
+    N("<checkout::App as Service>::call",30,16,
+    N("checkout::handle_request",90,44,
+      N("checkout::route_checkout",40,20,
+        N("auth::verify",20,10,
+          N("jwt::decode",60,30, N("ring::signature::verify",70,34, N("ring::ec::verify",40,18))),
+          N("redis::get_session",22,10, N("tokio::net::TcpStream::read",40,20, N("mio::sys::read",90,52, U("__libc_recv",60,40)))),
+        ),
+        N("db::query",50,90,
+          N("sqlx::Executor::execute",60,70,
+            N("sqlx::mysql::MySqlConnection::run",40,60,
+              N("sqlx::mysql::protocol::write_query",30,26, N("tokio::net::TcpStream::write",90,120, N("mio::sys::write",60,90))),
+              N("sqlx::mysql::protocol::read_rows",70,90, N("tokio::net::TcpStream::read",120,180, N("mio::sys::read",110,190, U("__libc_recv",44,70)))),
+            ),
+            N("sqlx::decode::decode_row",80,96, N("sqlx::parse_rows",120,150)),
+          ),
+          N("pool::acquire",10,40,
+            N("lock_wait",6,220, N("futex_wait",8,180)),
+            N("parking_lot::Mutex::lock",10,80, N("std::sync::park",6,60)),
+          ),
+        ),
+        N("checkout::serialize_response",20,10,
+          N("serde_json::to_vec",120,54, N("serde::ser::serialize",96,40, N("itoa::write",50,20))),
+        ),
+        N("cache::lookup",14,10,
+          N("cache_hit_path",210,4, N("hashbrown::get",120,3, N("ahash::hash",60,2))),
+          N("cache_miss_path",20,120, N("db::query",20,90, N("sqlx::Executor::execute",40,120, N("tokio::net::TcpStream::read",50,140)))),
+        ),
+      ),
+      N("checkout::route_cart",30,16,
+        N("cart::load_items",40,24, N("db::query",50,88, N("tokio::net::TcpStream::read",70,120, N("mio::sys::read",60,110)))),
+        N("cart::price",50,26, N("decimal::mul",120,58, N("num_bigint::mul",70,30))),
+      ),
+    )),
+    N("retry::backoff",0,90,
+      N("tokio::time::sleep",4,150, N("tokio::time::Sleep::poll",6,90)),
+      N("checkout::handle_request",6,60, N("db::query",8,70, N("sqlx::Executor::execute",6,80))),
+    ),
+    N("metrics::flush",24,12, N("hdrhistogram::record",52,20, N("hdrhistogram::index_for",30,12))),
+  ),
+);
+
+function agg(n){let a=n.self_a,b=n.self_b;for(const k of n.kids){agg(k);a+=k.a;b+=k.b;}n.a=a;n.b=b;return n;}
+agg(TREE);
+const TOTAL_A=TREE.a, TOTAL_B=TREE.b;
+
+/* ---------- color ---------- */
+function lerp(a,b,t){return a+(b-a)*t;}
+function hex(c){return"#"+c.map(x=>Math.max(0,Math.min(255,Math.round(x))).toString(16).padStart(2,"0")).join("");}
+const TEAL=[49,201,192],SLATE=[59,71,95],CORAL=[255,106,95];
+function diverge(t){if(t<0){const u=-t;return hex([lerp(SLATE[0],TEAL[0],u),lerp(SLATE[1],TEAL[1],u),lerp(SLATE[2],TEAL[2],u)]);}return hex([lerp(SLATE[0],CORAL[0],t),lerp(SLATE[1],CORAL[1],t),lerp(SLATE[2],CORAL[2],t)]);}
+function deltaColor(n){const af=n.a/TOTAL_A,bf=n.b/TOTAL_B,eps=0.4/Math.max(TOTAL_A,TOTAL_B);const s=Math.log2((bf+eps)/(af+eps));return diverge(Math.max(-1,Math.min(1,s/3)));}
+let HUE={};
+function modColor(name){const mod=name.split("::")[0];if(!(mod in HUE)){HUE[mod]=(Object.keys(HUE).length*61+20)%360;}return"hsl("+HUE[mod]+" 42% 50%)";}
+function hotColor(n,side){const f=(side==="a"?n.self_a/TOTAL_A:n.self_b/TOTAL_B);const t=Math.min(1,Math.pow(f*60,.5));return hex([lerp(60,255,t),lerp(70,150,t),lerp(90,40,t)]);}
+function colorOf(n,side,mode){if(n.opt.unsym)return"#2c3346";if(mode==="mod")return modColor(n.name);if(mode==="hot")return hotColor(n,side);return deltaColor(n);}
+
+/* ---------- flame layout + render ---------- */
+const PAD=1, TOP=8;
+function maxDepth(node,side,d){let m=d;for(const k of node.kids){if((side==="a"?k.a:k.b)>0)m=Math.max(m,maxDepth(k,side,d+1));}return m;}
+function layout(node,side,x,w,depth,out){
+  const val=side==="a"?node.a:node.b; if(val<=0||w<0.4)return;
+  out.push({node,x,w,depth});
+  let cx=x;
+  for(const k of node.kids){const kv=side==="a"?k.a:k.b; if(kv<=0)continue; const kw=kv/val*w; layout(k,side,cx,kw,depth+1,out); cx+=kw;}
+}
+function draw(canvas,side){
+  const wrap=canvas.parentElement,dpr=window.devicePixelRatio||1;
+  const W=wrap.clientWidth,H=wrap.clientHeight; if(W<2||H<2)return;
+  canvas.width=W*dpr; canvas.height=H*dpr;
+  const ctx=canvas.getContext("2d"); ctx.setTransform(dpr,0,0,dpr,0,0); ctx.clearRect(0,0,W,H);
+  const mode=document.getElementById(side==="a"?"colorA":"colorB").value;
+  const boxes=[]; layout(TREE.kids[0],side,6,W-12,0,boxes);
+  canvas._boxes=boxes;
+  // scale row height so the tree fills the panel (min 15, max 30), leaving a
+  // little breathing room at the bottom for the legend overlay.
+  const depth=maxDepth(TREE.kids[0],side,0)+1;
+  const ROW=Math.max(15,Math.min(42,Math.floor((H-TOP-30)/depth)));
+  canvas._row=ROW;
+  ctx.font=(ROW<18?'500 10px':'500 11.5px')+' "IBM Plex Mono",monospace'; ctx.textBaseline="middle";
+  for(const bx of boxes){
+    const y=TOP+bx.depth*ROW,h=ROW-PAD,col=colorOf(bx.node,side,mode);
+    ctx.fillStyle=col; roundRect(ctx,bx.x,y,Math.max(bx.w-1,.5),h,3); ctx.fill();
+    if(bx.node.opt.unsym){ctx.save();ctx.beginPath();roundRect(ctx,bx.x,y,Math.max(bx.w-1,.5),h,3);ctx.clip();ctx.strokeStyle="rgba(255,255,255,.10)";ctx.lineWidth=1;for(let i=-h;i<bx.w;i+=5){ctx.beginPath();ctx.moveTo(bx.x+i,y);ctx.lineTo(bx.x+i+h,y+h);ctx.stroke();}ctx.restore();}
+    if(bx.w>34){const lum=bx.node.opt.unsym?0:luma(col);ctx.fillStyle=lum>150?"rgba(10,14,22,.9)":"rgba(236,242,252,.94)";ctx.fillText(fit(ctx,bx.node.name,bx.w-8),bx.x+5,y+h/2+.5);}
+  }
+}
+function roundRect(ctx,x,y,w,h,r){r=Math.min(r,w/2,h/2);ctx.beginPath();ctx.moveTo(x+r,y);ctx.arcTo(x+w,y,x+w,y+h,r);ctx.arcTo(x+w,y+h,x,y+h,r);ctx.arcTo(x,y+h,x,y,r);ctx.arcTo(x,y,x+w,y,r);ctx.closePath();}
+function luma(c){if(c.startsWith("hsl"))return 120;const h=c.slice(1);return .299*parseInt(h.slice(0,2),16)+.587*parseInt(h.slice(2,4),16)+.114*parseInt(h.slice(4,6),16);}
+function fit(ctx,s,max){if(ctx.measureText(s).width<=max)return s;let lo=0,hi=s.length;while(lo<hi){const m=(lo+hi+1)>>1;if(ctx.measureText(s.slice(0,m)+"…").width<=max)lo=m;else hi=m-1;}return lo<1?"":s.slice(0,lo)+"…";}
+
+/* ---------- hover + context menu ---------- */
+function hookHover(canvas){
+  const tip=document.getElementById("tip");
+  canvas.addEventListener("mousemove",e=>{
+    const r=canvas.getBoundingClientRect(),mx=e.clientX-r.left,my=e.clientY-r.top;
+    const ROW=canvas._row||17;
+    const bx=(canvas._boxes||[]).find(b=>{const y=TOP+b.depth*ROW;return mx>=b.x&&mx<=b.x+b.w&&my>=y&&my<=y+ROW;});
+    if(!bx){tip.style.display="none";return;}
+    const n=bx.node,af=n.a/TOTAL_A*100,bf=n.b/TOTAL_B*100;
+    const dl=n.a===0?'<span style="color:var(--B)">new in B</span>':n.b===0?'<span style="color:var(--A)">gone in B</span>':(bf>=af?'<span style="color:var(--B)">+'+((bf/af-1)*100|0)+'% share in B</span>':'<span style="color:var(--A)">−'+((1-bf/af)*100|0)+'% share in B</span>');
+    tip.innerHTML='<div class="fn">'+n.name+(n.opt.unsym?' · <span style="color:var(--faint)">[unsymbolised — excluded]</span>':'')+'</div>'+
+      '<div class="row a"><span class="k">A · baseline</span><span class="v">'+af.toFixed(1)+'%  ('+n.a+' smp)</span></div>'+
+      '<div class="row b"><span class="k">B · focus</span><span class="v">'+bf.toFixed(1)+'%  ('+n.b+' smp)</span></div>'+
+      '<div class="delta">'+dl+'</div>';
+    tip.style.display="block";
+    tip.style.left=Math.min(e.clientX+14,innerWidth-tip.offsetWidth-10)+"px";
+    tip.style.top=Math.min(e.clientY+14,innerHeight-tip.offsetHeight-10)+"px";
+  });
+  canvas.addEventListener("mouseleave",()=>document.getElementById("tip").style.display="none");
+  canvas.addEventListener("contextmenu",e=>{e.preventDefault();const c=document.getElementById("ctx");c.style.display="block";c.style.left=Math.min(e.clientX,innerWidth-230)+"px";c.style.top=Math.min(e.clientY,innerHeight-200)+"px";});
+}
+addEventListener("click",e=>{if(!e.target.closest("#ctx"))document.getElementById("ctx").style.display="none";});
+
+/* ---------- flamegraph differences ---------- */
+function selfRows(){
+  const m={};
+  (function walk(n){if(!n.opt.unsym){(m[n.name]||(m[n.name]={a:0,b:0,name:n.name}));m[n.name].a+=n.self_a;m[n.name].b+=n.self_b;}n.kids.forEach(walk);})(TREE);
+  return Object.values(m).filter(r=>r.name!=="all"&&(r.a+r.b)>=20).map(r=>{
+    r.ap=r.a/TOTAL_A*100; r.bp=r.b/TOTAL_B*100; r.dShare=r.bp-r.ap; r.dAbs=r.b-r.a;
+    r.rel=r.a===0?Infinity:r.b===0?-1:r.b/r.a-1; return r;});
+}
+let RANK="share";
+function renderDiffFlame(){
+  const rows=selfRows();
+  rows.sort((x,y)=>RANK==="share"?Math.abs(y.dShare)-Math.abs(x.dShare):(Math.abs(y.rel===Infinity?9:y.rel)-Math.abs(x.rel===Infinity?9:x.rel)));
+  const top=rows.slice(0,9),maxv=Math.max(...top.map(r=>Math.max(r.ap,r.bp)),1);
+  document.getElementById("difflist").innerHTML=top.map(r=>{
+    const flag=r.a===0?'<span class="flag new">new</span>':r.b===0?'<span class="flag gone">gone</span>':'';
+    const up=r.dShare>=0;
+    const dlabel=r.a===0?'new':r.b===0?'−100%':(r.rel>=0?'+'+(r.rel*100|0)+'%':'−'+((-r.rel)*100|0)+'%');
+    return '<div class="diffrow"><div class="name"><span class="n">'+r.name+'</span>'+flag+'</div>'+
+      '<div class="delta '+(up?'up':'down')+'">'+dlabel+'<small>'+(up?'+':'')+r.dShare.toFixed(1)+' pp · '+(r.dAbs>=0?'+':'')+r.dAbs+' smp</small></div>'+
+      '<div class="cmpbar"><div class="track"><div class="va" style="width:'+(r.ap/maxv*100)+'%"></div><div class="vb" style="width:'+(r.bp/maxv*100)+'%"></div></div>'+
+      '<span class="vals"><span class="xa">A '+r.ap.toFixed(1)+'%</span> <span class="xb">B '+r.bp.toFixed(1)+'%</span></span></div></div>';
+  }).join("")+'<div class="foot">Δ share = shift in this frame’s % of the profile (percentage-points). “new / gone” = present on only one side. Unsymbolised frames are excluded — they always differ and would flood the ranking.</div>';
+}
+
+/* ---------- unified diff datasets ----------
+ * One row per identity, carrying BOTH sides. p50/p95/p99 in ns; occ = count;
+ * comp = 5-way composition [on-cpu, sched, sync-block, async-wait, unknown].
+ * The row renders as a DIFF (range dumbbell + reallocation), never two rows. */
+const COMPC=["var(--A)","#c9a13b","#c96f6f","var(--B-dim)","var(--neutral)"],COMPL=["on-cpu","sched","sync-block","async-wait","unknown"];
+const NS={us:1e3,ms:1e6};
+function ms(x){return x*NS.ms;} function us(x){return x*NS.us;}
+function fmtT(ns){if(ns>=1e9)return(ns/1e9).toFixed(ns>=1e10?0:1)+"s";if(ns>=1e6)return(ns/1e6).toFixed(ns>=1e7?0:0)+"ms";if(ns>=1e3)return(ns/1e3).toFixed(0)+"µs";return ns+"ns";}
+function fmtC(n){return n>=1e6?(n/1e6).toFixed(1)+"M":n>=1e3?(n/1e3).toFixed(0)+"K":""+n;}
+
+/* per side: [p50, p99, p999] in ns. Histogram is synthesized log-normally
+ * from p50/p99 so the OVERLAY + percentile MARKERS move together. */
+const SPANS=[
+  {n:"db.query",       occA:842000, occB:41000, aP:[ms(3),ms(12),ms(28)],   bP:[ms(120),ms(340),ms(520)], compA:[55,10,20,10,5], compB:[18,14,30,34,4]},
+  {n:"http.request",   occA:610000, occB:38000, aP:[ms(30),ms(140),ms(260)],bP:[ms(180),ms(620),ms(1200)],compA:[30,8,40,18,4], compB:[14,10,26,46,4]},
+  {n:"auth.verify",    occA:598000, occB:37000, aP:[ms(1.2),ms(6),ms(14)],  bP:[ms(4),ms(11),ms(20)],     compA:[70,6,14,6,4],  compB:[52,10,20,14,4]},
+  {n:"cache.get",      occA:1200000,occB:33000, aP:[us(400),ms(2),ms(5)],   bP:[us(500),ms(1),ms(3)],     compA:[80,4,8,4,4],   compB:[82,4,6,4,4]},
+  {n:"serialize.resp", occA:604000, occB:36000, aP:[us(800),ms(4),ms(9)],   bP:[ms(1),ms(3),ms(7)],       compA:[88,2,4,2,4],   compB:[86,2,4,4,4]},
+  {n:"retry.attempt",  occA:0,      occB:9000,  aP:null,                    bP:[ms(80),ms(300),ms(600)],  compA:null,           compB:[6,4,80,6,4]},
+];
+const TOKIO=[
+  {n:"axum::serve @ src/main.rs:243",           occA:1200000,occB:38000, aP:[us(20),us(40),us(90)],  bP:[us(700),ms(1.2),ms(3)],compA:[78,6,10,2,4], compB:[24,20,40,12,4]},
+  {n:"checkout::handler::spawn @ handler.rs:88",occA:891000, occB:1200000,aP:[ms(2),ms(6),ms(14)],   bP:[ms(120),ms(210),ms(380)],compA:[70,8,14,4,4], compB:[24,14,20,38,4]},
+  {n:"db::pool::spawn @ src/pool.rs:210",       occA:420000, occB:512000, aP:[us(300),ms(1),ms(3)],  bP:[ms(22),ms(44),ms(90)], compA:[61,10,20,5,4],compB:[19,16,55,6,4]},
+  {n:"metrics::flush::spawn @ src/main.rs:57",  occA:31000,  occB:33000,  aP:[us(60),us(90),us(140)],bP:[us(80),us(110),us(180)],compA:[95,1,2,1,1],  compB:[93,2,2,2,1]},
+];
+
+/* shared log axis across a dataset's full range so histograms line up row-to-row */
+function axisFor(rows){let lo=Infinity,hi=0;rows.forEach(r=>{[r.aP,r.bP].forEach(p=>{if(p){lo=Math.min(lo,p[0]);hi=Math.max(hi,p[2]);}});});
+  const l0=Math.floor(Math.log10(lo)),l1=Math.ceil(Math.log10(hi));return {l0,l1,span:Math.max(1,l1-l0)};}
+function xOf(ns,ax){return (Math.log10(ns)-ax.l0)/ax.span*100;}
+function gridTicks(ax){const t=[];for(let e=ax.l0;e<=ax.l1;e++)t.push(e);return t;}
+
+/* log-normal density in log10 space from p50 (median) & p99 */
+function densityFn(p50,p99){const mu=Math.log10(p50),sigma=Math.max(0.08,(Math.log10(p99)-mu)/2.326);
+  return lx=>Math.exp(-((lx-mu)*(lx-mu))/(2*sigma*sigma));}
+
+/* DURATION cell = overlaid A/B histogram on a shared log axis, with p50/p99/p999
+ * markers that visibly move with the distribution. Kept compact & flat. */
+const NB=44, HH=40;
+function histPath(fn,ax){let d="M0,"+HH,mx=0;const ys=[];for(let i=0;i<=NB;i++){const lx=ax.l0+ (i/NB)*ax.span; const v=fn(lx); ys.push(v); mx=Math.max(mx,v);}
+  for(let i=0;i<=NB;i++){const x=(i/NB)*100, y=HH-(ys[i]/(mx||1))*(HH-3); d+=" L"+x.toFixed(1)+","+y.toFixed(1);} d+=" L100,"+HH+" Z"; return d;}
+// p50 solid, p99 dashed, p999 dotted — same visual code both sides, so the
+// pattern reads the percentile and the color reads the side.
+const MK_DASH=["none","3 2","1 2.5"];      // p50, p99, p999
+const MK_W=[1.6,1.1,1.1];
+function markers(p,ax,cls){return p.map((v,i)=>{const x=xOf(v,ax);
+  return '<line class="mk '+cls+'" x1="'+x+'" x2="'+x+'" y1="0" y2="'+HH+'" stroke-dasharray="'+MK_DASH[i]+'" style="stroke-width:'+MK_W[i]+'"/>';}).join("");}
+function distCell(r,ax){
+  const grid=gridTicks(ax).map(e=>{const x=xOf(Math.pow(10,e),ax);return '<line class="gl" x1="'+x+'" x2="'+x+'" y1="0" y2="'+HH+'"/>';}).join("");
+  let areas="",mk="";
+  if(r.aP){areas+='<path class="ha" d="'+histPath(densityFn(r.aP[0],r.aP[1]),ax)+'"/>'; mk+=markers(r.aP,ax,"a");}
+  if(r.bP){areas+='<path class="hb" d="'+histPath(densityFn(r.bP[0],r.bP[1]),ax)+'"/>'; mk+=markers(r.bP,ax,"b");}
+  const tlabels=gridTicks(ax).map(e=>'<span style="left:'+xOf(Math.pow(10,e),ax)+'%">'+fmtT(Math.pow(10,e))+'</span>').join("");
+  // numeric readout: p50 / p99 / p999, A → B
+  let read="";
+  if(r.aP&&r.bP){read=["p50","p99","p999"].map((l,i)=>l+' <b class="ta">'+fmtT(r.aP[i])+'</b>→<b class="tb">'+fmtT(r.bP[i])+'</b>').join(' · ');}
+  else if(r.bP){read='<span class="tb">only in B</span> · p50 '+fmtT(r.bP[0])+' · p99 '+fmtT(r.bP[1])+' · p999 '+fmtT(r.bP[2]);}
+  else if(r.single){read='p50 '+fmtT(r.aP[0])+' · p99 '+fmtT(r.aP[1])+' · p999 '+fmtT(r.aP[2]);}
+  else {read='<span class="ta">only in A</span> · p50 '+fmtT(r.aP[0])+' · p99 '+fmtT(r.aP[1]);}
+  return '<div class="dist"><svg viewBox="0 0 100 '+HH+'" preserveAspectRatio="none" class="hsvg">'+grid+areas+mk+'</svg>'+
+    '<div class="axis">'+tlabels+'</div><div class="read">'+read+'</div></div>';
+}
+
+/* occurrences A→B */
+function occCell(r){
+  const a=r.occA?'<span class="ta">'+fmtC(r.occA)+'</span>':'<span style="color:var(--faint)">—</span>';
+  const b=r.occB?'<span class="tb">'+fmtC(r.occB)+'</span>':'<span style="color:var(--faint)">—</span>';
+  return '<span class="occ">'+a+' → '+b+'</span>';
+}
+
+/* COMPOSITION = two stacked bars, A over B. Segments carry INLINE labels +
+ * the time they represent (pct × that side's p99 elapsed), so you read the
+ * bar directly without crossing to a legend. Thin segments stay unlabeled. */
+function darkText(i){return i===1;} // sched (gold) needs dark ink
+function compTwoBar(comp,elapsed){
+  return '<span class="cbar">'+comp.map((v,i)=>{
+    const t=elapsed?fmtT(v/100*elapsed):null;
+    // label if the segment is wide enough to hold text
+    let inner="";
+    if(v>=22) inner='<em>'+COMPL[i]+(t?' · '+t:'')+'</em>';
+    else if(v>=12) inner='<em>'+(t||COMPL[i])+'</em>';
+    return '<span class="'+(darkText(i)?'dk':'')+'" style="width:'+v+'%;background:'+COMPC[i]+'" title="'+COMPL[i]+' '+v+'%'+(t?' · '+t:'')+'">'+inner+'</span>';
+  }).join("")+'</span>';
+}
+function compCell(r){
+  if(!r.compA||!r.compB){const c=r.compB||r.compA,el=(r.bP||r.aP)[1];return '<div class="comp2"><div class="crow"><span class="cl">'+(r.compB?'B':'A')+'</span>'+compTwoBar(c,el)+'</div><div class="cnote illu">'+(r.compB?'only in B':'only in A')+'</div></div>';}
+  const deltas=r.compB.map((v,i)=>({i,d:v-r.compA[i]})).filter(x=>Math.abs(x.d)>=3).sort((a,b)=>Math.abs(b.d)-Math.abs(a.d)).slice(0,2);
+  const note=deltas.length?'shift: '+deltas.map(x=>COMPL[x.i]+' '+(x.d>0?'+':'−')+Math.abs(x.d)+'pp').join(', '):'≈ unchanged';
+  return '<div class="comp2"><div class="crow"><span class="cl">A</span>'+compTwoBar(r.compA,r.aP[1])+'</div><div class="crow"><span class="cl">B</span>'+compTwoBar(r.compB,r.bP[1])+'</div><div class="cnote">'+note+' <span class="illu">· segment time @ p99</span></div></div>';
+}
+
+/* single-selection table (Inspect / B=∅): just A, no diff. */
+function singleTable(rows,isTokio){
+  const ax=axisFor(rows);
+  const idCol=isTokio?"spawn location":"span type";
+  const pkey='<span class="pkey"><b><span class="sw"></span>p50</b><b><span class="sw d"></span>p99</b><b><span class="sw t"></span>p999</b></span>';
+  const ckey='<span class="pkey">'+COMPL.map((l,i)=>'<b><i style="width:9px;height:9px;border-radius:2px;display:inline-block;background:'+COMPC[i]+'"></i>'+l+'</b>').join("")+'</span>';
+  const head='<tr><th>'+idCol+'</th><th>occurrences</th><th>duration distribution'+pkey+'</th><th>time composition <span class="ab">time @ p99</span>'+ckey+'</th></tr>';
+  const body=rows.filter(r=>r.aP).map(r=>{
+    return '<tr><td class="nm">'+r.n+'</td><td class="occ"><span style="color:var(--dim)">'+fmtC(r.occA)+'</span></td><td>'+distCell({aP:r.aP,bP:null,single:true},ax)+'</td><td><div class="comp2"><div class="crow"><span class="cl">A</span>'+compTwoBar(r.compA,r.aP[1])+'</div></div></td></tr>';
+  }).join("");
+  return '<table class="dtbl"><thead>'+head+'</thead><tbody>'+body+'</tbody></table>';
+}
+
+/* ONE aligned diff table for a dataset. Row = the diff. */
+function unifiedTable(rows,isTokio){
+  const ax=axisFor(rows);
+  const idCol=isTokio?"spawn location":"span type";
+  const pkey='<span class="pkey"><b><span class="sw"></span>p50</b><b><span class="sw d"></span>p99</b><b><span class="sw t"></span>p999</b></span>';
+  const ckey='<span class="pkey">'+COMPL.map((l,i)=>'<b><i style="width:9px;height:9px;border-radius:2px;display:inline-block;background:'+COMPC[i]+'"></i>'+l+'</b>').join("")+'</span>';
+  const head='<tr><th>'+idCol+'</th><th>occurrences A→B</th>'+
+    '<th>duration distribution <span class="ab"><span class="a">A</span> <span class="b">B</span></span>'+pkey+'</th>'+
+    '<th>time composition <span class="ab"><span class="a">A</span> / <span class="b">B</span> · time @ p99</span>'+ckey+'</th></tr>';
+  const body=rows.map(r=>{
+    const badge=r.occA===0?'<span class="rowbadge new">new in B</span>':r.occB===0?'<span class="rowbadge gone">gone in B</span>':'';
+    return '<tr><td class="nm">'+r.n+badge+'</td><td>'+occCell(r)+'</td><td>'+distCell(r,ax)+'</td><td>'+compCell(r)+'</td></tr>';
+  }).join("");
+  return '<table class="dtbl"><thead>'+head+'</thead><tbody>'+body+'</tbody></table>';
+}
+
+/* rail for tabular views: derive significance from the SAME row data (p99
+ * shift), so the rail and the aligned table never disagree. */
+function renderDiffTable(rows,isTokio){
+  const scored=rows.filter(r=>r.aP&&r.bP).map(r=>({name:r.n,a:r.aP[2],b:r.bP[2],rel:r.bP[2]/r.aP[2]-1}));
+  rows.filter(r=>!r.aP||!r.bP).forEach(r=>scored.push({name:r.n,a:r.aP?r.aP[2]:0,b:r.bP?r.bP[2]:0,rel:r.aP?-1:Infinity,mem:r.aP?"gone":"new"}));
+  scored.sort((x,y)=>(y.rel===Infinity?9:Math.abs(y.rel))-(x.rel===Infinity?9:Math.abs(x.rel)));
+  const maxb=Math.max(...scored.map(s=>Math.max(s.a,s.b)));
+  document.getElementById("difflist").innerHTML=scored.slice(0,8).map(r=>{
+    const up=r.rel>=0, dl=r.mem==="new"?'new':r.mem==="gone"?'−100%':(up?'+':'−')+Math.abs(r.rel*100|0)+'%';
+    const flag=r.mem==="new"?'<span class="flag new">new</span>':r.mem==="gone"?'<span class="flag gone">gone</span>':'';
+    return '<div class="diffrow"><div class="name"><span class="n">'+r.name+' · p99</span>'+flag+'</div>'+
+    '<div class="delta '+(up?'up':'down')+'">'+dl+'<small>'+fmtT(r.a)+' → '+fmtT(r.b)+'</small></div>'+
+    '<div class="cmpbar"><div class="track"><div class="va" style="width:'+(r.a/maxb*100)+'%"></div><div class="vb" style="width:'+(r.b/maxb*100)+'%"></div></div>'+
+    '<span class="vals"><span class="xa">A '+fmtT(r.a)+'</span> → <span class="xb">B '+fmtT(r.b)+'</span></span></div></div>';
+  }).join("")+'<div class="foot">Ranked by p99 shift — the same numbers the aligned table shows. “new/gone” = set-membership change. Same significance machinery as the flamegraph view.</div>';
+}
+
+/* ---------- view switching ---------- */
+let VIEW="flame";
+function renderView(){
+  const views=document.getElementById("views");
+  document.getElementById("viewLbl").textContent=VIEW;
+  document.body.classList.toggle("view-flame",VIEW==="flame");
+  views.querySelectorAll(".tblpanel,.unified").forEach(n=>n.remove());
+  const folded=document.body.classList.contains("folded");
+  if(VIEW==="flame"){
+    document.getElementById("flameA").style.display="";
+    document.getElementById("flameB").style.display="";
+    document.getElementById("railCap").textContent="Ranked frames whose self-time shifted most between A and B · unsymbolised excluded.";
+    redraw(); if(folded)renderDiffFlame();
+  }else{
+    document.getElementById("flameA").style.display="none";
+    document.getElementById("flameB").style.display="none";
+    const isTokio=VIEW==="tokio", rows=isTokio?TOKIO:SPANS;
+    document.getElementById("railCap").textContent=isTokio?"Ranked spawn locations whose poll-duration shifted most · same machinery as the flamegraph.":"Ranked span types whose percentile shifted most · same machinery as the flamegraph.";
+    const compare=document.body.classList.contains("compare");
+    const gb=isTokio?'<label>group by</label><select><option selected>spawn_location</option><option>span type</option><option>host</option><option>attribute…</option></select>':'<label>group by</label><select><option selected>span type</option><option>spawn_location</option><option>host</option><option>attribute…</option></select>';
+    const kind=isTokio?'kind=<b>tokio_poll</b>':'kind=<b>tracing</b>';
+    const legend='<div class="legendrow">'+(compare
+      ? '<span><i style="background:var(--A)"></i>A baseline</span><span><i style="background:var(--B)"></i>B focus</span><span class="illu">one aligned row per '+(isTokio?'spawn location':'span type')+' — each cell is the A→B difference</span>'
+      : '<span class="illu">single selection — press Compare to diff against a focus set</span>')+'</div>';
+    const title = compare?'A baseline &nbsp;⇄&nbsp; B focus':'baseline';
+    const foot = isTokio
+      ? 'Duration = overlaid A/B poll-time histograms with p50/p99/p999 markers. Composition = A-over-B stacked bars; note names the biggest mover.'
+      : 'Duration = overlaid A/B histograms on a shared log axis; the p50 / p99 / p999 markers move with the distribution. Composition = A-over-B stacked bars. New/gone badges = set membership.';
+    views.insertAdjacentHTML("beforeend",
+      '<div class="unified"><div class="panel-head"><span class="pb-badge" style="background:linear-gradient(135deg,rgba(49,201,192,.16),rgba(255,106,95,.16));color:var(--ink)">⋔</span>'+
+      '<div><div class="ptitle"><span class="aName">A</span> baseline &nbsp;⇄&nbsp; <span class="bName">B</span> focus</div></div><span class="psub">'+(compare?'the row is the diff':'B = ∅')+'</span><div class="grow"></div>'+
+      '<div class="tbl-head" style="margin:0"><span class="kindpill">'+kind+'</span>'+gb+'</div></div>'+
+      '<div class="tbl-view">'+legend+ (compare?unifiedTable(rows,isTokio):singleTable(rows,isTokio)) +'<div class="tblfoot">'+foot+'</div></div></div>');
+    if(folded)renderDiffTable(rows,isTokio);
+  }
+}
+document.getElementById("tabs").addEventListener("click",e=>{const t=e.target.closest(".tab");if(!t)return;document.querySelectorAll(".tab").forEach(x=>x.classList.remove("on"));t.classList.add("on");VIEW=t.dataset.view;renderView();});
+
+/* ---------- compare / inspect ---------- */
+function setCompare(on){
+  document.body.classList.toggle("compare",on);
+  document.getElementById("cmpBtn").style.display=on?"none":"";
+  document.getElementById("backBtn").style.display=on?"":"none";
+  document.getElementById("modeLbl").textContent=on?"Compare · A (baseline ∖ P)  vs  B (baseline ∩ P) · two synced panels":"Inspect · B = ∅ · single full-width panel";
+  document.getElementById("paSub").textContent=on?"— the fast / normal requests":"— all requests";
+  document.getElementById("paTitle").innerHTML=on?"baseline ∖ (dur&gt;340ms)":"baseline";
+  document.getElementById("rampLegend").style.display=on?"flex":"none";
+  // A/B-delta coloring is meaningless without B — default to by-module in Inspect.
+  const cA=document.getElementById("colorA"); cA.value=on?"delta":"mod";
+  const cB=document.getElementById("colorB"); if(cB)cB.value=on?"delta":"mod";
+  setTimeout(renderView,300);
+}
+document.getElementById("cmpBtn").addEventListener("click",()=>setCompare(true));
+document.getElementById("backBtn").addEventListener("click",()=>setCompare(false));
+
+/* ---------- fold / gate + controls ---------- */
+document.getElementById("foldBtn").addEventListener("click",()=>{
+  document.body.classList.add("folded");
+  covSet("covAf","covAp","covAfill",468,97.5); covSet("covBf","covBp","covBfill",461,96.0);
+  renderView();
+});
+function covSet(f,p,fill,files,pct){document.getElementById(f).textContent=files;document.getElementById(p).textContent=pct+"%";document.getElementById(fill).style.width=pct+"%";}
+document.getElementById("rankSeg").addEventListener("click",e=>{const b=e.target.closest("button");if(!b)return;document.querySelectorAll("#rankSeg button").forEach(x=>x.classList.remove("on"));b.classList.add("on");RANK=b.dataset.rank;if(document.body.classList.contains("folded")&&VIEW==="flame")renderDiffFlame();});
+document.getElementById("colorA").addEventListener("change",()=>draw(cvA,"a"));
+document.getElementById("colorB").addEventListener("change",()=>draw(cvB,"b"));
+document.getElementById("vlx").addEventListener("click",()=>document.querySelector(".vlocal").style.display="none");
+document.getElementById("notx").addEventListener("click",()=>{document.getElementById("notChip").style.display="none";document.getElementById("modeLbl").textContent="Compare · A (whole baseline)  vs  B (baseline ∩ P) · B ⊆ A";});
+document.getElementById("refreshBtn").addEventListener("click",()=>{document.getElementById("prov").textContent="derived: p99 @ cov 461/480 (refreshed)";});
+document.getElementById("permalink").addEventListener("click",function(){const s=this.querySelector(".pill"),o=s.textContent;s.textContent="copied ✓";setTimeout(()=>s.textContent=o,1400);});
+
+/* ---------- boot ---------- */
+const cvA=document.getElementById("cvA"),cvB=document.getElementById("cvB");
+hookHover(cvA); hookHover(cvB);
+function redraw(){if(VIEW==="flame"){draw(cvA,"a");if(document.body.classList.contains("compare"))draw(cvB,"b");}}
+addEventListener("resize",redraw);
+renderView();
+</script>
+</body>
+</html>

--- a/docs/ui-inventory/mocks/index.html
+++ b/docs/ui-inventory/mocks/index.html
@@ -27,6 +27,11 @@
     <p>Today's layout untouched; exactly three additions: panels auto-expanded to fill the void, minimap strip, status bar with URL state. The cheapest credible fix; comparison baseline.</p>
     <div class="refs">fixes: S1 S3(partial) S8 · hold C inside to compare</div></a>
   </div>
+  <div class="card"><a href="concept-diff-first.html">
+    <h2>Diff-first unified view (interactive)</h2>
+    <p>Every view compares two Selections A vs B; a single flamegraph is the B=∅ case. Inspect→Compare split into two synced panels, Flamegraph/Spans/Tokio as views over one selection, pop-out compare with NOT-P complement, coverage-symmetry gating, and a significant-differences table. Drives the CONTEXT.md "Unified diff-first view" model.</p>
+    <div class="refs">design: CONTEXT.md · ADR-0004/0005 · click Compare, switch views, simulate fold</div></a>
+  </div>
   <div class="card"><a href="keyboard.html">
     <h2>Track A - Keyboard model (interactive)</h2>
     <p>Behavioral mock you can actually drive: / search palette over tasks/spans/POIs, n/p POI stepping, g goto-time, z zoom-undo, f fit, unified ?. Try the keys.</p>


### PR DESCRIPTION
## Summary
- define the diff-first unified analysis model and delivery plan
- document generalized span analysis and its wire contract
- record the server-side diff and span-identity ADRs
- include the design guidance and concept mock without changing implementation

## Stack
Stacked on #694. PR 7 of 7.

## Validation
- `git diff --check`
- exactly 12 documentation/guidance/mock paths; no code
- final Git tree equals `split/source-backup` and untouched `diff-first-design-doc`: `f8f31b9080daf97fdb5f3836e43899612689a991`
- full binary diff between the final stack and both protected sources is empty
