### PR TITLE
Require explicit copy-link approval

### DIFF
--- a/dial9-viewer/ui/src/lib/url/copy-link.test.ts
+++ b/dial9-viewer/ui/src/lib/url/copy-link.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import type { CopyLinkOptions } from "./copy-link.js";
+
+describe("CopyLinkOptions", () => {
+  it("requires beforeCopy to explicitly approve or reject the copy", () => {
+    const options = { beforeCopy: () => true } satisfies CopyLinkOptions;
+    expect(options.beforeCopy()).toBe(true);
+
+    // @ts-expect-error A supplied hook must return an explicit decision.
+    const invalid: CopyLinkOptions = { beforeCopy: () => {} };
+    void invalid;
+  });
+});

--- a/dial9-viewer/ui/src/lib/url/copy-link.ts
+++ b/dial9-viewer/ui/src/lib/url/copy-link.ts
@@ -6,8 +6,8 @@
 // element, its inline look, and the copy mechanics.
 
 export interface CopyLinkOptions {
-  /** Run before reading the URL; return false to cancel an unshareable copy. */
-  beforeCopy?: () => void | boolean;
+  /** Run before reading the URL; return true to proceed or false to cancel. */
+  beforeCopy?: () => boolean;
   /** URL supplier; defaults to the live location href. */
   getText?: () => string;
   /** Clipboard write; injectable for tests/fallbacks. */

--- a/dial9-viewer/ui/src/pages/flamegraph/exact-mode.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/exact-mode.ts
@@ -33,6 +33,7 @@ export async function runExactMode(
   mountCopyLink(els.headerEl, {
     beforeCopy: () => {
       flushUrlState?.();
+      return true;
     },
   });
 

--- a/dial9-viewer/ui/src/pages/viewer/status-bar.ts
+++ b/dial9-viewer/ui/src/pages/viewer/status-bar.ts
@@ -131,8 +131,8 @@ function statusTemplate(vm: StatusViewModel, onClear: () => void): TemplateResul
 export interface StatusBarDeps {
   /** Clear affordance: clear the selection highlight state. */
   clearSelection(): void;
-  /** Flush live URL state, or return false when the source is not shareable. */
-  beforeCopyLink?(): void | boolean;
+  /** Flush live URL state and approve the copy, or reject an unshareable source. */
+  beforeCopyLink?(): boolean;
   /** URL text supplier for copy-link; defaults to the live location href. */
   copyLinkText?(): string;
   /** Clipboard writer; injectable for tests. */


### PR DESCRIPTION
Follow-up to #718 and review comment https://github.com/dial9-rs/dial9/pull/718#discussion_r3668235832.

- require supplied copy hooks to return an explicit boolean decision
- update the status-bar contract and flamegraph caller
- add a compile-time regression test for void-returning hooks

Verification:
- npx tsc --noEmit
- npm run check:types
- npm run test
- npm run build
- cargo build -p dial9-viewer