### PR TITLE
fix(viewer): separate spawn delay labels

### DIFF
--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
@@ -324,7 +324,7 @@ function wakeBandModel() {
 }
 
 describe("drawTaskDetailCanvas render input", () => {
-  it("keeps the first scheduling-delay duration clear of the spawn label", () => {
+  it("keeps the first scheduling-delay duration above the band and clear of the spawn label", () => {
     const delayNs = 400_000;
     const model = buildTaskDetailRenderModel({
       data: {
@@ -371,9 +371,12 @@ describe("drawTaskDetailCanvas render input", () => {
     const delayLabel = texts.find(
       (t) => t.text === formatHumanDuration(delayNs),
     );
-    expect(spawnLabel?.y).toBeLessThan(BAND_TOP);
-    expect(delayLabel?.y).toBeGreaterThan(BAND_TOP);
-    expect(delayLabel?.y).toBeLessThan(BAND_TOP + 30);
+    if (spawnLabel === undefined || delayLabel === undefined) {
+      throw new Error("expected spawn and scheduling-delay labels");
+    }
+    expect(spawnLabel.y).toBeLessThan(BAND_TOP);
+    expect(delayLabel.y).toBeLessThan(BAND_TOP);
+    expect(delayLabel.y - spawnLabel.y).toBeGreaterThanOrEqual(10);
   });
 
   it("draws a high spawn-to-first-poll delay in scheduling red", () => {

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
@@ -12,7 +12,11 @@
 //      the window markers surface a truncated/oversized window.
 
 import { describe, it, expect } from "vitest";
-import { EVENT_TYPES, type ParsedTrace } from "../../lib/trace/index.js";
+import {
+  EVENT_TYPES,
+  formatHumanDuration,
+  type ParsedTrace,
+} from "../../lib/trace/index.js";
 import { createViewerStore } from "./store.js";
 import {
   createTaskDetailDerivation,
@@ -237,6 +241,8 @@ describe("task-dump click dispatch", () => {
 
 interface DrawnText {
   text: string;
+  x: number;
+  y: number;
   font: string;
   fillStyle: string;
 }
@@ -266,9 +272,15 @@ function recordingCtx(): {
       const self = this as CanvasRenderingContext2D;
       rects.push({ x, w, fillStyle: String(self.fillStyle) });
     },
-    fillText(text: string, _x: number, _y: number) {
+    fillText(text: string, x: number, y: number) {
       const self = this as CanvasRenderingContext2D;
-      texts.push({ text, font: self.font, fillStyle: String(self.fillStyle) });
+      texts.push({
+        text,
+        x,
+        y,
+        font: self.font,
+        fillStyle: String(self.fillStyle),
+      });
     },
     strokeRect() {},
     beginPath() {},
@@ -312,6 +324,58 @@ function wakeBandModel() {
 }
 
 describe("drawTaskDetailCanvas render input", () => {
+  it("keeps the first scheduling-delay duration clear of the spawn label", () => {
+    const delayNs = 400_000;
+    const model = buildTaskDetailRenderModel({
+      data: {
+        taskId: 42,
+        polls: [
+          {
+            start: 1_400_000,
+            end: 1_500_000,
+            taskId: 42,
+            spawnLocId: "L",
+            spawnLoc: null,
+          },
+        ],
+        wakes: [],
+        pollWakes: [null],
+        pollCount: 1,
+        wakeCount: 0,
+        spawnLocation: null,
+        isInstrumented: true,
+        spawnTs: 1_000_000,
+        terminateTs: null,
+        hasTerminate: false,
+        lifetimeNs: null,
+        taskDumps: [],
+        workerIdCount: 1,
+        hasPolls: true,
+      },
+      viewStart: 0,
+      viewEnd: 10_000_000,
+      drawW: 1000,
+    });
+    const { ctx, texts } = recordingCtx();
+
+    drawTaskDetailCanvas(
+      ctx,
+      model,
+      null,
+      1000,
+      160,
+      COMPLETE_TASK_DETAIL_WINDOW,
+    );
+
+    const spawnLabel = texts.find((t) => t.text === "spawn▸");
+    const delayLabel = texts.find(
+      (t) => t.text === formatHumanDuration(delayNs),
+    );
+    expect(spawnLabel?.y).toBeLessThan(BAND_TOP);
+    expect(delayLabel?.y).toBeGreaterThan(BAND_TOP);
+    expect(delayLabel?.y).toBeLessThan(BAND_TOP + 30);
+  });
+
   it("draws a high spawn-to-first-poll delay in scheduling red", () => {
     const model = buildTaskDetailRenderModel({
       data: {

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
@@ -457,7 +457,9 @@ export function drawTaskDetailCanvas(
       ctx.fillStyle =
         band.severity === "high" ? "#ff4444" : band.severity === "mid" ? "#ff8a65" : "#888";
       ctx.textAlign = "center";
-      ctx.fillText(formatHumanDuration(band.delayNs), band.x1 + w / 2, BAND_TOP - 6);
+      const labelY =
+        band.kind === "spawn" ? BAND_TOP + BAND_H / 2 + 3 : BAND_TOP - 6;
+      ctx.fillText(formatHumanDuration(band.delayNs), band.x1 + w / 2, labelY);
     }
 
     if (band.kind !== "wake") continue;

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
@@ -55,6 +55,7 @@ const LIFESPAN_BORDER = "rgba(129,199,132,0.3)";
 const LIFESPAN_EDGE = "#81c784";
 const LEGEND_LABEL = "#aaa";
 const CROSSHATCH = "rgba(140,120,255,0.35)";
+const LIFESPAN_LABEL_Y = BAND_TOP - 18;
 
 /**
  * The store-cached task-detail derivation. Keyed on ["trace", "selection"] so a
@@ -419,7 +420,7 @@ export function drawTaskDetailCanvas(
       ctx.fillStyle = LIFESPAN_EDGE;
       ctx.font = "8px monospace";
       ctx.textAlign = "left";
-      ctx.fillText("spawn▸", l.x1 + 2, BAND_TOP - 8);
+      ctx.fillText("spawn▸", l.x1 + 2, LIFESPAN_LABEL_Y);
     }
     if (l.showDone) {
       ctx.strokeStyle = LIFESPAN_EDGE;
@@ -430,7 +431,7 @@ export function drawTaskDetailCanvas(
       ctx.fillStyle = LIFESPAN_EDGE;
       ctx.font = "8px monospace";
       ctx.textAlign = "right";
-      ctx.fillText("◂done", l.x2 - 2, BAND_TOP - 8);
+      ctx.fillText("◂done", l.x2 - 2, LIFESPAN_LABEL_Y);
     }
     ctx.font = "9px monospace";
   }
@@ -457,9 +458,7 @@ export function drawTaskDetailCanvas(
       ctx.fillStyle =
         band.severity === "high" ? "#ff4444" : band.severity === "mid" ? "#ff8a65" : "#888";
       ctx.textAlign = "center";
-      const labelY =
-        band.kind === "spawn" ? BAND_TOP + BAND_H / 2 + 3 : BAND_TOP - 6;
-      ctx.fillText(formatHumanDuration(band.delayNs), band.x1 + w / 2, labelY);
+      ctx.fillText(formatHumanDuration(band.delayNs), band.x1 + w / 2, BAND_TOP - 6);
     }
 
     if (band.kind !== "wake") continue;


### PR DESCRIPTION
## Summary

- move task lifecycle edge labels (`spawn` / `done`) to a separate upper row so they cannot overlap interval durations
- keep scheduling-delay duration labels on the existing shared row above the timeline, leaving task and task-dump content unobstructed
- add a canvas-coordinate regression test for the label separation

## Testing

- `npm run test`
- `npm run check:types`
- `npm run build`
- `cargo build -p dial9-viewer`