### PR TITLE
fix(viewer): Make tasks work when only the spawn event is present

### DIFF
--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.test.ts
@@ -324,6 +324,12 @@ describe("buildTaskDetailRenderModel: idle gaps + lifespan", () => {
     const m = buildTaskDetailRenderModel({ data, viewStart: 0, viewEnd: 1000, drawW: 1000 });
     expect(m.lifespan).toEqual({ x1: 50, x2: 800, showSpawn: true, showDone: true });
   });
+
+  it("shows the spawn edge when termination was not observed", () => {
+    const data = detailData({ polls: [poll(100, 200, 1)], spawnTs: 50 });
+    const m = buildTaskDetailRenderModel({ data, viewStart: 0, viewEnd: 1000, drawW: 1000 });
+    expect(m.lifespan).toEqual({ x1: 50, x2: 1000, showSpawn: true, showDone: false });
+  });
 });
 
 // ── Hit-region ordering + status/waker lookups ────────────────────────────

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.test.ts
@@ -229,6 +229,41 @@ function wakeInfo(effectiveWake: number, wakerTaskId: number, label: string): Po
 }
 
 describe("buildTaskDetailRenderModel: wake bands", () => {
+  it("renders spawn-to-first-poll as a scheduling delay without a waker", () => {
+    const spawnTs = 1_000_000;
+    const firstPollTs = 8_135_941;
+    const data = detailData({
+      polls: [poll(firstPollTs, firstPollTs + 100_000, 1)],
+      spawnTs,
+    });
+    const m = buildTaskDetailRenderModel({
+      data,
+      viewStart: 0,
+      viewEnd: 10_000_000,
+      drawW: 1000,
+    });
+
+    expect(m.schedulingBands).toEqual([
+      {
+        kind: "spawn",
+        x1: 100,
+        x2: 813.5941,
+        delayNs: 7_135_941,
+        severity: "high",
+        showDelayLabel: true,
+      },
+    ]);
+    expect(m.wakeRegions).toHaveLength(0);
+
+    const hit = m.hitRegions.find((r) => r.type === "scheduled");
+    expect(hit?.detail).toBe(
+      "Scheduled — waiting 7.14ms for first poll after task spawn",
+    );
+    expect(
+      statusTextAt(m, 500, BAND_TOP + BAND_H / 2),
+    ).toBe("⏳ Scheduled — waiting 7.14ms for first poll after task spawn");
+  });
+
   it("colours bands by delay severity and gates the labels on width", () => {
     // 1:1 ns->x would need a huge drawW; use a 10ms window / 1000px so the
     // three severities and both width thresholds are all exercised.
@@ -241,10 +276,12 @@ describe("buildTaskDetailRenderModel: wake bands", () => {
       ],
     });
     const m = buildTaskDetailRenderModel({ data, viewStart: 0, viewEnd: 10_000_000, drawW: 1000 });
-    expect(m.wakeBands.map((b) => b.severity)).toEqual(["high", "low", "mid"]);
+    expect(m.schedulingBands.map((b) => b.severity)).toEqual(["high", "low", "mid"]);
     // Width thresholds: delay label when > 25px, waker label when > 40px.
-    expect(m.wakeBands.map((b) => b.showDelayLabel)).toEqual([true, false, true]);
-    expect(m.wakeBands.map((b) => b.showWakerLabel)).toEqual([true, false, true]);
+    expect(m.schedulingBands.map((b) => b.showDelayLabel)).toEqual([true, false, true]);
+    expect(
+      m.schedulingBands.map((b) => b.kind === "wake" && b.showWakerLabel),
+    ).toEqual([true, false, true]);
     // A waker region exists only for the labelled (w>40) bands.
     expect(m.wakeRegions.map((r) => r.wakerTaskId)).toEqual([20, 22]);
     // Hit regions for the bands are typed "scheduled" and come first.
@@ -371,7 +408,7 @@ describe("hit-region order + status/waker lookups", () => {
 
   it("returns nothing for a degenerate view (drawW <= 0 / no polls)", () => {
     const empty = buildTaskDetailRenderModel({ data, viewStart: 0, viewEnd: 1000, drawW: 0 });
-    expect(empty.wakeBands).toHaveLength(0);
+    expect(empty.schedulingBands).toHaveLength(0);
     expect(empty.pollBars).toHaveLength(0);
     expect(empty.hitRegions).toHaveLength(0);
     expect(hitRegionAt(empty, 10, BAND_TOP + 1)).toBeNull();

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
@@ -11,7 +11,7 @@
 //      `derived(["trace","selection"], ...)` - a selection change invalidates, a
 //      pan does not.
 //   2. buildTaskDetailRenderModel(...) - viewport-dependent: the visible poll
-//      window, wake->poll delay bands, poll bars / coverage histogram, idle
+//      window, scheduling-delay bands, poll bars / coverage histogram, idle
 //      gaps, the lifespan bar, and the hit/wake regions the interaction layer
 //      reads. Memoized on its primitive inputs so a hover-only redraw never
 //      re-walks the collection.
@@ -304,24 +304,35 @@ export function formatTaskDetailSummary(data: TaskDetailData): string {
 export const BAND_TOP = 50;
 export const BAND_H = 30;
 
-/** Delay severity: green / orange / red. */
-export type WakeSeverity = "low" | "mid" | "high";
+/** Scheduling-delay severity: green / orange / red. */
+export type SchedulingSeverity = "low" | "mid" | "high";
 
-/** A wake->poll scheduling-delay band + its waker label. */
-export interface WakeBand {
-  /** Draw-area-relative x of the effective-wake edge (px). */
+interface SchedulingBandBase {
+  /** Draw-area-relative x of the delay's starting edge (px). */
   x1: number;
   /** Draw-area-relative x of the poll-start edge (px). */
   x2: number;
   delayNs: number;
-  severity: WakeSeverity;
-  wakerTaskId: number;
-  wakerLabel: string;
+  severity: SchedulingSeverity;
   /** Duration label shown only when the band is wider than 25px. */
   showDelayLabel: boolean;
+}
+
+/** The delay between task spawn and its first poll. */
+export interface SpawnSchedulingBand extends SchedulingBandBase {
+  kind: "spawn";
+}
+
+/** A wake->poll scheduling delay and its optional visible waker label. */
+export interface WakeSchedulingBand extends SchedulingBandBase {
+  kind: "wake";
+  wakerTaskId: number;
+  wakerLabel: string;
   /** Waker label shown (and clickable) only when wider than 40px. */
   showWakerLabel: boolean;
 }
+
+export type SchedulingBand = SpawnSchedulingBand | WakeSchedulingBand;
 
 /** A cyan poll bar (per-poll regime). */
 export interface PollBar {
@@ -385,7 +396,7 @@ export interface WakeRegion {
 export interface TaskDetailRenderModel {
   /** Task identity captured with this geometry; null for the empty model. */
   taskId: number | null;
-  wakeBands: readonly WakeBand[];
+  schedulingBands: readonly SchedulingBand[];
   /** Per-poll bars (empty when the coverage histogram is used instead). */
   pollBars: readonly PollBar[];
   /** Per-pixel coverage (opacity 0..1 per column); null in per-poll mode. */
@@ -403,7 +414,7 @@ export interface TaskDetailRenderModel {
 /** Empty model (no drawW / degenerate view). */
 const EMPTY_RENDER_MODEL: TaskDetailRenderModel = {
   taskId: null,
-  wakeBands: [],
+  schedulingBands: [],
   pollBars: [],
   coverage: null,
   visiblePolls: 0,
@@ -440,7 +451,7 @@ export function firstVisibleByEnd(
   return lo;
 }
 
-function severityOf(delayNs: number): WakeSeverity {
+function severityOf(delayNs: number): SchedulingSeverity {
   const delayUs = delayNs / 1000;
   if (delayUs > 1000) return "high";
   if (delayUs > 100) return "mid";
@@ -448,8 +459,9 @@ function severityOf(delayNs: number): WakeSeverity {
 }
 
 /**
- * Build the per-frame render model: wake->poll delay bands, the lifespan bar,
- * poll bars OR the coverage histogram, and idle gaps with their dump lookup.
+ * Build the per-frame render model: spawn/wake->poll scheduling-delay bands,
+ * the lifespan bar, poll bars OR the coverage histogram, and idle gaps with
+ * their dump lookup.
  * Draw-area-relative coordinates. Hit regions are emitted in scheduled ->
  * polling -> idle order so the first-match-wins status lookup matches.
  */
@@ -464,12 +476,43 @@ export function buildTaskDetailRenderModel(
   const span = viewEnd - viewStart;
   const nsToX = (ns: number): number => ((ns - viewStart) / span) * drawW;
 
-  const wakeBands: WakeBand[] = [];
+  const schedulingBands: SchedulingBand[] = [];
   const pollBars: PollBar[] = [];
   const idleBands: IdleBand[] = [];
   const hitRegions: HitRegion[] = [];
   const wakeRegions: WakeRegion[] = [];
   let lifespan: LifespanBar | null = null;
+
+  // ── Spawn->first-poll delay ──────────────────────────────────────────
+  const firstPoll = polls[0]!;
+  if (
+    data.spawnTs != null &&
+    data.spawnTs < firstPoll.start &&
+    firstPoll.start >= viewStart &&
+    data.spawnTs <= viewEnd
+  ) {
+    const delay = firstPoll.start - data.spawnTs;
+    const x1 = Math.max(0, nsToX(data.spawnTs));
+    const x2 = Math.min(drawW, nsToX(firstPoll.start));
+    const w = x2 - x1;
+    if (w >= 1) {
+      schedulingBands.push({
+        kind: "spawn",
+        x1,
+        x2,
+        delayNs: delay,
+        severity: severityOf(delay),
+        showDelayLabel: w > 25,
+      });
+      hitRegions.push({
+        x1,
+        x2,
+        type: "scheduled",
+        detail: `Scheduled — waiting ${formatHumanDuration(delay)} for first poll after task spawn`,
+        dumps: null,
+      });
+    }
+  }
 
   // ── Wake->poll delay bands + waker labels ────────────────────────────
   for (let i = 0; i < polls.length; i++) {
@@ -483,7 +526,8 @@ export function buildTaskDetailRenderModel(
     const w = x2 - x1;
     if (w < 1) continue;
     const showWakerLabel = w > 40;
-    wakeBands.push({
+    schedulingBands.push({
+      kind: "wake",
       x1,
       x2,
       delayNs: delay,
@@ -626,7 +670,7 @@ export function buildTaskDetailRenderModel(
 
   return {
     taskId: data.taskId,
-    wakeBands,
+    schedulingBands,
     pollBars,
     coverage,
     visiblePolls,

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
@@ -345,7 +345,7 @@ export interface IdleBand {
   showLabel: boolean;
 }
 
-/** The task lifespan bar, spawn -> terminate. */
+/** The observed task lifespan, from spawn through terminate or the visible edge. */
 export interface LifespanBar {
   x1: number;
   x2: number;
@@ -512,15 +512,15 @@ export function buildTaskDetailRenderModel(
   }
 
   // ── Task lifespan bar ────────────────────────────────────────────────
-  if (data.hasTerminate && data.spawnTs != null && data.terminateTs != null) {
+  if (data.spawnTs != null) {
     const lifeStart = data.spawnTs;
-    const lifeEnd = data.terminateTs;
+    const lifeEnd = data.terminateTs ?? viewEnd;
     if (lifeStart < viewEnd && lifeEnd > viewStart) {
       lifespan = {
         x1: Math.max(0, nsToX(lifeStart)),
         x2: Math.min(drawW, nsToX(lifeEnd)),
         showSpawn: lifeStart >= viewStart,
-        showDone: lifeEnd <= viewEnd,
+        showDone: data.terminateTs != null && lifeEnd <= viewEnd,
       };
     }
   }

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
@@ -312,6 +312,59 @@ function wakeBandModel() {
 }
 
 describe("drawTaskDetailCanvas render input", () => {
+  it("draws a high spawn-to-first-poll delay in scheduling red", () => {
+    const model = buildTaskDetailRenderModel({
+      data: {
+        taskId: 42,
+        polls: [
+          {
+            start: 8_135_941,
+            end: 8_235_941,
+            taskId: 42,
+            spawnLocId: "L",
+            spawnLoc: null,
+          },
+        ],
+        wakes: [],
+        pollWakes: [null],
+        pollCount: 1,
+        wakeCount: 0,
+        spawnLocation: null,
+        isInstrumented: true,
+        spawnTs: 1_000_000,
+        terminateTs: null,
+        hasTerminate: false,
+        lifetimeNs: null,
+        taskDumps: [],
+        workerIdCount: 1,
+        hasPolls: true,
+      },
+      viewStart: 0,
+      viewEnd: 10_000_000,
+      drawW: 1000,
+    });
+    const { ctx, rects, texts } = recordingCtx();
+
+    drawTaskDetailCanvas(
+      ctx,
+      model,
+      null,
+      1000,
+      160,
+      COMPLETE_TASK_DETAIL_WINDOW,
+    );
+
+    expect(
+      rects.some(
+        (r) =>
+          r.x === 100 &&
+          r.w === 713.5941 &&
+          r.fillStyle === "rgba(255,50,50,0.3)",
+      ),
+    ).toBe(true);
+    expect(texts.some((t) => t.text.startsWith("⬆"))).toBe(false);
+  });
+
   it("bolds the hovered waker's label", () => {
     const model = wakeBandModel();
     const hovered = recordingCtx();

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
@@ -376,9 +376,10 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
 
 /**
  * Draw the task-detail timeline into `ctx` (already DPR-scaled + sized to
- * drawW x height), in order: background, wake->poll delay bands, lifespan bar,
- * poll bars / coverage histogram, idle gaps, legend, then the window markers on
- * top. Draw-area-relative coordinates (the model's x's already omit LABEL_W).
+ * drawW x height), in order: background, lifespan bar, scheduling-delay bands,
+ * poll bars / coverage histogram, idle gaps, legend, then the window markers
+ * on top. Draw-area-relative coordinates (the model's x's already omit
+ * LABEL_W).
  */
 export function drawTaskDetailCanvas(
   ctx: CanvasRenderingContext2D,
@@ -394,51 +395,6 @@ export function drawTaskDetailCanvas(
   if (drawW <= 0 || height <= 0) return;
 
   ctx.font = "9px monospace";
-
-  // ── Wake->poll delay bands + waker labels ────────────────────────────
-  for (const band of model.wakeBands) {
-    const w = band.x2 - band.x1;
-    ctx.fillStyle =
-      band.severity === "high"
-        ? "rgba(255,50,50,0.3)"
-        : band.severity === "mid"
-          ? "rgba(255,150,50,0.3)"
-          : "rgba(100,200,100,0.15)";
-    ctx.fillRect(band.x1, BAND_TOP, w, BAND_H);
-
-    ctx.strokeStyle =
-      band.severity === "high" ? "#ff4444" : band.severity === "mid" ? "#ff8a65" : "#555";
-    ctx.lineWidth = 1;
-    ctx.setLineDash([2, 2]);
-    ctx.strokeRect(band.x1, BAND_TOP, w, BAND_H);
-    ctx.setLineDash([]);
-
-    if (band.showDelayLabel) {
-      ctx.fillStyle =
-        band.severity === "high" ? "#ff4444" : band.severity === "mid" ? "#ff8a65" : "#888";
-      ctx.textAlign = "center";
-      ctx.fillText(formatHumanDuration(band.delayNs), band.x1 + w / 2, BAND_TOP - 6);
-    }
-
-    // Wake marker (triangle) at the band's left edge.
-    const wx = band.x1;
-    ctx.fillStyle = WAKE_TRIANGLE;
-    ctx.beginPath();
-    ctx.moveTo(wx, BAND_TOP + BAND_H + 2);
-    ctx.lineTo(wx - 4, BAND_TOP + BAND_H + 9);
-    ctx.lineTo(wx + 4, BAND_TOP + BAND_H + 9);
-    ctx.closePath();
-    ctx.fill();
-
-    if (band.showWakerLabel) {
-      const isHovered = hoveredWakerTaskId === band.wakerTaskId;
-      ctx.fillStyle = isHovered ? "#fff" : "#66bb6a";
-      ctx.font = isHovered ? "bold 8px monospace" : "8px monospace";
-      ctx.textAlign = "left";
-      ctx.fillText("⬆ " + band.wakerLabel, wx, BAND_TOP + BAND_H + 20);
-      ctx.font = "9px monospace";
-    }
-  }
 
   // ── Task lifespan bar ────────────────────────────────────────────────
   if (model.lifespan !== null) {
@@ -477,6 +433,53 @@ export function drawTaskDetailCanvas(
       ctx.fillText("◂done", l.x2 - 2, BAND_TOP - 8);
     }
     ctx.font = "9px monospace";
+  }
+
+  // ── Scheduling-delay bands + wake labels ────────────────────────────
+  for (const band of model.schedulingBands) {
+    const w = band.x2 - band.x1;
+    ctx.fillStyle =
+      band.severity === "high"
+        ? "rgba(255,50,50,0.3)"
+        : band.severity === "mid"
+          ? "rgba(255,150,50,0.3)"
+          : "rgba(100,200,100,0.15)";
+    ctx.fillRect(band.x1, BAND_TOP, w, BAND_H);
+
+    ctx.strokeStyle =
+      band.severity === "high" ? "#ff4444" : band.severity === "mid" ? "#ff8a65" : "#555";
+    ctx.lineWidth = 1;
+    ctx.setLineDash([2, 2]);
+    ctx.strokeRect(band.x1, BAND_TOP, w, BAND_H);
+    ctx.setLineDash([]);
+
+    if (band.showDelayLabel) {
+      ctx.fillStyle =
+        band.severity === "high" ? "#ff4444" : band.severity === "mid" ? "#ff8a65" : "#888";
+      ctx.textAlign = "center";
+      ctx.fillText(formatHumanDuration(band.delayNs), band.x1 + w / 2, BAND_TOP - 6);
+    }
+
+    if (band.kind !== "wake") continue;
+
+    // Wake marker (triangle) at the band's left edge.
+    const wx = band.x1;
+    ctx.fillStyle = WAKE_TRIANGLE;
+    ctx.beginPath();
+    ctx.moveTo(wx, BAND_TOP + BAND_H + 2);
+    ctx.lineTo(wx - 4, BAND_TOP + BAND_H + 9);
+    ctx.lineTo(wx + 4, BAND_TOP + BAND_H + 9);
+    ctx.closePath();
+    ctx.fill();
+
+    if (band.showWakerLabel) {
+      const isHovered = hoveredWakerTaskId === band.wakerTaskId;
+      ctx.fillStyle = isHovered ? "#fff" : "#66bb6a";
+      ctx.font = isHovered ? "bold 8px monospace" : "8px monospace";
+      ctx.textAlign = "left";
+      ctx.fillText("⬆ " + band.wakerLabel, wx, BAND_TOP + BAND_H + 20);
+      ctx.font = "9px monospace";
+    }
   }
 
   // ── Polling sections: coverage histogram or per-poll bars ────────────

--- a/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./url-state.js";
 import { resolveUrlSelection } from "./url-selection.js";
 import { createViewerReconstruction } from "./viewer-reconstruction.js";
+import { taskIndexFor } from "./tasks-model.js";
 
 let settledTrace: ParsedTrace;
 let reconstructedTrace: ParsedTrace;
@@ -69,6 +70,23 @@ function normalizedProjection(
 }
 
 describe("viewer deep-link reconstruction", () => {
+  it("selects focus_task even when no span matches the focus window", () => {
+    const task = taskIndexFor(settledTrace).rows.find((row) => row.pollCount > 0)!;
+    const offset = settledTrace.clockOffsetNs ?? 0;
+    const focusStart = task.firstPollStart + offset;
+    const store = createViewerStore({ scheduler: () => {} });
+    const reconstruction = createViewerReconstruction(store, {
+      search:
+        `?focus_start=${focusStart}&focus_end=${focusStart + 1_000_000}` +
+        `&focus_span_name=definitely-absent&focus_task=${task.taskId}`,
+      hash: "",
+    });
+
+    reconstruction.applyLoadedTrace(settledTrace, "source");
+
+    expect(store.getState().selection.selectedTaskId).toBe(task.taskId);
+  });
+
   it("reconstructs every URL-owned analytical value after the trace loads", () => {
     const source = createViewerStore({ scheduler: () => {} });
     createViewerReconstruction(source, { search: "", hash: "" }).applyLoadedTrace(

--- a/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.ts
+++ b/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.ts
@@ -102,13 +102,14 @@ export function createViewerReconstruction(
       }
     }
 
-    if (
-      urlState.selectedTaskId !== undefined &&
-      taskIndexFor(trace).rows.some(
-        (row) => row.taskId === urlState.selectedTaskId,
-      )
-    ) {
-      selection.selectedTaskId = urlState.selectedTaskId;
+    // An explicit shareable task selection wins, followed by the exemplar's
+    // focus_task. Keep a task inferred from a matched span only when neither
+    // URL task anchor resolves against this trace.
+    for (const taskId of [urlState.selectedTaskId, focusLink?.taskId]) {
+      if (taskExists(trace, taskId)) {
+        selection.selectedTaskId = taskId;
+        break;
+      }
     }
     if (Object.keys(selection).length > 0) {
       store.update("selection", selection);


### PR DESCRIPTION

<img width="382" height="102" alt="Screenshot 2026-07-28 at 9 10 11 PM" src="https://github.com/user-attachments/assets/4238fde4-a0b9-4045-b58e-09fa9b296669" />

## Summary
- honor a valid focus_task even when no tracing span matches the exemplar window
- render a recorded task spawn when no terminate event exists in the source file
- extend the observed lifespan to the visible edge without showing a completion marker
- add regression coverage for task-focus reconstruction and open-ended task lifecycles

## Root cause
The fallback focus path only panned the viewport; it never copied focus_task into selectedTaskId. Because the task-detail track stayed closed, its spawn marker could not render. Separately, the lifespan model required both spawn and terminate events before drawing the spawn edge.

## Testing
- npm run test
- npm run build
- cargo build -p dial9-viewer