### PR TITLE
fix(viewer): carry queue step line's true level, not spike

### DIFF
--- a/dial9-viewer/ui/src/lib/canvas/stroke.test.ts
+++ b/dial9-viewer/ui/src/lib/canvas/stroke.test.ts
@@ -115,6 +115,49 @@ describe("downsampleSeriesToColumns", () => {
     expect(out[0]!.y).toBe(90);
   });
 
+  it("stepClose: emits the peak AND a close vertex at the column's last sample", () => {
+    // Spike (v=5) then drain-to-0 collapse into column 0; a far sample in col 8.
+    const pts: Pt[] = [
+      { t: 0.1, v: 5 }, // the spike
+      { t: 0.9, v: 0 }, // drained to 0, still column 0
+      { t: 8, v: 0 },
+    ];
+    const opts = {
+      xOf: (p: Pt) => p.t,
+      yOf: (p: Pt) => p.v,
+      weightOf: (p: Pt) => p.v,
+      drawW: 10,
+    };
+    // Without stepClose the drain is dropped: only the spike represents col 0.
+    expect(downsampleSeriesToColumns(pts, opts)).toEqual([
+      { x: 0.1, y: 5 },
+      { x: 8, y: 0 },
+    ]);
+    // With stepClose the column closes at its true ending level (0), so a step
+    // line carries 0 forward, not the spike's height.
+    expect(downsampleSeriesToColumns(pts, { ...opts, stepClose: true })).toEqual([
+      { x: 0.1, y: 5 },
+      { x: 0.9, y: 0 },
+      { x: 8, y: 0 },
+    ]);
+  });
+
+  it("stepClose: no close vertex when the peak IS the column's last sample", () => {
+    // Monotonic-up column: peak == last, so no zero-length close is emitted.
+    const pts: Pt[] = [
+      { t: 0.1, v: 1 },
+      { t: 0.9, v: 5 }, // peak and last
+    ];
+    const out = downsampleSeriesToColumns(pts, {
+      xOf: (p) => p.t,
+      yOf: (p) => p.v,
+      weightOf: (p) => p.v,
+      stepClose: true,
+      drawW: 10,
+    });
+    expect(out).toEqual([{ x: 0.9, y: 5 }]);
+  });
+
   it("clamps off-view samples into the edge columns (line keeps entry height)", () => {
     const pts: Pt[] = [
       { t: -50, v: 7 }, // the lowerBound-1 sample before the view
@@ -269,6 +312,30 @@ describe("makeStrokeBatcher", () => {
       { x: 19, y: 5 },
     ]);
     expect(pl!.length).toBeLessThanOrEqual(2 * Math.ceil(drawW));
+  });
+
+  it("stepSeries: a spike + drain in one column carries 0 forward, not the spike", () => {
+    // Regression for the per-worker queue line: a queue spike and its drain-to-0
+    // collapsing into one pixel column must not paint a high plateau across the
+    // following gap (a parked worker with local queue 0). weightOf keeps the
+    // spike visible; stepClose (auto-enabled by stepSeries) closes the column at
+    // 0 so the carried-forward level is the truth.
+    const b = makeStrokeBatcher();
+    const drawW = 10;
+    b.stepSeries(
+      "queue",
+      [
+        { t: 0.1, v: 5 }, // spike
+        { t: 0.9, v: 0 }, // drained, same column
+        { t: 8, v: 0 }, // far sample after a long gap (parked)
+      ] as Pt[],
+      { xOf: (p) => p.t, yOf: (p) => p.v, weightOf: (p) => p.v, drawW },
+    );
+    const [pl] = b.batches().get("queue")!.polylines;
+    // The spike is preserved at the left edge...
+    expect(pl!.some((v) => v.y === 5 && v.x < 1)).toBe(true);
+    // ...but everything from the drain onward is at 0 (no high plateau).
+    expect(pl!.filter((v) => v.x >= 1).every((v) => v.y === 0)).toBe(true);
   });
 });
 

--- a/dial9-viewer/ui/src/lib/canvas/stroke.ts
+++ b/dial9-viewer/ui/src/lib/canvas/stroke.ts
@@ -28,6 +28,19 @@ export interface ColumnSeriesOpts<P> {
    * (step semantics - the value that carries into the next column).
    */
   weightOf?: (p: P) => number;
+  /**
+   * Step-carry mode. When set, each column emits its weighted representative
+   * (the spike) AND a CLOSE vertex at the column's last sample (largest x), so a
+   * step line carries the true ending level forward instead of the spike's
+   * height. No-op without `weightOf` (the last sample already wins), so a
+   * plain line is unchanged. See `stepSeries`, which enables it.
+   *
+   * Without this, a spike and a later drain-to-0 that collapse into one pixel
+   * column would keep only the spike, and `expandSteps` would carry that spike's
+   * height across the whole gap to the right (wrong: the level had already
+   * dropped). Default false.
+   */
+  stepClose?: boolean;
   /** Left edge of the draw area in CSS px. Default 0. */
   x0?: number;
   /** Draw-area width in CSS px. */
@@ -35,9 +48,10 @@ export interface ColumnSeriesOpts<P> {
 }
 
 /**
- * Downsample a series to at most one vertex per pixel column. Returns
- * vertices in ascending column order, at most ceil(drawW) of them,
- * regardless of how many input points are visible.
+ * Downsample a series to at most one vertex per pixel column (at most two with
+ * `stepClose`). Returns vertices in ascending column order, at most ceil(drawW)
+ * of them (2 * ceil(drawW) with `stepClose`), regardless of how many input
+ * points are visible.
  *
  * `points` MUST be sorted ascending by xOf (same contract as the frozen
  * core's pixelDownsampleSpans); out-of-order input throws rather than
@@ -51,6 +65,7 @@ export function downsampleSeriesToColumns<P>(
 ): Vertex[] {
   const { xOf, yOf, weightOf, drawW } = opts;
   const x0 = opts.x0 ?? 0;
+  const stepClose = opts.stepClose ?? false;
   const nCols = Math.ceil(drawW);
   if (nCols <= 0 || points.length === 0) return [];
 
@@ -60,9 +75,21 @@ export function downsampleSeriesToColumns<P>(
   let repY = 0;
   let repWeight = -Infinity;
   let hasRep = false;
+  // The column's last sample (largest x), for stepClose. Input is x-sorted so
+  // the last point processed in a column has the largest x, i.e. lastX >= repX.
+  let lastX = 0;
+  let lastP: P | null = null;
 
   const flush = () => {
-    if (hasRep) out.push({ x: repX, y: repY });
+    if (!hasRep) return;
+    out.push({ x: repX, y: repY });
+    // Close the column at its true ending level so the carried-forward step is
+    // the last value, not the spike. Skip when the last sample IS the rep
+    // (monotonic-up / single-sample columns) to avoid a zero-length segment.
+    if (stepClose && lastP !== null) {
+      const ly = yOf(lastP);
+      if (lastX !== repX || ly !== repY) out.push({ x: lastX, y: ly });
+    }
   };
 
   for (const p of points) {
@@ -78,6 +105,7 @@ export function downsampleSeriesToColumns<P>(
       col = c;
       repWeight = -Infinity;
       hasRep = false;
+      lastP = null;
     }
     if (weightOf === undefined) {
       // Last point in the column wins.
@@ -92,6 +120,10 @@ export function downsampleSeriesToColumns<P>(
         repY = yOf(p);
         hasRep = true;
       }
+    }
+    if (stepClose) {
+      lastX = xc;
+      lastP = p;
     }
   }
   flush();
@@ -181,7 +213,11 @@ export function makeStrokeBatcher(): StrokeBatcher {
       if (vertices.length > 0) entry(styleKey).batch.polylines.push(vertices);
     },
     stepSeries(styleKey, points, opts) {
-      const vertices = expandSteps(downsampleSeriesToColumns(points, opts));
+      // stepClose: a step line must carry the column's LAST value forward, not
+      // its weighted spike. No-op when opts has no weightOf (last already wins).
+      const vertices = expandSteps(
+        downsampleSeriesToColumns(points, { ...opts, stepClose: true }),
+      );
       if (vertices.length > 0) entry(styleKey).batch.polylines.push(vertices);
     },
     polyline(styleKey, vertices) {


### PR DESCRIPTION
## Summary
The per-worker local-queue line (gold step line, bottom of each worker lane) drew a high plateau where depth was actually 0. A parked worker with tooltip `Local Q: 0` rendered high, and flickered low/high on horizontal scroll over the same time region.

The line downsamples to one max-weight vertex per pixel column (`weightOf: s.local`, added in migration #665 for perf). That vertex is used both as the spike and as the level `expandSteps` carries forward. When a spike and its drain-to-0 land in the same column, max-weight keeps the spike and drops the drain, then carries the spike height across the parked gap. Separate columns render correctly, hence the scroll flicker.

Add `stepClose` to `downsampleSeriesToColumns`: each column also emits a close vertex at its last sample, so the carried-forward step is the true ending level while the spike stays visible. `stepSeries` enables it; no-op without `weightOf`, so plain lines and the CPU track are unaffected. Restores pre-migration per-sample step semantics at O(pixels) cost.