### PR TITLE
docs: document segment metadata configuration

### DIFF
--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -197,6 +197,24 @@ impl<M: BufferMode> RecorderBuilder<M> {
 
     /// Static metadata written into every rotated segment header. Merged across
     /// calls (and across the tokio layer); on a key collision the later value wins.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dial9_core::buffer::MemoryBuffer;
+    /// use dial9_core::recorder::recorder;
+    ///
+    /// let recorder = recorder(MemoryBuffer::new(1024 * 1024)?)
+    ///     .segment_metadata([("service".into(), "checkout".into())])
+    ///     .segment_metadata([("environment".into(), "production".into())])
+    ///     .segment_metadata([("service".into(), "payments".into())])
+    ///     .build();
+    ///
+    /// // Metadata is merged across calls. The third call overrides `service`
+    /// // from the first, so its value is `payments`.
+    /// # recorder.graceful_shutdown(std::time::Duration::ZERO);
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn segment_metadata(mut self, entries: impl IntoIterator<Item = (String, String)>) -> Self {
         merge_segment_metadata(&mut self.segment_metadata, entries);
         self

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -49,13 +49,20 @@ fn my_config() -> io::Result<AttachedRuntime> {
         .build();
     // Downgrades to a disabled recorder if the writer can't be created; use
     // `dial9::recorder(writer?)` instead to surface writer errors explicitly.
-    dial9::recorder_or_disabled(writer).build().attach_tokio_runtime_with(
-        TokioAttachOptions::builder()
-            .runtime_name("main")
-            .task_tracking_enabled(true)
-            .build(),
-        |t| { t.worker_threads(4); },
-    )
+    dial9::recorder_or_disabled(writer)
+        .segment_metadata([("service".to_string(), "checkout".to_string())])
+        .segment_metadata([(
+            "application.version".to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+        )])
+        .build()
+        .attach_tokio_runtime_with(
+            TokioAttachOptions::builder()
+                .runtime_name("main")
+                .task_tracking_enabled(true)
+                .build(),
+            |t| { t.worker_threads(4); },
+        )
 }
 
 #[dial9::main(config = my_config)] // inline config function is also supported
@@ -67,6 +74,12 @@ async fn main() {
         .unwrap();
 }
 ```
+
+Use [`RecorderBuilder::segment_metadata`](https://docs.rs/dial9/latest/dial9/struct.RecorderBuilder.html#method.segment_metadata)
+for static context that should be available when any rotated segment is loaded
+independently, such as the service, host, deployment, or compiled application
+version. Calls are merged, including calls made by integration layers; when a
+key is repeated, the later value wins.
 
 For zero-code configuration in production, use `dial9::recorder_from_env`:
 

--- a/dial9/examples/production_use.rs
+++ b/dial9/examples/production_use.rs
@@ -103,6 +103,12 @@
 //! with different tracing behavior, and tooling (CDK, Docker, k8s, etc.)
 //! can flip knobs without a rebuild.
 //!
+//! ### Segment metadata
+//!
+//! Static build and deployment context belongs in segment metadata so it is
+//! available when any rotated segment is loaded independently. This example
+//! records the compiled application's Cargo package version in every segment.
+//!
 //! ### Getting Useful Data
 //!
 //! To get the most use out of dial9, you need application-specific events in your traces to make sense of your data. The best way to do this is to emit some sort
@@ -299,7 +305,12 @@ fn configure_dial9(opts: &Dial9Opts) -> Recorder {
     };
 
     let core = configure_sources(
-        dial9::recorder(writer).metrics_sink(stderr_metrics_sink()),
+        dial9::recorder(writer)
+            .segment_metadata([(
+                "application.version".to_string(),
+                env!("CARGO_PKG_VERSION").to_string(),
+            )])
+            .metrics_sink(stderr_metrics_sink()),
         opts,
     );
 


### PR DESCRIPTION
## Summary
- add a rustdoc example showing repeated segment_metadata calls and later-value-wins behavior
- document static segment metadata in the README quick start
- stamp production_use traces with application.version from CARGO_PKG_VERSION

## Testing
- cargo test -p dial9-core --doc
- cargo test -p dial9 --doc --all-features
- cargo check -p dial9 --example production_use --all-features
- cargo fmt --check
- cargo clippy --all-targets --all-features