### PR TITLE
test(dial9): compile-test README examples, drop all `ignore`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,10 +356,26 @@ jobs:
             -p dial9-tokio-telemetry \
             -p dial9-viewer
 
+  doctests:
+    name: Doc tests (dial9)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: ${{ env.STABLE_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Run dial9 doctests
+        run: cargo test -p dial9 --doc --all-features
+        env:
+          RUSTFLAGS: "--cfg tokio_unstable"
+
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, build, android-aarch64-build, feature-check, check-docs, trace-integrity, ui, asan, ecs-sim, shuttle, package]
+    needs: [fmt, clippy, build, android-aarch64-build, feature-check, check-docs, trace-integrity, ui, asan, ecs-sim, shuttle, package, doctests]
     if: always()
     steps:
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: sudo apt-get update && sudo apt-get install -y jq
+      - run: command -v jq >/dev/null || (sudo apt-get update && sudo apt-get install -y jq)
       - run: cargo install cargo-docs-rs
       - run: ./scripts/check-docsrs.sh
 

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -243,10 +243,10 @@ With the `process-resource` feature, dial9 can sample process-level resource
 usage from `getrusage(RUSAGE_SELF)`. Programmatic builders leave it disabled
 unless you opt in:
 
-```rust,ignore
+```rust,no_run
 use dial9::process::ProcessResourceUsageConfig;
 use dial9::RecorderPerfExt;
-
+# let writer = dial9::MemoryBuffer::new(1 << 20).unwrap();
 let recorder = dial9::recorder(writer)
     .with_process_resource_usage(ProcessResourceUsageConfig::default())
     .build();
@@ -269,10 +269,10 @@ process.
 Programmatic builders leave socket accept queue sampling disabled unless you
 opt in:
 
-```rust,ignore
+```rust,no_run
 use dial9::socket::SocketAcceptQueuesConfig;
 use dial9::RecorderPerfExt;
-
+# let writer = dial9::MemoryBuffer::new(1 << 20).unwrap();
 let recorder = dial9::recorder(writer)
     .with_socket_accept_queues(SocketAcceptQueuesConfig::default())
     .build();
@@ -310,39 +310,42 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
 
 **Enable CPU profiling** (`.with_cpu_profiling` on the recorder):
 
-```rust,ignore
+```rust,no_run
 use dial9::cpu::{CpuProfilingConfig, SchedEventConfig};
 use dial9::RecorderPerfExt;
-dial9::recorder(writer)
+# let writer = dial9::MemoryBuffer::new(1 << 20).unwrap();
+let recorder = dial9::recorder(writer)
     // Enable normal CPU profiles
     .with_cpu_profiling(CpuProfilingConfig::default())
     // Enable per-worker scheduler event capture
     .with_sched_events(SchedEventConfig::default().include_kernel(true))
-    // ...
+    .build();
 ```
 
 By default, dial9 tries the perf backend and falls back to ctimer if
 `perf_event_open` is blocked. You can select the backend explicitly:
 
-```rust,ignore
+```rust,no_run
+use dial9::cpu::{CpuProfilingConfig, EventSource};
+
 // Use ctimer directly — zero thread lifecycle overhead, ideal for workloads
 // with high thread churn (e.g. saturated block_in_place usage).
-CpuProfilingConfig::with_ctimer_backend()
+let ctimer = CpuProfilingConfig::with_ctimer_backend();
 
 // Require perf — fail instead of silently degrading. Needed for kernel
 // stacks or hardware event sources.
-CpuProfilingConfig::with_perf_backend()
+let perf = CpuProfilingConfig::with_perf_backend()
     .event_source(EventSource::SwCpuClock)
-    .include_kernel(true)
+    .include_kernel(true);
 ```
 
 To use dial9 as a CPU profiler without installing Tokio runtime hooks, build a
 recorder and don't attach a runtime to it:
 
-```rust,ignore
+```rust,no_run
 use dial9::cpu::CpuProfilingConfig;
 use dial9::RecorderPerfExt;
-
+# let writer = dial9::MemoryBuffer::new(1 << 20).unwrap();
 let recorder = dial9::recorder(writer)
     .with_cpu_profiling(CpuProfilingConfig::default())
     .build();
@@ -536,7 +539,7 @@ You can also register a callback that runs from dial9's flush thread and emits
 custom events. This is useful for draining application-owned queues or taking
 periodic snapshots without passing a [`Dial9Handle`] through your code:
 
-```rust,ignore
+```rust,no_run
 use dial9::core::CustomEventsConfig;
 use dial9::{RecorderSourceExt, recorder};
 use dial9_trace_format::TraceEvent;
@@ -547,7 +550,8 @@ struct CacheEvent {
     timestamp_ns: u64,
     entries: u64,
 }
-
+# let writer = dial9::MemoryBuffer::new(1 << 20).unwrap();
+# let (_tx, rx) = std::sync::mpsc::channel::<CacheEvent>();
 let recorder = recorder(writer)
     .with_custom_events(CustomEventsConfig::default(), move |ctx| {
         while let Ok(event) = rx.try_recv() {

--- a/dial9/src/lib.rs
+++ b/dial9/src/lib.rs
@@ -94,7 +94,8 @@ pub use dial9_perf_self_profile::RecorderPerfExt;
 #[cfg(feature = "cpu-profiling")]
 pub mod cpu {
     pub use dial9_perf_self_profile::{
-        CpuProfiler, CpuProfilingConfig, CpuSampleSource, SchedEventConfig, SchedProfiler,
+        CpuProfiler, CpuProfilingConfig, CpuSampleSource, EventSource, SchedEventConfig,
+        SchedProfiler,
     };
 }
 


### PR DESCRIPTION
Fixes examples in the main README to make them `no_run` rather than `ignore`. Adds a Linux `cargo test -p dial9 --doc --all-features` CI job, wired into `CI Pass`