### PR TITLE
fix(tokio): apply attach side effects after build

### DIFF
--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -52,7 +52,7 @@ const FRAME_BUF_INITIAL_CAPACITY: usize = 256;
 crate::primitives::thread_local! {
     /// This recorder's task-dump config for the current thread. Installed on
     /// every runtime-owned thread: worker thread-start, plus the block_on
-    /// thread in `register_runtime_context` (which thread-start doesn't fire for on a
+    /// thread in `attach_tokio_runtime` (which thread-start doesn't fire for on a
     /// current-thread runtime), and cleared on thread stop.
     /// `None` means task dumps aren't configured, so `TaskDumped` runs as a passthrough.
     static TASKDUMP_CONFIG: Cell<Option<TaskDumpConfig>> = const { Cell::new(None) };

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -229,21 +229,17 @@ fn register_hooks(
     });
 }
 
-/// Register dial9's telemetry hooks on `builder` and record the runtime's
-/// context. The caller builds the runtime; worker IDs are reserved lazily on
-/// the first poll (see `RuntimeContext::resolve_worker`), since caller-builds
-/// attach has no runtime to count at wire time.
-#[allow(clippy::too_many_arguments)]
-fn register_runtime_context(
+/// Register telemetry hooks and return a runtime context.
+/// Worker IDs are reserved lazily on the first poll.
+fn register_runtime_hooks(
     shared: &Arc<SharedState>,
-    contexts: &runtime_context::RuntimeContextRegistry,
     builder: &mut tokio::runtime::Builder,
     runtime_name: Option<String>,
     handle: &Dial9Handle,
     task_tracking_enabled: bool,
     tokio_hooks: TokioHooks,
     taskdump_config: Option<crate::telemetry::task_dump_config::TaskDumpConfig>,
-) {
+) -> Arc<RuntimeContext> {
     let ctx = Arc::new(RuntimeContext::new(runtime_name, handle.clone()));
     register_hooks(
         builder,
@@ -254,10 +250,7 @@ fn register_runtime_context(
         tokio_hooks,
         taskdump_config,
     );
-
-    // `TokioRuntimesSource` detects the new runtime and its workers from the
-    // registry on its next flush; no metadata announcement needed.
-    contexts.lock().unwrap().push(ctx);
+    ctx
 }
 
 #[cfg(all(test, not(shuttle)))]
@@ -289,6 +282,35 @@ mod tests {
         assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 1);
         drop(outer);
         assert_eq!(INSTRUMENTED_SPAWN.with(|c| c.get()), 0);
+    }
+
+    #[test]
+    fn runtime_hooks_do_not_publish_before_build() {
+        clear_tl_handle();
+        let rec = recorder(MemoryBuffer::new(CAPTURE_SIZE).unwrap()).build();
+        let shared = rec.shared().unwrap().clone();
+        let registry = recorder_tokio::runtime_registry(&shared).unwrap();
+        let mut builder = tokio::runtime::Builder::new_current_thread();
+
+        let ctx = register_runtime_hooks(
+            &shared,
+            &mut builder,
+            Some("aborted".to_string()),
+            rec.handle(),
+            false,
+            TokioHooks::default(),
+            None,
+        );
+        let weak = Arc::downgrade(&ctx);
+
+        assert!(registry.lock().unwrap().is_empty());
+        assert!(!Dial9Handle::current().is_enabled());
+
+        drop(builder);
+        drop(ctx);
+        assert!(weak.upgrade().is_none());
+
+        rec.graceful_shutdown(Duration::from_secs(1));
     }
 
     #[test]

--- a/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
@@ -48,7 +48,7 @@
 //! Lost shutdown telemetry is acceptable in this model; `#[dial9::main]` handles
 //! runtime-drop-before-shutdown ordering for you.
 
-use super::register_runtime_context;
+use super::register_runtime_hooks;
 use super::runtime_context::{RuntimeContextRegistry, TokioRuntimesSource};
 use crate::primitives::sync::{Arc, Mutex};
 use crate::telemetry::recorder::runtime_context::register_runtime_metrics;
@@ -342,74 +342,52 @@ impl Dial9HandleTokioExt for Dial9Handle {
         mut builder: tokio::runtime::Builder,
         options: TokioAttachOptions,
     ) -> io::Result<tokio::runtime::Runtime> {
-        if let Some(shared) = self.shared()
-            && shared.is_stopped()
-        {
+        let Some(shared) = self.shared() else {
+            return builder.build();
+        };
+        if shared.is_stopped() {
             return Err(io::Error::other(
                 "recorder has shut down; attach runtimes before graceful_shutdown",
             ));
         }
-        let instrumented = install_tokio_hooks(self, &mut builder, options)?;
+        if !options.tokio_instrumentation_enabled {
+            return builder.build();
+        }
+        let Some(registry) = runtime_registry(shared) else {
+            return Err(io::Error::other(
+                "dial9 source registry unavailable; Tokio runtime not attached",
+            ));
+        };
+
+        let task_dump_config = options.task_dump_config;
+        let ctx = register_runtime_hooks(
+            shared,
+            &mut builder,
+            options.runtime_name,
+            self,
+            options.task_tracking_enabled,
+            options.tokio_hooks,
+            task_dump_config,
+        );
+
         let runtime = builder.build()?;
 
-        if let Some(shared) = self.shared()
-            && instrumented
-        {
-            register_runtime_metrics(shared, runtime.handle().metrics());
+        // Publish attach state only after a successful build.
+        // `TokioRuntimesSource` picks the runtime up from the registry on its
+        // next flush.
+        registry.lock().unwrap().push(ctx);
+        // The current-thread driver does not fire `on_thread_start`, so without
+        // this the tracing layer and `dial9::spawn` find no handle until the
+        // first poll.
+        set_tl_handle(self.clone());
+        // Same for the task-dump config.
+        #[cfg(feature = "taskdump")]
+        if let Some(config) = task_dump_config {
+            crate::task_dumped::set_taskdump_config(config);
         }
+        register_runtime_metrics(shared, runtime.handle().metrics());
         Ok(runtime)
     }
-}
-
-/// Register dial9 hooks on a caller-owned Tokio builder and wire it into the
-/// recorder's shared runtime-context source. Worker IDs are reserved lazily on
-/// first poll.
-///
-/// Returns whether hooks were installed: a disabled recorder and
-/// `tokio_instrumentation_enabled(false)` both leave the builder untouched.
-/// Errors only when instrumentation was asked for and could not be wired up.
-///
-/// [`Dial9HandleTokioExt::attach_tokio_runtime`] is the public API that also
-/// builds the runtime.
-pub(crate) fn install_tokio_hooks(
-    handle: &Dial9Handle,
-    builder: &mut tokio::runtime::Builder,
-    options: TokioAttachOptions,
-) -> io::Result<bool> {
-    let Some(shared) = handle.shared() else {
-        return Ok(false);
-    };
-    if !options.tokio_instrumentation_enabled {
-        return Ok(false);
-    }
-    let Some(registry) = runtime_registry(shared) else {
-        return Err(io::Error::other(
-            "dial9 source registry unavailable; Tokio runtime not attached",
-        ));
-    };
-
-    let task_dump_config = options.task_dump_config;
-    register_runtime_context(
-        shared,
-        &registry,
-        builder,
-        options.runtime_name,
-        handle,
-        options.task_tracking_enabled,
-        options.tokio_hooks,
-        task_dump_config,
-    );
-    // Install the handle on this thread. For a current_thread runtime the
-    // caller builds and drives it on this same thread, which gets no
-    // on_thread_start, so the tracing layer and `dial9::spawn` would otherwise
-    // find no handle until the first task poll.
-    set_tl_handle(handle.clone());
-    // Same for the task-dump config: on_thread_start skips this thread.
-    #[cfg(feature = "taskdump")]
-    if let Some(config) = task_dump_config {
-        crate::task_dumped::set_taskdump_config(config);
-    }
-    Ok(true)
 }
 
 /// The recorder's runtime registry, installing the [`TokioRuntimesSource`] that


### PR DESCRIPTION
`attach_tokio_runtime` registered the runtime context and claimed the calling thread before `builder.build()`. Attach borrows a `Dial9Handle`, so the recorder outlives a failed build and keeps both: a context in the append-only registry
that no runtime backs, plus a thread-local handle.

For reference, 0.3 kept runtime publication and calling-thread state below `build()`, so an early return cleaned up on its own. This restores that ordering.

### Changes

`install_tokio_hooks` folded into `attach_tokio_runtime`. It only existed to
hook the builder while the caller built the runtime, and it had one call site.
Now with build in the same function the ordering is visible top to bottom:

```rust
let ctx = register_runtime_hooks(shared, &mut builder, ...);
let runtime = builder.build()?;
registry.lock().unwrap().push(ctx);
set_tl_handle(self.clone());
register_runtime_metrics(shared, runtime.handle().metrics());
```