### PR TITLE
refactor: make viewer/cli feature off by default & update changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,9 +134,16 @@ jobs:
         shell: bash
         run: npm ci && npm run build
 
-      - run: cargo build --release --target ${{ matrix.target }} -p dial9-viewer -p dial9
+      - run: cargo build --release --target ${{ matrix.target }} -p dial9-viewer -p dial9 --features dial9/cli
         env:
           RUSTFLAGS: "--cfg tokio_unstable"
+
+      - name: Smoke-test the dial9 binary
+        shell: bash
+        run: |
+          bin="target/${{ matrix.target }}/release/dial9"
+          [ "${{ matrix.archive }}" = "zip" ] && bin="${bin}.exe"
+          "$bin" --help
 
       - name: Determine tag and version
         id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0-rc0](https://github.com/dial9-rs/dial9/compare/dial9-tokio-telemetry-v0.5.0-rc0...dial9-tokio-telemetry-v0.5.0-rc0) - 2026-07-23
+
 `dial9` is now the facade for all dial9 features: one dependency, `dial9 = "0.5"`, re-exporting the recorder, the
 Tokio instrumentation, the perf sources, and the viewer CLI, and owning `#[dial9::main]` and
 `dial9::record_event`. This is a breaking release: you depend on `dial9` instead of
 `dial9-tokio-telemetry`, and the config, writer, and handle APIs all change.
 
 `Dial9Config` is gone. You build a writer, wrap it in `dial9::recorder(writer)`, chain sources,
-and build a `Recorder`. Tokio is one more source on it.
+and build a `Recorder`. Tokio instrumentation is one more source on it.
 
 ```rust
 let writer = DiskBuffer::builder().base_path("/tmp/dial9-traces").build()?;
@@ -30,8 +32,7 @@ hands back both, so `config` stays a single expression.
 async fn main() { /* ... */ }
 ```
 
-Each `attach_tokio_runtime` attaches another runtime, and returns the recorder so the next call can follow.
-A single and a multi-runtime setup share the same code:
+Each `attach_tokio_runtime` attaches another runtime and returns the recorder, so the next call chains on. Attaching two looks like attaching one:
 
 ```rust
 let recorder = dial9::recorder(writer)
@@ -67,28 +68,42 @@ start it later with `Recorder::enable()`; `build_and_start()` is gone, since `bu
 what it did.
 
 Per-source knobs (`.with_cpu_profiling`, `.with_memory_profiling`, …) and the pipeline overrides
-(`.with_custom_pipeline`, `.with_s3_uploader`) live on the recorder builder. 
-Per-runtime settings (runtime name, task tracking, task dumps, custom hooks) live in
-`TokioAttachOptions`. 
-`dial9::recorder_from_env()` builds a recorder and its runtime from the unchanged `DIAL9_*` vars. `dial9::recorder_or_disabled(writer)` starts a builder that downgrades to a disabled recorder when the writer cannot be created, so sources and a pipeline still chain onto it and a bad trace path costs telemetry rather than the process; `dial9::recorder_disabled()` covers telemetry-off. `TracedRuntime`, the low-level `TracedRuntime::builder()`, and the pipeline / trace-path type-state markers are gone.
+(`.with_custom_pipeline`, `.with_s3_uploader`) live on the recorder builder.
+Per-runtime settings (runtime name, task tracking, task dumps, custom hooks) live in `TokioAttachOptions`.
+`dial9::recorder_from_env()` builds a recorder and its runtime from the unchanged `DIAL9_*` vars. `dial9::recorder_or_disabled(writer)` starts a builder that downgrades to a disabled recorder when the writer cannot be created, so sources and a pipeline still chain onto it and a bad trace path costs telemetry rather than the process. `dial9::recorder_disabled()` covers telemetry-off.
 
-The refactor also renamed the trace writers to buffers (`RotatingWriter` → `DiskBuffer`, with
-`DiskBuffer` / `MemoryBuffer` the public storage backends and a fully in-memory pipeline that
-needs no filesystem: `SegmentData::segment()` now returns `&SegmentRef`), collapsed the handles
-(`TelemetryHandle` / `RuntimeTelemetryHandle` into `Dial9Handle` for record/control and
-`Dial9TokioHandle` for spawn, so `record_event(event, &handle)` becomes `handle.record_event(event)`),
-and moved the non-Tokio pieces (custom events, symbolization, process-resource and socket sources,
-memory profiling) into `dial9-core` / `dial9-perf-self-profile` with their public APIs
-(`Dial9Allocator`, `MemoryProfiler`, …) unchanged. 
+`TracedRuntime`, the low-level `TracedRuntime::builder()`, and the pipeline / trace-path type-state markers are gone.
+
+The refactor also renamed the trace writers to buffers: `RotatingWriter` → `DiskBuffer`, with
+`DiskBuffer` / `MemoryBuffer` the public storage backends and a fully in-memory pipeline that needs
+no filesystem (`SegmentData::segment()` now returns `&SegmentRef`). It collapsed the handles:
+`TelemetryHandle` / `RuntimeTelemetryHandle` into `Dial9Handle` for record/control and
+`Dial9TokioHandle` for spawn, so `record_event(event, &handle)` becomes `handle.record_event(event)`.
+And it moved the non-Tokio pieces (custom events, symbolization, process-resource and socket sources,
+memory profiling) into `dial9-core` / `dial9-perf-self-profile`, with their public APIs
+(`Dial9Allocator`, `MemoryProfiler`, …) unchanged.
+
 Custom processors gain `SegmentProcessor::finalize_dump` and `ProcessError::into_parts`.
 
 Profiling features (`cpu-profiling`, `memory-profiling`, `process-resource`, `linux-socket`) are
 now standalone sources that no longer pull in `tokio`: they auto-wire when `tokio` is on. The
 facade ships no default features, so a `dial9` library dependency pulls no viewer or CLI weight;
-install the CLI with `cargo install dial9 --features cli`. 
-One behavior flip to watch on upgrade: process resource usage (rusage) sampling is now opt-in behind the `process-resource`
-feature. It was on by default on Unix, so Unix users stop getting rss / page-fault events until
-they enable it.
+install the CLI with `cargo install dial9 --features cli`.
+
+### Migrating from 0.3
+
+| You had | You now write |
+| --- | --- |
+| `dial9-tokio-telemetry` dependency | `dial9` (enable the `tokio` feature) |
+| `#[dial9_tokio_telemetry::main]` | `#[dial9::main]` |
+| `Dial9Config::builder()…build()` | `dial9::recorder(writer).attach_tokio_runtime(..)` (build the writer first) |
+| `.on_disk_buffer(p)` / `.in_memory_buffer()` | `DiskBuffer::builder().base_path(p)…build()` / `MemoryBuffer::new(cap)` |
+| `Dial9Config::from_env()` | `dial9::recorder_from_env()` |
+| `TelemetryHandle` / `RuntimeTelemetryHandle` | `Dial9Handle` (spawn via `Dial9TokioHandle`) |
+| `record_event(event, &handle)` | `handle.record_event(event)` |
+| `build_and_start()` | `build()` (`.paused()` to opt out) |
+
+Process resource usage (rusage) sampling is now opt-in behind the `process-resource` feature. It was on by default on Unix, so Unix users stop getting rss / page-fault events until they enable it.
 
 ### Added
 
@@ -104,7 +119,7 @@ they enable it.
 
 ### Changed
 
-- Programs using `#[dial9::main]` now drain the telemetry worker on clean exit (up to the graceful-shutdown deadline, default 1s) instead of exiting immediately. This adds a bounded amount of shutdown latency but ensures the final segment is processed; opt out with `#[dial9::main(disable_graceful_shutdown)]` ([#479](https://github.com/dial9-rs/dial9/issues/479))
+- Programs using `#[dial9::main]` no longer exit immediately: clean exit now blocks up to the graceful-shutdown deadline (default 1s) to drain the final segment, a bounded amount of added latency (see Added for the config and opt-out) ([#479](https://github.com/dial9-rs/dial9/issues/479))
 - Worker IDs are now reserved when a runtime's workers first poll, rather than at attach time (the caller builds the runtime, so there is nothing to count when hooks are registered). A runtime's `runtime.{name}` → worker-ID mapping therefore appears in segment metadata once that runtime has run work, and the ID blocks follow worker start-up order rather than attach order ([#356](https://github.com/dial9-rs/dial9/issues/356))
 - **Breaking:** `Recorder::graceful_shutdown` returns `()` instead of an always-`Ok` `io::Result<()>`. Drain failures are logged, as they already were
 - **Breaking:** `Source` gains an `Any` supertrait, so a source must be `'static` (boxed sources already were). This lets a layer recover its own concrete source from the recorder, which is how a second `attach_tokio_runtime` finds the runtime registry the first one installed
@@ -115,6 +130,35 @@ they enable it.
 ### Fixed
 
 - Viewer: browsing a nonexistent bucket now returns HTTP 404 instead of 500, and a syntactically invalid bucket name returns HTTP 400. The S3 `NoSuchBucket`/`NoSuchKey` and `InvalidBucketName` error codes were falling through to the generic error arm, which logged an "unclassified S3 error" and reported a server `fault` — so a user typo in the bucket name polluted the viewer's fault metric. They now classify as `NotFound` (404) and `BadRequest` (400) respectively.
+
+### Viewer
+
+The trace viewer is rebuilt as a Vite + TypeScript app. The trace decoder and parser are unchanged (a frozen core), so the wire format and decoding behavior are identical.
+
+New:
+
+- Shareable URL state. Viewport, selection, canvas selections, issues-rail, span filters, and span focus all ride the URL, so a view links and reproduces exactly.
+- Search palette. `/` opens a search over tasks, spans, and points of interest.
+- Inspector sidebar. Tabbed, with poll detail, a related view, and an embedded region-analysis panel.
+- New tracks: worker lanes, CPU usage, queue depth, spans, task detail, and custom events, each with hover, click-to-pin, and a legend.
+- Per-track collapse and drag-reorder, persisted across sessions, with animated collapse.
+- Overview minimap and status bar, plus a responsive toolbar showing trace service and host.
+- Flamegraph inspect and diff modes, with a histogram and minimap.
+- Tokio Stats worker-activity rollup with focus deep-linking.
+- Large-trace handling. Columnar events and a main-thread loader remove the structured-clone OOM. Viewport scans are bounded, Set/Clear Range reparses instead of re-rendering, and POI counts are capped.
+- Keyboard shortcuts. Press `?` in the viewer for the list.
+
+Under the hood, all four pages (viewer, browser, flamegraph, tokio_stats) move from hand-written HTML/JS to typed modules under `dial9-viewer/ui/src`, bundled to `dist/` and embedded via rust-embed as before. The port is guarded by a parity harness and a Vitest suite, with an import-boundary check keeping pages out of the frozen core. The browser page also reaches WCAG AA contrast.
+
+### Other
+
+- [**breaking**] tokio instrumentation as a source ([#698](https://github.com/dial9-rs/dial9/pull/698))
+- make dial9 the facade ([#614](https://github.com/dial9-rs/dial9/pull/614))
+- move memory profiling to dial9-perf-self-profile ([#591](https://github.com/dial9-rs/dial9/pull/591))
+- move event bus to dial9-core ([#549](https://github.com/dial9-rs/dial9/pull/549))
+- setup dial9-core ([#540](https://github.com/dial9-rs/dial9/pull/540))
+- Drop aws-sdk-s3-transfer-manager, upload segments via aws-sdk-s3 PutObject ([#668](https://github.com/dial9-rs/dial9/pull/668))
+- *(deps)* bump s3s crates to 0.14.1 to pull in patched quick-xml ([#611](https://github.com/dial9-rs/dial9/pull/611))
 
 ## [0.3.13](https://github.com/dial9-rs/dial9/compare/dial9-tokio-telemetry-v0.3.12...dial9-tokio-telemetry-v0.3.13) - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,9 @@ memory profiling) into `dial9-core` / `dial9-perf-self-profile` with their publi
 Custom processors gain `SegmentProcessor::finalize_dump` and `ProcessError::into_parts`.
 
 Profiling features (`cpu-profiling`, `memory-profiling`, `process-resource`, `linux-socket`) are
-now standalone sources that no longer pull in `tokio`: they auto-wire when `tokio` is on, and the
-facade defaults to `["cli"]` so `cargo install dial9` still works. 
+now standalone sources that no longer pull in `tokio`: they auto-wire when `tokio` is on. The
+facade ships no default features, so a `dial9` library dependency pulls no viewer or CLI weight;
+install the CLI with `cargo install dial9 --features cli`. 
 One behavior flip to watch on upgrade: process resource usage (rusage) sampling is now opt-in behind the `process-resource`
 feature. It was on by default on Unix, so Unix users stop getting rss / page-fault events until
 they enable it.

--- a/dial9-viewer/skills/dial9-s3-analysis/SKILL.md
+++ b/dial9-viewer/skills/dial9-s3-analysis/SKILL.md
@@ -15,7 +15,7 @@ This skill guides you through analyzing dial9 trace data stored in S3. The workf
 ## Prerequisites
 
 - AWS CLI configured with read access to the target bucket
-- `dial9` CLI installed (`cargo install dial9` or `cargo binstall dial9`)
+- `dial9` CLI installed (`cargo install dial9 --features cli` or `cargo binstall dial9`)
 - Node.js 14+ for running the analysis toolkit
 
 ## Phase 1: Discovery
@@ -158,6 +158,6 @@ dial9 agents skill dial9-red-flags
 
 - **"Access Denied" or "NoSuchBucket"**: Verify credentials with `aws sts get-caller-identity` and check bucket region
 - **Empty bucket listings**: Verify date format is YYYY-MM-DD, region is correct, and prefix matches
-- **`dial9` not found**: `cargo install dial9` or `cargo binstall dial9`
+- **`dial9` not found**: `cargo install dial9 --features cli` or `cargo binstall dial9`
 - **Analysis errors on .gz files**: Decompress first — `analyze.js` requires raw `.bin` input
-- **"Unknown frame tag" errors**: Toolkit version is older than the trace format — update dial9 with `cargo install dial9`
+- **"Unknown frame tag" errors**: Toolkit version is older than the trace format — update dial9 with `cargo install dial9 --features cli`

--- a/dial9/Cargo.toml
+++ b/dial9/Cargo.toml
@@ -22,6 +22,10 @@ name = "dial9"
 path = "src/main.rs"
 required-features = ["cli"]
 
+[[test]]
+name = "cli_trace_shape"
+required-features = ["cli"]
+
 [dependencies]
 dial9-core = { workspace = true }
 dial9-perf-self-profile = { workspace = true, optional = true }

--- a/dial9/Cargo.toml
+++ b/dial9/Cargo.toml
@@ -39,7 +39,7 @@ bon = { version = "3", optional = true }
 tracing = { version = "0.1.44", optional = true }
 
 [features]
-default = ["cli"]
+default = []
 
 ## The `dial9` viewer/analysis binary (`dial9 serve`, `dial9 agents`).
 cli = ["dep:dial9-viewer", "dep:anyhow"]

--- a/dial9/Cargo.toml
+++ b/dial9/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["asynchronous", "development-tools::profiling"]
 
 [package.metadata.docs.rs]
 all-features = true
+# `--all-features` turns on `taskdump`, which requires `--cfg tokio_unstable`.
+rustdoc-args = ["--cfg", "tokio_unstable"]
+rustc-args = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/dial9-viewer-v{ version }/dial9-viewer-{ target }-v{ version }{ archive-suffix }"

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -693,8 +693,8 @@ For custom upload destinations or post-processing (e.g. shipping to a different 
 Pre-built binaries are available from [GitHub Releases](https://github.com/dial9-rs/dial9/releases) for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64).
 
 ```bash
-# From source via crates.io
-cargo install --locked dial9
+# From source via crates.io (the viewer/CLI is behind the `cli` feature)
+cargo install --locked dial9 --features cli
 
 # Or with cargo-binstall (downloads a pre-built binary, faster)
 cargo binstall dial9


### PR DESCRIPTION
Drops `cli` from `dial9`'s default features, and updates readme and skill.md. 
Updates the changelog (changlog changes were in #701 but it didn't got merged).

