### PR TITLE
docs: point manual attach at dial9::block_on

### DIFF
--- a/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
@@ -12,6 +12,7 @@
 //! use std::time::Duration;
 //! use dial9_core::buffer::DiskBuffer;
 //! use dial9_core::recorder::recorder;
+//! use dial9_tokio_telemetry::block_on;
 //! use dial9_tokio_telemetry::telemetry::{spawn, RecorderTokioExt, TokioAttachOptions};
 //!
 //! # fn main() -> std::io::Result<()> {
@@ -27,7 +28,7 @@
 //!     |t| { t.worker_threads(2); },
 //! )?;
 //!
-//! main_rt.block_on(async { spawn(async { /* work */ }).await.unwrap() });
+//! block_on(&main_rt, async { spawn(async { /* work */ }).await.unwrap() });
 //!
 //! // graceful_shutdown is synchronous; drop the runtimes first so their workers
 //! // flush, then drain.
@@ -268,6 +269,10 @@ pub trait RecorderTokioExt {
     /// Drop the runtime before
     /// [`Recorder::graceful_shutdown`](dial9_core::recording::Recorder::graceful_shutdown)
     /// so its workers flush.
+    ///
+    /// Drive the root future with [`block_on`](crate::block_on), not
+    /// [`Runtime::block_on`](tokio::runtime::Runtime::block_on): to ensure polls and wakes
+    /// are captured.
     ///
     /// ```no_run
     /// use dial9_core::buffer::MemoryBuffer;

--- a/dial9-viewer/skills/dial9-toolkit/scripts/diagnose_setup.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/diagnose_setup.js
@@ -7,6 +7,7 @@
 //   2. Missing wake events (tasks not instrumented)
 //   3. Missing debug symbols (no source locations)
 //   4. No scheduling events (informational)
+//   5. Runtime activity but no task polls (Runtime::block_on instead of dial9::block_on)
 "use strict";
 
 const fs = require('fs');
@@ -28,12 +29,19 @@ async function diagnoseSetup(tracePath) {
   let callchainDepths = [];
   let totalSymbols = 0, symbolsWithLocation = 0;
   let totalWakeEvents = 0, totalTaskSpawns = 0;
+  let totalPollStarts = 0, totalUnparks = 0;
   let uniqueAddresses = new Set();
 
   for await (const trace of parseTrace(tracePath)) {
     // Wake events
     totalWakeEvents += trace.events.filter(e => e.eventType === EVENT_TYPES.WakeEvent).length;
     totalTaskSpawns += trace.taskSpawnTimes.size;
+
+    // Runtime activity vs task polls
+    for (const e of trace.events) {
+      if (e.eventType === EVENT_TYPES.PollStart) totalPollStarts++;
+      else if (e.eventType === EVENT_TYPES.WorkerUnpark) totalUnparks++;
+    }
 
     // CPU samples
     for (const s of trace.cpuSamples) {
@@ -139,12 +147,32 @@ use spawn_blocking instead of running on the async runtime.`,
     });
   }
 
+  // ── Check 5: Runtime woke up repeatedly but never polled a task ──
+  // An idle runtime parks and stays parked; repeated unparks mean it had work.
+  if (totalUnparks > 10 && totalPollStarts === 0) {
+    findings.push({
+      severity: 'warning',
+      check: 'no-task-polls',
+      message: `The runtime unparked ${totalUnparks} times but recorded 0 task polls. Its work is running outside any task.`,
+      fix: `Drive the runtime with dial9's block_on instead of Runtime::block_on:
+
+use dial9::block_on;
+
+block_on(&runtime, async { /* your work */ });
+
+Poll and wake events come from Tokio's per-task hooks. Runtime::block_on polls
+its future on the calling thread, outside any task, so that future and anything
+awaited inline under it never reach the trace. dial9::block_on spawns it first.
+#[dial9::main] already does this.`,
+    });
+  }
+
   // ── Report ──
   console.log(`\n${'='.repeat(60)}`);
   console.log('DIAL9 SETUP DIAGNOSTIC');
   console.log(`${'='.repeat(60)}`);
   console.log(`CPU samples: ${totalOnCpu} on-CPU, ${totalOffCpu} off-CPU`);
-  console.log(`Tasks spawned: ${totalTaskSpawns}, Wake events: ${totalWakeEvents}`);
+  console.log(`Tasks spawned: ${totalTaskSpawns}, Wake events: ${totalWakeEvents}, Task polls: ${totalPollStarts}`);
   console.log(`Symbols: ${totalSymbols} resolved (${symbolsWithLocation} with source locations)`);
   console.log();
 

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -213,6 +213,11 @@ dial9 is fundamentally a central buffer that can collect data from different sou
 recorder too, so calling it again attaches another runtime to the same trace. Its return type,
 `std::io::Result<dial9::AttachedRuntime>`, is what a `#[dial9::main]` config must produce.
 
+Driving that runtime yourself, reach for [`dial9::block_on`](https://docs.rs/dial9/latest/dial9/fn.block_on.html) rather than
+`Runtime::block_on`. Poll and wake events come from Tokio's per-task hooks, and `Runtime::block_on` would
+polls its future outside any task, so that future and everything awaited inline under it would be absent
+from the trace. `dial9::block_on` spawns it first. `#[dial9::main]` already does this for you.
+
 ```rust,no_run
 # #[cfg(feature = "worker-s3")]
 # mod inner {


### PR DESCRIPTION
Since we've decided against a type like AttachedRuntime/TracedRuntime, some non-macro users (mostly concerned about agents working from memory) might do the root block_on on the returned Tokio runtime rather than through `dial9::block_on`. This adds some pointers to that in docs.