### PR TITLE
fix(viewer): preserve task and worker focus links

### DIFF
--- a/dial9-viewer/ui/src/pages/viewer/spans-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/spans-model.test.ts
@@ -5,7 +5,7 @@
 // case drives buildSpanData through real SpanEnter/SpanExit events.
 
 import { describe, it, expect } from "vitest";
-import type { CustomTraceEvent, TracingSpan, WorkerLane } from "../../lib/trace/index.js";
+import type { CustomTraceEvent, SpanData, TracingSpan, WorkerLane } from "../../lib/trace/index.js";
 import {
   buildSpanRenderModel,
   computeSpanTrackData,
@@ -168,6 +168,31 @@ describe("computeSpanTrackData", () => {
     ]).allSpans[0]!;
     expect(span.taskId).toBeNull();
     expect(span.activeNs).toBe(8000);
+  });
+
+  it("uses precomputedSpanData even when customEvents is empty (columnar all-span trace)", () => {
+    // Regression: the columnar path routes SPAN events OUT of customEvents into
+    // a separate store, so a trace of ONLY spans (e.g. a shale trace of just
+    // SpanEnter__/SpanExit__) leaves customEvents empty while the authoritative
+    // spans live in precomputedSpanData. computeSpanTrackData must NOT bail on
+    // the empty customEvents and discard them (the legacy viewer kept span
+    // events in customEvents, so its guard never tripped - hence the divergence).
+    const a = span("a", "load", 100, 300, { taskId: 7 });
+    const b = span("b", "auth", 150, 400);
+    const precomputed: SpanData = {
+      allSpans: [a, b],
+      spanMeta: new Map([
+        ["a", { spanName: "load", fields: {}, parentSpanId: null }],
+        ["b", { spanName: "auth", fields: {}, parentSpanId: null }],
+      ]),
+      childrenByParent: new Map(),
+      maxDepth: 0,
+      unmatchedSpans: [],
+    };
+    const data = computeSpanTrackData([], undefined, precomputed);
+    expect(data.allSpans.map((s) => s.spanId)).toEqual(["a", "b"]);
+    expect(data.spanNames).toEqual(["auth", "load"]);
+    expect(data.durationsByName.get("load")).toEqual([200]);
   });
 });
 

--- a/dial9-viewer/ui/src/pages/viewer/spans-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/spans-model.ts
@@ -94,7 +94,17 @@ export function computeSpanTrackData(
   workerSpans?: Record<number, LaneSpans>,
   precomputedSpanData?: SpanData,
 ): SpanTrackData {
-  if (customEvents == null || customEvents.length === 0) {
+  // The columnar path routes SPAN events OUT of `customEvents` into a separate
+  // span-event store, so `customEvents` can be empty even when the trace is
+  // ALL spans (e.g. a shale trace of only SpanEnter/SpanExit). In that case the
+  // authoritative span data lives in `precomputedSpanData`, so only bail early
+  // when there is NEITHER a precomputed result NOR any events to build one from.
+  // (The fat/legacy path keeps span events in `customEvents`, so its guard trips
+  // only for a genuinely span-free trace.)
+  if (
+    precomputedSpanData === undefined &&
+    (customEvents == null || customEvents.length === 0)
+  ) {
     return EMPTY_SPAN_TRACK_DATA;
   }
   // With workerSpans, each span's active segments are reconstructed from its
@@ -104,7 +114,7 @@ export function computeSpanTrackData(
   // so buildSpanData runs once per trace instead of once per span consumer.
   const data =
     precomputedSpanData ??
-    buildSpanData(customEvents, workerSpans && fatLanes(workerSpans));
+    buildSpanData(customEvents!, workerSpans && fatLanes(workerSpans));
   const cs = data.columnarSpans;
   const spanCount = cs ? cs.length : data.allSpans.length;
   if (spanCount === 0 && data.unmatchedSpans.length === 0) {


### PR DESCRIPTION
## Summary

- prevent unnamed poll focus links from selecting an unrelated overlapping tracing span
- apply `focus_task` selection and reveal the `focus_worker` lane in the migrated viewer
- preserve exact named-span focusing and the legacy viewer fallback behavior
- cover the reported `start`/`end`/hex `task` URL state

## Testing

- `npx vitest run src/pages/viewer/focus-link.test.ts src/pages/viewer/url-state.test.ts`
- `npm run check:types`
- `node test_focus_timebase.js`
- `cargo build -p dial9-viewer`