### PR TITLE
feat: re-export dial9-trace-format's event-authoring and decode surface

### DIFF
--- a/dial9/Cargo.toml
+++ b/dial9/Cargo.toml
@@ -37,6 +37,7 @@ missing_debug_implementations = "warn"
 
 [dependencies]
 dial9-core = { workspace = true }
+dial9-trace-format = { workspace = true }
 dial9-perf-self-profile = { workspace = true, optional = true }
 dial9-tokio-telemetry = { version = "0.5.0-rc1", path = "../dial9-tokio-telemetry", optional = true }
 dial9-macro = { workspace = true, optional = true }
@@ -117,8 +118,12 @@ tracing-layer = ["tokio", "dial9-tokio-telemetry/tracing-layer"]
 ## Standalone; combine with the `tokio` feature to capture task ids.
 metrique-sink = ["dep:dial9-metrique"]
 
+## Serde deserialization of decoded events (`RawEvent::deserialize`).
+## Reading a trace with [`Decoder`] needs no feature.
+deserialize = ["dial9-trace-format/serde-deserialize"]
+
 ## Trace file reading + analysis toolkit (offline decode).
-analysis = ["tokio", "dial9-tokio-telemetry/analysis"]
+analysis = ["deserialize", "tokio", "dial9-tokio-telemetry/analysis"]
 
 ## S3 upload pipeline stage.
 worker-s3 = ["tokio", "dial9-tokio-telemetry/worker-s3"]

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -585,8 +585,8 @@ You can emit your own application-level events into the trace alongside the buil
 ```rust,no_run
 # fn main() {
 use dial9::Dial9Handle;
-use dial9::TraceEvent;
 use dial9::core::clock_monotonic_ns;
+use dial9::format::TraceEvent;
 
 #[derive(TraceEvent)]
 struct RequestCompleted {
@@ -616,7 +616,8 @@ periodic snapshots without passing a [`Dial9Handle`] through your code:
 
 ```rust,no_run
 use dial9::core::CustomEventsConfig;
-use dial9::{RecorderSourceExt, TraceEvent, recorder};
+use dial9::format::TraceEvent;
+use dial9::{RecorderSourceExt, recorder};
 
 #[derive(TraceEvent)]
 struct CacheEvent {

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -585,8 +585,8 @@ You can emit your own application-level events into the trace alongside the buil
 ```rust,no_run
 # fn main() {
 use dial9::Dial9Handle;
+use dial9::TraceEvent;
 use dial9::core::clock_monotonic_ns;
-use dial9_trace_format::TraceEvent;
 
 #[derive(TraceEvent)]
 struct RequestCompleted {
@@ -616,8 +616,7 @@ periodic snapshots without passing a [`Dial9Handle`] through your code:
 
 ```rust,no_run
 use dial9::core::CustomEventsConfig;
-use dial9::{RecorderSourceExt, recorder};
-use dial9_trace_format::TraceEvent;
+use dial9::{RecorderSourceExt, TraceEvent, recorder};
 
 #[derive(TraceEvent)]
 struct CacheEvent {

--- a/dial9/examples/analyze_trace.rs
+++ b/dial9/examples/analyze_trace.rs
@@ -3,8 +3,8 @@
 //! Usage:
 //!   cargo run --example analyze_trace --features analysis -- <trace_file>
 
+use dial9::Decoder;
 use dial9::analysis::analysis_events::{Dial9Event, WorkerId};
-use dial9_trace_format::decoder::Decoder;
 use std::collections::HashMap;
 use std::env;
 

--- a/dial9/examples/analyze_trace.rs
+++ b/dial9/examples/analyze_trace.rs
@@ -3,8 +3,8 @@
 //! Usage:
 //!   cargo run --example analyze_trace --features analysis -- <trace_file>
 
-use dial9::Decoder;
 use dial9::analysis::analysis_events::{Dial9Event, WorkerId};
+use dial9::format::Decoder;
 use std::collections::HashMap;
 use std::env;
 

--- a/dial9/examples/cpu_profile_workload.rs
+++ b/dial9/examples/cpu_profile_workload.rs
@@ -12,11 +12,11 @@
 // Example prints the deprecated `CpuSampleEvent::worker_id` for illustration.
 #![allow(deprecated)]
 
+use dial9::Decoder;
 use dial9::analysis::analysis_events::{CpuSampleSource, Dial9Event, WorkerId};
 use dial9::cpu::CpuProfilingConfig;
 use dial9::{DiskBuffer, recorder};
 use dial9::{RecorderPerfExt, RecorderTokioExt, TokioAttachOptions};
-use dial9_trace_format::decoder::Decoder;
 use std::time::Duration;
 
 fn burn_cpu(duration: Duration) {

--- a/dial9/examples/cpu_profile_workload.rs
+++ b/dial9/examples/cpu_profile_workload.rs
@@ -12,9 +12,9 @@
 // Example prints the deprecated `CpuSampleEvent::worker_id` for illustration.
 #![allow(deprecated)]
 
-use dial9::Decoder;
 use dial9::analysis::analysis_events::{CpuSampleSource, Dial9Event, WorkerId};
 use dial9::cpu::CpuProfilingConfig;
+use dial9::format::Decoder;
 use dial9::{DiskBuffer, recorder};
 use dial9::{RecorderPerfExt, RecorderTokioExt, TokioAttachOptions};
 use std::time::Duration;

--- a/dial9/examples/custom_events.rs
+++ b/dial9/examples/custom_events.rs
@@ -9,8 +9,9 @@
 //! cargo run --example custom_events --features analysis
 //! ```
 
-use dial9::core::{Encodable, InternedString, ThreadLocalEncoder, clock_monotonic_ns};
-use dial9::{DiskBuffer, RecorderTokioExt, TraceEvent, recorder};
+use dial9::core::{Encodable, ThreadLocalEncoder, clock_monotonic_ns};
+use dial9::format::{InternedString, TraceEvent};
+use dial9::{DiskBuffer, RecorderTokioExt, recorder};
 use std::time::Duration;
 
 // ── Simple: derive-only, no interning ───────────────────────────────────────
@@ -110,7 +111,7 @@ fn main() -> std::io::Result<()> {
     let sealed = dir.path().join("trace.0.bin");
     let data = std::fs::read(&sealed)?;
     let mut decoder =
-        dial9::Decoder::new(&data).ok_or_else(|| std::io::Error::other("invalid trace"))?;
+        dial9::format::Decoder::new(&data).ok_or_else(|| std::io::Error::other("invalid trace"))?;
 
     let mut request_completed = 0u32;
     let mut http_request = 0u32;

--- a/dial9/examples/custom_events.rs
+++ b/dial9/examples/custom_events.rs
@@ -9,9 +9,8 @@
 //! cargo run --example custom_events --features analysis
 //! ```
 
-use dial9::core::{Encodable, ThreadLocalEncoder, clock_monotonic_ns};
-use dial9::{DiskBuffer, RecorderTokioExt, recorder};
-use dial9_trace_format::{InternedString, TraceEvent};
+use dial9::core::{Encodable, InternedString, ThreadLocalEncoder, clock_monotonic_ns};
+use dial9::{DiskBuffer, RecorderTokioExt, TraceEvent, recorder};
 use std::time::Duration;
 
 // ── Simple: derive-only, no interning ───────────────────────────────────────
@@ -110,8 +109,8 @@ fn main() -> std::io::Result<()> {
     // Verify: decode the trace and count our custom events
     let sealed = dir.path().join("trace.0.bin");
     let data = std::fs::read(&sealed)?;
-    let mut decoder = dial9_trace_format::decoder::Decoder::new(&data)
-        .ok_or_else(|| std::io::Error::other("invalid trace"))?;
+    let mut decoder =
+        dial9::Decoder::new(&data).ok_or_else(|| std::io::Error::other("invalid trace"))?;
 
     let mut request_completed = 0u32;
     let mut http_request = 0u32;

--- a/dial9/examples/kernel_sched_events.rs
+++ b/dial9/examples/kernel_sched_events.rs
@@ -45,11 +45,11 @@
 // Example prints the deprecated `CpuSampleEvent::worker_id` for illustration.
 #![allow(deprecated)]
 
+use dial9::Decoder;
 use dial9::analysis::analysis_events::{CpuSampleSource, Dial9Event};
 use dial9::cpu::SchedEventConfig;
 use dial9::{DiskBuffer, recorder};
 use dial9::{RecorderPerfExt, RecorderTokioExt, TokioAttachOptions};
-use dial9_trace_format::decoder::Decoder;
 use std::time::Duration;
 
 async fn blocking_task(id: usize) {

--- a/dial9/examples/kernel_sched_events.rs
+++ b/dial9/examples/kernel_sched_events.rs
@@ -45,9 +45,9 @@
 // Example prints the deprecated `CpuSampleEvent::worker_id` for illustration.
 #![allow(deprecated)]
 
-use dial9::Decoder;
 use dial9::analysis::analysis_events::{CpuSampleSource, Dial9Event};
 use dial9::cpu::SchedEventConfig;
+use dial9::format::Decoder;
 use dial9::{DiskBuffer, recorder};
 use dial9::{RecorderPerfExt, RecorderTokioExt, TokioAttachOptions};
 use std::time::Duration;

--- a/dial9/examples/thread_per_core.rs
+++ b/dial9/examples/thread_per_core.rs
@@ -16,9 +16,9 @@
 //! After running, inspect the trace:
 //!   cargo run --example analyze_trace -- /tmp/thread_per_core/trace.0.bin
 
+use dial9::Decoder;
 use dial9::analysis::analysis_events::{Dial9Event, WorkerId};
 use dial9::{DiskBuffer, RecorderTokioExt, TokioAttachOptions, recorder};
-use dial9_trace_format::decoder::Decoder;
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 

--- a/dial9/examples/thread_per_core.rs
+++ b/dial9/examples/thread_per_core.rs
@@ -16,8 +16,8 @@
 //! After running, inspect the trace:
 //!   cargo run --example analyze_trace -- /tmp/thread_per_core/trace.0.bin
 
-use dial9::Decoder;
 use dial9::analysis::analysis_events::{Dial9Event, WorkerId};
+use dial9::format::Decoder;
 use dial9::{DiskBuffer, RecorderTokioExt, TokioAttachOptions, recorder};
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;

--- a/dial9/examples/trace_to_jsonl.rs
+++ b/dial9/examples/trace_to_jsonl.rs
@@ -5,7 +5,7 @@
 //!
 //! If output is omitted, writes to stdout.
 
-use dial9_trace_format::decoder::Decoder;
+use dial9::Decoder;
 use std::io::{BufWriter, Write};
 
 fn main() -> std::io::Result<()> {

--- a/dial9/examples/trace_to_jsonl.rs
+++ b/dial9/examples/trace_to_jsonl.rs
@@ -5,7 +5,7 @@
 //!
 //! If output is omitted, writes to stdout.
 
-use dial9::Decoder;
+use dial9::format::Decoder;
 use std::io::{BufWriter, Write};
 
 fn main() -> std::io::Result<()> {

--- a/dial9/src/lib.rs
+++ b/dial9/src/lib.rs
@@ -8,16 +8,18 @@ pub use dial9_core::recorder::{
 };
 pub use dial9_core::recording::Recorder;
 
-/// Define custom events with `#[derive(TraceEvent)]` and record them with
-/// [`record_event`].
-pub use dial9_trace_format::{TraceEvent, TraceField};
+/// The trace format: define events with `#[derive(TraceEvent)]`, encode your own
+/// types with [`TraceField`](format::TraceField), read a trace back with
+/// [`Decoder`](format::Decoder).
+pub mod format {
+    pub use dial9_trace_format::decoder::{self, Decoder};
+    pub use dial9_trace_format::types::{self, EventEncoder, FieldType, InternedString};
+    pub use dial9_trace_format::{TraceEvent, TraceField};
 
-/// Read a trace file's events: [`Decoder::for_each_event`] hands each one to a
-/// callback as a [`RawEvent`](decoder::RawEvent), which deserializes into your
-/// own type.
-#[cfg(feature = "deserialize")]
-pub use dial9_trace_format::DeserError;
-pub use dial9_trace_format::decoder::{self, Decoder};
+    /// Error from [`RawEvent::deserialize`](decoder::RawEvent::deserialize).
+    #[cfg(feature = "deserialize")]
+    pub use dial9_trace_format::DeserError;
+}
 
 /// Building blocks for extending dial9: implement a [`Source`](crate::core::Source),
 /// write custom encoders, author custom segment processors, reach the raw
@@ -31,9 +33,6 @@ pub mod core {
     pub use dial9_core::recorder;
     pub use dial9_core::source::{self, FlushContext, Source};
     pub use dial9_core::thread::{ThreadTrackingGuard, current_tid};
-
-    /// Building blocks for a hand-written [`TraceField`](crate::TraceField) impl.
-    pub use dial9_trace_format::types::{self, EventEncoder, FieldType, InternedString};
 
     // Background pipeline (segment worker, on-demand dumps).
     #[cfg(feature = "pipeline")]

--- a/dial9/src/lib.rs
+++ b/dial9/src/lib.rs
@@ -8,6 +8,17 @@ pub use dial9_core::recorder::{
 };
 pub use dial9_core::recording::Recorder;
 
+/// Define custom events with `#[derive(TraceEvent)]` and record them with
+/// [`record_event`].
+pub use dial9_trace_format::{TraceEvent, TraceField};
+
+/// Read a trace file's events: [`Decoder::for_each_event`] hands each one to a
+/// callback as a [`RawEvent`](decoder::RawEvent), which deserializes into your
+/// own type.
+#[cfg(feature = "deserialize")]
+pub use dial9_trace_format::DeserError;
+pub use dial9_trace_format::decoder::{self, Decoder};
+
 /// Building blocks for extending dial9: implement a [`Source`](crate::core::Source),
 /// write custom encoders, author custom segment processors, reach the raw
 /// recording modules.
@@ -20,6 +31,9 @@ pub mod core {
     pub use dial9_core::recorder;
     pub use dial9_core::source::{self, FlushContext, Source};
     pub use dial9_core::thread::{ThreadTrackingGuard, current_tid};
+
+    /// Building blocks for a hand-written [`TraceField`](crate::TraceField) impl.
+    pub use dial9_trace_format::types::{self, EventEncoder, FieldType, InternedString};
 
     // Background pipeline (segment worker, on-demand dumps).
     #[cfg(feature = "pipeline")]


### PR DESCRIPTION
`#[derive(TraceEvent)]`, `TraceField`, `EventEncoder`, `FieldType`, `InternedString`, and `Decoder` now resolve through `dial9::` users no longer need a second direct dependency on `dial9-trace-format.

The `decoder` and `types` modules come with them, so `RawEvent`, `DecodeError` and the rest are
nameable too. Additive only: new `deserialize` feature (implied by `analysis`) gates `RawEvent::deserialize`, reading a trace with `Decoder` needs no feature.
