### PR TITLE
fix(release): allow-dirty publish for dial9-viewer

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -68,6 +68,9 @@ version_group = "trace-format"
 [[package]]
 name = "dial9-viewer"
 changelog_update = false
+# ui/dist is gitignored but force-included in the package, so the
+# CI-built dist trips cargo publish's dirty check. Allow it for this crate only.
+publish_allow_dirty = true
 
 [[package]]
 name = "dial9"


### PR DESCRIPTION
dial9-viewer bundles its CI-built `ui/dist` (gitignored, force-included so `cargo install` users don't need Node). cargo flags that as a dirty tree and refuses to publish. 

This sets `publish_allow_dirty` for the crate to allow publishing. 
This is blocking 0.5.0-rc0: https://github.com/dial9-rs/dial9/actions/runs/30044071056/job/89335911003