### PR TITLE
perf(trace-format): identity fast path for repeated dynamic Schema handles

### DIFF
--- a/dial9-metrique/src/lib.rs
+++ b/dial9-metrique/src/lib.rs
@@ -114,10 +114,10 @@
 //!
 //! Measured by `benches/metrique_sink_bench.rs`: `Dial9Context::capture()`
 //! costs ~31 ns on the request path, plus ~30 ns for the end-timestamp
-//! clock read when the entry closes. Encoding costs ~480-620 ns per entry
+//! clock read when the entry closes. Encoding costs ~420-535 ns per entry
 //! on the flush thread, from an all-scalar payload up to one carrying an
 //! allocating (non-interned) string; boxed entries from a global sink add
-//! ~60 ns. A paused recorder or a disabled handle costs ~3.5 ns per entry.
+//! ~35 ns. A paused recorder or a disabled handle costs ~3.5 ns per entry.
 //! [`Dial9Stream::tee`]'s field filtering adds well under a nanosecond per
 //! entry to the other sink.
 //!

--- a/dial9-tokio-telemetry/benches/tracing_layer_bench.rs
+++ b/dial9-tokio-telemetry/benches/tracing_layer_bench.rs
@@ -1,6 +1,11 @@
-//! Multi-thread bench for the tracing layer.
+//! Wall-clock benches for the tracing layer.
 //!
-//! Measures span emission throughput as N threads share one
+//! `single_thread`: per-span enter+exit cost through the full dial9 encode
+//! path (recorder + in-memory writer on a `current_thread` runtime), with a
+//! `tracing_only` comparator to isolate the dial9 encoding overhead. This is
+//! the wall-clock companion to `tracing_layer_iai.rs`.
+//!
+//! `multi_thread`: span emission throughput as N threads share one
 //! `Dial9TracingLayer` (and therefore one schemas Mutex). Each thread
 //! emits 100 spans after a barrier sync; the iteration is timed end to
 //! end across N ∈ {1, 2, 4, 8, 16, 32}.
@@ -9,10 +14,77 @@
 //!   cargo bench --bench tracing_layer_bench --features tracing-layer
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dial9_tokio_telemetry::telemetry::{Dial9Handle, MemoryBuffer, RecorderTokioExt, recorder};
 use dial9_tokio_telemetry::tracing_layer::Dial9TracingLayer;
 use std::sync::{Arc, Barrier};
 use tracing::Dispatch;
 use tracing_subscriber::prelude::*;
+
+fn bench_single_thread(c: &mut Criterion) {
+    let mut group = c.benchmark_group("single_thread");
+    group.measurement_time(std::time::Duration::from_secs(5));
+
+    // Recorder with an in-memory writer and a current_thread runtime, so
+    // block_on runs spans on a dial9-claimed thread and the layer encodes
+    // for real (no disk I/O in the measurement).
+    let (_recorder, runtime) = recorder(MemoryBuffer::new(64 * 1024 * 1024).unwrap())
+        .build()
+        .attach_tokio_runtime(|t| {
+            *t = tokio::runtime::Builder::new_current_thread();
+            t.enable_all();
+        })
+        .unwrap();
+
+    // Sanity check: the bench must exercise the enabled encode path.
+    runtime.block_on(async {
+        assert!(
+            Dial9Handle::current().is_enabled(),
+            "bench thread is not claimed by the dial9 runtime; \
+             the measurement would cover only the disabled early-return"
+        );
+    });
+
+    // Comparator: identical span workload with no dial9 layer, to separate
+    // tracing dispatch cost from dial9 encoding cost.
+    let tracing_only = Dispatch::new(tracing_subscriber::registry());
+    group.bench_function("tracing_only/span_enter_exit", |b| {
+        let _g = tracing::dispatcher::set_default(&tracing_only);
+        runtime.block_on(async {
+            b.iter(|| {
+                let span = tracing::info_span!("bench", key = "value");
+                let _enter = span.enter();
+            });
+        });
+    });
+
+    let with_dial9 = Dispatch::new(tracing_subscriber::registry().with(Dial9TracingLayer::new()));
+    group.bench_function("with_dial9/span_enter_exit", |b| {
+        let _g = tracing::dispatcher::set_default(&with_dial9);
+        runtime.block_on(async {
+            b.iter(|| {
+                let span = tracing::info_span!("bench", key = "value");
+                let _enter = span.enter();
+            });
+        });
+    });
+
+    group.bench_function("with_dial9/span_enter_exit_fields", |b| {
+        let _g = tracing::dispatcher::set_default(&with_dial9);
+        runtime.block_on(async {
+            b.iter(|| {
+                let span = tracing::info_span!(
+                    "fielded",
+                    user_id = 42,
+                    method = "GET",
+                    path = "/api/v1/users"
+                );
+                let _enter = span.enter();
+            });
+        });
+    });
+
+    group.finish();
+}
 
 fn bench_multi_thread(c: &mut Criterion) {
     let mut group = c.benchmark_group("multi_thread");
@@ -53,5 +125,5 @@ fn bench_multi_thread(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_multi_thread);
+criterion_group!(benches, bench_single_thread, bench_multi_thread);
 criterion_main!(benches);

--- a/dial9-tokio-telemetry/src/tracing_layer.rs
+++ b/dial9-tokio-telemetry/src/tracing_layer.rs
@@ -49,12 +49,15 @@
 //!
 //! # Overhead
 //!
-//! Each span enter+exit pair costs roughly **300ns** total (tracing dispatch
-//! plus dial9 encoding), of which **~50-100ns** is the dial9 encoding overhead.
-//! Measured with an in-memory writer on a `current_thread` runtime to
-//! isolate encoding from I/O. This scales linearly with nesting depth and is
-//! comparable to the cost of a single poll event, so the layer is suitable
-//! for production use with appropriate span filtering.
+//! Each span enter+exit pair costs roughly **650-800ns** total (tracing
+//! dispatch plus dial9 encoding), of which dial9 encoding is the majority:
+//! the same span through a bare `tracing_subscriber::registry()` costs
+//! ~100-200ns. Measured with an in-memory writer on a `current_thread`
+//! runtime pinned to one core of an AMD EPYC 9R14 (see the `single_thread`
+//! group in `benches/tracing_layer_bench.rs`); absolute numbers scale with
+//! hardware. Cost grows with the number of span fields and scales linearly
+//! with nesting depth, so the layer is suitable for production use with
+//! appropriate span filtering.
 
 use crate::telemetry::{Dial9Handle, clock_monotonic_ns, current_worker_id};
 use dial9_trace_format::TraceEvent;

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -98,7 +98,8 @@ pub type FxHashSet<T> = HashSet<T, FxBuildHasher>;
 /// itself with any encoder on first use. This means a `Schema` created on one
 /// encoder can be passed to a different encoder and it will just work.
 ///
-/// `Schema` is cheap to clone (internally `Arc`-backed).
+/// `Schema` is cheap to clone (internally `Arc`-backed). Create it once and
+/// reuse it across events; see [`Encoder::write_event`].
 #[derive(Clone, Debug)]
 pub struct Schema {
     pub(crate) entry: Arc<SchemaEntry>,
@@ -421,6 +422,12 @@ impl<W: Write> Encoder<W> {
     ///
     /// If this encoder hasn't seen `schema` before, it is auto-registered
     /// (the schema frame is written before the event).
+    ///
+    /// # Performance
+    ///
+    /// Create the `Schema` once and reuse it (or clones of it) across events.
+    /// Reused handles hit an identity cache; a fresh handle per event falls
+    /// back to registration by name (hash and compare) on every write.
     pub fn write_event(
         &mut self,
         schema: &Schema,

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -160,6 +160,11 @@ enum SchemaKey {
 ///
 /// The default type parameter (`Vec<u8>`) buffers everything in memory;
 /// use [`Encoder::new_to`] to write to an arbitrary [`Write`] sink.
+/// Upper bound on [`Encoder::dynamic_schema_cache`]. Far above any sane
+/// number of distinct live schema handles, small enough that pinned
+/// `SchemaEntry` Arcs stay negligible.
+const DYNAMIC_SCHEMA_CACHE_LIMIT: usize = 1024;
+
 pub struct Encoder<W: Write = Vec<u8>> {
     state: EncodeState<W>,
     registry: SchemaRegistry,
@@ -173,6 +178,12 @@ pub struct Encoder<W: Write = Vec<u8>> {
     /// `Arc` is kept alive in the value so the address cannot be reused
     /// while cached. Repeated `write_event` calls with the same handle skip
     /// the name hash and deep schema comparison in `ensure_registered`.
+    ///
+    /// Bounded to [`DYNAMIC_SCHEMA_CACHE_LIMIT`] entries and cleared when
+    /// full: a caller that mints a fresh `Schema` per event would otherwise
+    /// grow it (and pin the `Arc`s) without bound. Clearing only costs the
+    /// fast path; registration stays correct through the name-keyed slow
+    /// path.
     dynamic_schema_cache: FxHashMap<usize, (Arc<SchemaEntry>, WireTypeId)>,
     /// Per-type dense cache keyed by `TraceEvent::type_slot()`.
     /// Stores `wire_id + 1` so that `0` means "unset".
@@ -326,6 +337,12 @@ impl<W: Write> Encoder<W> {
             return Ok(*wire_id);
         }
         let wire_id = self.ensure_registered_slow(schema)?;
+        if self.dynamic_schema_cache.len() >= DYNAMIC_SCHEMA_CACHE_LIMIT {
+            // Pathological usage (a fresh handle per event); drop the cache
+            // rather than the memory. Well-behaved callers re-enter their
+            // entry on the next event.
+            self.dynamic_schema_cache.clear();
+        }
         self.dynamic_schema_cache
             .insert(identity, (Arc::clone(&schema.entry), wire_id));
         Ok(wire_id)
@@ -1497,5 +1514,80 @@ mod tests {
         assert_eq!(events[0].1, vec![FieldValue::Varint(1)]);
         assert_eq!(events[1].0, Some(2_000));
         assert_eq!(events[1].1, vec![FieldValue::Varint(2)]);
+    }
+}
+
+#[cfg(test)]
+mod dynamic_schema_cache_tests {
+    use super::*;
+    use crate::schema::{FieldDef, SchemaEntry};
+    use crate::types::{FieldType, FieldValue};
+
+    fn schema(name: &str) -> Schema {
+        Schema::from_entry(SchemaEntry::new(
+            name,
+            /* has_timestamp */ true,
+            vec![FieldDef::new("v", FieldType::Varint)],
+        ))
+    }
+
+    /// The same handle re-registers through the identity cache, and a fresh
+    /// handle for the same name resolves to the same wire id through the
+    /// slow path (then caches its own identity).
+    #[test]
+    fn identity_cache_agrees_with_name_registration() {
+        let mut enc = Encoder::new();
+        let a = schema("Ev");
+        let id1 = enc.ensure_registered(&a).unwrap();
+        let id2 = enc.ensure_registered(&a).unwrap();
+        assert_eq!(id1, id2, "same handle must reuse its wire id");
+
+        let b = schema("Ev"); // distinct allocation, same layout and name
+        let id3 = enc.ensure_registered(&b).unwrap();
+        assert_eq!(id1, id3, "same name must resolve to the same wire id");
+        assert_eq!(enc.dynamic_schema_cache.len(), 2);
+    }
+
+    /// A caller minting a fresh handle per event must not grow the cache
+    /// (and pin schema Arcs) without bound.
+    #[test]
+    fn identity_cache_is_bounded() {
+        let mut enc = Encoder::new();
+        for i in 0..(DYNAMIC_SCHEMA_CACHE_LIMIT * 2 + 7) {
+            // Cycle a few names so both fresh-per-event and fresh-name
+            // shapes are covered; every handle is a distinct allocation.
+            let s = schema(&format!("Ev{}", i % 3));
+            enc.ensure_registered(&s).unwrap();
+            assert!(
+                enc.dynamic_schema_cache.len() <= DYNAMIC_SCHEMA_CACHE_LIMIT,
+                "cache exceeded its bound at iteration {i}"
+            );
+        }
+    }
+
+    /// Clearing the cache must not affect decodability: events written
+    /// before and after the flush decode against one schema.
+    #[test]
+    fn events_across_cache_clears_decode() {
+        let mut enc = Encoder::new();
+        for i in 0..(DYNAMIC_SCHEMA_CACHE_LIMIT + 3) {
+            let s = schema("Ev");
+            // Timestamp plus the one schema field.
+            enc.write_event(
+                &s,
+                &[FieldValue::Varint(i as u64), FieldValue::Varint(i as u64)],
+            )
+            .unwrap();
+        }
+        let data = enc.finish();
+        let mut decoder = crate::decoder::Decoder::new(&data).unwrap();
+        let mut count = 0u64;
+        decoder
+            .for_each_event(|ev| {
+                assert_eq!(ev.name, "Ev");
+                count += 1;
+            })
+            .unwrap();
+        assert_eq!(count, (DYNAMIC_SCHEMA_CACHE_LIMIT + 3) as u64);
     }
 }

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -168,6 +168,12 @@ pub struct Encoder<W: Write = Vec<u8>> {
     stack_pool: FxHashMap<Box<[u64]>, u32>,
     next_stack_pool_id: u32,
     schema_ids: FxHashMap<SchemaKey, WireTypeId>,
+    /// Identity fast path for dynamic [`Schema`] handles: wire ids keyed by
+    /// the address of the schema's shared `SchemaEntry` allocation. The
+    /// `Arc` is kept alive in the value so the address cannot be reused
+    /// while cached. Repeated `write_event` calls with the same handle skip
+    /// the name hash and deep schema comparison in `ensure_registered`.
+    dynamic_schema_cache: FxHashMap<usize, (Arc<SchemaEntry>, WireTypeId)>,
     /// Per-type dense cache keyed by `TraceEvent::type_slot()`.
     /// Stores `wire_id + 1` so that `0` means "unset".
     slot_cache: Vec<u32>,
@@ -195,6 +201,7 @@ impl Encoder<Vec<u8>> {
             stack_pool: FxHashMap::default(),
             next_stack_pool_id: 0,
             schema_ids: FxHashMap::default(),
+            dynamic_schema_cache: FxHashMap::default(),
             slot_cache: Vec::new(),
             registered_ids: [0; (crate::STATIC_WIRE_ID_LIMIT as usize) / 64],
         }
@@ -219,6 +226,7 @@ impl<W: Write> Encoder<W> {
             stack_pool: FxHashMap::default(),
             next_stack_pool_id: 0,
             schema_ids: FxHashMap::default(),
+            dynamic_schema_cache: FxHashMap::default(),
             slot_cache: Vec::new(),
             registered_ids: [0; (crate::STATIC_WIRE_ID_LIMIT as usize) / 64],
         })
@@ -268,6 +276,7 @@ impl<W: Write> Encoder<W> {
             stack_pool: new_stack_pool,
             next_stack_pool_id,
             schema_ids,
+            dynamic_schema_cache: FxHashMap::default(),
             slot_cache: Vec::new(),
             registered_ids: [0; (crate::STATIC_WIRE_ID_LIMIT as usize) / 64],
         }
@@ -298,6 +307,7 @@ impl<W: Write> Encoder<W> {
         self.next_stack_pool_id = 0;
         self.registry.clear();
         self.schema_ids.clear();
+        self.dynamic_schema_cache.clear();
         self.slot_cache.fill(0);
         self.registered_ids.fill(0);
         // creating a new EncodeState resets the timestamp delta
@@ -311,6 +321,19 @@ impl<W: Write> Encoder<W> {
     /// Idempotent if the schema matches. Errors if a different schema was
     /// already registered under the same name.
     fn ensure_registered(&mut self, schema: &Schema) -> io::Result<WireTypeId> {
+        let identity = Arc::as_ptr(&schema.entry) as usize;
+        if let Some((_, wire_id)) = self.dynamic_schema_cache.get(&identity) {
+            return Ok(*wire_id);
+        }
+        let wire_id = self.ensure_registered_slow(schema)?;
+        self.dynamic_schema_cache
+            .insert(identity, (Arc::clone(&schema.entry), wire_id));
+        Ok(wire_id)
+    }
+
+    /// Name-keyed registration with collision validation; the slow path
+    /// behind the identity cache above.
+    fn ensure_registered_slow(&mut self, schema: &Schema) -> io::Result<WireTypeId> {
         let key = SchemaKey::Name(Arc::clone(&schema.name_key));
         if let Some(&wire_id) = self.schema_ids.get(&key) {
             // TODO: unify registry and schema_ids to avoid this error case

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -466,7 +466,7 @@ tracing_subscriber::registry()
     .init();
 ```
 
-Careful filtering of the data you send to dial9 strongly recommended. dial9 doesn't need _all_ the data, only enough to correlate with other data sources. Libraries like the AWS SDK emit many internal spans that can produce over 100K events per second. The example above captures only spans from my_app. Each span enter+exit costs ~300ns total (~50-100ns is dial9 encoding overhead).
+Careful filtering of the data you send to dial9 strongly recommended. dial9 doesn't need _all_ the data, only enough to correlate with other data sources. Libraries like the AWS SDK emit many internal spans that can produce over 100K events per second. The example above captures only spans from my_app. Each span enter+exit costs roughly 650-800ns total on a modern server core, most of which is dial9 encoding (the same span through a bare `tracing` registry costs ~100-200ns).
 
 ### Metrique metrics (opt-in)
 


### PR DESCRIPTION
Split out of dial9-rs/dial9#723 per review, so it can be tested and hardened independently.

### Summary

Dynamic-schema sources (the metrique sink, the tracing layer's span events) call `write_event` with a `Schema` handle they hold across events. Registration previously re-keyed by name on every event: hash the name, then deep-compare the schema on hit. This adds an identity fast path keyed by the address of the handle's shared `SchemaEntry` allocation, so a reused handle resolves its wire id with one map probe.

Measured in the metrique sink, this is worth 10-13% per entry: steady state ~592ns to ~534ns, with the scalar-only, all-interned, and boxed variants improving by ~46-82ns each.

On the tracing layer (new `single_thread` criterion group in `tracing_layer_bench.rs`, in-memory writer, pinned core, A/B against main with only `encoder.rs` swapped) it cuts span enter+exit from ~790ns to ~670ns and a 3-field span from ~925ns to ~815ns, a 12-14% reduction (two `write_event` calls per pair).

The cache pins each entry's `Arc` so the address cannot be reused while cached. A caller minting a fresh handle per event would grow the cache, and pin schemas, without bound. The cache is therefore bounded (1024 entries) and cleared when full; pathological callers lose the fast path, never memory, and correctness always comes from the name-keyed slow path.

### Pathological usage

For tracing layer and metrique sink usage, this is a strict improvement, trading a small and bounded amount of memory for better throughput.

The cases that would actually use a fresh handle per event:
  - Application code using the dynamic-schema API naively, building the schema inline inside the event loop instead of hoisting it - this one is an anti-pattern, I feel, and we can just document not to do this
  - Genuinely dynamic emitters, e.g. schemas derived per-message from runtime data (a proxy forwarding arbitrary upstream event shapes), where distinct schemas really are  unbounded. - this feels a bit esoteric, and we could add a new API if this ever became a use case
  - Repeatedly tearing down and recreating a layer/sink against the same long-lived thread-local encoder; each incarnation mints new allocations. - also a bit esoteric, also could be a new API

### Tracing benchmark discrepancy

The tracing layer docs previously claimed ~300ns per enter+exit pair with ~50-100ns of dial9 encoding. Those numbers do not reproduce: re-running the exact benchmark from the commit that produced them (#252) on the same host as the numbers above gives ~980ns incremental with dial9 vs ~90ns tracing-only.

Since even the original code does not reproduce the documented figures, the claim likely came from different hardware or a misread, not from a regression since. Two side findings: current main is already ~20% faster on that path than #252 was, and this PR updates the module docs and README to the measured numbers with an explicit hardware caveat.

### Testing

Unit tests cover the identity/name agreement (a fresh handle for the same name resolves to the same wire id), the bound under a fresh-handle-per-event caller cycling names, and decodability of a trace written across cache clears. The tracing layer numbers come from a new wall-clock `single_thread` group added to `tracing_layer_bench.rs`.
