### PR TITLE
feat(viewer): add virtual trace simulator

### DIFF
--- a/dial9-viewer/README.md
+++ b/dial9-viewer/README.md
@@ -11,6 +11,38 @@ cargo install --locked dial9
 
 See the [`dial9` README](https://crates.io/crates/dial9) for usage documentation.
 
+## Simulator mode
+
+Run the complete S3-browser and on-demand aggregation workflow without an S3
+bucket or AWS credentials:
+
+```bash
+# Sanitized synthetic traces
+dial9 serve --simulator --local
+
+# Rebase and replay the bundled demo trace in every virtual segment
+dial9 serve --simulator demo --local
+
+# Configure fleet size, segment spacing, data volume, and feature groups
+dial9 serve --simulator synthetic \
+  --simulator-hosts 8 \
+  --simulator-segment-secs 60 \
+  --simulator-repetitions 2 \
+  --simulator-symbols realistic \
+  --simulator-features cpu,scheduling,tasks,spans \
+  --local
+```
+
+Simulator objects use the production date/service/host key layout and the
+normal viewer storage API. The catalog is virtual: every requested time range
+has deterministic segments, and trace bytes are rendered only when fetched.
+Flamegraph, span, and Tokio-stat rollups are written to a process-local
+temporary directory and removed when the server exits. Run `dial9 serve
+--help` for all simulator size, duration, and symbol options. Synthetic symbol
+names remain anonymous placeholders by default; `--simulator-symbols
+realistic` emits deterministic Rust-like names for more representative
+flamegraphs.
+
 ## `trace-shape` — Trace Structural Fingerprints
 
 The `trace-shape` subcommand extracts and generates sanitized structural

--- a/dial9-viewer/src/cli.rs
+++ b/dial9-viewer/src/cli.rs
@@ -1,5 +1,6 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
+use std::time::Duration;
 
 mod skills {
     include!(concat!(env!("OUT_DIR"), "/skills.rs"));
@@ -44,6 +45,54 @@ enum Commands {
         /// S3 key prefix
         #[arg(long)]
         prefix: Option<String>,
+
+        /// Run without S3 using generated traces. With no value, uses
+        /// `synthetic`; `demo` replays the bundled demo trace in every segment.
+        #[arg(
+            long,
+            value_enum,
+            num_args = 0..=1,
+            default_missing_value = "synthetic",
+            conflicts_with_all = [
+                "bucket",
+                "local_dir",
+                "agg",
+                "agg_source_dir",
+                "agg_output_dir",
+                "agg_output_bucket",
+                "agg_output_prefix",
+                "agg_segment_secs",
+                "enable_upload"
+            ]
+        )]
+        simulator: Option<SimulatorModeArg>,
+
+        /// Number of simulated hosts.
+        #[arg(long, default_value_t = 3, requires = "simulator")]
+        simulator_hosts: usize,
+
+        /// Duration and key spacing of each simulated segment, in seconds.
+        #[arg(long, default_value_t = 60, requires = "simulator")]
+        simulator_segment_secs: u64,
+
+        /// Template repetitions inside each synthetic segment.
+        #[arg(long, default_value_t = 1, requires = "simulator")]
+        simulator_repetitions: u32,
+
+        /// Synthetic feature groups to include, comma-separated. Omit for all;
+        /// use `none` for clock/metadata events only.
+        #[arg(
+            long,
+            value_enum,
+            value_delimiter = ',',
+            num_args = 1..,
+            requires = "simulator"
+        )]
+        simulator_features: Option<Vec<SimulatorFeatureArg>>,
+
+        /// Synthetic stack-symbol naming. Omit for anonymous placeholders.
+        #[arg(long, value_enum, requires = "simulator")]
+        simulator_symbols: Option<SimulatorSymbolModeArg>,
 
         /// Serve traces from a local directory instead of S3
         #[arg(long, conflicts_with = "bucket")]
@@ -103,6 +152,30 @@ enum Commands {
         #[command(subcommand)]
         action: ReportAction,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum SimulatorModeArg {
+    Synthetic,
+    Demo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum SimulatorSymbolModeArg {
+    Anonymous,
+    Realistic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum SimulatorFeatureArg {
+    Cpu,
+    Scheduling,
+    Tasks,
+    Spans,
+    Memory,
+    Resources,
+    CustomEvents,
+    None,
 }
 
 #[derive(Subcommand, Debug)]
@@ -250,6 +323,12 @@ pub async fn run() -> anyhow::Result<()> {
             port,
             bucket,
             prefix,
+            simulator,
+            simulator_hosts,
+            simulator_segment_secs,
+            simulator_repetitions,
+            simulator_features,
+            simulator_symbols,
             local_dir,
             dev,
             local,
@@ -269,20 +348,53 @@ pub async fn run() -> anyhow::Result<()> {
             crate::init_tracing(local);
             let _metrics = crate::attach_request_metrics(local);
 
-            let app = crate::build_app(crate::ViewerConfig {
-                bucket,
-                prefix,
-                local_dir,
-                dev,
-                agg,
-                agg_source_dir,
-                agg_output_dir,
-                agg_output_bucket,
-                agg_output_prefix,
-                agg_segment_secs,
-                enable_upload,
-            })
-            .await?;
+            let app = if let Some(mode) = simulator {
+                if mode == SimulatorModeArg::Demo && simulator_features.is_some() {
+                    anyhow::bail!("--simulator-features applies only to synthetic simulator mode");
+                }
+                if mode == SimulatorModeArg::Demo && simulator_symbols.is_some() {
+                    anyhow::bail!("--simulator-symbols applies only to synthetic simulator mode");
+                }
+                let features = build_simulator_features(simulator_features.as_deref())?;
+                let symbol_mode = match simulator_symbols {
+                    Some(SimulatorSymbolModeArg::Realistic) => {
+                        crate::simulator::SimulatorSymbolMode::Realistic
+                    }
+                    Some(SimulatorSymbolModeArg::Anonymous) | None => {
+                        crate::simulator::SimulatorSymbolMode::Anonymous
+                    }
+                };
+                let trace_mode = match mode {
+                    SimulatorModeArg::Synthetic => crate::simulator::SimulatorTraceMode::Synthetic,
+                    SimulatorModeArg::Demo => crate::simulator::SimulatorTraceMode::DemoReplay,
+                };
+                let config = crate::simulator::SimulatorConfig::builder()
+                    .trace_mode(trace_mode)
+                    .hosts(simulator_hosts)
+                    .segment_duration(Duration::from_secs(simulator_segment_secs))
+                    .repetitions_per_segment(simulator_repetitions)
+                    .features(features)
+                    .symbol_mode(symbol_mode)
+                    .prefix(prefix.unwrap_or_else(|| "traces".to_string()))
+                    .dev(dev)
+                    .build();
+                crate::simulator::build_simulator_app(config).await?
+            } else {
+                crate::build_app(crate::ViewerConfig {
+                    bucket,
+                    prefix,
+                    local_dir,
+                    dev,
+                    agg,
+                    agg_source_dir,
+                    agg_output_dir,
+                    agg_output_bucket,
+                    agg_output_prefix,
+                    agg_segment_secs,
+                    enable_upload,
+                })
+                .await?
+            };
 
             let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
             tracing::info!(port, "dial9-viewer listening");
@@ -314,4 +426,119 @@ pub async fn run() -> anyhow::Result<()> {
         },
     }
     Ok(())
+}
+
+fn build_simulator_features(
+    selected: Option<&[SimulatorFeatureArg]>,
+) -> anyhow::Result<crate::simulator::SimulatorFeatures> {
+    let Some(selected) = selected else {
+        return Ok(crate::simulator::SimulatorFeatures::default());
+    };
+    let none = selected.contains(&SimulatorFeatureArg::None);
+    if none && selected.len() != 1 {
+        anyhow::bail!("simulator feature `none` cannot be combined with other feature groups");
+    }
+    let enabled = |feature| !none && selected.contains(&feature);
+    Ok(crate::simulator::SimulatorFeatures::builder()
+        .cpu(enabled(SimulatorFeatureArg::Cpu))
+        .scheduling(enabled(SimulatorFeatureArg::Scheduling))
+        .tasks(enabled(SimulatorFeatureArg::Tasks))
+        .spans(enabled(SimulatorFeatureArg::Spans))
+        .memory(enabled(SimulatorFeatureArg::Memory))
+        .resources(enabled(SimulatorFeatureArg::Resources))
+        .custom_events(enabled(SimulatorFeatureArg::CustomEvents))
+        .build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serve_without_simulator_still_parses() {
+        let cli = Cli::try_parse_from(["dial9", "serve"]).unwrap();
+        let Commands::Serve { simulator, .. } = cli.command else {
+            panic!("expected serve command");
+        };
+        assert_eq!(simulator, None);
+    }
+
+    #[test]
+    fn simulator_flag_defaults_to_synthetic_without_a_value() {
+        let cli = Cli::try_parse_from(["dial9", "serve", "--simulator"]).unwrap();
+        let Commands::Serve {
+            simulator,
+            simulator_hosts,
+            ..
+        } = cli.command
+        else {
+            panic!("expected serve command");
+        };
+        assert_eq!(simulator, Some(SimulatorModeArg::Synthetic));
+        assert_eq!(simulator_hosts, 3);
+    }
+
+    #[test]
+    fn simulator_parses_host_and_feature_configuration() {
+        let cli = Cli::try_parse_from([
+            "dial9",
+            "serve",
+            "--simulator",
+            "synthetic",
+            "--simulator-hosts",
+            "8",
+            "--simulator-features",
+            "cpu,spans",
+        ])
+        .unwrap();
+        let Commands::Serve {
+            simulator,
+            simulator_hosts,
+            simulator_features,
+            ..
+        } = cli.command
+        else {
+            panic!("expected serve command");
+        };
+        assert_eq!(simulator, Some(SimulatorModeArg::Synthetic));
+        assert_eq!(simulator_hosts, 8);
+        assert_eq!(
+            simulator_features,
+            Some(vec![SimulatorFeatureArg::Cpu, SimulatorFeatureArg::Spans])
+        );
+    }
+
+    #[test]
+    fn simulator_parses_realistic_symbol_mode() {
+        let cli = Cli::try_parse_from([
+            "dial9",
+            "serve",
+            "--simulator",
+            "synthetic",
+            "--simulator-symbols",
+            "realistic",
+        ])
+        .unwrap();
+        let Commands::Serve {
+            simulator_symbols, ..
+        } = cli.command
+        else {
+            panic!("expected serve command");
+        };
+        assert_eq!(simulator_symbols, Some(SimulatorSymbolModeArg::Realistic));
+    }
+
+    #[test]
+    fn simulator_rejects_real_storage_inputs() {
+        let error = Cli::try_parse_from([
+            "dial9",
+            "serve",
+            "--simulator",
+            "demo",
+            "--bucket",
+            "real-bucket",
+        ])
+        .unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
 }

--- a/dial9-viewer/src/lib.rs
+++ b/dial9-viewer/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cli;
 pub mod ingest;
 pub mod report_serve;
 pub mod server;
+pub mod simulator;
 pub mod storage;
 mod trace_shape;
 
@@ -13,6 +14,37 @@ pub use report_serve::report_serve_router;
 pub use server::metrics::attach_request_metrics;
 
 use std::path::PathBuf;
+
+pub(crate) fn resolve_dev_ui_dir(dev: bool) -> anyhow::Result<Option<PathBuf>> {
+    if !dev {
+        return Ok(None);
+    }
+
+    // Serve the BUILT UI (ui/dist), not the ui/ sources: the servable set
+    // is the vite build output (root assets such as demo-trace.bin and
+    // flamegraph.css live in ui/public/ and only appear at the served
+    // root via a build). Keep it fresh with `npm run dev:embedded`
+    // (vite build --watch) for the edit-refresh loop.
+    let candidates = [
+        PathBuf::from("ui/dist"),
+        PathBuf::from("dial9-viewer/ui/dist"),
+    ];
+    let Some(dir) = candidates.into_iter().find(|p| p.exists()) else {
+        anyhow::bail!(
+            "--dev: could not find ui/dist/ directory. Run from the dial9-viewer/ or repo root directory."
+        );
+    };
+
+    if !dir.join("index.html").exists() {
+        tracing::warn!(
+            path = %dir.display(),
+            "ui/dist has no built UI - run `npm run build` or `npm run dev:embedded` \
+             in dial9-viewer/ui first (UI work requires Node, see ui/README.md)"
+        );
+    }
+    tracing::info!(path = %dir.display(), "dev mode: serving UI from disk");
+    Ok(Some(dir))
+}
 
 async fn detect_bucket_region(bucket: &str) -> Option<String> {
     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
@@ -204,38 +236,7 @@ pub async fn build_app(
         None
     };
 
-    let dev_ui_dir = if dev {
-        // Serve the BUILT UI (ui/dist), not the ui/ sources: the servable set
-        // is the vite build output (root assets such as demo-trace.bin and
-        // flamegraph.css live in ui/public/ and only appear at the served
-        // root via a build). Keep it fresh with `npm run dev:embedded`
-        // (vite build --watch) for the edit-refresh loop.
-        let candidates = [
-            PathBuf::from("ui/dist"),
-            PathBuf::from("dial9-viewer/ui/dist"),
-        ];
-        let dir = candidates.into_iter().find(|p| p.exists());
-        match dir {
-            Some(d) => {
-                if !d.join("index.html").exists() {
-                    tracing::warn!(
-                        path = %d.display(),
-                        "ui/dist has no built UI - run `npm run build` or `npm run dev:embedded` \
-                         in dial9-viewer/ui first (UI work requires Node, see ui/README.md)"
-                    );
-                }
-                tracing::info!(path = %d.display(), "dev mode: serving UI from disk");
-                Some(d)
-            }
-            None => {
-                anyhow::bail!(
-                    "--dev: could not find ui/dist/ directory. Run from the dial9-viewer/ or repo root directory."
-                );
-            }
-        }
-    } else {
-        None
-    };
+    let dev_ui_dir = resolve_dev_ui_dir(dev)?;
 
     // Build the base state per backend. `source_is_s3` is true for every S3
     // backend; it is false only in local-dir mode (and local-source

--- a/dial9-viewer/src/server/browse.rs
+++ b/dial9-viewer/src/server/browse.rs
@@ -102,8 +102,8 @@ pub async fn browse(
 
     let window = params.to - params.from;
 
-    // Local mode: flat listing (no date-prefix fan-out).
-    if !state.allow_byo_creds {
+    // Flat-layout mode: one listing, with no date-prefix fan-out.
+    if !state.time_partitioned_source {
         return browse_local(backend, &bucket, &base, service).await;
     }
 
@@ -133,8 +133,7 @@ fn normalize_service(service: Option<&str>) -> Result<Option<&str>, (StatusCode,
     Ok(Some(service))
 }
 
-/// Local mode: flat listing filtered to trace segments.
-/// Called when `allow_byo_creds == false` (i.e. `--local-dir`).
+/// Flat-layout mode: one listing filtered to trace segments.
 /// No time filtering — the frontend shows all results, positioned by mtime.
 async fn browse_local(
     backend: Arc<dyn StorageBackend>,
@@ -316,7 +315,18 @@ fn service_time_prefixes(base: &str, from: i64, to: i64, service: &str) -> (Vec<
 
 pub(super) fn resolve_base(default_prefix: Option<&str>, key_prefix: Option<&str>) -> String {
     match (default_prefix, key_prefix) {
-        (Some(pfx), Some(kp)) => format!("{}/{}", pfx.trim_end_matches('/'), kp),
+        (Some(pfx), Some(kp)) => {
+            let default = pfx.trim_matches('/');
+            let requested = kp.trim_matches('/');
+            if default.is_empty()
+                || requested == default
+                || requested.starts_with(&format!("{default}/"))
+            {
+                requested.to_string()
+            } else {
+                format!("{default}/{requested}")
+            }
+        }
         (Some(pfx), None) => pfx.to_string(),
         (None, Some(kp)) => kp.to_string(),
         (None, None) => String::new(),
@@ -475,6 +485,19 @@ mod tests {
                 "traces/2026-06-09/1911/api/",
                 "traces/2026-06-09/1912/api/",
             ]
+        );
+    }
+
+    #[test]
+    fn scope_prefix_already_under_default_is_not_duplicated() {
+        assert_eq!(resolve_base(Some("traces"), Some("traces")), "traces");
+        assert_eq!(
+            resolve_base(Some("traces"), Some("traces/team-a")),
+            "traces/team-a"
+        );
+        assert_eq!(
+            resolve_base(Some("traces"), Some("team-a")),
+            "traces/team-a"
         );
     }
 

--- a/dial9-viewer/src/server/config.rs
+++ b/dial9-viewer/src/server/config.rs
@@ -14,6 +14,11 @@ pub struct ConfigResponse {
     pub aggregation_enabled: bool,
     /// Whether the UI should offer the bring-your-own-credentials panel.
     pub supports_byo_credentials: bool,
+    /// Shape of source keys used for browse and service discovery.
+    ///
+    /// Additive for compatibility: older clients infer this from credential
+    /// support, while current clients use it directly.
+    pub source_layout: &'static str,
     /// Whether the server will assume a caller-named role ARN
     /// (`x-dial9-aws-role-arn`) — i.e. an assumer is wired. Lets a client offer
     /// "read via role" as an alternative to pasting credentials.
@@ -36,6 +41,11 @@ pub async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
         aggregation_enabled: state.agg.is_some() || state.allow_byo_creds,
         // The credentials panel is only meaningful for an S3 source.
         supports_byo_credentials: state.allow_byo_creds,
+        source_layout: if state.time_partitioned_source {
+            "time-partitioned"
+        } else {
+            "flat"
+        },
         // Assume-role is available only when an assumer was wired (S3 source
         // with an ambient identity); see `AppState::role_assumer`.
         supports_assume_role: state.role_assumer.is_some(),

--- a/dial9-viewer/src/server/mod.rs
+++ b/dial9-viewer/src/server/mod.rs
@@ -58,6 +58,10 @@ pub(crate) async fn region_from_head_bucket(
 #[folder = "ui/dist/"]
 struct UiAssets;
 
+pub(crate) fn embedded_ui_asset(path: &str) -> Option<Vec<u8>> {
+    UiAssets::get(path).map(|file| file.data.into_owned())
+}
+
 /// Default output key prefix for aggregate part-files.
 const DEFAULT_AGG_OUTPUT_PREFIX: &str = "flamegraph-data";
 
@@ -167,6 +171,12 @@ pub struct AppState {
     /// aggregation: any S3 bucket can run the `/api/flamegraph` refinement loop,
     /// but a local-directory source cannot.
     pub allow_byo_creds: bool,
+    /// Whether source keys use the production date-partitioned S3 layout.
+    ///
+    /// This controls time-scoped browse and service-discovery listings. It is
+    /// independent of credentials because non-S3 backends such as the simulator
+    /// can expose the same layout.
+    time_partitioned_source: bool,
     /// Optional plumbing for ephemeral S3 client construction (test injection
     /// of the in-process fake; `None` in production → default HTTPS connector).
     #[doc(hidden)]
@@ -209,6 +219,7 @@ impl AppState {
             agg: None,
             uploads: None,
             allow_byo_creds: false,
+            time_partitioned_source: false,
             ephemeral_s3: None,
             role_assumer: None,
             agg_output: AggOutput::temporary(),
@@ -267,11 +278,22 @@ impl AppState {
         self
     }
 
-    /// Enable the bring-your-own-credentials path (S3 backends only). This also
-    /// enables on-demand aggregation; leave unset (the default) for local-dir
-    /// sources, where credentials are meaningless and aggregation is local.
+    /// Enable the bring-your-own-credentials path (S3 backends only).
+    ///
+    /// Enabling it also selects the production time-partitioned source layout
+    /// for backwards compatibility with existing S3 embedders.
     pub fn with_byo_creds(mut self, allow: bool) -> Self {
         self.allow_byo_creds = allow;
+        if allow {
+            self.time_partitioned_source = true;
+        }
+        self
+    }
+
+    /// Use production date/time-partitioned trace keys for browse and service
+    /// discovery without enabling AWS credential handling.
+    pub fn with_time_partitioned_source(mut self) -> Self {
+        self.time_partitioned_source = true;
         self
     }
 

--- a/dial9-viewer/src/server/services.rs
+++ b/dial9-viewer/src/server/services.rs
@@ -72,7 +72,7 @@ pub async fn list_services(
         .filter(|s| !s.is_empty());
     let base = resolve_base(state.default_prefix.as_deref(), key_prefix);
 
-    if !state.allow_byo_creds {
+    if !state.time_partitioned_source {
         let page = backend
             .list_objects(&bucket, &base, LOCAL_OBJECT_CAP)
             .await

--- a/dial9-viewer/src/simulator.rs
+++ b/dial9-viewer/src/simulator.rs
@@ -1,0 +1,1713 @@
+//! In-process trace source for exercising the complete S3-browser workflow.
+//!
+//! Simulator objects use the production S3 key layout and the production
+//! [`StorageBackend`] interface. The browser, object streaming, on-demand
+//! aggregation, span explorer, and flamegraph paths therefore cannot tell the
+//! difference between this source and a real trace bucket.
+
+use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::future::Future;
+use std::io::{Read, Write};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{Context, ensure};
+use dial9_trace_format::decoder::{Decoder, RawEvent};
+use dial9_trace_format::encoder::{Encoder, Schema};
+use dial9_trace_format::schema::{FieldDef, SchemaEntry};
+use dial9_trace_format::types::{FieldType, FieldValue, FieldValueRef};
+use time::{Date, Month, OffsetDateTime};
+
+use crate::ingest::aggregate::AggContext;
+use crate::server::{AggOutput, AppState};
+use crate::storage::{BucketInfo, ListPage, ObjectInfo, StorageBackend, StorageError};
+use crate::trace_shape::{self, ShapeEvent, ShapeSchema, ShapeValue, TraceShape};
+
+const DEFAULT_BUCKET: &str = "dial9-simulator";
+const DEFAULT_PREFIX: &str = "traces";
+const DEFAULT_SERVICE: &str = "simulated-service";
+const MAX_SIMULATED_HOSTS: usize = 100_000;
+const MAX_DEMO_TRACE_BYTES: u64 = 512 * 1024 * 1024;
+const PAYLOAD_CACHE_ENTRIES: usize = 8;
+
+/// Trace content used for each simulated segment.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SimulatorTraceMode {
+    /// Generate a sanitized structural copy of the bundled demo trace.
+    #[default]
+    Synthetic,
+    /// Replay the bundled demo's event data, rebased to each segment's time.
+    DemoReplay,
+}
+
+/// Stack-symbol naming used by synthetic simulator traces.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SimulatorSymbolMode {
+    /// Keep the privacy-preserving `s_NNNN` placeholders from trace shaping.
+    #[default]
+    Anonymous,
+    /// Replace symbol placeholders with deterministic Rust-like names.
+    Realistic,
+}
+
+/// Feature groups retained by [`SimulatorTraceMode::Synthetic`].
+///
+/// Construct with [`SimulatorFeatures::builder`]. Every feature defaults to
+/// enabled, so adding a future group will not break existing callers.
+#[derive(Debug, Clone, Copy, bon::Builder)]
+pub struct SimulatorFeatures {
+    #[builder(default = true)]
+    cpu: bool,
+    #[builder(default = true)]
+    scheduling: bool,
+    #[builder(default = true)]
+    tasks: bool,
+    #[builder(default = true)]
+    spans: bool,
+    #[builder(default = true)]
+    memory: bool,
+    #[builder(default = true)]
+    resources: bool,
+    #[builder(default = true)]
+    custom_events: bool,
+}
+
+impl Default for SimulatorFeatures {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+/// Configuration for [`build_simulator_app`].
+///
+/// All fields are private and defaulted. Use [`SimulatorConfig::builder`].
+#[derive(Debug, Clone, bon::Builder)]
+#[builder(on(String, into))]
+pub struct SimulatorConfig {
+    #[builder(default)]
+    trace_mode: SimulatorTraceMode,
+    /// Number of host rows generated in the browser (default 3).
+    #[builder(default = 3)]
+    hosts: usize,
+    /// Wall-clock coverage and key spacing of each object (default 60 seconds).
+    #[builder(default = Duration::from_secs(60))]
+    segment_duration: Duration,
+    /// Structural template repetitions inside each synthetic object (default 1).
+    ///
+    /// Demo replay always uses one complete demo trace per object.
+    #[builder(default = 1)]
+    repetitions_per_segment: u32,
+    #[builder(default)]
+    features: SimulatorFeatures,
+    /// Stack-symbol naming for synthetic traces.
+    #[builder(default)]
+    symbol_mode: SimulatorSymbolMode,
+    #[builder(default = DEFAULT_BUCKET.to_string())]
+    bucket: String,
+    #[builder(default = DEFAULT_PREFIX.to_string())]
+    prefix: String,
+    #[builder(default = DEFAULT_SERVICE.to_string())]
+    service: String,
+    /// Serve the built UI from `ui/dist` instead of embedded assets.
+    #[builder(default = false)]
+    dev: bool,
+}
+
+impl Default for SimulatorConfig {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+/// Build a viewer backed by generated S3-shaped trace objects.
+///
+/// The returned router includes demand-driven aggregation with a process-local
+/// temporary output store. Source objects are read-only and generated lazily;
+/// no AWS credentials, bucket, or persistent local directory is required.
+pub async fn build_simulator_app(config: SimulatorConfig) -> anyhow::Result<axum::Router> {
+    let dev = config.dev;
+    let backend = tokio::task::spawn_blocking(move || {
+        let demo = load_bundled_demo_trace()?;
+        SimulatorBackend::new(config, &demo)
+    })
+    .await
+    .context("simulator setup task panicked")??;
+
+    let bucket = backend.bucket.clone();
+    let prefix = backend.prefix.clone();
+    let segment_duration_secs = backend.segment_duration_secs;
+    let host_count = backend.host_count;
+    let mode = backend.mode;
+    let source: Arc<dyn StorageBackend> = Arc::new(backend);
+
+    let output = AggOutput::temporary();
+    let agg = AggContext {
+        source: Arc::clone(&source),
+        output: output.backend(),
+        source_bucket: bucket.clone(),
+        source_is_local: false,
+        output_bucket: output.output_bucket_for(&bucket),
+        output_prefix: output.prefix().to_string(),
+        source_prefixes: vec![prefix.clone()],
+        segment_duration_secs,
+    };
+
+    tracing::info!(
+        %bucket,
+        %prefix,
+        ?mode,
+        hosts = host_count,
+        segment_duration_secs,
+        "virtual simulator source ready"
+    );
+
+    let mut state = AppState::new(source, Some(bucket), Some(prefix))
+        .with_time_partitioned_source()
+        .with_agg(agg)
+        .with_agg_output(output)
+        .with_agg_segment_secs(segment_duration_secs)
+        .with_bucket_filter("");
+    if let Some(dir) = crate::resolve_dev_ui_dir(dev)? {
+        state = state.with_dev_ui_dir(dir);
+    }
+    Ok(crate::server::router(state))
+}
+
+struct SimulatorBackend {
+    bucket: String,
+    prefix: String,
+    service: String,
+    segment_duration_secs: i64,
+    host_count: usize,
+    mode: SimulatorTraceMode,
+    listed_size: i64,
+    payloads: Arc<PayloadFactory>,
+    cache: Arc<Mutex<PayloadCache>>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct PayloadCoordinates {
+    epoch_secs: i64,
+    boot_id: String,
+}
+
+impl SimulatorBackend {
+    fn new(mut config: SimulatorConfig, demo_trace: &[u8]) -> anyhow::Result<Self> {
+        validate_config(&config)?;
+        config.prefix = config.prefix.trim_matches('/').to_string();
+
+        let segment_duration_secs = i64::try_from(config.segment_duration.as_secs())
+            .context("simulator segment duration does not fit in i64 seconds")?;
+        let payloads = Arc::new(PayloadFactory::new(&config, demo_trace)?);
+        let segment_duration_ns = u64::try_from(config.segment_duration.as_nanos())
+            .context("simulator segment duration does not fit in u64 nanoseconds")?;
+        ensure!(
+            payloads.duration_ns() <= segment_duration_ns,
+            "simulator trace content spans {:.3}s but each segment covers only {}s; \
+             increase --simulator-segment-secs or reduce --simulator-repetitions",
+            payloads.duration_ns() as f64 / 1_000_000_000.0,
+            segment_duration_secs
+        );
+
+        Ok(Self {
+            bucket: config.bucket,
+            prefix: config.prefix,
+            service: config.service,
+            segment_duration_secs,
+            host_count: config.hosts,
+            mode: config.trace_mode,
+            listed_size: payloads.listed_size(),
+            payloads,
+            cache: Arc::new(Mutex::new(PayloadCache::default())),
+        })
+    }
+
+    fn ensure_bucket(&self, bucket: &str) -> Result<(), StorageError> {
+        if bucket == self.bucket {
+            Ok(())
+        } else {
+            Err(StorageError::NotFound(format!("bucket {bucket}")))
+        }
+    }
+
+    fn list_virtual_objects(
+        &self,
+        prefix: &str,
+        cap: Option<usize>,
+    ) -> Result<ListPage, StorageError> {
+        let (start, end) = match self.catalog_interval(prefix)? {
+            CatalogInterval::Empty => {
+                return Ok(ListPage {
+                    objects: Vec::new(),
+                    truncated: false,
+                });
+            }
+            CatalogInterval::Unbounded => {
+                return Err(StorageError::Other(
+                    "virtual simulator listings require a date or time prefix".to_string(),
+                ));
+            }
+            CatalogInterval::Finite { start, end } => (start.max(0), end),
+        };
+        if end <= start {
+            return Ok(ListPage {
+                objects: Vec::new(),
+                truncated: false,
+            });
+        }
+
+        let limit = cap.unwrap_or(usize::MAX);
+        let mut objects = Vec::new();
+        let first_minute = start - start.rem_euclid(60);
+        let mut minute_start = first_minute;
+        while minute_start < end {
+            let minute_end = minute_start.saturating_add(60).min(end);
+            let candidate_start = minute_start.max(start);
+            let mut epoch_secs = align_up(candidate_start, self.segment_duration_secs)
+                .ok_or_else(|| StorageError::Other("simulator timestamp overflow".to_string()))?;
+            let mut minute_objects = Vec::new();
+            while epoch_secs < minute_end {
+                for host_index in 0..self.host_count {
+                    minute_objects.push(self.object_info(host_index, epoch_secs)?);
+                }
+                epoch_secs = epoch_secs
+                    .checked_add(self.segment_duration_secs)
+                    .ok_or_else(|| {
+                        StorageError::Other("simulator timestamp overflow".to_string())
+                    })?;
+            }
+            minute_objects.sort_unstable_by(|a, b| a.key.cmp(&b.key));
+            for object in minute_objects {
+                if !object.key.starts_with(prefix) {
+                    continue;
+                }
+                if objects.len() == limit {
+                    return Ok(ListPage {
+                        objects,
+                        truncated: true,
+                    });
+                }
+                objects.push(object);
+            }
+            minute_start = minute_start.checked_add(60).ok_or_else(|| {
+                StorageError::Other("simulator listing range overflow".to_string())
+            })?;
+        }
+        Ok(ListPage {
+            objects,
+            truncated: false,
+        })
+    }
+
+    fn object_info(&self, host_index: usize, epoch_secs: i64) -> Result<ObjectInfo, StorageError> {
+        let host = simulator_host(host_index);
+        let boot_id = simulator_boot_id(host_index);
+        let key = simulator_key(
+            &self.prefix,
+            &self.service,
+            &host,
+            &boot_id,
+            epoch_secs,
+            self.segment_duration_secs,
+        )
+        .map_err(|error| StorageError::Other(format!("format simulator key: {error:#}")))?;
+        let modified_epoch = epoch_secs
+            .checked_add(self.segment_duration_secs)
+            .ok_or_else(|| StorageError::Other("simulator timestamp overflow".to_string()))?;
+        let last_modified = format_epoch(modified_epoch).map_err(|error| {
+            StorageError::Other(format!("format simulator timestamp: {error:#}"))
+        })?;
+        Ok(ObjectInfo {
+            key,
+            size: self.listed_size,
+            last_modified: Some(last_modified),
+        })
+    }
+
+    fn catalog_interval(&self, requested_prefix: &str) -> Result<CatalogInterval, StorageError> {
+        let tail = if self.prefix.is_empty() {
+            requested_prefix
+        } else if requested_prefix == self.prefix
+            || requested_prefix == format!("{}/", self.prefix)
+            || format!("{}/", self.prefix).starts_with(requested_prefix)
+        {
+            return Ok(CatalogInterval::Unbounded);
+        } else if let Some(tail) = requested_prefix.strip_prefix(&format!("{}/", self.prefix)) {
+            tail
+        } else {
+            return Ok(CatalogInterval::Empty);
+        };
+        if tail.is_empty() {
+            return Ok(CatalogInterval::Unbounded);
+        }
+
+        let mut parts = tail.split('/');
+        let Some(date) = parts.next().and_then(parse_catalog_date) else {
+            return Ok(CatalogInterval::Empty);
+        };
+        let day_start = date.midnight().assume_utc().unix_timestamp();
+        let Some(time_prefix) = parts.next() else {
+            return Ok(CatalogInterval::Finite {
+                start: day_start,
+                end: day_start + 86_400,
+            });
+        };
+        if time_prefix.is_empty() {
+            return Ok(CatalogInterval::Finite {
+                start: day_start,
+                end: day_start + 86_400,
+            });
+        }
+        let Some((offset, width)) = parse_time_prefix(time_prefix) else {
+            return Ok(CatalogInterval::Empty);
+        };
+        Ok(CatalogInterval::Finite {
+            start: day_start + offset,
+            end: day_start + offset + width,
+        })
+    }
+
+    fn parse_key(&self, key: &str) -> Result<PayloadCoordinates, StorageError> {
+        let tail = if self.prefix.is_empty() {
+            key
+        } else {
+            key.strip_prefix(&format!("{}/", self.prefix))
+                .ok_or_else(|| StorageError::NotFound(key.to_string()))?
+        };
+        let parts = tail.split('/').collect::<Vec<_>>();
+        if parts.len() != 6 {
+            return Err(StorageError::NotFound(key.to_string()));
+        }
+        let [date, minute, service, host, boot_id, file] = parts.as_slice() else {
+            unreachable!("length checked above");
+        };
+        if *service != self.service {
+            return Err(StorageError::NotFound(key.to_string()));
+        }
+        let host_index = parse_simulator_host(host, self.host_count)
+            .ok_or_else(|| StorageError::NotFound(key.to_string()))?;
+        if *boot_id != simulator_boot_id(host_index) {
+            return Err(StorageError::NotFound(key.to_string()));
+        }
+        let Some(stem) = file.strip_suffix(".bin.gz") else {
+            return Err(StorageError::NotFound(key.to_string()));
+        };
+        let Some((epoch, sequence)) = stem.split_once('-') else {
+            return Err(StorageError::NotFound(key.to_string()));
+        };
+        if sequence.contains('-') {
+            return Err(StorageError::NotFound(key.to_string()));
+        }
+        let epoch_secs = epoch
+            .parse::<i64>()
+            .ok()
+            .filter(|epoch| *epoch >= 0 && epoch.rem_euclid(self.segment_duration_secs) == 0)
+            .ok_or_else(|| StorageError::NotFound(key.to_string()))?;
+        let expected_sequence = virtual_segment_sequence(epoch_secs, self.segment_duration_secs)
+            .ok_or_else(|| StorageError::NotFound(key.to_string()))?;
+        if sequence.parse::<u64>().ok() != Some(expected_sequence) {
+            return Err(StorageError::NotFound(key.to_string()));
+        }
+        let canonical = simulator_key(
+            &self.prefix,
+            &self.service,
+            host,
+            boot_id,
+            epoch_secs,
+            self.segment_duration_secs,
+        )
+        .map_err(|_| StorageError::NotFound(key.to_string()))?;
+        if canonical != key || !canonical.contains(&format!("/{date}/{minute}/")) {
+            return Err(StorageError::NotFound(key.to_string()));
+        }
+        Ok(PayloadCoordinates {
+            epoch_secs,
+            boot_id: boot_id.to_string(),
+        })
+    }
+}
+
+enum CatalogInterval {
+    Empty,
+    Unbounded,
+    Finite { start: i64, end: i64 },
+}
+
+impl StorageBackend for SimulatorBackend {
+    fn list_buckets(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<BucketInfo>, StorageError>> + Send + '_>> {
+        let bucket = self.bucket.clone();
+        Box::pin(async move { Ok(vec![BucketInfo::new(bucket, None)]) })
+    }
+
+    fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        cap: usize,
+    ) -> Pin<Box<dyn Future<Output = Result<ListPage, StorageError>> + Send + '_>> {
+        let result = self
+            .ensure_bucket(bucket)
+            .and_then(|()| self.list_virtual_objects(prefix, Some(cap)));
+        Box::pin(async move { result })
+    }
+
+    fn list_objects_all(
+        &self,
+        bucket: &str,
+        prefix: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ObjectInfo>, StorageError>> + Send + '_>> {
+        let result = self
+            .ensure_bucket(bucket)
+            .and_then(|()| self.list_virtual_objects(prefix, None))
+            .map(|page| page.objects);
+        Box::pin(async move { result })
+    }
+
+    fn list_prefixes(
+        &self,
+        bucket: &str,
+        prefix: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, StorageError>> + Send + '_>> {
+        let result = self.ensure_bucket(bucket).and_then(|()| {
+            let catalog_root = if self.prefix.is_empty() {
+                String::new()
+            } else {
+                format!("{}/", self.prefix)
+            };
+            if !catalog_root.is_empty()
+                && catalog_root.starts_with(prefix)
+                && prefix != catalog_root
+            {
+                let rest = &catalog_root[prefix.len()..];
+                let slash = rest.find('/').unwrap_or(rest.len().saturating_sub(1));
+                return Ok(vec![format!("{prefix}{}", &rest[..=slash])]);
+            }
+            let page = self.list_virtual_objects(prefix, None)?;
+            let mut prefixes = BTreeSet::new();
+            for object in page.objects {
+                let Some(rest) = object.key.strip_prefix(prefix) else {
+                    continue;
+                };
+                let Some(slash) = rest.find('/') else {
+                    continue;
+                };
+                prefixes.insert(format!("{prefix}{}", &rest[..=slash]));
+            }
+            Ok(prefixes.into_iter().collect())
+        });
+        Box::pin(async move { result })
+    }
+
+    fn get_object(
+        &self,
+        bucket: &str,
+        key: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, StorageError>> + Send + '_>> {
+        let result = self
+            .ensure_bucket(bucket)
+            .and_then(|()| self.parse_key(key));
+        let payloads = Arc::clone(&self.payloads);
+        let cache = Arc::clone(&self.cache);
+        Box::pin(async move {
+            let coordinates = result?;
+            if let Some(bytes) = cache
+                .lock()
+                .map_err(|_| StorageError::Other("simulator payload cache poisoned".into()))?
+                .get(&coordinates)
+            {
+                return Ok(bytes.as_ref().clone());
+            }
+
+            let render_coordinates = coordinates.clone();
+            let rendered = tokio::task::spawn_blocking(move || {
+                payloads.render(render_coordinates.epoch_secs, &render_coordinates.boot_id)
+            })
+            .await
+            .map_err(|e| StorageError::Other(format!("simulator render task panicked: {e}")))?
+            .map_err(|e| StorageError::Other(format!("generate simulator trace: {e:#}")))?;
+            let rendered = Arc::new(rendered);
+            cache
+                .lock()
+                .map_err(|_| StorageError::Other("simulator payload cache poisoned".into()))?
+                .insert(coordinates, Arc::clone(&rendered));
+            Ok(rendered.as_ref().clone())
+        })
+    }
+
+    fn put_object(
+        &self,
+        _bucket: &str,
+        _key: &str,
+        _data: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), StorageError>> + Send + '_>> {
+        Box::pin(async {
+            Err(StorageError::Other(
+                "the simulator trace source is read-only".to_string(),
+            ))
+        })
+    }
+}
+
+#[derive(Default)]
+struct PayloadCache {
+    entries: VecDeque<(PayloadCoordinates, Arc<Vec<u8>>)>,
+}
+
+impl PayloadCache {
+    fn get(&mut self, coordinates: &PayloadCoordinates) -> Option<Arc<Vec<u8>>> {
+        let index = self
+            .entries
+            .iter()
+            .position(|(key, _)| key == coordinates)?;
+        let entry = self.entries.remove(index)?;
+        let result = Arc::clone(&entry.1);
+        self.entries.push_back(entry);
+        Some(result)
+    }
+
+    fn insert(&mut self, coordinates: PayloadCoordinates, bytes: Arc<Vec<u8>>) {
+        if let Some(index) = self.entries.iter().position(|(key, _)| key == &coordinates) {
+            self.entries.remove(index);
+        }
+        self.entries.push_back((coordinates, bytes));
+        while self.entries.len() > PAYLOAD_CACHE_ENTRIES {
+            self.entries.pop_front();
+        }
+    }
+}
+
+enum PayloadTemplate {
+    Replay {
+        raw: Arc<Vec<u8>>,
+        first_timestamp_ns: u64,
+        first_wall_ns: u64,
+        duration_ns: u64,
+    },
+    Synthetic {
+        shape: Arc<TraceShape>,
+        repetitions: u32,
+        duration_ns: u64,
+    },
+}
+
+struct PayloadFactory {
+    template: PayloadTemplate,
+    listed_size: i64,
+}
+
+impl PayloadFactory {
+    fn new(config: &SimulatorConfig, demo_trace: &[u8]) -> anyhow::Result<Self> {
+        let repetitions = match config.trace_mode {
+            SimulatorTraceMode::Synthetic => u64::from(config.repetitions_per_segment),
+            SimulatorTraceMode::DemoReplay => 1,
+        };
+        let listed_size = u64::try_from(demo_trace.len())
+            .context("bundled demo trace size does not fit in u64")?
+            .checked_mul(repetitions)
+            .context("simulator listed size overflow")
+            .and_then(|size| i64::try_from(size).context("simulator listed size exceeds i64"))?;
+        let raw = decode_trace_file(demo_trace)?;
+        let (first_timestamp_ns, last_timestamp_ns) = timestamp_bounds(&raw)?;
+        let template = match config.trace_mode {
+            SimulatorTraceMode::DemoReplay => {
+                ensure!(
+                    config.repetitions_per_segment == 1,
+                    "--simulator-repetitions applies only to synthetic mode; \
+                     use more segments to replay the demo trace repeatedly"
+                );
+                ensure!(
+                    first_timestamp_ns > 0,
+                    "the bundled demo trace has an invalid timestamp range"
+                );
+                let (clock_timestamp_ns, clock_realtime_ns) = first_clock_sync(&raw)?;
+                let first_wall_ns =
+                    rebase_value(clock_realtime_ns, clock_timestamp_ns, first_timestamp_ns)
+                        .context("the bundled demo trace clock cannot cover its first event")?;
+                PayloadTemplate::Replay {
+                    raw: Arc::new(raw),
+                    first_timestamp_ns,
+                    first_wall_ns,
+                    duration_ns: last_timestamp_ns.saturating_sub(first_timestamp_ns),
+                }
+            }
+            SimulatorTraceMode::Synthetic => {
+                let mut shape =
+                    trace_shape::extract_shape(&raw).context("extract bundled demo trace shape")?;
+                let dropped = trace_shape::rebase_timeline_from_first_nonzero_event(&mut shape)?;
+                if dropped > 0 {
+                    tracing::warn!(
+                        events_dropped = dropped,
+                        "simulator synthetic template omitted zero-timestamp demo events"
+                    );
+                }
+                apply_symbol_mode(&mut shape, config.symbol_mode)?;
+                trace_shape::retain_events(&mut shape, |schema, event| {
+                    feature_enabled(config.features, schema, event)
+                })?;
+                let template_duration = shape.summary.duration_ns.max(10_000);
+                let repetitions = u64::from(config.repetitions_per_segment);
+                let duration_ns = template_duration
+                    .checked_mul(repetitions)
+                    .and_then(|duration| {
+                        duration.checked_add(10_000u64.saturating_mul(repetitions - 1))
+                    })
+                    .context("synthetic simulator duration overflow")?;
+                PayloadTemplate::Synthetic {
+                    shape: Arc::new(shape),
+                    repetitions: config.repetitions_per_segment,
+                    duration_ns,
+                }
+            }
+        };
+        Ok(Self {
+            template,
+            listed_size,
+        })
+    }
+
+    fn duration_ns(&self) -> u64 {
+        match &self.template {
+            PayloadTemplate::Replay { duration_ns, .. }
+            | PayloadTemplate::Synthetic { duration_ns, .. } => *duration_ns,
+        }
+    }
+
+    fn listed_size(&self) -> i64 {
+        self.listed_size
+    }
+
+    fn render(&self, epoch_secs: i64, boot_id: &str) -> anyhow::Result<Vec<u8>> {
+        let wall_start_ns = u64::try_from(epoch_secs)
+            .context("simulator timestamp predates the Unix epoch")?
+            .checked_mul(1_000_000_000)
+            .context("simulator wall-clock timestamp overflow")?;
+        let raw = match &self.template {
+            PayloadTemplate::Replay {
+                raw,
+                first_timestamp_ns,
+                first_wall_ns,
+                ..
+            } => rebase_replay(
+                raw,
+                *first_timestamp_ns,
+                *first_wall_ns,
+                wall_start_ns,
+                boot_id,
+            )?,
+            PayloadTemplate::Synthetic {
+                shape, repetitions, ..
+            } => {
+                let generated = trace_shape::generate_trace_with_bases(
+                    shape,
+                    *repetitions,
+                    wall_start_ns,
+                    wall_start_ns,
+                )?;
+                rewrite_segment_boot_id(&generated, boot_id)?
+            }
+        };
+        gzip(&raw)
+    }
+}
+
+fn validate_config(config: &SimulatorConfig) -> anyhow::Result<()> {
+    ensure!(config.hosts > 0, "simulator hosts must be at least 1");
+    ensure!(
+        config.hosts <= MAX_SIMULATED_HOSTS,
+        "simulator host count {} exceeds the {MAX_SIMULATED_HOSTS} limit",
+        config.hosts
+    );
+    ensure!(
+        config.repetitions_per_segment > 0,
+        "simulator repetitions must be at least 1"
+    );
+    ensure!(
+        !config.segment_duration.is_zero() && config.segment_duration.subsec_nanos() == 0,
+        "simulator segment duration must be a positive whole number of seconds"
+    );
+    validate_path_value("bucket", &config.bucket, false, false)?;
+    validate_path_value("prefix", &config.prefix, true, true)?;
+    validate_path_value("service", &config.service, false, false)?;
+    Ok(())
+}
+
+fn validate_path_value(
+    name: &str,
+    value: &str,
+    allow_slash: bool,
+    allow_empty: bool,
+) -> anyhow::Result<()> {
+    ensure!(
+        allow_empty || !value.trim().is_empty(),
+        "simulator {name} must not be empty"
+    );
+    ensure!(
+        !value.chars().any(char::is_control),
+        "simulator {name} must not contain control characters"
+    );
+    ensure!(
+        allow_slash || !value.contains('/'),
+        "simulator {name} must be one path segment"
+    );
+    ensure!(
+        !value.split('/').any(|part| part == ".."),
+        "simulator {name} must not contain '..' path segments"
+    );
+    Ok(())
+}
+
+fn feature_enabled(features: SimulatorFeatures, schema: &ShapeSchema, event: &ShapeEvent) -> bool {
+    match schema.name.as_str() {
+        "ClockSyncEvent" | "SegmentMetadataEvent" => true,
+        "CpuSampleEvent" => {
+            let source = field_u64(schema, event, "source");
+            if source == Some(1) {
+                features.scheduling
+            } else {
+                features.cpu
+            }
+        }
+        "WorkerParkEvent" | "WorkerUnparkEvent" => features.scheduling,
+        "PollStartEvent" | "PollEndEvent" | "QueueSampleEvent" | "TaskSpawnEvent"
+        | "TaskTerminateEvent" | "WakeEventEvent" | "TaskDumpEvent" => features.tasks,
+        "SpanCloseEvent" => features.spans,
+        "AllocEvent" | "FreeEvent" | "MemoryProfileOverflowEvent" => features.memory,
+        "ProcessResourceUsageEvent" | "TcpAcceptQueueEvent" => features.resources,
+        "SymbolTableEntry" => {
+            features.cpu
+                || features.scheduling
+                || features.tasks
+                || features.spans
+                || features.memory
+        }
+        name if name.starts_with("SpanEnter:") || name.starts_with("SpanExit:") => features.spans,
+        _ => features.custom_events,
+    }
+}
+
+fn field_u64(schema: &ShapeSchema, event: &ShapeEvent, name: &str) -> Option<u64> {
+    let index = schema.fields.iter().position(|field| field.name == name)?;
+    match event.values.get(index)? {
+        ShapeValue::U(value) => Some(*value),
+        _ => None,
+    }
+}
+
+fn apply_symbol_mode(
+    shape: &mut TraceShape,
+    symbol_mode: SimulatorSymbolMode,
+) -> anyhow::Result<()> {
+    if symbol_mode == SimulatorSymbolMode::Anonymous {
+        return Ok(());
+    }
+
+    let Some(schema_index) = shape
+        .schemas
+        .iter()
+        .position(|schema| schema.name == "SymbolTableEntry")
+    else {
+        return Ok(());
+    };
+    let schema = &shape.schemas[schema_index];
+    let symbol_name_index = schema
+        .fields
+        .iter()
+        .position(|field| field.name == "symbol_name")
+        .context("SymbolTableEntry has no symbol_name field")?;
+    let source_file_index = schema
+        .fields
+        .iter()
+        .position(|field| field.name == "source_file");
+
+    let mut ordinal = 0usize;
+    for event in &mut shape.events {
+        if event.schema_index as usize != schema_index {
+            continue;
+        }
+        let (symbol_name, source_file) = realistic_symbol(ordinal);
+        replace_shape_string(
+            event
+                .values
+                .get_mut(symbol_name_index)
+                .context("SymbolTableEntry is missing symbol_name")?,
+            symbol_name,
+        )?;
+        if let Some(index) = source_file_index {
+            replace_shape_string(
+                event
+                    .values
+                    .get_mut(index)
+                    .context("SymbolTableEntry is missing source_file")?,
+                source_file,
+            )?;
+        }
+        ordinal += 1;
+    }
+    Ok(())
+}
+
+fn replace_shape_string(value: &mut ShapeValue, replacement: String) -> anyhow::Result<()> {
+    match value {
+        ShapeValue::S(value) | ShapeValue::PS(value) => {
+            *value = replacement;
+            Ok(())
+        }
+        ShapeValue::None => Ok(()),
+        _ => anyhow::bail!("synthetic symbol field is not a string"),
+    }
+}
+
+fn realistic_symbol(mut ordinal: usize) -> (String, String) {
+    const CRATES: &[&str] = &[
+        "telemetry",
+        "runtime",
+        "storage",
+        "network",
+        "protocol",
+        "service",
+        "metrics",
+        "scheduler",
+        "tracing",
+        "database",
+        "cache",
+        "gateway",
+    ];
+    const MODULES: &[&str] = &[
+        "collector",
+        "worker",
+        "buffer",
+        "request",
+        "response",
+        "segment",
+        "connection",
+        "stream",
+        "task",
+        "queue",
+        "profile",
+        "event",
+        "batch",
+        "client",
+        "server",
+        "codec",
+        "index",
+        "state",
+    ];
+    const VERBS: &[&str] = &[
+        "poll", "read", "write", "flush", "dispatch", "decode", "encode", "collect", "record",
+        "resolve", "schedule", "process", "handle", "update", "load", "store", "acquire",
+        "release", "prepare", "commit",
+    ];
+    const NOUNS: &[&str] = &[
+        "trace", "sample", "frame", "span", "metric", "packet", "message", "record", "cursor",
+        "future", "resource", "snapshot",
+    ];
+
+    let crate_name = CRATES[ordinal % CRATES.len()];
+    ordinal /= CRATES.len();
+    let module = MODULES[ordinal % MODULES.len()];
+    ordinal /= MODULES.len();
+    let verb = VERBS[ordinal % VERBS.len()];
+    ordinal /= VERBS.len();
+    let noun = NOUNS[ordinal % NOUNS.len()];
+    (
+        format!("{crate_name}::{module}::{verb}_{noun}"),
+        format!("src/{module}/{noun}.rs"),
+    )
+}
+
+fn rebase_replay(
+    raw: &[u8],
+    first_timestamp_ns: u64,
+    first_wall_ns: u64,
+    wall_start_ns: u64,
+    boot_id: &str,
+) -> anyhow::Result<Vec<u8>> {
+    reencode_trace(
+        raw,
+        boot_id,
+        Some(TimelineRebase {
+            first_timestamp_ns,
+            first_wall_ns,
+            wall_start_ns,
+        }),
+    )
+}
+
+fn rewrite_segment_boot_id(raw: &[u8], boot_id: &str) -> anyhow::Result<Vec<u8>> {
+    reencode_trace(raw, boot_id, None)
+}
+
+#[derive(Clone, Copy)]
+struct TimelineRebase {
+    first_timestamp_ns: u64,
+    first_wall_ns: u64,
+    wall_start_ns: u64,
+}
+
+fn reencode_trace(
+    raw: &[u8],
+    boot_id: &str,
+    timeline: Option<TimelineRebase>,
+) -> anyhow::Result<Vec<u8>> {
+    let mut decoder = Decoder::new(raw).context("invalid bundled demo trace")?;
+    let mut encoder = Encoder::new();
+    let mut schemas = HashMap::<String, (SchemaEntry, Schema)>::new();
+
+    decoder
+        .try_for_each_event(|event| {
+            let timestamp_ns = event
+                .timestamp_ns
+                .context("demo replay event has no timestamp")?;
+            let timestamp_ns = if let Some(timeline) = timeline {
+                rebase_value(
+                    timestamp_ns,
+                    timeline.first_timestamp_ns,
+                    timeline.wall_start_ns,
+                )
+                .context("demo replay timestamp shift overflow")?
+            } else {
+                timestamp_ns
+            };
+
+            let entry = normalized_replay_schema(event.schema);
+            let schema = if let Some((existing, schema)) = schemas.get(event.name) {
+                ensure!(
+                    existing == &entry,
+                    "demo replay schema '{}' changed definition after a stream reset",
+                    event.name
+                );
+                schema.clone()
+            } else {
+                let schema = Schema::from_entry(entry.clone());
+                schemas.insert(event.name.to_string(), (entry, schema.clone()));
+                schema
+            };
+
+            let mut values = Vec::with_capacity(event.fields.len() + 1);
+            values.push(FieldValue::Varint(timestamp_ns));
+            for (field, value) in event.schema.fields().iter().zip(event.fields.iter()) {
+                let mut value = if event.name == "SegmentMetadataEvent" && field.name() == "entries"
+                {
+                    rewrite_boot_id_value(value, boot_id)?
+                } else {
+                    replay_value(value, &event, &mut encoder)?
+                };
+                if let Some(timeline) = timeline
+                    && event.name == "ClockSyncEvent"
+                    && field.name() == "realtime_ns"
+                {
+                    let FieldValue::Varint(realtime_ns) = value else {
+                        anyhow::bail!("demo ClockSyncEvent.realtime_ns is not a varint");
+                    };
+                    value = FieldValue::Varint(
+                        rebase_value(realtime_ns, timeline.first_wall_ns, timeline.wall_start_ns)
+                            .context("demo replay realtime shift overflow")?,
+                    );
+                } else if let Some(timeline) = timeline
+                    && field.name() == "alloc_timestamp_ns"
+                {
+                    value = match value {
+                        FieldValue::Varint(timestamp_ns) => FieldValue::Varint(
+                            rebase_value(
+                                timestamp_ns,
+                                timeline.first_timestamp_ns,
+                                timeline.wall_start_ns,
+                            )
+                            .context("demo replay timestamp reference shift overflow")?,
+                        ),
+                        FieldValue::None => FieldValue::None,
+                        _ => anyhow::bail!(
+                            "demo replay alloc_timestamp_ns is neither a varint nor absent"
+                        ),
+                    };
+                }
+                values.push(value);
+            }
+            encoder
+                .write_event(&schema, &values)
+                .with_context(|| format!("re-encode demo event '{}'", event.name))
+        })
+        .map_err(|error| match error {
+            dial9_trace_format::decoder::TryForEachError::Decode(error) => {
+                anyhow::anyhow!(
+                    "decode bundled demo trace at {}: {}",
+                    error.pos,
+                    error.message
+                )
+            }
+            dial9_trace_format::decoder::TryForEachError::User(error) => error,
+        })?;
+    ensure!(
+        decoder.position() == decoder.data_len(),
+        "bundled demo trace has trailing undecodable bytes"
+    );
+    Ok(encoder.finish())
+}
+
+fn rewrite_boot_id_value(value: &FieldValueRef<'_>, boot_id: &str) -> anyhow::Result<FieldValue> {
+    let FieldValueRef::StringMap(entries) = value else {
+        anyhow::bail!("SegmentMetadataEvent.entries is not a string map");
+    };
+    let mut found = false;
+    let mut rewritten = entries
+        .iter()
+        .map(|(key, value)| {
+            let value = if key == "boot_id" {
+                found = true;
+                boot_id
+            } else {
+                value
+            };
+            (key.as_bytes().to_vec(), value.as_bytes().to_vec())
+        })
+        .collect::<Vec<_>>();
+    if !found {
+        rewritten.push((b"boot_id".to_vec(), boot_id.as_bytes().to_vec()));
+    }
+    Ok(FieldValue::StringMap(rewritten))
+}
+
+fn normalized_replay_schema(schema: &SchemaEntry) -> SchemaEntry {
+    SchemaEntry::with_annotations(
+        schema.name(),
+        schema.has_timestamp(),
+        schema.fields().iter().map(|field| {
+            FieldDef::new(
+                field.name(),
+                normalize_replay_field_type(field.field_type()),
+            )
+        }),
+        schema.annotations().iter().cloned(),
+    )
+}
+
+fn normalize_replay_field_type(field_type: FieldType) -> FieldType {
+    match field_type {
+        FieldType::U8 | FieldType::U16 | FieldType::U32 => FieldType::Varint,
+        FieldType::OptionalU8 | FieldType::OptionalU16 | FieldType::OptionalU32 => {
+            FieldType::OptionalVarint
+        }
+        other => other,
+    }
+}
+
+fn replay_value(
+    value: &FieldValueRef<'_>,
+    event: &RawEvent<'_, '_>,
+    encoder: &mut Encoder,
+) -> anyhow::Result<FieldValue> {
+    Ok(match value {
+        FieldValueRef::PooledString(id) => {
+            let string = event
+                .string_pool
+                .get(*id)
+                .with_context(|| format!("demo replay references missing string pool id {id:?}"))?;
+            FieldValue::PooledString(encoder.intern_string(string)?)
+        }
+        FieldValueRef::PooledStackFrames(id) => {
+            let frames = event
+                .stack_pool
+                .get(*id)
+                .with_context(|| format!("demo replay references missing stack pool id {id:?}"))?;
+            FieldValue::PooledStackFrames(encoder.intern_stack_frames(frames)?)
+        }
+        FieldValueRef::List(list) => FieldValue::List(
+            list.iter()
+                .map(|value| replay_value(value, event, encoder))
+                .collect::<anyhow::Result<_>>()?,
+        ),
+        FieldValueRef::Map(map) => FieldValue::Map(
+            map.iter()
+                .map(|(key, value)| {
+                    Ok((
+                        replay_value(key, event, encoder)?,
+                        replay_value(value, event, encoder)?,
+                    ))
+                })
+                .collect::<anyhow::Result<_>>()?,
+        ),
+        _ => value.to_owned(),
+    })
+}
+
+fn rebase_value(value: u64, source_base: u64, target_base: u64) -> Option<u64> {
+    if value >= source_base {
+        target_base.checked_add(value - source_base)
+    } else {
+        target_base.checked_sub(source_base - value)
+    }
+}
+
+fn first_clock_sync(raw: &[u8]) -> anyhow::Result<(u64, u64)> {
+    let mut decoder = Decoder::new(raw).context("invalid bundled demo trace")?;
+    let mut clock = None;
+    decoder
+        .try_for_each_event(|event| {
+            if clock.is_some() || event.name != "ClockSyncEvent" {
+                return Ok::<_, anyhow::Error>(());
+            }
+            let timestamp_ns = event
+                .timestamp_ns
+                .context("demo ClockSyncEvent has no timestamp")?;
+            let realtime_ns = event
+                .field_names()
+                .zip(event.fields.iter())
+                .find(|(name, _)| *name == "realtime_ns")
+                .and_then(|(_, value)| match value {
+                    FieldValueRef::Varint(value) => Some(*value),
+                    _ => None,
+                })
+                .context("demo ClockSyncEvent has no varint realtime_ns")?;
+            if timestamp_ns > 0 && realtime_ns > 0 {
+                clock = Some((timestamp_ns, realtime_ns));
+            }
+            Ok(())
+        })
+        .map_err(|error| match error {
+            dial9_trace_format::decoder::TryForEachError::Decode(error) => {
+                anyhow::anyhow!(
+                    "decode bundled demo trace at {}: {}",
+                    error.pos,
+                    error.message
+                )
+            }
+            dial9_trace_format::decoder::TryForEachError::User(error) => error,
+        })?;
+    clock.context("bundled demo trace has no valid ClockSyncEvent")
+}
+
+fn timestamp_bounds(raw: &[u8]) -> anyhow::Result<(u64, u64)> {
+    let mut decoder = Decoder::new(raw).context("invalid bundled demo trace")?;
+    let mut min = None;
+    let mut max = None;
+    decoder
+        .try_for_each_event(|event| {
+            let timestamp = event
+                .timestamp_ns
+                .ok_or_else(|| anyhow::anyhow!("demo event has no timestamp"))?;
+            if timestamp == 0 {
+                return Ok::<_, anyhow::Error>(());
+            }
+            min = Some(min.map_or(timestamp, |value: u64| value.min(timestamp)));
+            max = Some(max.map_or(timestamp, |value: u64| value.max(timestamp)));
+            Ok::<_, anyhow::Error>(())
+        })
+        .map_err(|error| match error {
+            dial9_trace_format::decoder::TryForEachError::Decode(error) => {
+                anyhow::anyhow!(
+                    "decode bundled demo trace at {}: {}",
+                    error.pos,
+                    error.message
+                )
+            }
+            dial9_trace_format::decoder::TryForEachError::User(error) => error,
+        })?;
+    ensure!(
+        decoder.position() == decoder.data_len(),
+        "bundled demo trace has trailing undecodable bytes"
+    );
+    Ok((
+        min.context("bundled demo trace has no events")?,
+        max.context("bundled demo trace has no events")?,
+    ))
+}
+
+fn simulator_key(
+    prefix: &str,
+    service: &str,
+    host: &str,
+    boot_id: &str,
+    epoch_secs: i64,
+    segment_duration_secs: i64,
+) -> anyhow::Result<String> {
+    let timestamp = OffsetDateTime::from_unix_timestamp(epoch_secs)
+        .context("simulator timestamp out of range")?;
+    let date = format!(
+        "{:04}-{:02}-{:02}",
+        timestamp.year(),
+        u8::from(timestamp.month()),
+        timestamp.day()
+    );
+    let minute = format!("{:02}{:02}", timestamp.hour(), timestamp.minute());
+    let sequence = virtual_segment_sequence(epoch_secs, segment_duration_secs)
+        .context("simulator segment sequence out of range")?;
+    let tail = format!("{date}/{minute}/{service}/{host}/{boot_id}/{epoch_secs}-{sequence}.bin.gz");
+    if prefix.is_empty() {
+        Ok(tail)
+    } else {
+        Ok(format!("{prefix}/{tail}"))
+    }
+}
+
+fn simulator_host(host_index: usize) -> String {
+    format!("host-{:03}", host_index + 1)
+}
+
+fn parse_simulator_host(host: &str, host_count: usize) -> Option<usize> {
+    let number = host.strip_prefix("host-")?.parse::<usize>().ok()?;
+    let host_index = number.checked_sub(1)?;
+    (host_index < host_count && simulator_host(host_index) == host).then_some(host_index)
+}
+
+fn simulator_boot_id(host_index: usize) -> String {
+    format!("simu-{:06}", host_index + 1)
+}
+
+fn virtual_segment_sequence(epoch_secs: i64, segment_duration_secs: i64) -> Option<u64> {
+    u64::try_from(epoch_secs.checked_div(segment_duration_secs)?).ok()
+}
+
+fn align_up(value: i64, alignment: i64) -> Option<i64> {
+    let remainder = value.rem_euclid(alignment);
+    if remainder == 0 {
+        Some(value)
+    } else {
+        value.checked_add(alignment - remainder)
+    }
+}
+
+fn parse_catalog_date(value: &str) -> Option<Date> {
+    let mut parts = value.split('-');
+    let year = parts.next()?.parse::<i32>().ok()?;
+    let month = parts.next()?.parse::<u8>().ok()?;
+    let day = parts.next()?.parse::<u8>().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Date::from_calendar_date(year, Month::try_from(month).ok()?, day).ok()
+}
+
+fn parse_time_prefix(value: &str) -> Option<(i64, i64)> {
+    if !(1..=4).contains(&value.len()) || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let (hour, minute, width) = match value.len() {
+        1 => {
+            let hour_tens = value.parse::<u8>().ok()?;
+            if hour_tens > 2 {
+                return None;
+            }
+            let start_hour = hour_tens * 10;
+            let hours = 10u8.min(24 - start_hour);
+            (start_hour, 0, i64::from(hours) * 3_600)
+        }
+        2 => (value.parse::<u8>().ok()?, 0, 3_600),
+        3 => {
+            let hour = value[..2].parse::<u8>().ok()?;
+            let minute_tens = value[2..].parse::<u8>().ok()?;
+            if minute_tens > 5 {
+                return None;
+            }
+            (hour, minute_tens * 10, 600)
+        }
+        4 => (
+            value[..2].parse::<u8>().ok()?,
+            value[2..].parse::<u8>().ok()?,
+            60,
+        ),
+        _ => unreachable!("length checked above"),
+    };
+    if hour >= 24 || minute >= 60 {
+        return None;
+    }
+    Some((i64::from(hour) * 3_600 + i64::from(minute) * 60, width))
+}
+
+fn format_epoch(epoch_secs: i64) -> anyhow::Result<String> {
+    let timestamp = OffsetDateTime::from_unix_timestamp(epoch_secs)
+        .context("simulator timestamp out of range")?;
+    Ok(format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        timestamp.year(),
+        u8::from(timestamp.month()),
+        timestamp.day(),
+        timestamp.hour(),
+        timestamp.minute(),
+        timestamp.second()
+    ))
+}
+
+fn gzip(raw: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    encoder.write_all(raw).context("compress simulator trace")?;
+    encoder.finish().context("finish simulator trace gzip")
+}
+
+fn decode_trace_file(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
+    if !bytes.starts_with(&[0x1f, 0x8b]) {
+        ensure!(
+            bytes.len() as u64 <= MAX_DEMO_TRACE_BYTES,
+            "bundled demo trace exceeds the decompressed size limit"
+        );
+        return Ok(bytes.to_vec());
+    }
+
+    let decoder = flate2::read::GzDecoder::new(bytes);
+    let mut bounded = decoder.take(MAX_DEMO_TRACE_BYTES + 1);
+    let mut raw = Vec::new();
+    bounded
+        .read_to_end(&mut raw)
+        .context("decompress bundled demo trace")?;
+    ensure!(
+        raw.len() as u64 <= MAX_DEMO_TRACE_BYTES,
+        "bundled demo trace exceeds the {MAX_DEMO_TRACE_BYTES} byte decompressed limit"
+    );
+    Ok(raw)
+}
+
+fn load_bundled_demo_trace() -> anyhow::Result<Vec<u8>> {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    for path in [
+        manifest_dir.join("ui/public/demo-trace.bin"),
+        manifest_dir.join("ui/dist/demo-trace.bin"),
+    ] {
+        match std::fs::read(&path) {
+            Ok(bytes) => return Ok(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("read {}", path.display()));
+            }
+        }
+    }
+    crate::server::embedded_ui_asset("demo-trace.bin").context(
+        "the bundled demo trace is unavailable; build the viewer UI before using simulator mode",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct ClockSync {
+        timestamp_ns: u64,
+        realtime_ns: u64,
+    }
+
+    #[derive(Deserialize)]
+    struct SegmentMetadata {
+        entries: HashMap<String, String>,
+    }
+
+    fn only_cpu() -> SimulatorFeatures {
+        SimulatorFeatures::builder()
+            .cpu(true)
+            .scheduling(false)
+            .tasks(false)
+            .spans(false)
+            .memory(false)
+            .resources(false)
+            .custom_events(false)
+            .build()
+    }
+
+    fn trace_boot_id(raw: &[u8]) -> String {
+        let mut decoder = Decoder::new(raw).unwrap();
+        let mut boot_id = None;
+        decoder
+            .for_each_event(|event| {
+                if event.name == "SegmentMetadataEvent"
+                    && let Ok(metadata) = event.deserialize::<SegmentMetadata>()
+                    && let Some(value) = metadata.entries.get("boot_id")
+                {
+                    boot_id = Some(value.clone());
+                }
+            })
+            .unwrap();
+        boot_id.expect("simulator trace should contain boot_id metadata")
+    }
+
+    #[tokio::test]
+    async fn replay_backend_lists_virtual_fleet_without_rendering_and_rebases_on_fetch() {
+        let demo = load_bundled_demo_trace().unwrap();
+        let config = SimulatorConfig::builder()
+            .trace_mode(SimulatorTraceMode::DemoReplay)
+            .hosts(2)
+            .build();
+        let backend = SimulatorBackend::new(config, &demo).unwrap();
+
+        assert_eq!(
+            backend.list_prefixes(DEFAULT_BUCKET, "").await.unwrap(),
+            vec!["traces/"]
+        );
+        let page = backend
+            .list_objects(DEFAULT_BUCKET, "traces/2026-07-28/0000/", 10)
+            .await
+            .unwrap();
+        assert!(!page.truncated);
+        assert_eq!(page.objects.len(), 2);
+        assert!(
+            page.objects
+                .iter()
+                .all(|object| object.key.starts_with("traces/2026-07-28/0000/"))
+        );
+        assert!(
+            backend.cache.lock().unwrap().entries.is_empty(),
+            "listing must not render or cache trace payloads"
+        );
+
+        let first = &page.objects[0];
+        let first_epoch = backend.parse_key(&first.key).unwrap().epoch_secs;
+        let gz = backend
+            .get_object(DEFAULT_BUCKET, &first.key)
+            .await
+            .unwrap();
+        assert_eq!(backend.cache.lock().unwrap().entries.len(), 1);
+        let raw = decode_trace_file(&gz).unwrap();
+        let mut decoder = Decoder::new(&raw).unwrap();
+        let mut first_clock = None;
+        let mut min_cpu_timestamp = u64::MAX;
+        let mut cpu_samples = 0;
+        let mut span_events = 0;
+        decoder
+            .for_each_event(|event| {
+                if event.name == "ClockSyncEvent" && first_clock.is_none() {
+                    first_clock = event.deserialize::<ClockSync>().ok();
+                }
+                if event.name == "CpuSampleEvent" {
+                    min_cpu_timestamp = min_cpu_timestamp.min(event.timestamp_ns.unwrap());
+                    cpu_samples += 1;
+                }
+                if event.name.starts_with("SpanEnter:") {
+                    span_events += 1;
+                }
+            })
+            .unwrap();
+        let clock = first_clock.unwrap();
+        let expected_start = u64::try_from(first_epoch).unwrap() * 1_000_000_000;
+        assert!((expected_start..expected_start + 60_000_000_000).contains(&min_cpu_timestamp));
+        assert_eq!(
+            clock.realtime_ns, clock.timestamp_ns,
+            "rebased monotonic and realtime clocks should share the segment epoch"
+        );
+        assert!(cpu_samples > 0);
+        assert!(span_events > 0);
+        assert_eq!(trace_boot_id(&raw), "simu-000001");
+
+        let second_host = page
+            .objects
+            .iter()
+            .find(|object| object.key.contains("/host-002/"))
+            .unwrap();
+        assert!(second_host.key.contains("/simu-000002/"));
+        let second_gz = backend
+            .get_object(DEFAULT_BUCKET, &second_host.key)
+            .await
+            .unwrap();
+        let second_raw = decode_trace_file(&second_gz).unwrap();
+        assert_eq!(trace_boot_id(&second_raw), "simu-000002");
+        assert_ne!(
+            raw, second_raw,
+            "hosts at the same epoch need distinct identity metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_is_unbounded_deterministic_and_rejects_noncanonical_keys() {
+        let demo = load_bundled_demo_trace().unwrap();
+        assert!(
+            SimulatorBackend::new(
+                SimulatorConfig::builder()
+                    .hosts(MAX_SIMULATED_HOSTS + 1)
+                    .build(),
+                &demo,
+            )
+            .is_err()
+        );
+        let backend =
+            SimulatorBackend::new(SimulatorConfig::builder().hosts(2).build(), &demo).unwrap();
+
+        let old = backend
+            .list_objects(DEFAULT_BUCKET, "traces/2001-02-03/0405/", 10)
+            .await
+            .unwrap();
+        let future = backend
+            .list_objects(DEFAULT_BUCKET, "traces/2037-08-09/1011/", 10)
+            .await
+            .unwrap();
+        let repeated = backend
+            .list_objects(DEFAULT_BUCKET, "traces/2037-08-09/1011/", 10)
+            .await
+            .unwrap();
+        assert_eq!(old.objects.len(), 2);
+        assert_eq!(future.objects.len(), 2);
+        assert_eq!(
+            future
+                .objects
+                .iter()
+                .map(|object| &object.key)
+                .collect::<Vec<_>>(),
+            repeated
+                .objects
+                .iter()
+                .map(|object| &object.key)
+                .collect::<Vec<_>>()
+        );
+        assert!(backend.cache.lock().unwrap().entries.is_empty());
+
+        let capped = backend
+            .list_objects(DEFAULT_BUCKET, "traces/2037-08-09/10", 1)
+            .await
+            .unwrap();
+        assert_eq!(capped.objects.len(), 1);
+        assert!(capped.truncated);
+
+        let key = &future.objects[0].key;
+        let forged = key.replace("/simu-000001/", "/simu-999999/");
+        assert!(matches!(
+            backend.get_object(DEFAULT_BUCKET, &forged).await,
+            Err(StorageError::NotFound(_))
+        ));
+        let (parent, file) = key.rsplit_once('/').unwrap();
+        let epoch = file.split('-').next().unwrap();
+        let forged = format!("{parent}/{epoch}-0.bin.gz");
+        assert!(matches!(
+            backend.get_object(DEFAULT_BUCKET, &forged).await,
+            Err(StorageError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn synthetic_features_filter_scheduler_tasks_and_spans() {
+        let demo = load_bundled_demo_trace().unwrap();
+        let config = SimulatorConfig::builder()
+            .features(only_cpu())
+            .hosts(1)
+            .build();
+        let backend = SimulatorBackend::new(config, &demo).unwrap();
+        let page = backend
+            .list_objects(DEFAULT_BUCKET, "traces/2026-07-28/0000/", 1)
+            .await
+            .unwrap();
+        let gz = backend
+            .get_object(DEFAULT_BUCKET, &page.objects[0].key)
+            .await
+            .unwrap();
+        let raw = decode_trace_file(&gz).unwrap();
+        assert_eq!(trace_boot_id(&raw), "simu-000001");
+        let mut decoder = Decoder::new(&raw).unwrap();
+        let mut cpu = 0;
+        let mut forbidden = Vec::new();
+        decoder
+            .for_each_event(|event| match event.name {
+                "CpuSampleEvent" => {
+                    let source = event
+                        .field_names()
+                        .zip(event.fields.iter())
+                        .find(|(name, _)| *name == "source")
+                        .and_then(|(_, value)| match value {
+                            dial9_trace_format::types::FieldValueRef::Varint(value) => Some(*value),
+                            _ => None,
+                        });
+                    if source == Some(1) {
+                        forbidden.push("scheduler sample".to_string());
+                    } else {
+                        cpu += 1;
+                    }
+                }
+                "WorkerParkEvent" | "WorkerUnparkEvent" | "PollStartEvent" | "PollEndEvent"
+                | "SpanCloseEvent" => forbidden.push(event.name.to_string()),
+                name if name.starts_with("SpanEnter:") || name.starts_with("SpanExit:") => {
+                    forbidden.push(name.to_string())
+                }
+                _ => {}
+            })
+            .unwrap();
+        assert!(cpu > 0);
+        assert!(forbidden.is_empty(), "unexpected events: {forbidden:?}");
+    }
+
+    #[tokio::test]
+    async fn synthetic_realistic_symbols_resolve_cpu_stack_addresses() {
+        let demo = load_bundled_demo_trace().unwrap();
+        let config = SimulatorConfig::builder()
+            .features(only_cpu())
+            .symbol_mode(SimulatorSymbolMode::Realistic)
+            .segment_duration(Duration::from_secs(15))
+            .hosts(1)
+            .build();
+        let backend = SimulatorBackend::new(config, &demo).unwrap();
+        let page = backend
+            .list_objects(DEFAULT_BUCKET, "traces/2026-07-28/0000/", 1)
+            .await
+            .unwrap();
+        let gz = backend
+            .get_object(DEFAULT_BUCKET, &page.objects[0].key)
+            .await
+            .unwrap();
+        let raw = decode_trace_file(&gz).unwrap();
+
+        let mut symbols = std::collections::BTreeMap::new();
+        let mut symbol_names = Vec::new();
+        let mut cpu_frames = Vec::new();
+        let mut decoder = Decoder::new(&raw).unwrap();
+        decoder
+            .for_each_event(|event| {
+                if event.name == "SymbolTableEntry" {
+                    let mut base = None;
+                    let mut size = None;
+                    let mut name = None;
+                    for (field, value) in event.field_names().zip(event.fields.iter()) {
+                        match (field, value) {
+                            ("addr" | "base_addr", FieldValueRef::Varint(value)) => {
+                                base = Some(*value);
+                            }
+                            ("size", FieldValueRef::Varint(value)) => size = Some(*value),
+                            ("symbol_name", FieldValueRef::PooledString(id)) => {
+                                name = event.string_pool.get(*id).map(str::to_string);
+                            }
+                            _ => {}
+                        }
+                    }
+                    if let (Some(base), Some(size), Some(name)) = (base, size, name) {
+                        symbols.insert(base, size.max(1));
+                        symbol_names.push(name);
+                    }
+                } else if event.name == "CpuSampleEvent"
+                    && let Some((_, callchain)) = event
+                        .field_names()
+                        .zip(event.fields.iter())
+                        .find(|(field, _)| *field == "callchain")
+                {
+                    match callchain {
+                        FieldValueRef::StackFrames(frames) => {
+                            cpu_frames.extend(frames.iter());
+                        }
+                        FieldValueRef::PooledStackFrames(id) => {
+                            if let Some(frames) = event.stack_pool.get(*id) {
+                                cpu_frames.extend(frames.iter().copied());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            })
+            .unwrap();
+
+        assert!(
+            symbol_names.len() > 100,
+            "expected a populated symbol table"
+        );
+        assert!(
+            symbol_names
+                .iter()
+                .all(|name| name.contains("::") && !name.starts_with("s_")),
+            "unexpected synthetic symbol names"
+        );
+        assert!(
+            cpu_frames.iter().any(|frame| {
+                symbols
+                    .range(..=frame)
+                    .next_back()
+                    .is_some_and(|(base, size)| *frame < base.saturating_add(*size))
+            }),
+            "CPU callchains should resolve against the synthetic symbol table"
+        );
+    }
+}

--- a/dial9-viewer/src/trace_shape.rs
+++ b/dial9-viewer/src/trace_shape.rs
@@ -1624,7 +1624,7 @@ fn compute_quantiles(values: &mut [u64]) -> Option<Quantiles> {
 /// processed while its active schema, string_pool, and stack_pool are still valid
 /// (reset frames clear these). This fixes panics on traces with mid-stream resets.
 #[allow(clippy::collapsible_if)] // Nested if-let chains are clearer for field matching
-fn extract_shape(data: &[u8]) -> anyhow::Result<TraceShape> {
+pub(crate) fn extract_shape(data: &[u8]) -> anyhow::Result<TraceShape> {
     // ─── Pass 1: determine global min/max timestamps ────────────────────
     let mut decoder1 = Decoder::new(data).context("invalid trace file header")?;
     let mut global_min_ts: Option<u64> = None;
@@ -1878,6 +1878,128 @@ fn extract_shape(data: &[u8]) -> anyhow::Result<TraceShape> {
     validate_shape(&shape).context("extracted shape failed validation")?;
 
     Ok(shape)
+}
+
+/// Retain only events accepted by `keep`, then rebuild and validate every
+/// summary field affected by the filtered event set.
+///
+/// Schemas are deliberately retained even when no surviving event references
+/// them. They are small, and keeping their indices stable avoids rewriting
+/// every event while still ensuring disabled features emit no data.
+pub(crate) fn retain_events(
+    shape: &mut TraceShape,
+    mut keep: impl FnMut(&ShapeSchema, &ShapeEvent) -> bool,
+) -> anyhow::Result<()> {
+    let schemas = &shape.schemas;
+    shape
+        .events
+        .retain(|event| keep(&schemas[event.schema_index as usize], event));
+    ensure!(
+        !shape.events.is_empty(),
+        "event filter removed every event from the trace shape"
+    );
+
+    rebuild_summary(shape);
+    validate_shape(shape).context("filtered shape failed validation")
+}
+
+/// Drop zero-timestamp framing events and move the remaining synthetic
+/// timeline to a zero base. Zero-timestamp symbol records are retained at the
+/// new base because stack samples need them for address resolution.
+///
+/// This is simulator-specific cleanup for source fixtures containing framing
+/// events at timestamp zero. Timestamp-reference fields participate in choosing
+/// the base so subtracting it never invents a plausible fallback value.
+pub(crate) fn rebase_timeline_from_first_nonzero_event(
+    shape: &mut TraceShape,
+) -> anyhow::Result<usize> {
+    let original_len = shape.events.len();
+    shape.events.retain(|event| {
+        let timestamp = event.timestamp_offset_ns;
+        timestamp.is_some_and(|timestamp| timestamp > 0)
+            || (timestamp == Some(0)
+                && shape.schemas[event.schema_index as usize].name == "SymbolTableEntry")
+    });
+    ensure!(
+        !shape.events.is_empty(),
+        "trace shape has no nonzero-timestamp events"
+    );
+
+    let mut base = shape
+        .events
+        .iter()
+        .filter_map(|event| event.timestamp_offset_ns)
+        .filter(|timestamp| *timestamp > 0)
+        .min()
+        .context("trace shape has no positive timestamped events")?;
+    for event in &shape.events {
+        let schema = &shape.schemas[event.schema_index as usize];
+        for (field, value) in schema.fields.iter().zip(event.values.iter()) {
+            if field_shifts_with_timeline(field)
+                && let ShapeValue::U(value) = value
+                && *value > 0
+            {
+                base = base.min(*value);
+            }
+        }
+    }
+
+    for event in &mut shape.events {
+        let timestamp = event
+            .timestamp_offset_ns
+            .context("trace shape event lost its timestamp")?;
+        if timestamp > 0 {
+            event.timestamp_offset_ns = Some(
+                timestamp
+                    .checked_sub(base)
+                    .context("trace shape timestamp precedes selected timeline base")?,
+            );
+        }
+
+        let schema = &shape.schemas[event.schema_index as usize];
+        for (field, value) in schema.fields.iter().zip(event.values.iter_mut()) {
+            if field_shifts_with_timeline(field)
+                && let ShapeValue::U(value) = value
+                && *value > 0
+            {
+                *value = value
+                    .checked_sub(base)
+                    .context("trace shape timestamp reference precedes timeline base")?;
+            }
+        }
+    }
+
+    rebuild_summary(shape);
+    validate_shape(shape).context("rebased shape failed validation")?;
+    Ok(original_len - shape.events.len())
+}
+
+fn field_shifts_with_timeline(field: &ShapeField) -> bool {
+    field.repeat_meta.as_ref().is_some_and(|metadata| {
+        matches!(
+            metadata.semantics,
+            FieldSemantics::TimestampRef | FieldSemantics::RealtimeOffset
+        )
+    })
+}
+
+fn rebuild_summary(shape: &mut TraceShape) {
+    let mut event_type_counts = BTreeMap::new();
+    for event in &shape.events {
+        let name = &shape.schemas[event.schema_index as usize].name;
+        *event_type_counts.entry(name.clone()).or_default() += 1;
+    }
+
+    let recomputed = recompute_summary(shape);
+    shape.summary = ShapeSummary {
+        event_count: recomputed.event_count,
+        duration_ns: recomputed.duration_ns,
+        event_type_counts,
+        worker_cardinality: recomputed.worker_cardinality,
+        task_cardinality: recomputed.task_cardinality,
+        poll_duration_quantiles: recomputed.poll_duration_quantiles,
+        span_duration_quantiles: recomputed.span_duration_quantiles,
+    };
 }
 
 // ─── Validation ─────────────────────────────────────────────────────────────
@@ -3108,16 +3230,41 @@ fn compute_namespace_strides(shape: &TraceShape) -> anyhow::Result<HashMap<Names
 /// Used by tests that need a Vec<u8> result.
 #[cfg(test)]
 fn generate_trace(shape: &TraceShape, repeat: u32) -> anyhow::Result<Vec<u8>> {
+    generate_trace_with_bases(shape, repeat, 0, SYNTHETIC_EPOCH_NS)
+}
+
+/// Generate an in-memory trace with independently configurable monotonic and
+/// realtime bases.
+///
+/// The CLI uses the fixed privacy-preserving epoch through [`generate_trace`]
+/// and [`generate_to_writer`]. Simulator segments use their S3-key start time
+/// for both bases, which makes repeated objects occupy distinct ranges while
+/// keeping aggregation and browser scope filters in the same wall-clock domain.
+pub(crate) fn generate_trace_with_bases(
+    shape: &TraceShape,
+    repeat: u32,
+    timestamp_base_ns: u64,
+    realtime_base_ns: u64,
+) -> anyhow::Result<Vec<u8>> {
     let mut buf = Vec::new();
-    // For the Vec path, we still want preflight checks
     validate_repeat_preflight(shape, repeat)?;
-    generate_to_writer(shape, repeat, &mut buf)?;
+    generate_to_writer_with_bases(shape, repeat, timestamp_base_ns, realtime_base_ns, &mut buf)?;
     Ok(buf)
 }
 
 /// F: Stream trace output through an Encoder writing to any `W: Write`.
 /// Caller must ensure validation and preflight have passed before calling.
 fn generate_to_writer<W: Write>(shape: &TraceShape, repeat: u32, writer: W) -> anyhow::Result<()> {
+    generate_to_writer_with_bases(shape, repeat, 0, SYNTHETIC_EPOCH_NS, writer)
+}
+
+fn generate_to_writer_with_bases<W: Write>(
+    shape: &TraceShape,
+    repeat: u32,
+    timestamp_base_ns: u64,
+    realtime_base_ns: u64,
+    writer: W,
+) -> anyhow::Result<()> {
     // Compute duration and gap with checked arithmetic
     let actual_duration = shape
         .events
@@ -3175,14 +3322,19 @@ fn generate_to_writer<W: Write>(shape: &TraceShape, repeat: u32, writer: W) -> a
                     .ok_or_else(|| anyhow::anyhow!("template_duration + gap overflow"))?,
             )
             .ok_or_else(|| anyhow::anyhow!("rep * (duration+gap) overflow at rep={rep}"))?;
+        let timeline = GenerationTimeline {
+            time_shift_ns: time_shift,
+            realtime_base_ns,
+        };
 
         for event in &shape.events {
             let schema = &schemas[event.schema_index as usize];
             let shape_schema = &shape.schemas[event.schema_index as usize];
 
             let ts_offset = event.timestamp_offset_ns.unwrap_or(0);
-            let ts_ns = ts_offset
-                .checked_add(time_shift)
+            let ts_ns = timestamp_base_ns
+                .checked_add(ts_offset)
+                .and_then(|timestamp| timestamp.checked_add(time_shift))
                 .ok_or_else(|| anyhow::anyhow!("timestamp overflow at rep={rep}"))?;
 
             let mut values = Vec::with_capacity(shape_schema.fields.len() + 1);
@@ -3197,7 +3349,7 @@ fn generate_to_writer<W: Write>(shape: &TraceShape, repeat: u32, writer: W) -> a
                     ft,
                     meta,
                     rep,
-                    time_shift,
+                    timeline,
                     &strides,
                     &mut encoder,
                 )?;
@@ -3217,13 +3369,19 @@ fn generate_to_writer<W: Write>(shape: &TraceShape, repeat: u32, writer: W) -> a
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+struct GenerationTimeline {
+    time_shift_ns: u64,
+    realtime_base_ns: u64,
+}
+
 /// Convert a ShapeValue to a FieldValue for encoding, applying repetition shifts.
 fn shape_value_to_field_value<W: Write>(
     sv: &ShapeValue,
     ft: FieldType,
     meta: Option<&FieldRepeatMeta>,
     rep: u32,
-    time_shift: u64,
+    timeline: GenerationTimeline,
     strides: &HashMap<NamespaceId, u64>,
     encoder: &mut Encoder<W>,
 ) -> anyhow::Result<FieldValue> {
@@ -3257,14 +3415,16 @@ fn shape_value_to_field_value<W: Write>(
                 }
                 FieldSemantics::TimestampRef => {
                     // alloc_timestamp_ns: add repetition time shift
-                    v.checked_add(time_shift)
+                    v.checked_add(timeline.time_shift_ns)
                         .ok_or_else(|| anyhow::anyhow!("alloc_timestamp_ns overflow"))?
                 }
                 FieldSemantics::RealtimeOffset => {
-                    // B - CLOCK PRIVACY: SYNTHETIC_EPOCH + event_offset + time_shift
-                    SYNTHETIC_EPOCH_NS
+                    // B - CLOCK PRIVACY: configured synthetic epoch + event
+                    // offset + repetition shift.
+                    timeline
+                        .realtime_base_ns
                         .checked_add(*v)
-                        .and_then(|x| x.checked_add(time_shift))
+                        .and_then(|x| x.checked_add(timeline.time_shift_ns))
                         .ok_or_else(|| anyhow::anyhow!("realtime_ns overflow"))?
                 }
                 FieldSemantics::Structural => *v,
@@ -3343,7 +3503,9 @@ fn shape_value_to_field_value<W: Write>(
         ShapeValue::List(items) => {
             let mapped: Vec<FieldValue> = items
                 .iter()
-                .map(|item| convert_nested_shape_value(item, rep, time_shift, strides, encoder))
+                .map(|item| {
+                    convert_nested_shape_value(item, rep, timeline.time_shift_ns, strides, encoder)
+                })
                 .collect::<anyhow::Result<_>>()?;
             Ok(FieldValue::List(mapped))
         }
@@ -3351,8 +3513,20 @@ fn shape_value_to_field_value<W: Write>(
             let mapped: Vec<(FieldValue, FieldValue)> = pairs
                 .iter()
                 .map(|(k, v)| {
-                    let kv = convert_nested_shape_value(k, rep, time_shift, strides, encoder)?;
-                    let vv = convert_nested_shape_value(v, rep, time_shift, strides, encoder)?;
+                    let kv = convert_nested_shape_value(
+                        k,
+                        rep,
+                        timeline.time_shift_ns,
+                        strides,
+                        encoder,
+                    )?;
+                    let vv = convert_nested_shape_value(
+                        v,
+                        rep,
+                        timeline.time_shift_ns,
+                        strides,
+                        encoder,
+                    )?;
                     Ok((kv, vv))
                 })
                 .collect::<anyhow::Result<_>>()?;

--- a/dial9-viewer/tests/simulator_test.rs
+++ b/dial9-viewer/tests/simulator_test.rs
@@ -1,0 +1,185 @@
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use dial9_viewer::simulator::{SimulatorConfig, SimulatorTraceMode, build_simulator_app};
+use serde_json::Value;
+use tower::ServiceExt;
+
+async fn get(app: &Router, uri: &str) -> (StatusCode, Vec<u8>) {
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = to_bytes(response.into_body(), 64 * 1024 * 1024)
+        .await
+        .unwrap()
+        .to_vec();
+    (status, body)
+}
+
+fn json(body: &[u8]) -> Value {
+    serde_json::from_slice(body).unwrap()
+}
+
+fn final_sse_data(body: &[u8]) -> &str {
+    let text = std::str::from_utf8(body).unwrap();
+    text.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .next_back()
+        .unwrap_or_else(|| panic!("SSE response contained no data event: {text}"))
+}
+
+// Flamegraph trees can exceed serde_json's default recursion limit. These
+// generated responses contain each numeric field once, so inspect only the
+// shallow counters needed by this integration test.
+fn response_u64(json: &str, field: &str) -> u64 {
+    let needle = format!("\"{field}\":");
+    let start = json.find(&needle).unwrap() + needle.len();
+    let value = &json[start..];
+    let end = value
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(value.len());
+    value[..end].parse().unwrap()
+}
+
+#[tokio::test]
+async fn demo_simulator_drives_browser_objects_and_aggregate_views_without_s3() {
+    let app = build_simulator_app(
+        SimulatorConfig::builder()
+            .trace_mode(SimulatorTraceMode::DemoReplay)
+            .hosts(1)
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    let (status, body) = get(&app, "/api/config").await;
+    assert_eq!(status, StatusCode::OK);
+    let config = json(&body);
+    assert_eq!(config["default_bucket"], "dial9-simulator");
+    assert_eq!(config["default_prefix"], "traces");
+    assert_eq!(config["source_layout"], "time-partitioned");
+    assert_eq!(config["supports_byo_credentials"], false);
+    assert_eq!(config["aggregation_enabled"], true);
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let (status, body) = get(
+        &app,
+        &format!(
+            "/api/services?bucket=dial9-simulator&from={}&to={}",
+            now - 180,
+            now + 60
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let services = json(&body);
+    assert_eq!(
+        services["services"],
+        serde_json::json!(["simulated-service"])
+    );
+    assert_eq!(services["service_metadata"][0]["host_count"], 1);
+
+    let (status, body) = get(
+        &app,
+        &format!(
+            "/api/browse?bucket=dial9-simulator&service=simulated-service&from={}&to={}",
+            now - 180,
+            now + 60
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let browse = json(&body);
+    let objects = browse["objects"].as_array().unwrap();
+    assert!(
+        objects.len() >= 4,
+        "the requested four-minute window should have virtual coverage"
+    );
+    let key = objects[0]["key"].as_str().unwrap();
+    assert!(key.starts_with("traces/"));
+    assert!(key.contains("/simulated-service/host-001/"));
+
+    let (status, object) = get(
+        &app,
+        &format!(
+            "/api/object?bucket=dial9-simulator&key={}",
+            urlencoding::encode(key)
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        object.starts_with(&[0x1f, 0x8b]),
+        "object should remain gzip"
+    );
+
+    let epoch_secs = key
+        .rsplit('/')
+        .next()
+        .unwrap()
+        .split('-')
+        .next()
+        .unwrap()
+        .parse::<i64>()
+        .unwrap();
+
+    // viewer.html resolves the compact selection scope by re-listing with the
+    // key-derived prefix, even when that prefix is also the server default.
+    let (status, body) = get(
+        &app,
+        &format!(
+            "/api/browse?bucket=dial9-simulator&prefix=traces\
+             &service=simulated-service&from={epoch_secs}&to={}",
+            epoch_secs + 60
+        )
+        .replace(' ', ""),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let scope_browse = json(&body);
+    assert!(
+        scope_browse["objects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|object| object["key"] == key),
+        "scope re-list should return the selected virtual trace"
+    );
+
+    let scope = format!(
+        "bucket=dial9-simulator&prefix=traces&service=simulated-service&host=host-001\
+         &start_ns={}&end_ns={}&max_files=1",
+        epoch_secs * 1_000_000_000,
+        (epoch_secs + 60) * 1_000_000_000
+    )
+    .replace(' ', "");
+
+    let (status, body) = get(&app, &format!("/api/flamegraph?{scope}")).await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    let flamegraph = final_sse_data(&body);
+    assert!(response_u64(flamegraph, "total_samples") > 0);
+    assert!(
+        flamegraph.contains("\"children\":[{"),
+        "flamegraph tree should be non-trivial"
+    );
+    assert_eq!(response_u64(flamegraph, "fold_errors"), 0);
+
+    let (status, body) = get(&app, &format!("/api/span-stats?{scope}")).await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    let spans: Value = serde_json::from_str(final_sse_data(&body)).unwrap();
+    assert!(
+        !spans["span_types"].as_array().unwrap().is_empty(),
+        "demo replay should expose aggregated spans"
+    );
+
+    let (status, body) = get(&app, &format!("/api/tokio-stats?{scope}")).await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    let tokio_stats: Value = serde_json::from_str(final_sse_data(&body)).unwrap();
+    assert!(tokio_stats["total_polls"].as_u64().unwrap() > 0);
+}

--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -498,7 +498,7 @@
     let rawObjects = [];       // raw search results
     let currentTab = 'browse';
     let aggregationEnabled = false; // server runs demand-driven aggregation
-    let localMode = false;             // true when server is local-dir (no BYO creds)
+    let localMode = false;             // true when source keys use a flat layout
     let currentQuickRange = null;   // hours, when a "Last Nhr" quick range is active
                                     // (null once the user edits the range manually)
 
@@ -941,7 +941,7 @@
         // When the server runs demand-driven aggregation, the flamegraph button
         // drives the sampled server-side loop instead of decoding raw traces.
         aggregationEnabled = !!config.aggregation_enabled;
-        localMode = !config.supports_byo_credentials;
+        localMode = usesFlatSourceLayout(config);
         if (config.supports_byo_credentials) initCredsUi();
         // Server defaults (bucket/prefix) were filled programmatically above;
         // reflect them in the URL so the link is complete.
@@ -954,6 +954,13 @@
             .then(() => discoverPrefixes())
             .then(discoverServices);
     }).catch(() => { discoverPrefixes().then(discoverServices); });
+
+    function usesFlatSourceLayout(config) {
+        if (config.source_layout === 'flat') return true;
+        if (config.source_layout === 'time-partitioned') return false;
+        // Compatibility with servers that predate the explicit layout field.
+        return !config.supports_byo_credentials;
+    }
 
     window.addEventListener('popstate', () => {
         const state = Dial9UrlState.parse(window.location.search);

--- a/dial9-viewer/ui/src/lib/trace/trace_scope.test.ts
+++ b/dial9-viewer/ui/src/lib/trace/trace_scope.test.ts
@@ -37,7 +37,7 @@ describe("scopeFromKeys", () => {
   it("derives the window from key epochs when none is supplied (raw mode)", () => {
     const s = scopeFromKeys("bkt", [key("h1", 1782760100, 1), key("h1", 1782760300, 2)], null, null);
     expect(s!.from).toBe(1782760100);
-    expect(s!.to).toBe(1782760300);
+    expect(s!.to).toBe(1782760301);
     expect(s!.region).toBe("");
   });
 

--- a/dial9-viewer/ui/src/pages/browser/api.test.ts
+++ b/dial9-viewer/ui/src/pages/browser/api.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { usesFlatSourceLayout } from "./api.js";
+
+describe("usesFlatSourceLayout", () => {
+  it("uses the explicit source layout independently of credentials", () => {
+    expect(
+      usesFlatSourceLayout({
+        source_layout: "time-partitioned",
+        supports_byo_credentials: false,
+      }),
+    ).toBe(false);
+    expect(
+      usesFlatSourceLayout({
+        source_layout: "flat",
+        supports_byo_credentials: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to credential support for older servers", () => {
+    expect(usesFlatSourceLayout({ supports_byo_credentials: false })).toBe(true);
+    expect(usesFlatSourceLayout({ supports_byo_credentials: true })).toBe(false);
+  });
+});

--- a/dial9-viewer/ui/src/pages/browser/api.ts
+++ b/dial9-viewer/ui/src/pages/browser/api.ts
@@ -39,9 +39,19 @@ export interface ApiConfig {
   default_prefix?: string | undefined;
   aggregation_enabled?: boolean | undefined;
   supports_byo_credentials?: boolean | undefined;
+  /** Source-key layout; absent on servers predating simulator support. */
+  source_layout?: "flat" | "time-partitioned" | undefined;
   /** Bucket-picker filter substring; may be absent on servers predating
    * the field - the client falls back to "dial9". */
   bucket_filter?: string | undefined;
+}
+
+/** Whether selected traces must open directly by key instead of by scope. */
+export function usesFlatSourceLayout(config: ApiConfig): boolean {
+  if (config.source_layout === "flat") return true;
+  if (config.source_layout === "time-partitioned") return false;
+  // Compatibility with servers that predate the explicit layout capability.
+  return !config.supports_byo_credentials;
 }
 
 /** GET /api/browse response fields the page reads. */

--- a/dial9-viewer/ui/src/pages/browser/main.ts
+++ b/dial9-viewer/ui/src/pages/browser/main.ts
@@ -6,7 +6,7 @@
 
 import "../../styles/browser.css";
 import { createActions } from "./actions.js";
-import type { ApiConfig } from "./api.js";
+import { usesFlatSourceLayout, type ApiConfig } from "./api.js";
 import { mountActionsBar } from "./actions-bar.js";
 import { resolveBucketFilter } from "./bucket-filter.js";
 import { mountBrowseView } from "./browse-view.js";
@@ -180,9 +180,10 @@ function boot(): void {
       // button drives the sampled server-side loop instead of decoding raw
       // traces; Tokio Stats enables on selection.
       store.update("config", { aggregationEnabled: !!config.aggregation_enabled });
-      // Local-dir servers have no BYO credentials; their buffer-style keys
-      // carry no scope, so selections open directly by key (#627).
-      store.update("config", { localMode: !config.supports_byo_credentials });
+      // Flat-layout sources carry no scope in buffer-style keys, so selections
+      // open directly by key (#627). Simulator keys are time-partitioned even
+      // though the simulator intentionally has no credential support.
+      store.update("config", { localMode: usesFlatSourceLayout(config) });
       // The server's bucket-picker filter applies unless the page URL
       // pinned an override at load (which wins). Servers predating the
       // field leave the "dial9" default in place.

--- a/dial9-viewer/ui/src/pages/browser/state.ts
+++ b/dial9-viewer/ui/src/pages/browser/state.ts
@@ -90,9 +90,8 @@ export interface UiSlice {
 export interface ConfigSlice {
   /** Server runs demand-driven aggregation. */
   aggregationEnabled: boolean;
-  /** Server is a local directory (no bring-your-own credentials): traces
-   * open directly by key rather than via a scope, since buffer-style local
-   * key names carry no service/host/date to build a scope from (#627). */
+  /** Server uses flat source keys: traces open directly by key rather than via
+   * a scope, since buffer-style keys carry no service/host/date (#627). */
   localMode: boolean;
   /** Server declared a default prefix; Search waits for one. */
   serverHasPrefix: boolean;

--- a/dial9-viewer/ui/test_trace_scope.js
+++ b/dial9-viewer/ui/test_trace_scope.js
@@ -251,7 +251,7 @@ test("scopeFromKeys derives the window from key epochs when none is supplied", (
   const keys = [key("h1", 1782760100, 1), key("h1", 1782760300, 2)];
   const s = scope.scopeFromKeys("bkt", keys, null, null);
   assert.strictEqual(s.from, 1782760100, "min epoch");
-  assert.strictEqual(s.to, 1782760300, "max epoch");
+  assert.strictEqual(s.to, 1782760301, "exclusive bound after max epoch");
 });
 
 test("scopeFromKeys returns null when no window and no parseable epochs", () => {
@@ -298,6 +298,46 @@ asyncTests.push(testAsync("resolveScope lists the window, filters to the host se
   assert.strictEqual(urls.length, 1, "only the in-window h1 object survives");
   assert.ok(urls[0].startsWith("/api/object?"), "maps to /api/object");
   assert.ok(urls[0].includes(encodeURIComponent(key("h1", 1782760100, 1))), "carries the right key");
+}));
+
+asyncTests.push(testAsync("resolveScope uses half-open boundaries for adjacent segments", async () => {
+  const s = {
+    bucket: "bkt",
+    prefix: "traces",
+    service: "shale",
+    hosts: ["h1"],
+    from: 1782760100,
+    to: 1782760160,
+  };
+  const selected = key("h1", 1782760100, 1);
+  const adjacent = key("h1", 1782760160, 2);
+  const previous = key("h1", 1782760040, 0);
+  const browse = {
+    objects: [
+      {
+        key: previous,
+        size: 10,
+        last_modified: "2026-06-29T19:08:20Z",
+      },
+      {
+        key: selected,
+        size: 10,
+        last_modified: "2026-06-29T19:09:20Z",
+      },
+      {
+        key: adjacent,
+        size: 10,
+        last_modified: "2026-06-29T19:10:20Z",
+      },
+    ],
+  };
+
+  const urls = await scope.resolveScope(s, async () => browse);
+  assert.strictEqual(urls.length, 1, "segments touching either scope boundary must be excluded");
+  assert.strictEqual(
+    new URL(urls[0], "http://dial9.test").searchParams.get("key"),
+    selected,
+  );
 }));
 
 asyncTests.push(testAsync("resolveScope sends an encoded service and retains client-side service filtering", async () => {

--- a/dial9-viewer/ui/tests/browser_source_layout.test.ts
+++ b/dial9-viewer/ui/tests/browser_source_layout.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const indexHtml = readFileSync(
+  fileURLToPath(new URL("../index.html", import.meta.url)),
+  "utf8",
+);
+
+const match = indexHtml.match(
+  /    function usesFlatSourceLayout\(config\) \{([\s\S]*?)\n    \}/,
+);
+if (!match) throw new Error("canonical index.html must define usesFlatSourceLayout()");
+
+const usesFlatSourceLayout = new Function(
+  `function usesFlatSourceLayout(config) {${match[1]}\n    }
+   return usesFlatSourceLayout;`,
+)() as (config: {
+  source_layout?: string;
+  supports_byo_credentials?: boolean;
+}) => boolean;
+
+describe("legacy browser source layout", () => {
+  it("uses an explicit layout independently of credential support", () => {
+    expect(
+      usesFlatSourceLayout({
+        source_layout: "time-partitioned",
+        supports_byo_credentials: false,
+      }),
+    ).toBe(false);
+    expect(
+      usesFlatSourceLayout({
+        source_layout: "flat",
+        supports_byo_credentials: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("retains the old credential-based fallback", () => {
+    expect(usesFlatSourceLayout({ supports_byo_credentials: false })).toBe(true);
+    expect(usesFlatSourceLayout({ supports_byo_credentials: true })).toBe(false);
+  });
+});

--- a/dial9-viewer/ui/trace_scope.js
+++ b/dial9-viewer/ui/trace_scope.js
@@ -38,7 +38,7 @@
     service: "s_svc",
     host: "s_host", // repeatable
     from: "s_from", // epoch seconds (inclusive)
-    to: "s_to", // epoch seconds (inclusive)
+    to: "s_to", // epoch seconds (exclusive)
   };
 
   // Parse an S3 trace key into its {service, host, bootId, epoch, segIndex}.
@@ -146,7 +146,10 @@
     // /api/browse params (400) — a silently broken deep link.
     if ((t0 == null || t1 == null) && !epochs.length) return null;
     const from = t0 != null ? Math.floor(t0) : Math.min(...epochs);
-    const to = t1 != null ? Math.ceil(t1) : Math.max(...epochs);
+    // Explicit heatmap windows already carry the end of the final segment.
+    // Raw selections only carry segment start epochs, so extend the latest by
+    // one second to keep it inside the half-open [from, to) scope.
+    const to = t1 != null ? Math.ceil(t1) : Math.max(...epochs) + 1;
     return {
       bucket: bucket || "",
       region: region || "",
@@ -279,7 +282,7 @@
       const end = obj.last_modified
         ? new Date(obj.last_modified).getTime() / 1000
         : start;
-      if (start > scope.to || end < scope.from) continue;
+      if (start >= scope.to || end <= scope.from) continue;
       if (scope.service && p.service && p.service !== scope.service) continue;
       if (hostSet.size && !hostSet.has(p.host)) continue;
       matched.push({ key: obj.key, epoch: start });

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -830,9 +830,49 @@ dial9 serve --local-dir /tmp/my_traces
 
 # Serve traces from S3
 AWS_PROFILE=my-profile dial9 serve --bucket my-trace-bucket
+
+# Explore the complete browser and aggregation flow without S3
+dial9 serve --simulator --local
 ```
 
 Open `http://localhost:3000` to browse traces. Enter a search prefix (e.g. `2026-04-09/1910/checkout-api`), select one or more segments, and click "View Selected" to open them in the viewer.
+
+#### Simulator mode
+
+Simulator mode exposes lazily generated traces through the same S3-shaped keys
+and storage interface as a real trace bucket. Browser discovery, object
+downloads, spans, flamegraphs, and Tokio stats therefore use their production
+paths, while aggregate rollups stay in a process-local temporary directory.
+No bucket or AWS credentials are required.
+
+```bash
+# Sanitized synthetic traces with every feature group enabled
+dial9 serve --simulator --local
+
+# Replay the bundled demo trace in each virtual segment
+dial9 serve --simulator demo --local
+
+# Model a larger fleet with five-minute segments
+dial9 serve --simulator --simulator-hosts 12 --simulator-segment-secs 300 --local
+
+# Keep selected synthetic features and repeat the template for more data
+dial9 serve --simulator synthetic \
+  --simulator-features cpu,scheduling,tasks,spans \
+  --simulator-repetitions 3 \
+  --simulator-symbols realistic --local
+```
+
+The default fleet has 3 hosts and one-minute virtual segments across any
+requested time range. The catalog is deterministic and independent of server
+uptime; payload bytes are generated only when an object is fetched. Use
+`--simulator-hosts`, `--simulator-segment-secs`, and
+`--simulator-repetitions` to change its shape and data volume. Synthetic
+feature groups are `cpu`, `scheduling`, `tasks`, `spans`, `memory`,
+`resources`, and `custom-events`; omit `--simulator-features` to enable all of
+them, or pass `none` for clock and segment metadata only. Use
+`--simulator-symbols realistic` for deterministic Rust-like stack-frame names;
+anonymous placeholders remain the default. Demo replay preserves the bundled
+trace's event data while rebasing one copy into every virtual segment.
 
 ### `agents`
 


### PR DESCRIPTION
## Summary
- add an unbounded virtual trace catalog with deterministic keys and lazy segment rendering
- support configurable 15-second synthetic or demo-replay segments, feature groups, host counts, repetitions, and realistic symbols
- teach both viewer implementations about time-partitioned sources and half-open segment scopes
- add focused simulator, server, browser, and trace-scope coverage

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `npm run test` (1,887 Vitest tests; all legacy Node suites)
- `cargo nextest run --no-fail-fast` (1,292 passed)
- `cargo nextest run --stress-duration 20s` (1,292 passed)
- Playwright demo validation with one 15-second segment, realistic symbols, one object request, and no console/request errors