### PR TITLE
Fix task-dump clicks in the new viewer

### DIFF
--- a/dial9-viewer/ui/src/pages/viewer/events-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/events-track.ts
@@ -440,6 +440,7 @@ export function dispatchEventPin(
     selectedTaskId: null,
     spanFocus: null,
     focusedSpanId: null,
+    taskDump: null,
   });
 }
 

--- a/dial9-viewer/ui/src/pages/viewer/inspector-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/inspector-model.test.ts
@@ -11,6 +11,7 @@ import {
   buildSpawnedTasksView,
   hasNoSelection,
   preferredTab,
+  resolveTaskDumpCaptures,
   tabAvailability,
   type RelatedContext,
   type RelatedUiState,
@@ -64,6 +65,7 @@ function sel(over: Partial<SelectionSlice>): SelectionSlice {
     focusedSpanId: null,
     pinnedEvent: null,
     pollDetail: null,
+    taskDump: null,
     sidebarRange: null,
     hoveredWakerTaskId: null,
     spawnedTasksRange: null,
@@ -270,6 +272,23 @@ describe("buildSpawnedTasksView", () => {
 });
 
 // ── Tab families + activation ────────────────────────────────────────────────
+describe("task-dump selection resolution", () => {
+  it("re-resolves timestamps against the current trace after replacement", () => {
+    const oldDump = { timestamp: 3, callchain: ["old"] };
+    const newDump = { timestamp: 3, callchain: ["new"] };
+    const selection = { taskId: 9, timestamps: [3] };
+    const traceWith = (dump: typeof oldDump | null) =>
+      ({
+        taskDumps: new Map(dump === null ? [] : [[9, [dump]]]),
+      }) as Parameters<typeof resolveTaskDumpCaptures>[0];
+
+    expect(resolveTaskDumpCaptures(traceWith(oldDump), selection)).toEqual([oldDump]);
+    expect(resolveTaskDumpCaptures(traceWith(null), selection)).toEqual([]);
+    const resolved = resolveTaskDumpCaptures(traceWith(newDump), selection);
+    expect(resolved).toEqual([newDump]);
+    expect(resolved[0]).not.toBe(oldDump);
+  });
+});
 
 describe("tab availability + preferred tab", () => {
   it("a poll click enables + prefers Poll", () => {
@@ -299,10 +318,15 @@ describe("tab availability + preferred tab", () => {
     expect(tabAvailability(cluster).related).toBe(false);
   });
 
-  it("a task select prefers Task; a range prefers Stack", () => {
+  it("a task select prefers Task; a range or task dump prefers Stack", () => {
     expect(preferredTab(sel({ selectedTaskId: 9 }))).toBe("task");
     expect(preferredTab(sel({ spawnedTasksRange: { startNs: 0, endNs: 5 } }))).toBe("stack");
     expect(preferredTab(sel({ sidebarRange: { startNs: 0, endNs: 5 } }))).toBe("stack");
+    const taskDump = { taskId: 9, timestamps: [3] };
+    const dumpSelection = sel({ taskDump });
+    expect(tabAvailability(dumpSelection).stack).toBe(true);
+    expect(preferredTab(dumpSelection)).toBe("stack");
+    expect(hasNoSelection(dumpSelection)).toBe(false);
   });
 
   it("hasNoSelection is true only at rest, and preferredTab is null then", () => {

--- a/dial9-viewer/ui/src/pages/viewer/inspector-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/inspector-model.ts
@@ -17,13 +17,19 @@ import type { FlamegraphDataSample } from "../../lib/canvas/index.js";
 import type {
   CallframeSymbols,
   CustomTraceEvent,
+  ParsedTrace,
   PollSpan,
   SampleGroup,
   SymbolFrame,
+  TaskDump,
   TracingSpan,
   WorkerLane,
 } from "../../lib/trace/index.js";
-import type { PinnedCustomEvent, SelectionSlice } from "../../types/state.js";
+import type {
+  PinnedCustomEvent,
+  SelectionSlice,
+  TaskDumpSelection,
+} from "../../types/state.js";
 
 // ── Frame formatting ─────────────────────────────────────────────────────
 
@@ -579,6 +585,20 @@ export function buildSpawnedTasksView(
 
 // ── Tab availability ──────────────────────────────────────────────────────
 
+/** Resolve a task-dump selection against the current trace after load/reparse. */
+export function resolveTaskDumpCaptures(
+  trace: Pick<ParsedTrace, "taskDumps"> | null,
+  selection: TaskDumpSelection | null,
+): readonly TaskDump[] {
+  if (trace === null || selection === null || selection.timestamps.length === 0) {
+    return [];
+  }
+  const wanted = new Set(selection.timestamps);
+  return (trace.taskDumps.get(selection.taskId) ?? []).filter((dump) =>
+    wanted.has(dump.timestamp),
+  );
+}
+
 /** The inspector tabs. */
 export type InspectorTab = "task" | "poll" | "event" | "related" | "stack";
 
@@ -603,7 +623,7 @@ export interface TabAvailability {
  * Compute which tabs have content for the current selection. A single pinned
  * event enables Event + Related; a cluster pin enables Event only (Related is
  * single-event). A selected task enables Task; a clicked poll enables Poll; a
- * retained range (spawned-tasks or region) enables Stack.
+ * task-dump trace or retained range (spawned-tasks or region) enables Stack.
  */
 export function tabAvailability(sel: SelectionSlice): TabAvailability {
   const pinned = sel.pinnedEvent;
@@ -612,14 +632,18 @@ export function tabAvailability(sel: SelectionSlice): TabAvailability {
     poll: sel.pollDetail !== null,
     event: pinned !== null,
     related: pinned !== null && pinned.detailEvent !== null,
-    stack: sel.spawnedTasksRange !== null || sel.sidebarRange !== null,
+    stack:
+      sel.taskDump !== null ||
+      sel.spawnedTasksRange !== null ||
+      sel.sidebarRange !== null,
   };
 }
 
 /**
  * The tab a fresh selection should activate (re-scope in the same action).
  * Ordered by the interaction that most likely just happened: a poll click ->
- * Poll; an event pin -> Event; a range drag -> Stack; a task select -> Task.
+ * Poll; an event pin -> Event; a range or task-dump click -> Stack; a task
+ * select -> Task.
  * Returns null when nothing is selected (the inspector shows its resting
  * at-cursor readout).
  */
@@ -627,6 +651,7 @@ export function preferredTab(sel: SelectionSlice): InspectorTab | null {
   if (sel.pollDetail !== null) return "poll";
   if (sel.pinnedEvent !== null) return "event";
   if (sel.spawnedTasksRange !== null || sel.sidebarRange !== null) return "stack";
+  if (sel.taskDump !== null) return "stack";
   if (sel.selectedTaskId !== null) return "task";
   return null;
 }
@@ -637,6 +662,7 @@ export function hasNoSelection(sel: SelectionSlice): boolean {
     sel.selectedTaskId === null &&
     sel.pollDetail === null &&
     sel.pinnedEvent === null &&
+    sel.taskDump === null &&
     sel.spawnedTasksRange === null &&
     sel.sidebarRange === null
   );

--- a/dial9-viewer/ui/src/pages/viewer/inspector.ts
+++ b/dial9-viewer/ui/src/pages/viewer/inspector.ts
@@ -14,8 +14,9 @@
 //
 // The heavy derivations are the pure inspector-model plus consumed contracts:
 // the Task-tab derivation, transient.atCursor (readout), selection.pinnedEvent
-// (Event/Related KV), and selection.spawnedTasksRange + computeSpawnedTasks.
-// Trace-invariant lookups are cached in a store.derived over the trace slice.
+// (Event/Related KV), selection.taskDump (async-stack flamegraph), and
+// selection.spawnedTasksRange + computeSpawnedTasks. Trace-invariant lookups
+// are cached in a store.derived over the trace slice.
 
 import { html, render, nothing, type TemplateResult } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
@@ -45,6 +46,7 @@ import {
   buildSpawnedTasksView,
   hasNoSelection,
   preferredTab,
+  resolveTaskDumpCaptures,
   tabAvailability,
   type FrameLine,
   type InspectorTab,
@@ -165,6 +167,20 @@ export function mountInspector(
     doc: host.ownerDocument,
     className: "d9-poll-fg",
   });
+  const taskDumpFg = createFlamegraphHost({
+    doc: host.ownerDocument,
+    className: "d9-task-dump-fg",
+  });
+  const traceIds = new WeakMap<object, number>();
+  let nextTraceId = 1;
+  function traceId(trace: StoreState["trace"]["trace"]): number {
+    if (trace === null) return 0;
+    const existing = traceIds.get(trace);
+    if (existing !== undefined) return existing;
+    const id = nextTraceId++;
+    traceIds.set(trace, id);
+    return id;
+  }
   // Related tab UI state; reset when the detail event changes.
   let relatedUi: RelatedUiState = { collapsed: {}, expand: {}, correlate: null };
   let lastDetailEventRef: CustomTraceEvent | null = null;
@@ -191,6 +207,9 @@ export function mountInspector(
     return [
       sel.selectedTaskId ?? "-",
       sel.pollDetail ? `${sel.pollDetail.start}-${sel.pollDetail.end}` : "-",
+      sel.taskDump
+        ? `${sel.taskDump.taskId}:${sel.taskDump.timestamps.join(",")}`
+        : "-",
       sel.pinnedEvent ? `${sel.pinnedEvent.timestamp}:${sel.pinnedEvent.events.length}` : "-",
       sel.pinnedEvent?.detailEvent ? sel.pinnedEvent.detailEvent.timestamp : "-",
       sel.spawnedTasksRange ? `${sel.spawnedTasksRange.startNs}-${sel.spawnedTasksRange.endNs}` : "-",
@@ -271,6 +290,9 @@ export function mountInspector(
     // Same, for the Poll tab's flamegraph: the host node exists only after the
     // render above.
     syncPollFlamegraph(s);
+    // A task-dump click also renders a flamegraph in the Stack tab from the
+    // selection stored by the task-detail track.
+    syncTaskDumpFlamegraph(s);
   }
 
   /** Readout-only render (transient channel; the at-moment surface). */
@@ -354,6 +376,10 @@ export function mountInspector(
       return p.events.length > 1
         ? `Cluster of ${p.events.length} events selected`
         : `Event ${p.name} selected`;
+    }
+    if (sel.taskDump !== null) {
+      const count = sel.taskDump.timestamps.length;
+      return `Task dump trace selected · ${count} capture${count === 1 ? "" : "s"}`;
     }
     if (sel.spawnedTasksRange !== null) return "Spawn-range selected";
     if (sel.sidebarRange !== null) return "Region selected";
@@ -612,6 +638,38 @@ export function mountInspector(
     });
   }
 
+  function syncTaskDumpFlamegraph(s: StoreState): void {
+    const selected = s.selection.taskDump;
+    if (activeTab !== "stack" || selected === null) {
+      taskDumpFg.detach();
+      return;
+    }
+    const hostEl = host.querySelector<HTMLElement>("[data-task-dump-fg-host]");
+    if (hostEl === null) {
+      taskDumpFg.detach();
+      return;
+    }
+    const dumps = resolveTaskDumpCaptures(s.trace.trace, selected);
+    const samples = dumps.map((dump) => ({
+      callchain: dump.callchain,
+      workerId: 0,
+    }));
+    if (samples.length === 0) {
+      taskDumpFg.detach();
+      return;
+    }
+    const count = samples.length;
+    const sig = `${traceId(s.trace.trace)}:${selected.taskId}:${selected.timestamps.join(",")}`;
+    taskDumpFg.sync({
+      hostEl,
+      sig,
+      apply: (instance) =>
+        instance.setData(samples, data().callframeSymbols, {
+          exportTitle: `Waiting on — ${count} async stack capture${count === 1 ? "" : "s"}`,
+        }),
+    });
+  }
+
   function sampleGroup(g: SampleGroupView, kind: "sched" | "cpu", idx: number): TemplateResult {
     const key = `${kind}-${idx}`;
     const expanded = expandedGroups.has(key);
@@ -791,9 +849,26 @@ export function mountInspector(
     </button>`;
   }
 
-  // ── Stack tab (spawned tasks + region analysis) ──────────────────────────
+  // ── Stack tab (task dumps + spawned tasks + region analysis) ─────────────
 
   function stackTemplate(sel: SelectionSlice): TemplateResult {
+    if (sel.taskDump !== null) {
+      const dumps = resolveTaskDumpCaptures(state().trace.trace, sel.taskDump);
+      const count = dumps.length;
+      if (count === 0) {
+        return html`<p class="d9-inspector-hint">
+          The selected task-dump captures are not present in the current trace.
+        </p>`;
+      }
+      return html`
+        <div class="d9-task-dump">
+          <div class="d9-spawned-head">
+            Waiting on — ${count} async stack capture${count === 1 ? "" : "s"}
+          </div>
+          <div class="d9-task-dump-fg-host" data-task-dump-fg-host></div>
+        </div>
+      `;
+    }
     if (sel.spawnedTasksRange !== null) {
       const range = sel.spawnedTasksRange;
       const result = computeSpawnedTasks(data().queueData, range);
@@ -927,6 +1002,7 @@ export function mountInspector(
       },
       selectedTaskId: null,
       pollDetail: null,
+      taskDump: null,
     });
     centerViewOn(ev.timestamp);
   }
@@ -951,7 +1027,12 @@ export function mountInspector(
 
   function selectTask(taskId: number): void {
     // A spawned-task link selects the task (re-scopes to the Task tab).
-    store.update("selection", { selectedTaskId: taskId, pinnedEvent: null, pollDetail: null });
+    store.update("selection", {
+      selectedTaskId: taskId,
+      pinnedEvent: null,
+      pollDetail: null,
+      taskDump: null,
+    });
   }
 
   function clearSelection(): void {
@@ -962,6 +1043,7 @@ export function mountInspector(
       focusedSpanId: null,
       pinnedEvent: null,
       pollDetail: null,
+      taskDump: null,
       sidebarRange: null,
       spawnedTasksRange: null,
       hoveredWakerTaskId: null,
@@ -1035,6 +1117,7 @@ export function mountInspector(
       const sel = state().selection;
       return (
         sel.pollDetail !== null ||
+        sel.taskDump !== null ||
         sel.pinnedEvent !== null ||
         sel.sidebarRange !== null ||
         sel.spawnedTasksRange !== null
@@ -1044,6 +1127,7 @@ export function mountInspector(
       store.update("selection", {
         pinnedEvent: null,
         pollDetail: null,
+        taskDump: null,
         sidebarRange: null,
         spawnedTasksRange: null,
       });
@@ -1059,6 +1143,7 @@ export function mountInspector(
       unsubReadout();
       unregisterEsc();
       pollFg.destroy();
+      taskDumpFg.destroy();
       window.removeEventListener("mousemove", onResizeMove);
       window.removeEventListener("mouseup", onResizeUp);
     },

--- a/dial9-viewer/ui/src/pages/viewer/issues-rail.ts
+++ b/dial9-viewer/ui/src/pages/viewer/issues-rail.ts
@@ -139,7 +139,10 @@ export function createIssuesRail(store: ViewerStore): IssuesRailController {
     if (poi === undefined) return;
     const jump = poiJump(poi, store.getState().viewport);
     store.update("viewport", { viewStart: jump.viewStart, viewEnd: jump.viewEnd });
-    store.update("selection", { selectedTaskId: jump.selectedTaskId });
+    store.update("selection", {
+      selectedTaskId: jump.selectedTaskId,
+      taskDump: null,
+    });
     store.update("poi", { index });
     // Moving the time window is not enough: the lanes box scrolls
     // independently, so a POI on a lane below the fold would leave the user
@@ -163,6 +166,7 @@ export function createIssuesRail(store: ViewerStore): IssuesRailController {
       selectedTaskId: task.taskId,
       pinnedEvent: null,
       pollDetail: null,
+      taskDump: null,
     });
     store.update("poi", { taskIndex: index });
     if (task.firstPollWorker >= 0) revealWorker(task.firstPollWorker);

--- a/dial9-viewer/ui/src/pages/viewer/lane-interaction.ts
+++ b/dial9-viewer/ui/src/pages/viewer/lane-interaction.ts
@@ -165,7 +165,10 @@ export function mountLaneInteraction(
         } else {
           // Hand the range to the store; the region panel opens by data
           // present. This also retains the range (blocks kb-selection).
-          store.update("selection", { sidebarRange: { startNs: cmd.startNs, endNs: cmd.endNs } });
+          store.update("selection", {
+            sidebarRange: { startNs: cmd.startNs, endNs: cmd.endNs },
+            taskDump: null,
+          });
         }
         return;
       case "cursor":
@@ -251,7 +254,12 @@ export function mountLaneInteraction(
     const mouseXCol = e.clientX - geom.rectLeft;
     // Any lanes click clears the pinned custom-event marker.
     if (mouseXCol < LABEL_W || mouseXCol > LABEL_W + geom.drawW) {
-      store.update("selection", { selectedTaskId: null, pinnedEvent: null, pollDetail: null });
+      store.update("selection", {
+        selectedTaskId: null,
+        pinnedEvent: null,
+        pollDetail: null,
+        taskDump: null,
+      });
       return;
     }
     // A click on a runtime header band folds/unfolds that runtime - never a
@@ -264,7 +272,12 @@ export function mountLaneInteraction(
     const ns = geom.layout.panelXToNs(mouseXCol);
     const workerId = workerAtClientY(e.clientY, data);
     if (workerId === null) {
-      store.update("selection", { selectedTaskId: null, pinnedEvent: null, pollDetail: null });
+      store.update("selection", {
+        selectedTaskId: null,
+        pinnedEvent: null,
+        pollDetail: null,
+        taskDump: null,
+      });
       return;
     }
     const polls = data.workerSpans[workerId]?.polls ?? [];
@@ -287,6 +300,7 @@ export function mountLaneInteraction(
       // Detail. `openStackFor` is null in both no-sample cases, so this
       // dispatch doubles as the close.
       pollDetail: result.openStackFor,
+      taskDump: null,
     });
   }
 

--- a/dial9-viewer/ui/src/pages/viewer/main.ts
+++ b/dial9-viewer/ui/src/pages/viewer/main.ts
@@ -143,18 +143,25 @@ function boot(): void {
       const j = poiJump(r.nav.poi, vp);
       store.update("viewport", { viewStart: j.viewStart, viewEnd: j.viewEnd });
       if (j.selectedTaskId !== null) {
-        store.update("selection", { selectedTaskId: j.selectedTaskId });
+        store.update("selection", {
+          selectedTaskId: j.selectedTaskId,
+          taskDump: null,
+        });
       }
       return;
     }
     const win = searchWindow(r.nav.startNs, r.nav.endNs, vp.minTs, vp.maxTs);
     store.update("viewport", { viewStart: win.start, viewEnd: win.end });
     if (r.nav.kind === "task") {
-      store.update("selection", { selectedTaskId: r.nav.taskId });
+      store.update("selection", {
+        selectedTaskId: r.nav.taskId,
+        taskDump: null,
+      });
     } else {
       store.update("selection", {
         spanFocus: { spanId: r.nav.spanId, chain: new Set([r.nav.spanId]) },
         focusedSpanId: r.nav.spanId,
+        taskDump: null,
       });
     }
   }
@@ -245,6 +252,7 @@ function boot(): void {
         spanFocus: null,
         focusedSpanId: null,
         pinnedEvent: null,
+        taskDump: null,
       });
     },
     // Flush the debounced URL write so copy-link copies the live state.

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.ts
@@ -324,7 +324,7 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
       return;
     }
     if (cur !== null && cur.startNs === range.startNs && cur.endNs === range.endNs) return;
-    store.update("selection", { spawnedTasksRange: range });
+    store.update("selection", { spawnedTasksRange: range, taskDump: null });
   }
 
   function queueSeries(): QueueData {

--- a/dial9-viewer/ui/src/pages/viewer/region-analysis.ts
+++ b/dial9-viewer/ui/src/pages/viewer/region-analysis.ts
@@ -641,6 +641,7 @@ export function createRegionAnalysis(
       sidebarRange: { startNs: vp.minTs, endNs: vp.maxTs },
       pinnedEvent: null,
       pollDetail: null,
+      taskDump: null,
       spawnedTasksRange: null,
     });
   }

--- a/dial9-viewer/ui/src/pages/viewer/selection-overlay.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/selection-overlay.test.ts
@@ -25,6 +25,7 @@ function selection(over: Partial<SelectionSlice> = {}): SelectionSlice {
     focusedSpanId: null,
     pollDetail: null,
     pinnedEvent: null,
+    taskDump: null,
     sidebarRange: null,
     hoveredWakerTaskId: null,
     spawnedTasksRange: null,

--- a/dial9-viewer/ui/src/pages/viewer/spans-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/spans-track.ts
@@ -238,6 +238,7 @@ export function createSpansTrack(store: ViewerStore): SpansTrackController {
       focusedSpanId: spanId,
       spanFocus: { spanId, chain },
       pinnedEvent: null,
+      taskDump: null,
     };
     if (taskId !== null) patch.selectedTaskId = taskId;
     store.update("selection", patch);
@@ -249,6 +250,7 @@ export function createSpansTrack(store: ViewerStore): SpansTrackController {
       spanFocus: null,
       selectedTaskId: null,
       pinnedEvent: null,
+      taskDump: null,
     });
   }
 
@@ -269,6 +271,7 @@ export function createSpansTrack(store: ViewerStore): SpansTrackController {
     store.update("viewport", { viewStart, viewEnd });
     store.update("selection", {
       spanFocus: { spanId: span.spanId, chain: spanFocusChain(span.spanId, data) },
+      taskDump: null,
     });
   }
 

--- a/dial9-viewer/ui/src/pages/viewer/store.ts
+++ b/dial9-viewer/ui/src/pages/viewer/store.ts
@@ -31,6 +31,7 @@ export function initialViewerState(): StoreState {
       focusedSpanId: null,
       pinnedEvent: null,
       pollDetail: null,
+      taskDump: null,
       sidebarRange: null,
       hoveredWakerTaskId: null,
       spawnedTasksRange: null,

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
@@ -383,6 +383,8 @@ export interface WakeRegion {
  * the shared LABEL_W DOM gutter, so no LABEL_W is added to the coordinates.
  */
 export interface TaskDetailRenderModel {
+  /** Task identity captured with this geometry; null for the empty model. */
+  taskId: number | null;
   wakeBands: readonly WakeBand[];
   /** Per-poll bars (empty when the coverage histogram is used instead). */
   pollBars: readonly PollBar[];
@@ -400,6 +402,7 @@ export interface TaskDetailRenderModel {
 
 /** Empty model (no drawW / degenerate view). */
 const EMPTY_RENDER_MODEL: TaskDetailRenderModel = {
+  taskId: null,
   wakeBands: [],
   pollBars: [],
   coverage: null,
@@ -622,6 +625,7 @@ export function buildTaskDetailRenderModel(
   }
 
   return {
+    taskId: data.taskId,
     wakeBands,
     pollBars,
     coverage,

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
@@ -6,7 +6,9 @@
 //      waker-hover selection write reuses it (no O(all-polls) re-collect).
 //   2. waker-hover dispatch: hovering a waker label writes
 //      selection.hoveredWakerTaskId - the store field the lanes consume.
-//   3. drawTaskDetailCanvas render input: the hovered waker's label bolds, and
+//   3. canvas click dispatch: waker labels select their task, while dumped idle
+//      spans store their captures for the inspector Stack flamegraph.
+//   4. drawTaskDetailCanvas render input: the hovered waker's label bolds, and
 //      the window markers surface a truncated/oversized window.
 
 import { describe, it, expect } from "vitest";
@@ -166,13 +168,72 @@ describe("waker-hover dispatch (the lanes contract)", () => {
   it("clicking a waker label selects that waker task", () => {
     const { store, track, model } = setup();
     const region = model.wakeRegions[0]!;
-    track.clickWaker(model, (region.x1 + region.x2) / 2, (region.y1 + region.y2) / 2);
+    track.clickAt(model, (region.x1 + region.x2) / 2, (region.y1 + region.y2) / 2);
     expect(store.getState().selection.selectedTaskId).toBe(500);
     expect(store.getState().selection.hoveredWakerTaskId).toBeNull();
   });
 });
 
-// ── 3. drawTaskDetailCanvas render input (bolding + markers) ───────────────
+// ── 3. Task-dump click dispatch ───────────────────────────────────────────
+
+describe("task-dump click dispatch", () => {
+  function setup() {
+    const store = createViewerStore({ scheduler: () => {} });
+    const track = createTaskDetailTrack(store);
+    const dumps = [{ timestamp: 200, callchain: ["leaf", "root"] }];
+    const model = buildTaskDetailRenderModel({
+      data: {
+        taskId: 42,
+        polls: [
+          { start: 100, end: 150, taskId: 42, spawnLocId: "L", spawnLoc: null },
+          { start: 300, end: 350, taskId: 42, spawnLocId: "L", spawnLoc: null },
+          { start: 600, end: 650, taskId: 42, spawnLocId: "L", spawnLoc: null },
+        ],
+        wakes: [],
+        pollWakes: [null, null, null],
+        pollCount: 3,
+        wakeCount: 0,
+        spawnLocation: null,
+        isInstrumented: true,
+        spawnTs: null,
+        terminateTs: null,
+        hasTerminate: false,
+        lifetimeNs: null,
+        taskDumps: dumps,
+        workerIdCount: 1,
+        hasPolls: true,
+      },
+      viewStart: 0,
+      viewEnd: 1000,
+      drawW: 1000,
+    });
+    const hit = model.hitRegions.find((region) => region.dumps !== null)!;
+    return { store, track, model, hit };
+  }
+
+  it("stores a semantic anchor for the clicked dump-bearing idle span", () => {
+    const { store, track, model, hit } = setup();
+    store.update("selection", { selectedTaskId: 42 });
+
+    track.clickAt(model, (hit.x1 + hit.x2) / 2, BAND_TOP + 1);
+
+    expect(store.getState().selection.taskDump).toEqual({
+      taskId: 42,
+      timestamps: [200],
+    });
+  });
+
+  it("ignores a click when the painted model belongs to the previously selected task", () => {
+    const { store, track, model, hit } = setup();
+    store.update("selection", { selectedTaskId: 7 });
+
+    track.clickAt(model, (hit.x1 + hit.x2) / 2, BAND_TOP + 1);
+
+    expect(store.getState().selection.taskDump).toBeNull();
+  });
+});
+
+// ── 4. drawTaskDetailCanvas render input (bolding + markers) ───────────────
 
 interface DrawnText {
   text: string;

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
@@ -121,8 +121,8 @@ export interface TaskDetailTrackController {
    * is testable without a canvas/DOM.
    */
   hoverWaker(model: TaskDetailRenderModel, mx: number, my: number): void;
-  /** Clicking a waker label selects that waker task (via the store). */
-  clickWaker(model: TaskDetailRenderModel, mx: number, my: number): void;
+  /** Dispatch a task-detail canvas click to its waker or task-dump target. */
+  clickAt(model: TaskDetailRenderModel, mx: number, my: number): void;
   /** Clear the waker highlight (pointer left the canvas). */
   clearHover(): void;
   /** Tear down (no external resources today; symmetry with other tracks). */
@@ -266,7 +266,44 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
       store.update("selection", {
         selectedTaskId: waker.wakerTaskId,
         hoveredWakerTaskId: null,
+        taskDump: null,
       });
+    }
+  }
+
+  function clickTaskDump(
+    model: TaskDetailRenderModel,
+    mx: number,
+    my: number,
+  ): void {
+    const hit = hitRegionAt(model, mx, my);
+    const dumps = hit?.dumps ?? null;
+    const selectedTaskId = state().selection.selectedTaskId;
+    if (
+      model.taskId === null ||
+      selectedTaskId !== model.taskId ||
+      dumps === null ||
+      dumps.length === 0
+    ) {
+      return;
+    }
+    store.update("selection", {
+      taskDump: {
+        taskId: model.taskId,
+        timestamps: dumps.map((dump) => dump.timestamp),
+      },
+      pinnedEvent: null,
+      pollDetail: null,
+      sidebarRange: null,
+      spawnedTasksRange: null,
+    });
+  }
+
+  function clickAt(model: TaskDetailRenderModel, mx: number, my: number): void {
+    if (wakeRegionAt(model, mx, my) !== null) {
+      clickWaker(model, mx, my);
+    } else {
+      clickTaskDump(model, mx, my);
     }
   }
 
@@ -310,7 +347,7 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
     const model = lastModel;
     if (model === null) return;
     const { mx, my } = pointerAt(canvas, ev);
-    clickWaker(model, mx, my);
+    clickAt(model, mx, my);
   }
 
   function taskDetail(): TaskDetailData {
@@ -324,7 +361,15 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
     sizerCanvas = null;
   }
 
-  return { rowTemplate, paint, taskDetail, hoverWaker, clickWaker, clearHover, dispose };
+  return {
+    rowTemplate,
+    paint,
+    taskDetail,
+    hoverWaker,
+    clickAt,
+    clearHover,
+    dispose,
+  };
 }
 
 // ── Canvas draw (extracted so the render input is unit-testable) ───────────

--- a/dial9-viewer/ui/src/pages/viewer/url-state.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/url-state.test.ts
@@ -24,6 +24,7 @@ function mkState(over: {
       focusedSpanId: null,
       pinnedEvent: null,
       pollDetail: null,
+      taskDump: null,
       sidebarRange: null,
       hoveredWakerTaskId: null,
       spawnedTasksRange: null,

--- a/dial9-viewer/ui/src/store/store.test.ts
+++ b/dial9-viewer/ui/src/store/store.test.ts
@@ -49,6 +49,7 @@ function initialViewerState(): StoreState {
       focusedSpanId: null,
       pinnedEvent: null,
       pollDetail: null,
+      taskDump: null,
       sidebarRange: null,
       hoveredWakerTaskId: null,
       spawnedTasksRange: null,

--- a/dial9-viewer/ui/src/styles/viewer.css
+++ b/dial9-viewer/ui/src/styles/viewer.css
@@ -1618,8 +1618,10 @@ body {
 }
 .d9-poll-fg-section.on { color: #fff; background: var(--d9-accent); border-color: var(--d9-accent); }
 .d9-poll-fg-section:focus-visible { outline: 2px solid var(--d9-accent); outline-offset: -2px; }
-.d9-poll-fg-host { min-height: 320px; height: 42vh; position: relative; }
-.d9-poll-fg { width: 100%; height: 100%; }
+.d9-poll-fg-host,
+.d9-task-dump-fg-host { min-height: 320px; height: 42vh; position: relative; }
+.d9-poll-fg,
+.d9-task-dump-fg { width: 100%; height: 100%; }
 
 /* Blocking-calls panel. */
 .d9-block-groupby select {

--- a/dial9-viewer/ui/src/types/exhaustive.test.ts
+++ b/dial9-viewer/ui/src/types/exhaustive.test.ts
@@ -173,6 +173,7 @@ const initialState: StoreState = {
     focusedSpanId: null,
     pinnedEvent: null,
     pollDetail: null,
+    taskDump: null,
     sidebarRange: null,
     hoveredWakerTaskId: null,
     spawnedTasksRange: null,
@@ -232,6 +233,10 @@ function populatedState(): StoreState {
         detailEvent: null,
       },
       pollDetail: poll,
+      taskDump: {
+        taskId: 42,
+        timestamps: [2_500],
+      },
       sidebarRange: range,
       hoveredWakerTaskId: 7,
       spawnedTasksRange: range,

--- a/dial9-viewer/ui/src/types/state.d.ts
+++ b/dial9-viewer/ui/src/types/state.d.ts
@@ -115,6 +115,18 @@ export interface SpanFocus {
 }
 
 /**
+ * Async stack captures selected by clicking a dump-bearing idle span in the
+ * task-detail track. Store semantic timestamps rather than trace-owned objects
+ * so a reparse resolves against the replacement trace.
+ */
+export interface TaskDumpSelection {
+  /** Task whose idle span produced these captures. */
+  taskId: number;
+  /** Capture timestamps attributed to the clicked idle span. */
+  timestamps: readonly number[];
+}
+
+/**
  * Cross-highlight state. All fields are independently clearable, hence all
  * explicitly nullable.
  */
@@ -138,6 +150,11 @@ export interface SelectionSlice {
    * groups from it.
    */
   pollDetail: PollSpan | null;
+  /**
+   * Task-dump captures shown in the Stack inspector after clicking a dumped
+   * idle span in the task-detail track.
+   */
+  taskDump: TaskDumpSelection | null;
   /**
    * Range retained while the sidebar shows a region analysis (region
    * select -> flamegraph/blocking calls); blocks keyboard selection until


### PR DESCRIPTION
## Summary
- route clicks on dump-bearing task idle spans through a tested canvas interaction seam
- store a semantic task-dump selection (`taskId` + capture timestamps) and resolve it against the current trace
- open the Stack inspector with an embedded flamegraph for the selected async stack captures
- reject stale painted task models and clear task-dump state when another analytical selection takes over

## Classification
This is a pre-existing migrated-viewer bug, not a regression from #718. The task-detail track has had a pointer cursor and dump-bearing hit regions since the viewer migration, but its click handler only dispatched waker-task clicks. The same handler is present on `main`, and #718 does not modify the task-detail track or model.

This PR intentionally targets `main` independently. Per the repository PR policy, #718 should rebase onto `main` after this merges rather than targeting this branch as a stacked PR.

## Validation
- `npm run check:types`
- focused task-detail/inspector suites — 53 tests passed
- `npm test` — 1,851 tests passed; all legacy Node suites passed
- `npm run build`
- `cargo build -p dial9-viewer`
- `git diff --check`
- independent re-review: no blocking findings
