### PR TITLE
fix(release): build the dial9 bin with its feature, fix Windows paths

### DIFF
--- a/.github/workflows/build-viewer-binaries.yml
+++ b/.github/workflows/build-viewer-binaries.yml
@@ -1,0 +1,115 @@
+name: Build viewer binaries
+
+# Builds the dial9-viewer and dial9 binaries for a tag and uploads them
+# to that tag's GitHub release.
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to build from and upload assets to"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build for (e.g. dial9-viewer-v0.5.0-rc1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      # Archive names carry the bare version, not the crate-name prefix.
+      - name: Resolve version
+        id: r
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag }}
+        run: echo "version=${TAG#dial9-viewer-}" >> "$GITHUB_OUTPUT"
+
+      # Build the tagged commit, not a branch head: the branch can move between
+      # release-plz publishing and this job starting.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: dial9-viewer/ui/package-lock.json
+
+      # rust-embed embeds ui/dist into dial9-viewer at compile time.
+      - name: Build viewer UI
+        working-directory: dial9-viewer/ui
+        shell: bash
+        run: npm ci && npm run build
+
+      # The dial9 binary is behind the `cli` feature; build it on its own with
+      # the feature (a multi-package `--features dial9/cli` doesn't enable it).
+      - run: cargo build --release --target ${{ matrix.target }} -p dial9-viewer
+        env:
+          RUSTFLAGS: "--cfg tokio_unstable"
+      - run: cargo build --release --target ${{ matrix.target }} -p dial9 --features cli
+        env:
+          RUSTFLAGS: "--cfg tokio_unstable"
+
+      # x86_64-apple-darwin is cross-built on the arm runner and runs under
+      # Rosetta, which the macos-latest image provides.
+      - name: Smoke-test the dial9 binary
+        shell: bash
+        run: |
+          bin="target/${{ matrix.target }}/release/dial9"
+          [ "${{ matrix.archive }}" = "zip" ] && bin="${bin}.exe"
+          "$bin" --help
+
+      - name: Package (Unix)
+        if: ${{ matrix.archive == 'tar.gz' }}
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar -czvf ../../../dial9-viewer-${{ matrix.target }}-${{ steps.r.outputs.version }}.tar.gz dial9-viewer dial9
+
+      - name: Package (Windows)
+        if: ${{ matrix.archive == 'zip' }}
+        shell: pwsh
+        run: |
+          cd target/${{ matrix.target }}/release
+          Compress-Archive -Path dial9-viewer.exe,dial9.exe -DestinationPath ../../../dial9-viewer-${{ matrix.target }}-${{ steps.r.outputs.version }}.zip
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: dial9-viewer-${{ matrix.target }}-${{ steps.r.outputs.version }}.${{ matrix.archive }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,23 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+  windows-cli-check:
+    name: Windows CLI check
+    runs-on: windows-latest
+    if: github.event_name == 'push'
+    env:
+      RUSTFLAGS: "--cfg tokio_unstable"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: ${{ env.STABLE_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: cargo check -p dial9-viewer
+      - run: cargo check -p dial9 --features cli
+
   android-aarch64-build:
     name: Android aarch64 build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,93 +83,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-  build-viewer-binaries:
-    name: Build dial9-viewer ${{ matrix.target }}
+  # Extract the dial9-viewer tag from release-plz's output, then hand off to the
+  # binary-build workflow.
+  resolve-release:
+    name: Resolve release tag
     needs: release-plz-release
     if: >-
       needs.release-plz-release.outputs.releases_created == 'true' &&
       contains(needs.release-plz-release.outputs.releases, '"package_name":"dial9-viewer"')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            archive: tar.gz
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
-            archive: tar.gz
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            archive: tar.gz
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            archive: tar.gz
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            archive: zip
-
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ inputs.release_branch }}
-          persist-credentials: false
-
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: dial9-viewer/ui/package-lock.json
-
-      # Build the viewer UI BEFORE the binaries: rust-embed embeds ui/dist
-      # into dial9-viewer at compile time.
-      - name: Build viewer UI
-        working-directory: dial9-viewer/ui
-        shell: bash
-        run: npm ci && npm run build
-
-      - run: cargo build --release --target ${{ matrix.target }} -p dial9-viewer -p dial9 --features dial9/cli
-        env:
-          RUSTFLAGS: "--cfg tokio_unstable"
-
-      - name: Smoke-test the dial9 binary
-        shell: bash
-        run: |
-          bin="target/${{ matrix.target }}/release/dial9"
-          [ "${{ matrix.archive }}" = "zip" ] && bin="${bin}.exe"
-          "$bin" --help
-
-      - name: Determine tag and version
+      - name: Determine tag
         id: version
         shell: bash
+        env:
+          RELEASES: ${{ needs.release-plz-release.outputs.releases }}
         run: |
-          TAG=$(echo '${{ needs.release-plz-release.outputs.releases }}' | jq -r '.[] | select(.package_name == "dial9-viewer") | .tag')
-          VERSION=$(echo '${{ needs.release-plz-release.outputs.releases }}' | jq -r '.[] | select(.package_name == "dial9-viewer") | .version')
+          TAG=$(jq -r '.[] | select(.package_name == "dial9-viewer") | .tag' <<<"$RELEASES")
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Package (Unix)
-        if: ${{ matrix.archive == 'tar.gz' }}
-        shell: bash
-        run: |
-          cd target/${{ matrix.target }}/release
-          tar -czvf ../../../dial9-viewer-${{ matrix.target }}-${{ steps.version.outputs.version }}.tar.gz dial9-viewer dial9
-
-      - name: Package (Windows)
-        if: ${{ matrix.archive == 'zip' }}
-        shell: pwsh
-        run: |
-          cd target/${{ matrix.target }}/release
-          Compress-Archive -Path dial9-viewer.exe,dial9.exe -DestinationPath ../../../dial9-viewer-${{ matrix.target }}-${{ steps.version.outputs.version }}.zip
-
-      - name: Upload release asset
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          files: dial9-viewer-${{ matrix.target }}-${{ steps.version.outputs.version }}.${{ matrix.archive }}
+  build-viewer-binaries:
+    needs: resolve-release
+    uses: ./.github/workflows/build-viewer-binaries.yml
+    with:
+      tag: ${{ needs.resolve-release.outputs.tag }}

--- a/dial9-viewer/build.rs
+++ b/dial9-viewer/build.rs
@@ -156,7 +156,9 @@ struct SkillInfo {
 }
 
 fn env_dir_include_str(env: &str, path: impl AsRef<Path>) -> String {
-    let path = path.as_ref().to_str().unwrap();
+    // Emit forward slashes: `include_str!` accepts them on all platforms, and a
+    // backslash path (Windows) would be invalid escapes in the generated string.
+    let path = path.as_ref().to_str().unwrap().replace('\\', "/");
     format!("include_str!(concat!(env!(\"{env}\"), \"/{path}\"))")
 }
 
@@ -188,10 +190,10 @@ fn collect_files(
         if abs_path.is_dir() && !abs_path.is_symlink() {
             collect_files(manifest_dir, base, &rel, out);
         } else if abs_path.is_file() || abs_path.is_symlink() {
-            out.push((
-                rel.to_string_lossy().into_owned(),
-                RelReference::SrcRel(base.join(rel)),
-            ));
+            // Forward slashes: this string is both the archive key and what
+            // `TOOLKIT_FILES` prefix-matches on, so it must not vary by host OS.
+            let key = rel.to_string_lossy().replace('\\', "/");
+            out.push((key, RelReference::SrcRel(base.join(rel))));
         }
     }
 }

--- a/dial9/Cargo.toml
+++ b/dial9/Cargo.toml
@@ -20,6 +20,9 @@ pkg-url = "{ repo }/releases/download/dial9-viewer-v{ version }/dial9-viewer-{ t
 pkg-fmt = "tgz"
 bin-dir = "dial9{ binary-ext }"
 
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
 [[bin]]
 name = "dial9"
 path = "src/main.rs"


### PR DESCRIPTION
rc1 published fine but failed at buidling release binaries. None of this is visible on PRs: CI has no windows runner, and the release build command lives only in `release.yml`.

## Issues

- linux + macos: `-p dial9-viewer -p dial9 --features dial9/cli` doesn't satisfy `required-features` in a multi-package build, so cargo silently skipped the `dial9` bin. Regression from #712 (`cli` now off by default).
- **windows:** `build.rs` interpolates skill paths raw into `include_str!` literals, so backslashes land as invalid escapes. likely broken back in #515.
- windows, silent: the same backslashes break `TOOLKIT_FILES` (`starts_with("scripts/")`), so `agents toolkit` writes zero files, no error.
- binstall on windows: AFAIK never worked. `pkg-fmt = "tgz"` with no per-target override, but releases upload `.zip`. Verified against 0.3.13.

## Fixes

- Build `dial9` on its own with `--features cli`.
- Normalize to forward slashes in `build.rs`, at both sites.
- Add a binstall `zip` override for `x86_64-pc-windows-msvc`.

## Added

- Reusable `build-viewer-binaries.yml`. `release.yml` calls it, and it's dispatchable to rebuild any tag's assets without re-running a publish. It checks out the tag, not the release branch.
- `windows-cli-check` CI job, main-only and out of `ci-pass`.

## After merge

Dispatch it with `tag = dial9-viewer-v0.5.0-rc1` to backfill rc1's binaries.

Expect 4 green and windows red. The workflow comes from main, so the cargo fix applies, but it compiles the tag, which still has the old `build.rs`. Windows needs a release built after this merges. 