### PR TITLE
feat!: remove optional timestamps from trace format API

### DIFF
--- a/dial9-core/src/buffer.rs
+++ b/dial9-core/src/buffer.rs
@@ -941,7 +941,7 @@ mod tests {
             else {
                 continue;
             };
-            let ts = timestamp_ns.unwrap_or(0);
+            let ts = timestamp_ns;
             let name = dec.registry().get(type_id).map(|s| s.name());
             match name {
                 Some("ClockSyncEvent") => {

--- a/dial9-core/src/encoder.rs
+++ b/dial9-core/src/encoder.rs
@@ -68,8 +68,8 @@ impl ThreadLocalEncoder<'_> {
 
     /// Write an event with a dynamically-registered schema.
     ///
-    /// The first element of `values` must be `FieldValue::Varint(timestamp_ns)`.
-    /// The remaining values must match the schema's field definitions in order.
+    /// `timestamp_ns` is the event's monotonic clock timestamp.
+    /// `values` must match the schema's field definitions in order (excluding the timestamp).
     /// The schema is auto-registered on first use per buffer flush cycle.
     ///
     /// # Example
@@ -77,13 +77,11 @@ impl ThreadLocalEncoder<'_> {
     /// ```ignore
     /// use dial9_trace_format::types::FieldValue;
     ///
-    /// enc.write_event(&schema, &[
-    ///     FieldValue::Varint(timestamp_ns),  // must be first
+    /// enc.write_event(&schema, timestamp_ns, &[
     ///     FieldValue::Varint(worker_id),
     ///     FieldValue::PooledString(enc.intern_string("hello")),
     /// ]);
     /// ```
-    // TODO(GH-XXX): replace with a version that takes timestamp as a separate parameter
     #[doc(hidden)]
     /// Errors on validation failure; the event is dropped and the calling
     /// thread is never panicked. The caller decides whether and how to
@@ -92,9 +90,10 @@ impl ThreadLocalEncoder<'_> {
     pub fn write_event(
         &mut self,
         schema: &dial9_trace_format::encoder::Schema,
+        timestamp_ns: u64,
         values: &[dial9_trace_format::types::FieldValue],
     ) -> std::io::Result<()> {
-        self.encoder.write_event(schema, values)?;
+        self.encoder.write_event(schema, timestamp_ns, values)?;
         *self.events_written += 1;
         Ok(())
     }

--- a/dial9-core/src/sealed.rs
+++ b/dial9-core/src/sealed.rs
@@ -178,11 +178,8 @@ fn parse_segment_timestamp(data: &[u8]) -> Result<u64, ParseTimestampError> {
                         _ => Err(ParseTimestampError::MissingRealtimeField),
                     };
                 }
-                if name == "SegmentMetadataEvent"
-                    && let Some(ts) = timestamp_ns
-                    && ts >= LEGACY_EPOCH_NS_FLOOR
-                {
-                    legacy_fallback = Some(ts);
+                if name == "SegmentMetadataEvent" && timestamp_ns >= LEGACY_EPOCH_NS_FLOOR {
+                    legacy_fallback = Some(timestamp_ns);
                 }
                 if events_seen >= 10 {
                     return legacy_fallback.ok_or(ParseTimestampError::NoAnchorInFirst10Events);

--- a/dial9-metrique/src/plan.rs
+++ b/dial9-metrique/src/plan.rs
@@ -393,7 +393,6 @@ pub(crate) fn build_plan(
     let schema_name = schema_name(&entry_name, inert, &fields, &annotations, used_names);
     let schema = Schema::from_entry(SchemaEntry::with_annotations(
         schema_name,
-        /* has_timestamp */ true,
         fields,
         annotations,
     ));

--- a/dial9-metrique/src/stream.rs
+++ b/dial9-metrique/src/stream.rs
@@ -265,7 +265,11 @@ impl EntryIoStream for Dial9Stream {
                 }
                 return;
             }
-            match enc.write_event(&plan.schema, values) {
+            let timestamp_ns = match values[0] {
+                FieldValue::Varint(ts) => ts,
+                _ => unreachable!("timestamp slot must be Varint"),
+            };
+            match enc.write_event(&plan.schema, timestamp_ns, &values[1..]) {
                 Ok(()) => emitted = true,
                 Err(e) => {
                     dropped = true;

--- a/dial9-metrique/tests/metrique_sink.rs
+++ b/dial9-metrique/tests/metrique_sink.rs
@@ -143,7 +143,7 @@ fn decode_metrique_events(dir: &std::path::Path) -> Vec<DecodedEvent> {
             }
             events.push(DecodedEvent {
                 schema_name: ev.name.to_owned(),
-                timestamp_ns: ev.timestamp_ns.expect("metrique event missing timestamp"),
+                timestamp_ns: ev.timestamp_ns,
                 fields,
                 field_names,
                 units,

--- a/dial9-trace-format-derive/src/lib.rs
+++ b/dial9-trace-format-derive/src/lib.rs
@@ -190,7 +190,6 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
             fn schema_entry() -> ::dial9_trace_format::schema::SchemaEntry {
                 ::dial9_trace_format::schema::SchemaEntry::with_annotations(
                     Self::event_name(),
-                    Self::has_timestamp(),
                     Self::field_defs(),
                     vec![#(#annotation_tokens),*],
                 )

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__kind_attribute.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__kind_attribute.snap
@@ -1,6 +1,6 @@
 ---
 source: dial9-trace-format-derive/src/lib.rs
-assertion_line: 365
+assertion_line: 364
 expression: "expand_to_string(quote!\n{\n    struct Metrics\n    {\n        #[traceevent(timestamp)] timestamp_ns: u64,\n        #[traceevent(unit = \"ns\", kind = \"counter\")] cpu_time_ns: u64,\n        #[traceevent(kind = \"gauge\")] queue_depth: u64,\n        #[traceevent(kind = \"updown-counter\")] active_requests: i64,\n    }\n})"
 ---
 impl ::dial9_trace_format::TraceEvent for Metrics {
@@ -20,7 +20,6 @@ impl ::dial9_trace_format::TraceEvent for Metrics {
     fn schema_entry() -> ::dial9_trace_format::schema::SchemaEntry {
         ::dial9_trace_format::schema::SchemaEntry::with_annotations(
             Self::event_name(),
-            Self::has_timestamp(),
             Self::field_defs(),
             vec![
                 ::dial9_trace_format::schema::FieldAnnotation::new(0u16, "unit", "ns"),

--- a/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__unit_attribute.snap
+++ b/dial9-trace-format-derive/src/snapshots/dial9_trace_format_derive__tests__unit_attribute.snap
@@ -1,5 +1,6 @@
 ---
 source: dial9-trace-format-derive/src/lib.rs
+assertion_line: 349
 expression: "expand_to_string(quote!\n{\n    struct ResourceUsage\n    {\n        #[traceevent(timestamp)] timestamp_ns: u64, #[traceevent(unit = \"ns\")]\n        user_cpu_ns: u64, minor_faults: u64, #[traceevent(unit = \"bytes\")]\n        max_rss_bytes: u64,\n    }\n})"
 ---
 impl ::dial9_trace_format::TraceEvent for ResourceUsage {
@@ -19,7 +20,6 @@ impl ::dial9_trace_format::TraceEvent for ResourceUsage {
     fn schema_entry() -> ::dial9_trace_format::schema::SchemaEntry {
         ::dial9_trace_format::schema::SchemaEntry::with_annotations(
             Self::event_name(),
-            Self::has_timestamp(),
             Self::field_defs(),
             vec![
                 ::dial9_trace_format::schema::FieldAnnotation::new(0u16, "unit", "ns"),

--- a/dial9-trace-format/src/codec.rs
+++ b/dial9-trace-format/src/codec.rs
@@ -68,11 +68,15 @@ pub(crate) enum Frame {
     Schema {
         type_id: WireTypeId,
         entry: SchemaEntry,
+        /// Whether the wire schema byte indicated a packed timestamp. Always
+        /// true for schemas produced by current encoders.
+        has_timestamp_on_wire: bool,
     },
     Event {
         type_id: WireTypeId,
-        /// Absolute timestamp in nanoseconds, if the schema has `has_timestamp`.
-        timestamp_ns: Option<u64>,
+        /// Absolute timestamp in nanoseconds. For legacy schemas without a
+        /// packed timestamp on the wire, this is the current timestamp base.
+        timestamp_ns: u64,
         values: Vec<FieldValue>,
     },
     StringPool(Vec<PoolEntry>),
@@ -127,10 +131,11 @@ pub(crate) enum FrameRef<'a> {
     Schema {
         type_id: WireTypeId,
         entry: SchemaEntry,
+        has_timestamp_on_wire: bool,
     },
     Event {
         type_id: WireTypeId,
-        timestamp_ns: Option<u64>,
+        timestamp_ns: u64,
         values: Vec<FieldValueRef<'a>>,
     },
     StringPool(Vec<PoolEntryRef<'a>>),
@@ -142,11 +147,15 @@ pub(crate) enum FrameRef<'a> {
     },
 }
 
-/// Schema info needed by the decoder: raw field type tags + has_timestamp flag.
+/// Schema info needed by the decoder: raw field type tags + whether the wire
+/// schema declared a packed timestamp (needed to know how many bytes to read).
 /// Raw tags preserve the optional bit (0x80) for correct decode handling.
 pub(crate) struct SchemaInfo<'a> {
     pub field_tags: &'a [u8],
-    pub has_timestamp: bool,
+    /// Whether the on-wire schema byte indicated a packed timestamp. This is
+    /// always true for schemas produced by current encoders but may be false
+    /// for hypothetical legacy traces.
+    pub has_timestamp_on_wire: bool,
 }
 
 // --- Encoding ---
@@ -166,7 +175,9 @@ pub(crate) fn encode_schema(
     let name_bytes = entry.name.as_bytes();
     w.write_all(&(name_bytes.len() as u16).to_le_bytes())?;
     w.write_all(name_bytes)?;
-    w.write_all(&[if entry.has_timestamp { 1 } else { 0 }])?;
+    // Always write has_timestamp=1. The byte is preserved on the wire for
+    // forward compatibility, but new encoders always produce timestamped events.
+    w.write_all(&[1u8])?;
     w.write_all(&(entry.fields.len() as u16).to_le_bytes())?;
     for f in &entry.fields {
         let fname = f.name.as_bytes();
@@ -286,7 +297,7 @@ fn decode_schema_frame(data: &[u8]) -> Option<(Frame, usize)> {
     pos += 2;
     let name = String::from_utf8(data.get(pos..pos + name_len)?.to_vec()).ok()?;
     pos += name_len;
-    let has_timestamp = *data.get(pos)? != 0;
+    let has_timestamp_on_wire = *data.get(pos)? != 0;
     pos += 1;
     let field_count = u16::from_le_bytes(data.get(pos..pos + 2)?.try_into().ok()?) as usize;
     pos += 2;
@@ -309,10 +320,10 @@ fn decode_schema_frame(data: &[u8]) -> Option<(Frame, usize)> {
             type_id,
             entry: SchemaEntry {
                 name,
-                has_timestamp,
                 fields,
                 annotations: Vec::new(),
             },
+            has_timestamp_on_wire,
         },
         pos,
     ))
@@ -328,12 +339,13 @@ fn decode_event_frame<'s>(
     pos += 2;
     let info = schema_lookup(type_id)?;
 
-    let timestamp_ns = if info.has_timestamp {
+    let timestamp_ns = if info.has_timestamp_on_wire {
         let delta = decode_u24_le(&data[pos..])?;
         pos += 3;
-        Some(timestamp_base_ns.checked_add(delta as u64)?)
+        timestamp_base_ns.checked_add(delta as u64)?
     } else {
-        None
+        // Legacy schema without packed timestamp: use the current base.
+        timestamp_base_ns
     };
 
     let mut values = Vec::with_capacity(info.field_tags.len());
@@ -450,9 +462,18 @@ pub(crate) fn decode_frame_ref<'a, 's>(
         TAG_SCHEMA => {
             let (frame, consumed) = decode_schema_frame(data)?;
             match frame {
-                Frame::Schema { type_id, entry } => {
-                    Some((FrameRef::Schema { type_id, entry }, consumed))
-                }
+                Frame::Schema {
+                    type_id,
+                    entry,
+                    has_timestamp_on_wire,
+                } => Some((
+                    FrameRef::Schema {
+                        type_id,
+                        entry,
+                        has_timestamp_on_wire,
+                    },
+                    consumed,
+                )),
                 _ => unreachable!(),
             }
         }
@@ -493,12 +514,13 @@ fn decode_event_frame_ref<'a, 's>(
     pos += 2;
     let info = schema_lookup(type_id)?;
 
-    let timestamp_ns = if info.has_timestamp {
+    let timestamp_ns = if info.has_timestamp_on_wire {
         let delta = decode_u24_le(&data[pos..])?;
         pos += 3;
-        Some(timestamp_base_ns.checked_add(delta as u64)?)
+        timestamp_base_ns.checked_add(delta as u64)?
     } else {
-        None
+        // Legacy schema without packed timestamp: use the current base.
+        timestamp_base_ns
     };
 
     let mut values = Vec::with_capacity(info.field_tags.len());
@@ -596,7 +618,6 @@ mod tests {
         let type_id = WireTypeId(1);
         let entry = SchemaEntry {
             name: "PollStart".into(),
-            has_timestamp: true,
             fields: vec![FieldDef {
                 name: "worker".into(),
                 field_type: FieldType::Varint,
@@ -608,7 +629,14 @@ mod tests {
         assert_eq!(buf[0], TAG_SCHEMA);
         let (frame, consumed) = decode_frame(&buf, |_| None, 0).unwrap();
         assert_eq!(consumed, buf.len());
-        assert_eq!(frame, Frame::Schema { type_id, entry });
+        assert_eq!(
+            frame,
+            Frame::Schema {
+                type_id,
+                entry,
+                has_timestamp_on_wire: true,
+            }
+        );
     }
 
     #[test]
@@ -616,14 +644,20 @@ mod tests {
         let type_id = WireTypeId(0);
         let entry = SchemaEntry {
             name: "Empty".into(),
-            has_timestamp: false,
             fields: vec![],
             annotations: Vec::new(),
         };
         let mut buf = Vec::new();
         encode_schema(type_id, &entry, &mut buf).unwrap();
         let (frame, _) = decode_frame(&buf, |_| None, 0).unwrap();
-        assert_eq!(frame, Frame::Schema { type_id, entry });
+        assert_eq!(
+            frame,
+            Frame::Schema {
+                type_id,
+                entry,
+                has_timestamp_on_wire: true,
+            }
+        );
     }
 
     // --- Event frame tests ---
@@ -648,7 +682,7 @@ mod tests {
             if id == WireTypeId(1) {
                 Some(SchemaInfo {
                     field_tags: &tags,
-                    has_timestamp: false,
+                    has_timestamp_on_wire: false,
                 })
             } else {
                 None
@@ -660,7 +694,8 @@ mod tests {
             frame,
             Frame::Event {
                 type_id: WireTypeId(1),
-                timestamp_ns: None,
+                // No packed timestamp on wire; uses the base (0).
+                timestamp_ns: 0,
                 values
             }
         );
@@ -677,7 +712,7 @@ mod tests {
             if id == WireTypeId(1) {
                 Some(SchemaInfo {
                     field_tags: &tags,
-                    has_timestamp: true,
+                    has_timestamp_on_wire: true,
                 })
             } else {
                 None
@@ -689,7 +724,7 @@ mod tests {
             frame,
             Frame::Event {
                 type_id: WireTypeId(1),
-                timestamp_ns: Some(5_000_000 + 1_000_000),
+                timestamp_ns: 5_000_000 + 1_000_000,
                 values,
             }
         );
@@ -718,7 +753,7 @@ mod tests {
             if id == WireTypeId(2) {
                 Some(SchemaInfo {
                     field_tags: &tags,
-                    has_timestamp: false,
+                    has_timestamp_on_wire: false,
                 })
             } else {
                 None
@@ -730,7 +765,7 @@ mod tests {
             frame,
             Frame::Event {
                 type_id: WireTypeId(2),
-                timestamp_ns: None,
+                timestamp_ns: 0,
                 values
             }
         );
@@ -780,7 +815,7 @@ mod tests {
             |_| {
                 Some(SchemaInfo {
                     field_tags: &tags,
-                    has_timestamp: false,
+                    has_timestamp_on_wire: false,
                 })
             },
             0,

--- a/dial9-trace-format/src/de.rs
+++ b/dial9-trace-format/src/de.rs
@@ -9,8 +9,7 @@
 //! The deserializer presents each event as a map with these entries (in order):
 //!
 //! 1. `"event"` → the schema name (the discriminant for `#[serde(tag = "event")]`).
-//! 2. `"timestamp_ns"` → the absolute frame-header timestamp (only if the
-//!    schema has `has_timestamp = true`).
+//! 2. `"timestamp_ns"` → the absolute frame-header timestamp.
 //! 3. One entry per schema field, keyed by field name.
 //!
 //! Pool resolution is automatic:
@@ -106,7 +105,7 @@ pub fn from_raw_event<'a, 'f, T: serde::de::DeserializeOwned>(
 ) -> Result<T, DeserError> {
     T::deserialize(RawEventDeserializer {
         name: raw.name,
-        timestamp_ns: raw.timestamp_ns,
+        timestamp_ns: Some(raw.timestamp_ns),
         fields: raw.fields,
         schema: raw.schema,
         string_pool: raw.string_pool,

--- a/dial9-trace-format/src/decoder.rs
+++ b/dial9-trace-format/src/decoder.rs
@@ -58,7 +58,7 @@ impl<E: fmt::Display + fmt::Debug> std::error::Error for TryForEachError<E> {}
 pub struct RawEvent<'a, 'f> {
     pub type_id: WireTypeId,
     pub name: &'f str,
-    pub timestamp_ns: Option<u64>,
+    pub timestamp_ns: u64,
     pub fields: &'f [FieldValueRef<'a>],
     pub schema: &'f SchemaEntry,
     pub string_pool: &'f StringPool,
@@ -77,8 +77,7 @@ impl<'a, 'f> RawEvent<'a, 'f> {
     ///
     /// 1. `"event"` → the schema name (the discriminant for
     ///    `#[serde(tag = "event")]`).
-    /// 2. `"timestamp_ns"` → the absolute frame-header timestamp (only if
-    ///    the schema has `has_timestamp = true`).
+    /// 2. `"timestamp_ns"` → the absolute frame-header timestamp.
     /// 3. One entry per schema field, keyed by field name.
     ///
     /// Pool-resolved values appear as their resolved form: `PooledString`
@@ -166,8 +165,8 @@ pub enum DecodedFrame {
     Schema(SchemaEntry),
     Event {
         type_id: WireTypeId,
-        /// Absolute timestamp in nanoseconds, if the schema has `has_timestamp`.
-        timestamp_ns: Option<u64>,
+        /// Absolute timestamp in nanoseconds.
+        timestamp_ns: u64,
         values: Vec<crate::types::FieldValue>,
     },
     StringPool(Vec<PoolEntry>),
@@ -184,7 +183,7 @@ pub enum DecodedFrameRef<'a> {
     Schema(SchemaEntry),
     Event {
         type_id: WireTypeId,
-        timestamp_ns: Option<u64>,
+        timestamp_ns: u64,
         values: Vec<FieldValueRef<'a>>,
     },
     StringPool(Vec<PoolEntryRef<'a>>),
@@ -199,6 +198,8 @@ struct SchemaCache {
     entry: SchemaEntry,
     /// Raw field type tags for fast decode (avoids re-extracting from entry.fields).
     field_tags: Vec<u8>,
+    /// Whether the on-wire schema byte indicated a packed timestamp.
+    has_timestamp_on_wire: bool,
 }
 
 /// Streaming trace file decoder.
@@ -308,11 +309,16 @@ impl<'a> Decoder<'a> {
             .and_then(|s| s.as_ref())
             .map(|c| SchemaInfo {
                 field_tags: &c.field_tags,
-                has_timestamp: c.entry.has_timestamp,
+                has_timestamp_on_wire: c.has_timestamp_on_wire,
             })
     }
 
-    fn register_schema(&mut self, type_id: WireTypeId, entry: SchemaEntry) -> Result<(), String> {
+    fn register_schema(
+        &mut self,
+        type_id: WireTypeId,
+        entry: SchemaEntry,
+        has_timestamp_on_wire: bool,
+    ) -> Result<(), String> {
         let idx = type_id.0 as usize;
         if idx >= self.schema_cache.len() {
             self.schema_cache.resize_with(idx + 1, || None);
@@ -320,6 +326,7 @@ impl<'a> Decoder<'a> {
         self.schema_cache[idx] = Some(SchemaCache {
             field_tags: entry.fields.iter().map(|f| f.field_type as u8).collect(),
             entry: entry.clone(),
+            has_timestamp_on_wire,
         });
         self.registry.register(type_id, entry)
     }
@@ -343,9 +350,13 @@ impl<'a> Decoder<'a> {
             };
         self.pos += consumed;
         match frame {
-            Frame::Schema { type_id, entry } => {
+            Frame::Schema {
+                type_id,
+                entry,
+                has_timestamp_on_wire,
+            } => {
                 let result = DecodedFrame::Schema(entry.clone());
-                self.register_schema(type_id, entry)
+                self.register_schema(type_id, entry, has_timestamp_on_wire)
                     .map_err(|msg| DecodeError {
                         pos: self.pos,
                         message: msg,
@@ -357,9 +368,7 @@ impl<'a> Decoder<'a> {
                 timestamp_ns,
                 values,
             } => {
-                if let Some(ts) = timestamp_ns {
-                    self.timestamp_base_ns = ts;
-                }
+                self.timestamp_base_ns = timestamp_ns;
                 Ok(Some(DecodedFrame::Event {
                     type_id,
                     timestamp_ns,
@@ -435,9 +444,13 @@ impl<'a> Decoder<'a> {
             };
         self.pos += consumed;
         match frame {
-            FrameRef::Schema { type_id, entry } => {
+            FrameRef::Schema {
+                type_id,
+                entry,
+                has_timestamp_on_wire,
+            } => {
                 let result = DecodedFrameRef::Schema(entry.clone());
-                self.register_schema(type_id, entry)
+                self.register_schema(type_id, entry, has_timestamp_on_wire)
                     .map_err(|msg| DecodeError {
                         pos: self.pos,
                         message: msg,
@@ -449,9 +462,7 @@ impl<'a> Decoder<'a> {
                 timestamp_ns,
                 values,
             } => {
-                if let Some(ts) = timestamp_ns {
-                    self.timestamp_base_ns = ts;
-                }
+                self.timestamp_base_ns = timestamp_ns;
                 Ok(Some(DecodedFrameRef::Event {
                     type_id,
                     timestamp_ns,
@@ -573,11 +584,11 @@ impl<'a> Decoder<'a> {
                         }
                     };
 
-                    let timestamp_ns = if cache.entry.has_timestamp {
+                    let timestamp_ns = if cache.has_timestamp_on_wire {
                         match codec::decode_u24_le(&remaining[pos..]) {
                             Some(delta) => {
                                 pos += 3;
-                                Some(self.timestamp_base_ns + delta as u64)
+                                self.timestamp_base_ns + delta as u64
                             }
                             None => {
                                 return Err(TryForEachError::Decode(DecodeError {
@@ -587,7 +598,8 @@ impl<'a> Decoder<'a> {
                             }
                         }
                     } else {
-                        None
+                        // Legacy schema without packed timestamp: use the current base.
+                        self.timestamp_base_ns
                     };
 
                     values_buf.clear();
@@ -657,9 +669,7 @@ impl<'a> Decoder<'a> {
                             ..
                         } = self;
                         *self_pos += pos;
-                        if let Some(ts) = timestamp_ns {
-                            *timestamp_base_ns = ts;
-                        }
+                        *timestamp_base_ns = timestamp_ns;
                     }
                     f(RawEvent {
                         type_id,
@@ -787,11 +797,8 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-        )
-        .unwrap();
+        enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+            .unwrap();
         let data = enc.finish();
 
         let mut dec = Decoder::new(&data).unwrap();
@@ -828,11 +835,8 @@ mod tests {
             )
             .unwrap();
         for i in 0..10u64 {
-            enc.write_event(
-                &schema,
-                &[FieldValue::Varint(i * 1000), FieldValue::Varint(i)],
-            )
-            .unwrap();
+            enc.write_event(&schema, i * 1000, &[FieldValue::Varint(i)])
+                .unwrap();
         }
         let data = enc.finish();
 
@@ -859,11 +863,8 @@ mod tests {
             )
             .unwrap();
         for i in 0..3u64 {
-            enc.write_event(
-                &schema,
-                &[FieldValue::Varint(i * 1000), FieldValue::Varint(i)],
-            )
-            .unwrap();
+            enc.write_event(&schema, i * 1000, &[FieldValue::Varint(i)])
+                .unwrap();
         }
         let data = enc.finish();
 
@@ -888,11 +889,8 @@ mod tests {
             )
             .unwrap();
         for i in 0..10u64 {
-            enc.write_event(
-                &schema,
-                &[FieldValue::Varint(i * 1000), FieldValue::Varint(i)],
-            )
-            .unwrap();
+            enc.write_event(&schema, i * 1000, &[FieldValue::Varint(i)])
+                .unwrap();
         }
         let data = enc.finish();
 
@@ -917,16 +915,10 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-        )
-        .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(2_000), FieldValue::Varint(99)],
-        )
-        .unwrap();
+        enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+            .unwrap();
+        enc.write_event(&schema, 2_000, &[FieldValue::Varint(99)])
+            .unwrap();
         let data = enc.finish();
 
         let mut dec = Decoder::new(&data).unwrap();
@@ -951,11 +943,8 @@ mod tests {
             )
             .unwrap();
         for i in 0..5u64 {
-            enc.write_event(
-                &schema,
-                &[FieldValue::Varint(i * 1000), FieldValue::Varint(i)],
-            )
-            .unwrap();
+            enc.write_event(&schema, i * 1000, &[FieldValue::Varint(i)])
+                .unwrap();
         }
         let data = enc.finish();
 

--- a/dial9-trace-format/src/encoder.rs
+++ b/dial9-trace-format/src/encoder.rs
@@ -118,7 +118,6 @@ impl Schema {
         Self {
             entry: Arc::new(SchemaEntry {
                 name: name.to_string(),
-                has_timestamp: true,
                 fields,
                 annotations: Vec::new(),
             }),
@@ -391,10 +390,6 @@ impl<W: Write> Encoder<W> {
     /// passed to [`write_event`](Self::write_event) (on this or any other
     /// encoder).
     ///
-    /// All schemas have timestamps. When writing events, the first element of
-    /// `values` must be `FieldValue::Varint(timestamp_ns)`. It is extracted and
-    /// encoded in the event header (not as a regular field).
-    ///
     /// Eagerly writes the schema frame. Idempotent if the definition matches.
     pub fn register_schema(
         &mut self,
@@ -416,9 +411,9 @@ impl<W: Write> Encoder<W> {
 
     /// Write an event for a schema.
     ///
-    /// The first element of `values` must be `FieldValue::Varint(timestamp_ns)`
-    /// — it is extracted and encoded in the event header, not as a regular
-    /// field. The remaining values must match the schema's field count.
+    /// `timestamp_ns` is the event's monotonic nanosecond timestamp, encoded
+    /// in the event frame header. `values` must match the schema's field count
+    /// exactly — the timestamp is not included in values.
     ///
     /// If this encoder hasn't seen `schema` before, it is auto-registered
     /// (the schema frame is written before the event).
@@ -431,42 +426,30 @@ impl<W: Write> Encoder<W> {
     pub fn write_event(
         &mut self,
         schema: &Schema,
+        timestamp_ns: u64,
         values: &[crate::types::FieldValue],
     ) -> io::Result<()> {
-        use crate::types::FieldValue;
-
         let type_id = self.ensure_registered(schema)?;
         let expected_fields = schema.entry.fields.len();
 
-        let ts_ns = match values.first() {
-            Some(FieldValue::Varint(ns)) => *ns,
-            _ => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "first value must be FieldValue::Varint(timestamp_ns)",
-                ));
-            }
-        };
-        let field_values = &values[1..];
-
-        if field_values.len() != expected_fields {
+        if values.len() != expected_fields {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!(
                     "value count ({}) does not match schema field count ({}) for schema '{}'",
-                    field_values.len(),
+                    values.len(),
                     expected_fields,
                     schema.name(),
                 ),
             ));
         }
 
-        let ts_delta = self.state.encode_timestamp_delta(ts_ns)?;
+        let ts_delta = self.state.encode_timestamp_delta(timestamp_ns)?;
         self.state.writer.write_all(&[codec::TAG_EVENT])?;
         self.state.writer.write_all(&type_id.0.to_le_bytes())?;
         codec::encode_u24_le(ts_delta, &mut self.state.writer)?;
         let mut enc = EventEncoder::new(&mut self.state);
-        for (i, v) in field_values.iter().enumerate() {
+        for (i, v) in values.iter().enumerate() {
             enc.write_field_value(v, schema.entry.fields[i].field_type)?;
         }
         Ok(())
@@ -693,11 +676,8 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-        )
-        .unwrap();
+        enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+            .unwrap();
         let data = enc.finish();
         assert!(data.len() > 5);
     }
@@ -750,11 +730,8 @@ mod tests {
 
         // Write to an encoder that hasn't seen this schema — auto-registers
         let mut enc = Encoder::new();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-        )
-        .unwrap();
+        enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+            .unwrap();
 
         let bytes = enc.finish();
         let mut dec = Decoder::new(&bytes).unwrap();
@@ -781,12 +758,12 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc1.write_event(&schema, &[FieldValue::Varint(1_000), FieldValue::Varint(1)])
+        enc1.write_event(&schema, 1_000, &[FieldValue::Varint(1)])
             .unwrap();
 
         // Pass the same Schema to a different encoder
         let mut enc2 = Encoder::new();
-        enc2.write_event(&schema, &[FieldValue::Varint(2_000), FieldValue::Varint(2)])
+        enc2.write_event(&schema, 2_000, &[FieldValue::Varint(2)])
             .unwrap();
 
         // Both encoders produce valid output
@@ -868,14 +845,8 @@ mod tests {
             .unwrap();
         let stack: &[u64] = &[0x1234, 0x5678, 0x9abc];
         let id = enc.intern_stack_frames(stack).unwrap();
-        enc.write_event(
-            &schema,
-            &[
-                FieldValue::Varint(1_000_000),
-                FieldValue::PooledStackFrames(id),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&schema, 1_000_000, &[FieldValue::PooledStackFrames(id)])
+            .unwrap();
         let bytes = enc.finish();
 
         let mut dec = Decoder::new(&bytes).unwrap();
@@ -983,13 +954,13 @@ mod tests {
         let ts2 = 50_000u64;
         let ts3 = 200_000_000u64;
         let ts4 = 100_000_000u64;
-        enc.write_event(&schema, &[FieldValue::Varint(ts1), FieldValue::Varint(1)])
+        enc.write_event(&schema, ts1, &[FieldValue::Varint(1)])
             .unwrap();
-        enc.write_event(&schema, &[FieldValue::Varint(ts2), FieldValue::Varint(2)])
+        enc.write_event(&schema, ts2, &[FieldValue::Varint(2)])
             .unwrap();
-        enc.write_event(&schema, &[FieldValue::Varint(ts3), FieldValue::Varint(3)])
+        enc.write_event(&schema, ts3, &[FieldValue::Varint(3)])
             .unwrap();
-        enc.write_event(&schema, &[FieldValue::Varint(ts4), FieldValue::Varint(4)])
+        enc.write_event(&schema, ts4, &[FieldValue::Varint(4)])
             .unwrap();
 
         let bytes = enc.finish();
@@ -1008,13 +979,13 @@ mod tests {
             .collect();
 
         assert_eq!(events.len(), 4);
-        assert_eq!(events[0].0, Some(ts1));
+        assert_eq!(events[0].0, ts1);
         assert_eq!(events[0].1, vec![FieldValue::Varint(1)]);
-        assert_eq!(events[1].0, Some(ts2));
+        assert_eq!(events[1].0, ts2);
         assert_eq!(events[1].1, vec![FieldValue::Varint(2)]);
-        assert_eq!(events[2].0, Some(ts3));
+        assert_eq!(events[2].0, ts3);
         assert_eq!(events[2].1, vec![FieldValue::Varint(3)]);
-        assert_eq!(events[3].0, Some(ts4));
+        assert_eq!(events[3].0, ts4);
         assert_eq!(events[3].1, vec![FieldValue::Varint(4)]);
     }
 
@@ -1042,7 +1013,7 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc.write_event(&schema, &[FieldValue::Varint(1_000), FieldValue::Varint(1)])
+        enc.write_event(&schema, 1_000, &[FieldValue::Varint(1)])
             .unwrap();
         let base = enc.finish();
 
@@ -1052,7 +1023,7 @@ mod tests {
         let mut output = Vec::new();
         let mut ext = decoder.into_encoder(&mut output);
         // Schema "Ev" is already known — no duplicate schema frame emitted
-        ext.write_event(&schema, &[FieldValue::Varint(2_000), FieldValue::Varint(2)])
+        ext.write_event(&schema, 2_000, &[FieldValue::Varint(2)])
             .unwrap();
         drop(ext);
 
@@ -1073,8 +1044,8 @@ mod tests {
             })
             .collect();
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].0, Some(1_000));
-        assert_eq!(events[1].0, Some(2_000));
+        assert_eq!(events[0].0, 1_000);
+        assert_eq!(events[1].0, 2_000);
     }
 
     #[test]
@@ -1151,11 +1122,8 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc.write_event(
-            &dynamic,
-            &[FieldValue::Varint(2_000), FieldValue::Varint(1)],
-        )
-        .unwrap();
+        enc.write_event(&dynamic, 2_000, &[FieldValue::Varint(1)])
+            .unwrap();
         let bytes = enc.finish();
 
         let mut dec = Decoder::new(&bytes).unwrap();
@@ -1198,11 +1166,8 @@ mod tests {
 
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(1_000_000),
-                FieldValue::Varint(42),
-                FieldValue::String("hello".into()),
-            ],
+            1_000_000,
+            &[FieldValue::Varint(42), FieldValue::String("hello".into())],
         )
         .unwrap();
 
@@ -1221,7 +1186,7 @@ mod tests {
             })
             .collect();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].0, Some(1_000_000));
+        assert_eq!(events[0].0, 1_000_000);
         assert_eq!(events[0].1[0], FieldValue::Varint(42));
         assert_eq!(events[0].1[1], FieldValue::String("hello".into()));
     }
@@ -1260,14 +1225,7 @@ mod tests {
             )
             .unwrap();
         // Pass 3 values (ts + 2 fields) for a 1-field schema
-        let result = enc.write_event(
-            &schema,
-            &[
-                FieldValue::Varint(0),
-                FieldValue::Varint(1),
-                FieldValue::Varint(2),
-            ],
-        );
+        let result = enc.write_event(&schema, 0, &[FieldValue::Varint(1), FieldValue::Varint(2)]);
         assert!(result.is_err());
     }
 
@@ -1290,9 +1248,9 @@ mod tests {
 
         let ts1 = 12_000_000u64;
         let ts2 = 24_000_000u64;
-        enc.write_event(&schema, &[FieldValue::Varint(ts1), FieldValue::Varint(1)])
+        enc.write_event(&schema, ts1, &[FieldValue::Varint(1)])
             .unwrap();
-        enc.write_event(&schema, &[FieldValue::Varint(ts2), FieldValue::Varint(2)])
+        enc.write_event(&schema, ts2, &[FieldValue::Varint(2)])
             .unwrap();
 
         let bytes = enc.finish();
@@ -1308,7 +1266,7 @@ mod tests {
             .decode_all()
             .into_iter()
             .filter_map(|f| match f {
-                DecodedFrame::Event { timestamp_ns, .. } => timestamp_ns,
+                DecodedFrame::Event { timestamp_ns, .. } => Some(timestamp_ns),
                 _ => None,
             })
             .collect();
@@ -1344,11 +1302,8 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-        )
-        .unwrap();
+        enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+            .unwrap();
         let _s = enc.intern_string("hello").unwrap();
 
         let old_bytes_written = enc.bytes_written();
@@ -1382,11 +1337,8 @@ mod tests {
 
         // Invariant 3: schemas are cleared — same schema must re-register
         // (write_event auto-registers, so we verify a new schema frame appears)
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(2_000), FieldValue::Varint(99)],
-        )
-        .unwrap();
+        enc.write_event(&schema, 2_000, &[FieldValue::Varint(99)])
+            .unwrap();
 
         // Invariant 4: string pool is cleared — re-interning emits a new pool frame
         let _s2 = enc.intern_string("hello").unwrap();
@@ -1421,7 +1373,7 @@ mod tests {
                 _ => None,
             })
             .expect("new trace must contain event");
-        assert_eq!(*event.0, Some(2_000));
+        assert_eq!(*event.0, 2_000);
         assert_eq!(event.1[0], FieldValue::Varint(99));
     }
 
@@ -1437,11 +1389,8 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-        )
-        .unwrap();
+        enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+            .unwrap();
 
         let bytes_before = enc.bytes_written();
         assert!(bytes_before > 0);
@@ -1486,14 +1435,14 @@ mod tests {
                 }],
             )
             .unwrap();
-        enc.write_event(&schema, &[FieldValue::Varint(1_000), FieldValue::Varint(1)])
+        enc.write_event(&schema, 1_000, &[FieldValue::Varint(1)])
             .unwrap();
 
         // Build a raw batch with the same schema
         let raw_batch = {
             let mut batch_enc = Encoder::new();
             batch_enc
-                .write_event(&schema, &[FieldValue::Varint(2_000), FieldValue::Varint(2)])
+                .write_event(&schema, 2_000, &[FieldValue::Varint(2)])
                 .unwrap();
             batch_enc.finish()
         };
@@ -1517,9 +1466,9 @@ mod tests {
             .collect();
 
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].0, Some(1_000));
+        assert_eq!(events[0].0, 1_000);
         assert_eq!(events[0].1, vec![FieldValue::Varint(1)]);
-        assert_eq!(events[1].0, Some(2_000));
+        assert_eq!(events[1].0, 2_000);
         assert_eq!(events[1].1, vec![FieldValue::Varint(2)]);
     }
 }
@@ -1533,7 +1482,6 @@ mod dynamic_schema_cache_tests {
     fn schema(name: &str) -> Schema {
         Schema::from_entry(SchemaEntry::new(
             name,
-            /* has_timestamp */ true,
             vec![FieldDef::new("v", FieldType::Varint)],
         ))
     }
@@ -1580,11 +1528,8 @@ mod dynamic_schema_cache_tests {
         for i in 0..(DYNAMIC_SCHEMA_CACHE_LIMIT + 3) {
             let s = schema("Ev");
             // Timestamp plus the one schema field.
-            enc.write_event(
-                &s,
-                &[FieldValue::Varint(i as u64), FieldValue::Varint(i as u64)],
-            )
-            .unwrap();
+            enc.write_event(&s, i as u64, &[FieldValue::Varint(i as u64)])
+                .unwrap();
         }
         let data = enc.finish();
         let mut decoder = crate::decoder::Decoder::new(&data).unwrap();

--- a/dial9-trace-format/src/lib.rs
+++ b/dial9-trace-format/src/lib.rs
@@ -61,13 +61,9 @@ pub trait TraceEvent {
     /// The event type name (used in schema registration).
     fn event_name() -> &'static str;
     /// Field definitions for schema registration.
-    /// When `has_timestamp()` is true, the timestamp is NOT included here —
-    /// it is encoded in the event frame header.
+    /// The timestamp is NOT included here — it is encoded in the event frame
+    /// header.
     fn field_defs() -> Vec<FieldDef>;
-    /// Whether this event type carries a packed timestamp in the event header.
-    fn has_timestamp() -> bool {
-        true
-    }
     /// Return the event's timestamp in nanoseconds.
     fn timestamp(&self) -> u64;
     /// Encode this event's non-timestamp fields into the encoder.
@@ -80,7 +76,6 @@ pub trait TraceEvent {
     fn schema_entry() -> SchemaEntry {
         SchemaEntry {
             name: Self::event_name().to_string(),
-            has_timestamp: Self::has_timestamp(),
             fields: Self::field_defs(),
             annotations: Vec::new(),
         }

--- a/dial9-trace-format/src/schema.rs
+++ b/dial9-trace-format/src/schema.rs
@@ -89,21 +89,15 @@ impl FieldDef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaEntry {
     pub(crate) name: String,
-    pub(crate) has_timestamp: bool,
     pub(crate) fields: Vec<FieldDef>,
     pub(crate) annotations: Vec<FieldAnnotation>,
 }
 
 impl SchemaEntry {
     /// Construct a new schema entry.
-    pub fn new(
-        name: impl Into<String>,
-        has_timestamp: bool,
-        fields: impl IntoIterator<Item = FieldDef>,
-    ) -> Self {
+    pub fn new(name: impl Into<String>, fields: impl IntoIterator<Item = FieldDef>) -> Self {
         Self {
             name: name.into(),
-            has_timestamp,
             fields: fields.into_iter().collect(),
             annotations: Vec::new(),
         }
@@ -112,13 +106,11 @@ impl SchemaEntry {
     /// Construct a schema entry with annotations.
     pub fn with_annotations(
         name: impl Into<String>,
-        has_timestamp: bool,
         fields: impl IntoIterator<Item = FieldDef>,
         annotations: impl IntoIterator<Item = FieldAnnotation>,
     ) -> Self {
         Self {
             name: name.into(),
-            has_timestamp,
             fields: fields.into_iter().collect(),
             annotations: annotations.into_iter().collect(),
         }
@@ -127,11 +119,6 @@ impl SchemaEntry {
     /// Event type name (e.g. `"PollStart"`).
     pub fn name(&self) -> &str {
         &self.name
-    }
-
-    /// Whether events of this type carry a packed timestamp in the event header.
-    pub fn has_timestamp(&self) -> bool {
-        self.has_timestamp
     }
 
     /// Ordered list of fields (excluding the timestamp).
@@ -227,7 +214,6 @@ mod tests {
         let id = reg.next_type_id();
         let entry = SchemaEntry {
             name: "PollStart".into(),
-            has_timestamp: true,
             fields: vec![
                 FieldDef {
                     name: "timestamp_ns".into(),
@@ -251,7 +237,6 @@ mod tests {
         let id = reg.next_type_id();
         let entry = SchemaEntry {
             name: "A".into(),
-            has_timestamp: true,
             fields: vec![],
             annotations: Vec::new(),
         };
@@ -267,7 +252,6 @@ mod tests {
             id,
             SchemaEntry {
                 name: "A".into(),
-                has_timestamp: true,
                 fields: vec![],
                 annotations: Vec::new(),
             },
@@ -278,7 +262,6 @@ mod tests {
                 id,
                 SchemaEntry {
                     name: "B".into(),
-                    has_timestamp: true,
                     fields: vec![],
                     annotations: Vec::new(),
                 }
@@ -295,7 +278,6 @@ mod tests {
             id1,
             SchemaEntry {
                 name: "A".into(),
-                has_timestamp: true,
                 fields: vec![],
                 annotations: Vec::new(),
             },
@@ -306,7 +288,6 @@ mod tests {
             id2,
             SchemaEntry {
                 name: "B".into(),
-                has_timestamp: true,
                 fields: vec![],
                 annotations: Vec::new(),
             },

--- a/dial9-trace-format/tests/annotations.rs
+++ b/dial9-trace-format/tests/annotations.rs
@@ -9,7 +9,6 @@ fn annotations_round_trip() {
     let mut enc = Encoder::new();
     let entry = SchemaEntry::with_annotations(
         "Latency",
-        true,
         vec![
             FieldDef::new("duration_us", FieldType::Varint),
             FieldDef::new("endpoint", FieldType::PooledString),
@@ -26,8 +25,8 @@ fn annotations_round_trip() {
     let endpoint_id = enc.intern_string("/api/health").unwrap();
     enc.write_event(
         &schema,
+        1_000_000,
         &[
-            FieldValue::Varint(1_000_000),
             FieldValue::Varint(42),
             FieldValue::PooledString(endpoint_id),
         ],
@@ -107,13 +106,11 @@ fn multiple_schemas_with_mixed_annotations() {
 
     let annotated = SchemaEntry::with_annotations(
         "Annotated",
-        true,
         vec![FieldDef::new("val", FieldType::Varint)],
         vec![FieldAnnotation::new(0, "unit", "ms")],
     );
     let plain = SchemaEntry::with_annotations(
         "Plain",
-        true,
         vec![FieldDef::new("val", FieldType::Varint)],
         Vec::new(),
     );
@@ -156,7 +153,6 @@ fn annotations_silent_truncation() {
     let mut enc = Encoder::new();
     let entry = SchemaEntry::with_annotations(
         "Ev",
-        true,
         vec![FieldDef::new("x", FieldType::Varint)],
         vec![FieldAnnotation::new(0, "key", "value")],
     );
@@ -191,11 +187,8 @@ fn annotations_unknown_type_id_skipped() {
         .register_schema("Real", vec![FieldDef::new("x", FieldType::Varint)])
         .unwrap();
 
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1_000_000), FieldValue::Varint(42)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1_000_000, &[FieldValue::Varint(42)])
+        .unwrap();
 
     let mut data = enc.finish();
 
@@ -237,17 +230,13 @@ fn annotations_round_trip_ref() {
     let mut enc = Encoder::new();
     let entry = SchemaEntry::with_annotations(
         "Ev",
-        true,
         vec![FieldDef::new("x", FieldType::Varint)],
         vec![FieldAnnotation::new(0, "key", "val")],
     );
     let schema = Schema::from_entry(entry);
     enc.register_existing(&schema).unwrap();
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1_000_000), FieldValue::Varint(7)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1_000_000, &[FieldValue::Varint(7)])
+        .unwrap();
 
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
@@ -270,17 +259,13 @@ fn annotations_for_each_event_works() {
     let mut enc = Encoder::new();
     let entry = SchemaEntry::with_annotations(
         "Metric",
-        true,
         vec![FieldDef::new("val", FieldType::Varint)],
         vec![FieldAnnotation::new(0, "unit", "bytes")],
     );
     let schema = Schema::from_entry(entry);
     enc.register_existing(&schema).unwrap();
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1_000_000), FieldValue::Varint(1024)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1_000_000, &[FieldValue::Varint(1024)])
+        .unwrap();
 
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();

--- a/dial9-trace-format/tests/container_round_trip.rs
+++ b/dial9-trace-format/tests/container_round_trip.rs
@@ -20,11 +20,8 @@ fn dynamic_list_round_trip() {
         FieldValue::String("world".into()),
         FieldValue::Varint(42),
     ];
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1000), FieldValue::List(items.clone())],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1000, &[FieldValue::List(items.clone())])
+        .unwrap();
 
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
@@ -58,11 +55,8 @@ fn dynamic_map_round_trip() {
             FieldValue::String("test".into()),
         ),
     ];
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(2000), FieldValue::Map(pairs.clone())],
-    )
-    .unwrap();
+    enc.write_event(&schema, 2000, &[FieldValue::Map(pairs.clone())])
+        .unwrap();
 
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
@@ -91,14 +85,10 @@ fn optional_dynamic_list_round_trip() {
 
     // Present
     let items = vec![FieldValue::Varint(1), FieldValue::Varint(2)];
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(3000), FieldValue::List(items.clone())],
-    )
-    .unwrap();
-    // Absent
-    enc.write_event(&schema, &[FieldValue::Varint(3001), FieldValue::None])
+    enc.write_event(&schema, 3000, &[FieldValue::List(items.clone())])
         .unwrap();
+    // Absent
+    enc.write_event(&schema, 3001, &[FieldValue::None]).unwrap();
 
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
@@ -133,11 +123,8 @@ fn heterogeneous_list_round_trip() {
         FieldValue::F64(1.5),
         FieldValue::I64(-1),
     ];
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(4000), FieldValue::List(items.clone())],
-    )
-    .unwrap();
+    enc.write_event(&schema, 4000, &[FieldValue::List(items.clone())])
+        .unwrap();
 
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
@@ -166,11 +153,8 @@ fn nested_list_in_map_round_trip() {
 
     let inner_list = FieldValue::List(vec![FieldValue::Varint(1), FieldValue::Varint(2)]);
     let pairs = vec![(FieldValue::String("nums".into()), inner_list.clone())];
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(5000), FieldValue::Map(pairs.clone())],
-    )
-    .unwrap();
+    enc.write_event(&schema, 5000, &[FieldValue::Map(pairs.clone())])
+        .unwrap();
 
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
@@ -202,11 +186,8 @@ fn empty_list_and_map_round_trip() {
 
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(6000),
-            FieldValue::List(vec![]),
-            FieldValue::Map(vec![]),
-        ],
+        6000,
+        &[FieldValue::List(vec![]), FieldValue::Map(vec![])],
     )
     .unwrap();
 

--- a/dial9-trace-format/tests/js_parser.rs
+++ b/dial9-trace-format/tests/js_parser.rs
@@ -46,8 +46,9 @@ fn js_decodes_all_field_types() {
     let pool_id = enc.intern_string("hello").unwrap();
     enc.write_event(
         &tid,
+        1_000_000,
         &[
-            FieldValue::Varint(1_000_000), // timestamp
+            // timestamp
             FieldValue::Varint(42),
             FieldValue::I64(-7),
             FieldValue::F64(std::f64::consts::PI),
@@ -82,8 +83,9 @@ fn js_decodes_all_field_types() {
             .unwrap();
         ext.write_event(
             &sym_schema,
+            0,
             &[
-                FieldValue::Varint(0), // timestamp
+                // timestamp
                 FieldValue::Varint(0x1000),
                 FieldValue::Varint(256),
                 FieldValue::PooledString(pool_id),
@@ -139,11 +141,8 @@ fn js_decodes_truncated_trace_gracefully() {
         .unwrap();
     // Write two events so the first one is fully decodable.
     for i in 0..2u64 {
-        enc.write_event(
-            &tid,
-            &[FieldValue::Varint(i * 1_000_000), FieldValue::Varint(i)],
-        )
-        .unwrap();
+        enc.write_event(&tid, i * 1_000_000, &[FieldValue::Varint(i)])
+            .unwrap();
     }
     let full = enc.finish();
 
@@ -173,14 +172,8 @@ fn js_decodes_multiple_events() {
         .register_schema("Tick", vec![FieldDef::new("ts", FieldType::Varint)])
         .unwrap();
     for i in 0..5u64 {
-        enc.write_event(
-            &tid,
-            &[
-                FieldValue::Varint(i * 1_000_000),
-                FieldValue::Varint(i * 1000),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&tid, i * 1_000_000, &[FieldValue::Varint(i * 1000)])
+            .unwrap();
     }
     let data = enc.finish();
     let json = js_decode(&data);
@@ -209,24 +202,14 @@ fn js_decodes_optional_pooled_string() {
     let name_id = enc.intern_string("hello").unwrap();
     enc.write_event(
         &tid,
-        &[
-            FieldValue::Varint(1_000_000),
-            FieldValue::Varint(42),
-            FieldValue::PooledString(name_id),
-        ],
+        1_000_000,
+        &[FieldValue::Varint(42), FieldValue::PooledString(name_id)],
     )
     .unwrap();
 
     // Event with None
-    enc.write_event(
-        &tid,
-        &[
-            FieldValue::Varint(2_000_000),
-            FieldValue::Varint(99),
-            FieldValue::None,
-        ],
-    )
-    .unwrap();
+    enc.write_event(&tid, 2_000_000, &[FieldValue::Varint(99), FieldValue::None])
+        .unwrap();
 
     let data = enc.finish();
     let json = js_decode(&data);
@@ -262,8 +245,8 @@ fn js_decodes_pooled_stack_frames() {
 
     enc.write_event(
         &tid,
+        1_000_000,
         &[
-            FieldValue::Varint(1_000_000),
             FieldValue::Varint(1),
             FieldValue::PooledStackFrames(stack_a),
         ],
@@ -271,8 +254,8 @@ fn js_decodes_pooled_stack_frames() {
     .unwrap();
     enc.write_event(
         &tid,
+        2_000_000,
         &[
-            FieldValue::Varint(2_000_000),
             FieldValue::Varint(2),
             FieldValue::PooledStackFrames(stack_b),
         ],
@@ -280,8 +263,8 @@ fn js_decodes_pooled_stack_frames() {
     .unwrap();
     enc.write_event(
         &tid,
+        3_000_000,
         &[
-            FieldValue::Varint(3_000_000),
             FieldValue::Varint(3),
             FieldValue::PooledStackFrames(stack_a),
         ],
@@ -337,15 +320,9 @@ fn js_decodes_optional_pooled_stack_frames() {
         .unwrap();
 
     let stack = enc.intern_stack_frames(&[0xAAAA, 0xBBBB]).unwrap();
-    enc.write_event(
-        &tid,
-        &[
-            FieldValue::Varint(1_000_000),
-            FieldValue::PooledStackFrames(stack),
-        ],
-    )
-    .unwrap();
-    enc.write_event(&tid, &[FieldValue::Varint(2_000_000), FieldValue::None])
+    enc.write_event(&tid, 1_000_000, &[FieldValue::PooledStackFrames(stack)])
+        .unwrap();
+    enc.write_event(&tid, 2_000_000, &[FieldValue::None])
         .unwrap();
 
     let data = enc.finish();
@@ -386,8 +363,7 @@ fn js_decodes_dynamic_list_and_map() {
         FieldValue::String("key".into()),
         FieldValue::Varint(99),
     )]);
-    enc.write_event(&tid, &[FieldValue::Varint(1000), list, map])
-        .unwrap();
+    enc.write_event(&tid, 1000, &[list, map]).unwrap();
 
     let data = enc.finish();
     let json = js_decode(&data);

--- a/dial9-trace-format/tests/round_trip.rs
+++ b/dial9-trace-format/tests/round_trip.rs
@@ -30,19 +30,16 @@ fn full_round_trip() {
 
     enc.write_event(
         &poll_id,
-        &[
-            FieldValue::Varint(1_000_000),
-            FieldValue::Varint(0),
-            FieldValue::Varint(42),
-        ],
+        1_000_000,
+        &[FieldValue::Varint(0), FieldValue::Varint(42)],
     )
     .unwrap();
 
     let frames = vec![0x5555_5555_1234u64, 0x5555_5555_0a00, 0x5555_5555_0800];
     enc.write_event(
         &cpu_id,
+        1_000_100,
         &[
-            FieldValue::Varint(1_000_100),
             FieldValue::PooledString(thread_id),
             FieldValue::StackFrames(frames.clone().into()),
         ],
@@ -64,8 +61,8 @@ fn full_round_trip() {
         .unwrap();
     enc.write_event(
         &sym_schema,
+        0,
         &[
-            FieldValue::Varint(0), // timestamp
             FieldValue::Varint(0x5555_5555_0000),
             FieldValue::Varint(0x2000),
             FieldValue::PooledString(sym_name_id),
@@ -137,7 +134,6 @@ fn round_trip_all_field_types() {
 
     let pool_id = enc.intern_string("test").unwrap();
     let values = vec![
-        FieldValue::Varint(1_000_000), // timestamp
         FieldValue::Varint(u64::MAX),
         FieldValue::I64(i64::MIN),
         FieldValue::F64(std::f64::consts::E),
@@ -147,7 +143,7 @@ fn round_trip_all_field_types() {
         FieldValue::PooledString(pool_id),
         FieldValue::StackFrames(vec![0xAAAA, 0xBBBB, 0xCCCC].into()),
     ];
-    enc.write_event(&tid, &values).unwrap();
+    enc.write_event(&tid, 1_000_000, &values).unwrap();
     let data = enc.finish();
 
     let mut dec = Decoder::new(&data).unwrap();
@@ -162,6 +158,6 @@ fn round_trip_all_field_types() {
     } = event
     {
         // Decoded values don't include the timestamp (it's in the header)
-        assert_eq!(decoded_values, &values[1..]);
+        assert_eq!(decoded_values, &values);
     }
 }

--- a/dial9-trace-format/tests/serde_deserialize.rs
+++ b/dial9-trace-format/tests/serde_deserialize.rs
@@ -71,11 +71,8 @@ fn varint_round_trip() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(1_000_000_000),
-            FieldValue::Varint(7),
-            FieldValue::Varint(42),
-        ],
+        1_000_000_000,
+        &[FieldValue::Varint(7), FieldValue::Varint(42)],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -109,14 +106,8 @@ fn pooled_string_resolves_to_string() {
             vec![FieldDef::new("label", FieldType::PooledString)],
         )
         .unwrap();
-    enc.write_event(
-        &schema,
-        &[
-            FieldValue::Varint(2_000),
-            FieldValue::PooledString(interned),
-        ],
-    )
-    .unwrap();
+    enc.write_event(&schema, 2_000, &[FieldValue::PooledString(interned)])
+        .unwrap();
     let bytes = enc.finish();
 
     let event: WithPool = decode_first(&bytes);
@@ -144,14 +135,8 @@ fn pooled_stack_frames_resolve_to_vec_u64() {
             vec![FieldDef::new("callchain", FieldType::PooledStackFrames)],
         )
         .unwrap();
-    enc.write_event(
-        &schema,
-        &[
-            FieldValue::Varint(5_000),
-            FieldValue::PooledStackFrames(stack),
-        ],
-    )
-    .unwrap();
+    enc.write_event(&schema, 5_000, &[FieldValue::PooledStackFrames(stack)])
+        .unwrap();
     let bytes = enc.finish();
 
     let event: WithStack = decode_first(&bytes);
@@ -172,10 +157,8 @@ fn inline_stack_frames_deserialize_as_vec_u64() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(6_000),
-            FieldValue::StackFrames(StackFrames::from(vec![1u64, 2, 3])),
-        ],
+        6_000,
+        &[FieldValue::StackFrames(StackFrames::from(vec![1u64, 2, 3]))],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -204,10 +187,8 @@ fn bytes_field_round_trip() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(6_500),
-            FieldValue::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
-        ],
+        6_500,
+        &[FieldValue::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF])],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -241,11 +222,8 @@ fn optional_fields_present() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(7_000),
-            FieldValue::PooledString(pooled),
-            FieldValue::Varint(99),
-        ],
+        7_000,
+        &[FieldValue::PooledString(pooled), FieldValue::Varint(99)],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -268,15 +246,8 @@ fn optional_fields_absent() {
             ],
         )
         .unwrap();
-    enc.write_event(
-        &schema,
-        &[
-            FieldValue::Varint(8_000),
-            FieldValue::None,
-            FieldValue::None,
-        ],
-    )
-    .unwrap();
+    enc.write_event(&schema, 8_000, &[FieldValue::None, FieldValue::None])
+        .unwrap();
     let bytes = enc.finish();
 
     let event: WithOption = decode_first(&bytes);
@@ -389,18 +360,12 @@ fn serde_other_catches_unknown_events() {
 
     enc.write_event(
         &known,
-        &[
-            FieldValue::Varint(10_000),
-            FieldValue::Varint(0),
-            FieldValue::Varint(1),
-        ],
+        10_000,
+        &[FieldValue::Varint(0), FieldValue::Varint(1)],
     )
     .unwrap();
-    enc.write_event(
-        &unknown,
-        &[FieldValue::Varint(11_000), FieldValue::Varint(99)],
-    )
-    .unwrap();
+    enc.write_event(&unknown, 11_000, &[FieldValue::Varint(99)])
+        .unwrap();
     let bytes = enc.finish();
 
     let events: Vec<OnlyKnown> = decode_all(&bytes);
@@ -445,11 +410,8 @@ fn missing_required_field_errors() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(12_000),
-            FieldValue::Varint(0),
-            FieldValue::Varint(1),
-        ],
+        12_000,
+        &[FieldValue::Varint(0), FieldValue::Varint(1)],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -556,8 +518,8 @@ fn float_bool_signed_round_trip() {
         .unwrap();
     enc.write_event(
         &schema,
+        13_000,
         &[
-            FieldValue::Varint(13_000),
             FieldValue::F64(std::f64::consts::PI),
             FieldValue::Bool(true),
             FieldValue::I64(-9_999),
@@ -599,11 +561,8 @@ fn option_field_absent_from_schema_defaults_to_none() {
             vec![FieldDef::new("worker_id", FieldType::Varint)],
         )
         .unwrap();
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+        .unwrap();
     let bytes = enc.finish();
 
     let event: NewerStruct = decode_first(&bytes);
@@ -626,10 +585,8 @@ fn pooled_string_miss_returns_error() {
     // Write an event referencing pool ID 999 which was never interned.
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(1_000),
-            FieldValue::PooledString(InternedString::from_raw(999)),
-        ],
+        1_000,
+        &[FieldValue::PooledString(InternedString::from_raw(999))],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -660,10 +617,10 @@ fn pooled_stack_frames_miss_returns_error() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(2_000),
-            FieldValue::PooledStackFrames(InternedStackFrames::from_raw(999)),
-        ],
+        2_000,
+        &[FieldValue::PooledStackFrames(
+            InternedStackFrames::from_raw(999),
+        )],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -698,11 +655,8 @@ fn type_coercion_bool_from_varint_returns_error() {
         .register_schema("WantsBool", vec![FieldDef::new("flag", FieldType::Varint)])
         .unwrap();
     // Wire has a varint where the struct expects a bool.
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+        .unwrap();
     let bytes = enc.finish();
 
     let mut dec = Decoder::new(&bytes).expect("valid header");
@@ -739,13 +693,11 @@ fn dynamic_list_deserializes_to_vec() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(1_000),
-            FieldValue::List(vec![
-                FieldValue::String("hello".into()),
-                FieldValue::String("world".into()),
-            ]),
-        ],
+        1_000,
+        &[FieldValue::List(vec![
+            FieldValue::String("hello".into()),
+            FieldValue::String("world".into()),
+        ])],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -776,13 +728,11 @@ fn string_map_deserializes_to_hashmap() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(2_000),
-            FieldValue::StringMap(vec![
-                ("content-type".into(), "application/json".into()),
-                ("x-request-id".into(), "abc123".into()),
-            ]),
-        ],
+        2_000,
+        &[FieldValue::StringMap(vec![
+            ("content-type".into(), "application/json".into()),
+            ("x-request-id".into(), "abc123".into()),
+        ])],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -814,13 +764,11 @@ fn dynamic_map_deserializes_to_hashmap() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(3_000),
-            FieldValue::Map(vec![
-                (FieldValue::String("reads".into()), FieldValue::Varint(100)),
-                (FieldValue::String("writes".into()), FieldValue::Varint(42)),
-            ]),
-        ],
+        3_000,
+        &[FieldValue::Map(vec![
+            (FieldValue::String("reads".into()), FieldValue::Varint(100)),
+            (FieldValue::String("writes".into()), FieldValue::Varint(42)),
+        ])],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -858,16 +806,14 @@ fn dynamic_map_deserializes_to_struct() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(4_000),
-            FieldValue::Map(vec![
-                (FieldValue::String("status".into()), FieldValue::Varint(200)),
-                (
-                    FieldValue::String("path".into()),
-                    FieldValue::String("/api/users".into()),
-                ),
-            ]),
-        ],
+        4_000,
+        &[FieldValue::Map(vec![
+            (FieldValue::String("status".into()), FieldValue::Varint(200)),
+            (
+                FieldValue::String("path".into()),
+                FieldValue::String("/api/users".into()),
+            ),
+        ])],
     )
     .unwrap();
     let bytes = enc.finish();
@@ -907,13 +853,11 @@ fn string_map_deserializes_to_vec_of_tuples() {
         .unwrap();
     enc.write_event(
         &schema,
-        &[
-            FieldValue::Varint(5_000),
-            FieldValue::StringMap(vec![
-                ("content-type".into(), "application/json".into()),
-                ("x-request-id".into(), "abc123".into()),
-            ]),
-        ],
+        5_000,
+        &[FieldValue::StringMap(vec![
+            ("content-type".into(), "application/json".into()),
+            ("x-request-id".into(), "abc123".into()),
+        ])],
     )
     .unwrap();
     let bytes = enc.finish();

--- a/dial9-trace-format/tests/spec_edge_cases.rs
+++ b/dial9-trace-format/tests/spec_edge_cases.rs
@@ -31,11 +31,8 @@ fn schema_max_type_id_via_encoder() {
     let mut enc = Encoder::new();
     let fields = vec![FieldDef::new("v", FieldType::Varint)];
     let schema = enc.register_schema("Ev", fields).unwrap();
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+        .unwrap();
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
     let frames = dec.decode_all();
@@ -51,7 +48,7 @@ fn schema_max_type_id_via_encoder() {
 fn schema_empty_name_via_encoder() {
     let mut enc = Encoder::new();
     let schema = enc.register_schema("", vec![]).unwrap();
-    enc.write_event(&schema, &[FieldValue::Varint(0)]).unwrap();
+    enc.write_event(&schema, 0, &[]).unwrap();
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
     let frames = dec.decode_all();
@@ -65,9 +62,8 @@ fn schema_many_fields_via_encoder() {
         .map(|i| FieldDef::new(format!("f{i}"), FieldType::Varint))
         .collect();
     let schema = enc.register_schema("Wide", fields).unwrap();
-    let mut values = vec![FieldValue::Varint(0)]; // timestamp
-    values.extend((0..256).map(FieldValue::Varint));
-    enc.write_event(&schema, &values).unwrap();
+    let values: Vec<FieldValue> = (0..256).map(FieldValue::Varint).collect();
+    enc.write_event(&schema, 0, &values).unwrap();
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
     let frames = dec.decode_all();
@@ -260,14 +256,8 @@ fn multiple_schemas_then_events() {
         })
         .collect();
     for (i, s) in schemas.iter().enumerate() {
-        enc.write_event(
-            s,
-            &[
-                FieldValue::Varint(i as u64 * 1000),
-                FieldValue::Varint(i as u64),
-            ],
-        )
-        .unwrap();
+        enc.write_event(s, i as u64 * 1000, &[FieldValue::Varint(i as u64)])
+            .unwrap();
     }
     let data = enc.finish();
     let mut dec = Decoder::new(&data).unwrap();
@@ -288,17 +278,11 @@ fn interleaved_pool_and_events() {
         .register_schema("Ev", vec![FieldDef::new("s", FieldType::PooledString)])
         .unwrap();
     let id0 = enc.intern_string("first").unwrap();
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1_000), FieldValue::PooledString(id0)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1_000, &[FieldValue::PooledString(id0)])
+        .unwrap();
     let id1 = enc.intern_string("second").unwrap();
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(2_000), FieldValue::PooledString(id1)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 2_000, &[FieldValue::PooledString(id1)])
+        .unwrap();
     let data = enc.finish();
 
     let mut dec = Decoder::new(&data).unwrap();

--- a/dial9-trace-format/tests/threadlocal_encoding.rs
+++ b/dial9-trace-format/tests/threadlocal_encoding.rs
@@ -41,7 +41,7 @@ fn test_reset_to_returns_decodable_bytes() {
     let mut count = 0;
     dec.for_each_event(|ev| {
         count += 1;
-        assert!(ev.timestamp_ns.is_some());
+        assert!(ev.timestamp_ns > 0);
     })
     .unwrap();
     assert_eq!(count, 2);
@@ -102,7 +102,7 @@ fn test_rawcopy_round_trip_single_batch() {
         events.push(ev.timestamp_ns);
     })
     .unwrap();
-    assert_eq!(events, vec![Some(1000), Some(2000)]);
+    assert_eq!(events, vec![1000, 2000]);
 }
 
 #[test]
@@ -168,7 +168,7 @@ fn test_rawcopy_timestamp_preserved() {
         timestamps.push(ev.timestamp_ns);
     })
     .unwrap();
-    assert_eq!(timestamps, vec![Some(5000), Some(10000)]);
+    assert_eq!(timestamps, vec![5000, 10000]);
 }
 
 #[test]

--- a/dial9-utils/src/tracing_layer.rs
+++ b/dial9-utils/src/tracing_layer.rs
@@ -341,8 +341,7 @@ where
             let span_name = data.meta.name();
 
             // Encode directly into the thread-local buffer (no clone needed)
-            let mut values = Vec::with_capacity(5 + schemas.field_names.len());
-            values.push(FieldValue::Varint(ts));
+            let mut values = Vec::with_capacity(4 + schemas.field_names.len());
             match task_id {
                 Some(task_id) => values.push(FieldValue::Varint(task_id)),
                 None => values.push(FieldValue::None),
@@ -359,7 +358,7 @@ where
                     None => values.push(FieldValue::None),
                 }
             }
-            if let Err(e) = enc.write_event(&schemas.enter, &values) {
+            if let Err(e) = enc.write_event(&schemas.enter, ts, &values) {
                 dial9_core::rate_limit::rate_limited!(std::time::Duration::from_secs(60), {
                     tracing::error!(span = %span_name, "dropping span-enter event: {e}");
                 });
@@ -386,8 +385,7 @@ where
             let schemas = self.get_schemas(data.meta);
             let span_name = data.meta.name();
 
-            let mut values = Vec::with_capacity(4 + schemas.field_names.len());
-            values.push(FieldValue::Varint(ts));
+            let mut values = Vec::with_capacity(3 + schemas.field_names.len());
             match task_id {
                 Some(task_id) => values.push(FieldValue::Varint(task_id)),
                 None => values.push(FieldValue::None),
@@ -400,7 +398,7 @@ where
                     None => values.push(FieldValue::None),
                 }
             }
-            if let Err(e) = enc.write_event(&schemas.exit, &values) {
+            if let Err(e) = enc.write_event(&schemas.exit, ts, &values) {
                 dial9_core::rate_limit::rate_limited!(std::time::Duration::from_secs(60), {
                     tracing::error!(span = %span_name, "dropping span-exit event: {e}");
                 });

--- a/dial9-viewer/src/bin/gen_fixtures.rs
+++ b/dial9-viewer/src/bin/gen_fixtures.rs
@@ -548,36 +548,26 @@ impl<'a> SegmentWriter<'a> {
                 let loc = self.intern(loc)?;
                 self.enc.write_event(
                     &self.sch.poll_start,
-                    &[
-                        Varint(ts),
-                        Varint(worker),
-                        Varint(0),
-                        Varint(task),
-                        PooledString(loc),
-                    ],
+                    ts,
+                    &[Varint(worker), Varint(0), Varint(task), PooledString(loc)],
                 )?;
             }
             Ev::PollEnd { worker } => {
                 self.enc
-                    .write_event(&self.sch.poll_end, &[Varint(ts), Varint(worker)])?;
+                    .write_event(&self.sch.poll_end, ts, &[Varint(worker)])?;
             }
             Ev::Park { worker, cpu, tid } => {
                 self.enc.write_event(
                     &self.sch.park,
-                    &[
-                        Varint(ts),
-                        Varint(worker),
-                        Varint(0),
-                        Varint(cpu),
-                        Varint(tid),
-                    ],
+                    ts,
+                    &[Varint(worker), Varint(0), Varint(cpu), Varint(tid)],
                 )?;
             }
             Ev::Unpark { worker, cpu, tid } => {
                 self.enc.write_event(
                     &self.sch.unpark,
+                    ts,
                     &[
-                        Varint(ts),
                         Varint(worker),
                         Varint(0),
                         Varint(cpu),
@@ -588,13 +578,14 @@ impl<'a> SegmentWriter<'a> {
             }
             Ev::Queue { depth } => {
                 self.enc
-                    .write_event(&self.sch.queue, &[Varint(ts), Varint(depth)])?;
+                    .write_event(&self.sch.queue, ts, &[Varint(depth)])?;
             }
             Ev::Spawn { task, loc } => {
                 let loc = self.intern(loc)?;
                 self.enc.write_event(
                     &self.sch.task_spawn,
-                    &[Varint(ts), Varint(task), PooledString(loc), Bool(true)],
+                    ts,
+                    &[Varint(task), PooledString(loc), Bool(true)],
                 )?;
             }
         }
@@ -604,7 +595,8 @@ impl<'a> SegmentWriter<'a> {
     fn clock_sync(&mut self, mono_ns: u64, real_ns: u64) -> Result<()> {
         self.enc.write_event(
             &self.sch.clock_sync,
-            &[FieldValue::Varint(mono_ns), FieldValue::Varint(real_ns)],
+            mono_ns,
+            &[FieldValue::Varint(real_ns)],
         )?;
         Ok(())
     }
@@ -614,10 +606,8 @@ impl<'a> SegmentWriter<'a> {
             .iter()
             .map(|(k, v)| (k.as_bytes().to_vec(), v.as_bytes().to_vec()))
             .collect();
-        self.enc.write_event(
-            &self.sch.metadata,
-            &[FieldValue::Varint(ts), FieldValue::StringMap(pairs)],
-        )?;
+        self.enc
+            .write_event(&self.sch.metadata, ts, &[FieldValue::StringMap(pairs)])?;
         Ok(())
     }
 

--- a/dial9-viewer/src/ingest/decode.rs
+++ b/dial9-viewer/src/ingest/decode.rs
@@ -1305,7 +1305,6 @@ mod tests {
         );
         let single_event_schema = Schema::from_entry(SchemaEntry::with_annotations(
             "producer:RequestMetrics",
-            true,
             vec![
                 FieldDef::new("started", FieldType::OptionalVarint),
                 FieldDef::new("os_thread", FieldType::OptionalVarint),
@@ -1334,11 +1333,8 @@ mod tests {
         .unwrap();
         enc.write_event(
             &unpark_schema,
-            &[
-                FieldValue::Varint(50),
-                FieldValue::Varint(3),
-                FieldValue::Varint(500),
-            ],
+            50,
+            &[FieldValue::Varint(3), FieldValue::Varint(500)],
         )
         .unwrap();
 
@@ -1346,18 +1342,12 @@ mod tests {
         for (start, end) in [(90, 120), (180, 220)] {
             enc.write_event(
                 &poll_start_schema,
-                &[
-                    FieldValue::Varint(start),
-                    FieldValue::Varint(3),
-                    FieldValue::Varint(77),
-                ],
+                start,
+                &[FieldValue::Varint(3), FieldValue::Varint(77)],
             )
             .unwrap();
-            enc.write_event(
-                &poll_end_schema,
-                &[FieldValue::Varint(end), FieldValue::Varint(3)],
-            )
-            .unwrap();
+            enc.write_event(&poll_end_schema, end, &[FieldValue::Varint(3)])
+                .unwrap();
         }
 
         // One sample lands in an active poll interval; one lands in the async
@@ -1365,8 +1355,8 @@ mod tests {
         for timestamp in [110, 150] {
             enc.write_event(
                 &sample_schema,
+                timestamp,
                 &[
-                    FieldValue::Varint(timestamp),
                     FieldValue::Varint(500),
                     FieldValue::Varint(SOURCE_CPU_PROFILE as u64),
                     FieldValue::StackFrames(vec![0xabc].into()),
@@ -1380,8 +1370,8 @@ mod tests {
         // field so the delta-encoded timestamp stream stays in emission order.
         enc.write_event(
             &single_event_schema,
+            250,
             &[
-                FieldValue::Varint(250),
                 FieldValue::Varint(100),
                 FieldValue::Varint(500),
                 FieldValue::Varint(77),
@@ -1397,8 +1387,8 @@ mod tests {
         // and cannot be projected as a span.
         enc.write_event(
             &single_event_schema,
+            300,
             &[
-                FieldValue::Varint(300),
                 FieldValue::None,
                 FieldValue::None,
                 FieldValue::None,
@@ -1505,12 +1495,17 @@ mod tests {
         // Enter span_id=1 on worker 0
         enc.write_event(
             &enter_schema,
+            100,
             &[
-                FieldValue::Varint(100),                   // timestamp
-                FieldValue::Varint(0),                     // worker_id
-                FieldValue::Varint(1),                     // span_id
-                FieldValue::None,                          // parent_span_id (absent)
-                FieldValue::String("do_work".to_string()), // span_name
+                // timestamp
+                FieldValue::Varint(0),
+                // worker_id
+                FieldValue::Varint(1),
+                // span_id
+                FieldValue::None,
+                // parent_span_id (absent)
+                FieldValue::String("do_work".to_string()),
+                // span_name,
             ],
         )
         .unwrap();
@@ -1518,11 +1513,15 @@ mod tests {
         // Exit span_id=1 on worker 0
         enc.write_event(
             &exit_schema,
+            200,
             &[
-                FieldValue::Varint(200),                   // timestamp
-                FieldValue::Varint(0),                     // worker_id
-                FieldValue::Varint(1),                     // span_id
-                FieldValue::String("do_work".to_string()), // span_name
+                // timestamp
+                FieldValue::Varint(0),
+                // worker_id
+                FieldValue::Varint(1),
+                // span_id
+                FieldValue::String("do_work".to_string()),
+                // span_name,
             ],
         )
         .unwrap();
@@ -1530,9 +1529,11 @@ mod tests {
         // Close span_id=1
         enc.write_event(
             &close_schema,
+            250,
             &[
-                FieldValue::Varint(250), // timestamp
-                FieldValue::Varint(1),   // span_id
+                // timestamp
+                FieldValue::Varint(1),
+                // span_id,
             ],
         )
         .unwrap();
@@ -1613,34 +1614,33 @@ mod tests {
         .unwrap();
         enc.write_event(
             &enter_schema,
+            100,
             &[
-                FieldValue::Varint(100),
                 FieldValue::Varint(0),
                 FieldValue::Varint(1),
                 FieldValue::None,
                 FieldValue::String("handle".to_string()),
                 FieldValue::String("5d051ec2-999b-4a25-93b6-0f9cf83fa8b2".to_string()),
-                FieldValue::Varint(0), // status not yet known at enter
+                FieldValue::Varint(0),
+                // status not yet known at enter,
             ],
         )
         .unwrap();
         enc.write_event(
             &exit_schema,
+            200,
             &[
-                FieldValue::Varint(200),
                 FieldValue::Varint(0),
                 FieldValue::Varint(1),
                 FieldValue::String("handle".to_string()),
                 FieldValue::String("5d051ec2-999b-4a25-93b6-0f9cf83fa8b2".to_string()),
-                FieldValue::Varint(500), // final status known at exit
+                FieldValue::Varint(500),
+                // final status known at exit,
             ],
         )
         .unwrap();
-        enc.write_event(
-            &close_schema,
-            &[FieldValue::Varint(250), FieldValue::Varint(1)],
-        )
-        .unwrap();
+        enc.write_event(&close_schema, 250, &[FieldValue::Varint(1)])
+            .unwrap();
 
         let (_, _, _, spans) =
             decode_samples(&enc.into_inner(), "2026-07-17/1746/svc/host/boot/0.bin").unwrap();
@@ -1710,8 +1710,8 @@ mod tests {
         .unwrap();
         enc.write_event(
             &exit_schema,
+            100,
             &[
-                FieldValue::Varint(100),
                 FieldValue::Varint(0),
                 FieldValue::Varint(7),
                 FieldValue::String("equal_timestamp".to_string()),
@@ -1720,8 +1720,8 @@ mod tests {
         .unwrap();
         enc.write_event(
             &enter_schema,
+            100,
             &[
-                FieldValue::Varint(100),
                 FieldValue::Varint(0),
                 FieldValue::Varint(7),
                 FieldValue::None,
@@ -1729,11 +1729,8 @@ mod tests {
             ],
         )
         .unwrap();
-        enc.write_event(
-            &close_schema,
-            &[FieldValue::Varint(101), FieldValue::Varint(7)],
-        )
-        .unwrap();
+        enc.write_event(&close_schema, 101, &[FieldValue::Varint(7)])
+            .unwrap();
 
         let (_, _, _, spans) = decode_samples(
             &enc.into_inner(),
@@ -1804,8 +1801,8 @@ mod tests {
         // Enter span_id=42 on worker 3.
         enc.write_event(
             &enter_schema,
+            1000,
             &[
-                FieldValue::Varint(1000),
                 FieldValue::Varint(3),
                 FieldValue::Varint(42),
                 FieldValue::None,
@@ -1818,8 +1815,8 @@ mod tests {
         // Exit span_id=42 on worker 3. Note: NO close event follows.
         enc.write_event(
             &exit_schema,
+            5000,
             &[
-                FieldValue::Varint(5000),
                 FieldValue::Varint(3),
                 FieldValue::Varint(42),
                 FieldValue::String("/jobs/next".to_string()),
@@ -1889,7 +1886,6 @@ mod tests {
         ] {
             let values = if schema.name().starts_with("SpanEnter__") {
                 vec![
-                    FieldValue::Varint(timestamp),
                     FieldValue::Varint(0),
                     FieldValue::Varint(span_id),
                     FieldValue::None,
@@ -1897,13 +1893,12 @@ mod tests {
                 ]
             } else {
                 vec![
-                    FieldValue::Varint(timestamp),
                     FieldValue::Varint(0),
                     FieldValue::Varint(span_id),
                     FieldValue::String("shared-runtime-name".to_string()),
                 ]
             };
-            enc.write_event(schema, &values).unwrap();
+            enc.write_event(schema, timestamp, &values).unwrap();
         }
 
         let (_, _, _, spans) = decode_samples(
@@ -1951,7 +1946,6 @@ mod tests {
         ] {
             let values = if schema.name().starts_with("SpanEnter__") {
                 vec![
-                    FieldValue::Varint(timestamp),
                     FieldValue::Varint(0),
                     FieldValue::Varint(span_id),
                     FieldValue::None,
@@ -1959,13 +1953,12 @@ mod tests {
                 ]
             } else {
                 vec![
-                    FieldValue::Varint(timestamp),
                     FieldValue::Varint(0),
                     FieldValue::Varint(span_id),
                     FieldValue::String(runtime_name.to_string()),
                 ]
             };
-            enc.write_event(schema, &values).unwrap();
+            enc.write_event(schema, timestamp, &values).unwrap();
         }
 
         let (_, _, _, spans) = decode_samples(
@@ -2030,8 +2023,8 @@ mod tests {
         // Enter span_id=42 on worker 3.
         enc.write_event(
             &enter_schema,
+            1000,
             &[
-                FieldValue::Varint(1000),
                 FieldValue::Varint(3),
                 FieldValue::Varint(42),
                 FieldValue::None,
@@ -2042,8 +2035,8 @@ mod tests {
         // Exit span_id=42 on a DIFFERENT worker (7) — the task migrated.
         enc.write_event(
             &exit_schema,
+            5000,
             &[
-                FieldValue::Varint(5000),
                 FieldValue::Varint(7),
                 FieldValue::Varint(42),
                 FieldValue::String("/jobs/next".to_string()),
@@ -2137,13 +2130,19 @@ mod tests {
         // Bind tid 500 → worker 3.
         enc.write_event(
             &unpark_schema,
+            500,
             &[
-                FieldValue::Varint(500), // ts
-                FieldValue::Varint(3),   // worker_id
-                FieldValue::Varint(0),   // local_queue
-                FieldValue::Varint(0),   // cpu_time_ns
-                FieldValue::None,        // sched_wait_ns
-                FieldValue::Varint(500), // tid
+                // ts
+                FieldValue::Varint(3),
+                // worker_id
+                FieldValue::Varint(0),
+                // local_queue
+                FieldValue::Varint(0),
+                // cpu_time_ns
+                FieldValue::None,
+                // sched_wait_ns
+                FieldValue::Varint(500),
+                // tid,
             ],
         )
         .unwrap();
@@ -2151,26 +2150,27 @@ mod tests {
         // Poll of task 77 on worker 3 covering the span's enter: [900, 1100].
         enc.write_event(
             &poll_start_schema,
+            900,
             &[
-                FieldValue::Varint(900), // ts
-                FieldValue::Varint(3),   // worker_id
-                FieldValue::Varint(0),   // local_queue
-                FieldValue::Varint(77),  // task_id
+                // ts
+                FieldValue::Varint(3),
+                // worker_id
+                FieldValue::Varint(0),
+                // local_queue
+                FieldValue::Varint(77),
+                // task_id
                 FieldValue::String("app::handler".to_string()),
             ],
         )
         .unwrap();
-        enc.write_event(
-            &poll_end_schema,
-            &[FieldValue::Varint(1100), FieldValue::Varint(3)],
-        )
-        .unwrap();
+        enc.write_event(&poll_end_schema, 1100, &[FieldValue::Varint(3)])
+            .unwrap();
 
         // Enter span_id=42 on worker 3 at t=1000 (inside poll [900,1100] → task 77).
         enc.write_event(
             &enter_schema,
+            1000,
             &[
-                FieldValue::Varint(1000),
                 FieldValue::Varint(3),
                 FieldValue::Varint(42),
                 FieldValue::None,
@@ -2183,8 +2183,8 @@ mod tests {
         // (Non-overlapping with the first — a worker polls one task at a time.)
         enc.write_event(
             &poll_start_schema,
+            5000,
             &[
-                FieldValue::Varint(5000),
                 FieldValue::Varint(3),
                 FieldValue::Varint(0),
                 FieldValue::Varint(77),
@@ -2192,18 +2192,15 @@ mod tests {
             ],
         )
         .unwrap();
-        enc.write_event(
-            &poll_end_schema,
-            &[FieldValue::Varint(5100), FieldValue::Varint(3)],
-        )
-        .unwrap();
+        enc.write_event(&poll_end_schema, 5100, &[FieldValue::Varint(3)])
+            .unwrap();
 
         // Exit span_id=42 much later at t=9000: the span was entered across a
         // long await; the task was only on-CPU during the two polls above.
         enc.write_event(
             &exit_schema,
+            9000,
             &[
-                FieldValue::Varint(9000),
                 FieldValue::Varint(3),
                 FieldValue::Varint(42),
                 FieldValue::String("/jobs/next".to_string()),
@@ -2292,8 +2289,8 @@ mod tests {
         // First use of span_id=1
         enc.write_event(
             &enter_schema,
+            100,
             &[
-                FieldValue::Varint(100),
                 FieldValue::Varint(0),
                 FieldValue::Varint(1),
                 FieldValue::None,
@@ -2303,19 +2300,16 @@ mod tests {
         .unwrap();
         enc.write_event(
             &exit_schema,
+            200,
             &[
-                FieldValue::Varint(200),
                 FieldValue::Varint(0),
                 FieldValue::Varint(1),
                 FieldValue::String("op".to_string()),
             ],
         )
         .unwrap();
-        enc.write_event(
-            &close_schema,
-            &[FieldValue::Varint(250), FieldValue::Varint(1)],
-        )
-        .unwrap();
+        enc.write_event(&close_schema, 250, &[FieldValue::Varint(1)])
+            .unwrap();
 
         // One enter/exit/close cycle for span_id=1 produces one row.
         let data = enc.into_inner();
@@ -2385,8 +2379,8 @@ mod tests {
         let enter = |enc: &mut Encoder, ts: u64| {
             enc.write_event(
                 &enter_schema,
+                ts,
                 &[
-                    FieldValue::Varint(ts),
                     FieldValue::Varint(0),
                     FieldValue::Varint(1),
                     FieldValue::None,
@@ -2398,8 +2392,8 @@ mod tests {
         let exit = |enc: &mut Encoder, ts: u64| {
             enc.write_event(
                 &exit_schema,
+                ts,
                 &[
-                    FieldValue::Varint(ts),
                     FieldValue::Varint(0),
                     FieldValue::Varint(1),
                     FieldValue::String("handle".to_string()),
@@ -2408,11 +2402,8 @@ mod tests {
             .unwrap();
         };
         let close = |enc: &mut Encoder, ts: u64| {
-            enc.write_event(
-                &close_schema,
-                &[FieldValue::Varint(ts), FieldValue::Varint(1)],
-            )
-            .unwrap();
+            enc.write_event(&close_schema, ts, &[FieldValue::Varint(1)])
+                .unwrap();
         };
 
         enter(&mut enc, 1_000);

--- a/dial9-viewer/src/ingest/decode/events.rs
+++ b/dial9-viewer/src/ingest/decode/events.rs
@@ -275,8 +275,6 @@ struct TimingField {
 struct TimingLayout {
     start: Option<TimingField>,
     duration: Option<TimingField>,
-    /// The packed event timestamp is available as the end (in ns).
-    packed_end: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -397,10 +395,9 @@ fn compile_single_event_span(schema: &SchemaEntry) -> CompiledSingleEventSpan {
         None => None,
     };
     // A span is placed from any two of {start, duration, end}. The end is the
-    // packed event timestamp, so verify at least two are available.
-    let packed_end = schema.has_timestamp();
-    let quantities =
-        usize::from(start.is_some()) + usize::from(duration.is_some()) + usize::from(packed_end);
+    // packed event timestamp (always present), so we need at least one of
+    // start or duration.
+    let quantities = usize::from(start.is_some()) + usize::from(duration.is_some()) + 1;
     if quantities < 2 {
         return CompiledSingleEventSpan::Invalid(
             "single-event span schema needs two of span.start, span.duration, and the packed \
@@ -409,11 +406,7 @@ fn compile_single_event_span(schema: &SchemaEntry) -> CompiledSingleEventSpan {
         );
     }
 
-    let timing = TimingLayout {
-        start,
-        duration,
-        packed_end,
-    };
+    let timing = TimingLayout { start, duration };
 
     if let Some(index) = name_index
         && !is_string_field(schema.fields()[index].field_type())
@@ -543,10 +536,10 @@ impl TimingLayout {
     }
 
     /// Resolve `(start_ns, end_ns)` from any two of start, duration, and end,
-    /// where the end is the packed event timestamp. The compiler has already
-    /// guaranteed at least two quantities are present in the schema; this
-    /// handles a value being absent at runtime (optional field) and the
-    /// arithmetic.
+    /// where the end is the packed event timestamp (always present). The
+    /// compiler has already guaranteed at least one of start/duration is
+    /// present in the schema; this handles a value being absent at runtime
+    /// (optional field) and the arithmetic.
     fn resolve(&self, ev: &RawEvent<'_, '_>) -> Result<(u64, u64), &'static str> {
         let start = match self.start {
             Some(field) => Self::read(field, ev)?,
@@ -556,16 +549,12 @@ impl TimingLayout {
             Some(field) => Self::read(field, ev)?,
             None => None,
         };
-        let end = if self.packed_end {
-            ev.timestamp_ns
-        } else {
-            None
-        };
+        let end = ev.timestamp_ns;
 
-        match (start, duration, end) {
+        match (start, duration) {
             // Start + end (the common metrique-style case uses end + duration
             // below; this covers a start field with the packed end).
-            (Some(start), _, Some(end)) => {
+            (Some(start), _) => {
                 if start > end {
                     return Err("single-event span start follows its end");
                 }
@@ -573,17 +562,10 @@ impl TimingLayout {
             }
             // End + duration: derive start. Duration is unsigned, so a start
             // after end is unrepresentable; saturate rather than underflow.
-            (None, Some(duration), Some(end)) => Ok((end.saturating_sub(duration), end)),
-            // Start + duration, no end available: derive end.
-            (Some(start), Some(duration), None) => {
-                let end = start
-                    .checked_add(duration)
-                    .ok_or("single-event span end overflows nanoseconds")?;
-                Ok((start, end))
-            }
-            // Fewer than two quantities resolvable at runtime (an optional
-            // timing field was absent on this event).
-            _ => Err("single-event span is missing a required timing value"),
+            (None, Some(duration)) => Ok((end.saturating_sub(duration), end)),
+            // Neither start nor duration resolvable at runtime (both optional
+            // timing fields were absent on this event).
+            (None, None) => Err("single-event span is missing a required timing value"),
         }
     }
 }
@@ -1041,7 +1023,6 @@ mod tests {
     ) -> SchemaEntry {
         SchemaEntry::with_annotations(
             name,
-            true,
             fields
                 .into_iter()
                 .map(|(name, field_type)| FieldDef::new(name, field_type)),
@@ -1080,8 +1061,8 @@ mod tests {
         encoder
             .write_event(
                 &current_schema,
+                100,
                 &[
-                    FieldValue::Varint(100),
                     FieldValue::Varint(42),
                     FieldValue::Varint(1),
                     FieldValue::None,
@@ -1093,8 +1074,8 @@ mod tests {
         encoder
             .write_event(
                 &legacy_schema,
+                200,
                 &[
-                    FieldValue::Varint(200),
                     FieldValue::Varint(7),
                     FieldValue::Varint(2),
                     FieldValue::None,
@@ -1168,7 +1149,6 @@ mod tests {
         assert_eq!(layout.timing.start.map(|f| f.index), Some(0));
         assert_eq!(layout.timing.start.map(|f| f.multiplier), Some(1_000_000));
         assert!(layout.timing.duration.is_none());
-        assert!(layout.timing.packed_end);
         assert_eq!(layout.name_index, Some(1));
         assert_eq!(layout.span_type, "test-producer");
         assert_eq!(layout.attribute_indices, vec![1, 2, 3]);
@@ -1193,19 +1173,15 @@ mod tests {
         assert_eq!(layout.timing.duration.map(|f| f.index), Some(0));
         assert_eq!(layout.timing.duration.map(|f| f.multiplier), Some(1));
         assert!(layout.timing.start.is_none());
-        assert!(layout.timing.packed_end);
         assert_eq!(layout.name_index, Some(1));
     }
 
     #[test]
-    fn start_plus_duration_compiles_without_a_packed_timestamp() {
-        // Two explicit timing quantities are enough to place a span even with
-        // no packed end. (Every event the encoder writes carries a packed
-        // timestamp, so at decode time `resolve` derives end from start+end;
-        // this guards the schema-compile side of the start+duration path.)
-        let no_packed = SchemaEntry::with_annotations(
+    fn start_plus_duration_compiles() {
+        // Two explicit timing quantities plus the packed end: all three timing
+        // sources are available.
+        let schema = SchemaEntry::with_annotations(
             "producer:StartDur",
-            /* has_timestamp */ false,
             [
                 FieldDef::new("start", FieldType::Varint),
                 FieldDef::new("dur", FieldType::Varint),
@@ -1215,20 +1191,18 @@ mod tests {
                 FieldAnnotation::new(1, schema_extensions::ROLE_KEY, roles::SPAN_DURATION),
             ],
         );
-        let CompiledSingleEventSpan::Layout(layout) = compile_single_event_span(&no_packed) else {
-            panic!("start + duration must compile even without a packed timestamp");
+        let CompiledSingleEventSpan::Layout(layout) = compile_single_event_span(&schema) else {
+            panic!("start + duration must compile");
         };
         assert_eq!(layout.timing.start.map(|f| f.index), Some(0));
         assert_eq!(layout.timing.duration.map(|f| f.index), Some(1));
-        assert!(!layout.timing.packed_end);
-        // The start+duration -> end derivation is exercised end-to-end by the
-        // packed-timestamp span tests above; here we only assert that two
-        // explicit quantities are accepted without a packed end.
     }
 
     #[test]
-    fn single_timing_quantity_without_packed_end_is_invalid() {
-        // A duration with no packed end cannot place a span.
+    fn single_duration_with_packed_end_is_valid() {
+        // With packed_end always true (all events carry a timestamp),
+        // duration + packed end gives two quantities, which is enough to
+        // place a span.
         let schema = schema(
             "producer:OnlyDuration",
             [("dur", FieldType::Varint)],
@@ -1238,17 +1212,11 @@ mod tests {
                 roles::SPAN_DURATION,
             )],
         );
-        // The `schema` helper sets has_timestamp = true, so build one without.
-        let no_packed = SchemaEntry::with_annotations(
-            "producer:OnlyDuration",
-            /* has_timestamp */ false,
-            schema.fields().to_vec(),
-            schema.annotations().to_vec(),
-        );
-        assert!(matches!(
-            compile_single_event_span(&no_packed),
-            CompiledSingleEventSpan::Invalid(_)
-        ));
+        let CompiledSingleEventSpan::Layout(layout) = compile_single_event_span(&schema) else {
+            panic!("duration + packed end should be valid");
+        };
+        assert_eq!(layout.timing.duration.map(|f| f.index), Some(0));
+        assert!(layout.timing.start.is_none());
     }
 
     #[test]
@@ -1281,7 +1249,7 @@ mod tests {
         ));
         let mut encoder = Encoder::new();
         encoder
-            .write_event(&schema, &[FieldValue::Varint(500), FieldValue::Varint(120)])
+            .write_event(&schema, 500, &[FieldValue::Varint(120)])
             .unwrap();
         let decoded = decode_trace(&encoder.into_inner(), "source").unwrap();
         assert_eq!(decoded.single_event_spans.len(), 1);
@@ -1304,7 +1272,7 @@ mod tests {
         ));
         let mut encoder = Encoder::new();
         encoder
-            .write_event(&schema, &[FieldValue::Varint(100), FieldValue::Varint(999)])
+            .write_event(&schema, 100, &[FieldValue::Varint(999)])
             .unwrap();
         let decoded = decode_trace(&encoder.into_inner(), "source").unwrap();
         assert_eq!(decoded.single_event_spans.len(), 1);
@@ -1389,11 +1357,8 @@ mod tests {
         encoder
             .write_event(
                 &schema,
-                &[
-                    FieldValue::Varint(200),
-                    FieldValue::Varint(100),
-                    FieldValue::Varint(42),
-                ],
+                200,
+                &[FieldValue::Varint(100), FieldValue::Varint(42)],
             )
             .unwrap();
 
@@ -1428,8 +1393,8 @@ mod tests {
             encoder
                 .write_event(
                     &schema,
+                    200,
                     &[
-                        FieldValue::Varint(200),
                         FieldValue::Varint(100),
                         FieldValue::Varint(1_000),
                         FieldValue::Varint(200),

--- a/dial9-viewer/src/simulator.rs
+++ b/dial9-viewer/src/simulator.rs
@@ -969,9 +969,7 @@ fn reencode_trace(
 
     decoder
         .try_for_each_event(|event| {
-            let timestamp_ns = event
-                .timestamp_ns
-                .context("demo replay event has no timestamp")?;
+            let timestamp_ns = event.timestamp_ns;
             let timestamp_ns = if let Some(timeline) = timeline {
                 rebase_value(
                     timestamp_ns,
@@ -997,8 +995,7 @@ fn reencode_trace(
                 schema
             };
 
-            let mut values = Vec::with_capacity(event.fields.len() + 1);
-            values.push(FieldValue::Varint(timestamp_ns));
+            let mut values = Vec::with_capacity(event.fields.len());
             for (field, value) in event.schema.fields().iter().zip(event.fields.iter()) {
                 let mut value = if event.name == "SegmentMetadataEvent" && field.name() == "entries"
                 {
@@ -1038,7 +1035,7 @@ fn reencode_trace(
                 values.push(value);
             }
             encoder
-                .write_event(&schema, &values)
+                .write_event(&schema, timestamp_ns, &values)
                 .with_context(|| format!("re-encode demo event '{}'", event.name))
         })
         .map_err(|error| match error {
@@ -1084,7 +1081,6 @@ fn rewrite_boot_id_value(value: &FieldValueRef<'_>, boot_id: &str) -> anyhow::Re
 fn normalized_replay_schema(schema: &SchemaEntry) -> SchemaEntry {
     SchemaEntry::with_annotations(
         schema.name(),
-        schema.has_timestamp(),
         schema.fields().iter().map(|field| {
             FieldDef::new(
                 field.name(),
@@ -1160,9 +1156,7 @@ fn first_clock_sync(raw: &[u8]) -> anyhow::Result<(u64, u64)> {
             if clock.is_some() || event.name != "ClockSyncEvent" {
                 return Ok::<_, anyhow::Error>(());
             }
-            let timestamp_ns = event
-                .timestamp_ns
-                .context("demo ClockSyncEvent has no timestamp")?;
+            let timestamp_ns = event.timestamp_ns;
             let realtime_ns = event
                 .field_names()
                 .zip(event.fields.iter())
@@ -1196,9 +1190,7 @@ fn timestamp_bounds(raw: &[u8]) -> anyhow::Result<(u64, u64)> {
     let mut max = None;
     decoder
         .try_for_each_event(|event| {
-            let timestamp = event
-                .timestamp_ns
-                .ok_or_else(|| anyhow::anyhow!("demo event has no timestamp"))?;
+            let timestamp = event.timestamp_ns;
             if timestamp == 0 {
                 return Ok::<_, anyhow::Error>(());
             }
@@ -1480,7 +1472,7 @@ mod tests {
                     first_clock = event.deserialize::<ClockSync>().ok();
                 }
                 if event.name == "CpuSampleEvent" {
-                    min_cpu_timestamp = min_cpu_timestamp.min(event.timestamp_ns.unwrap());
+                    min_cpu_timestamp = min_cpu_timestamp.min(event.timestamp_ns);
                     cpu_samples += 1;
                 }
                 if event.name.starts_with("SpanEnter:") {

--- a/dial9-viewer/src/trace_shape.rs
+++ b/dial9-viewer/src/trace_shape.rs
@@ -1664,9 +1664,7 @@ pub(crate) fn extract_shape(data: &[u8]) -> anyhow::Result<TraceShape> {
 
     decoder1
         .try_for_each_event(|ev| {
-            let ts = ev.timestamp_ns.ok_or_else(|| {
-                anyhow::anyhow!("event for schema '{}' has no timestamp", ev.name)
-            })?;
+            let ts = ev.timestamp_ns;
             global_min_ts = Some(global_min_ts.map_or(ts, |m| m.min(ts)));
             global_max_ts = Some(global_max_ts.map_or(ts, |m| m.max(ts)));
             Ok::<(), anyhow::Error>(())
@@ -1775,7 +1773,7 @@ pub(crate) fn extract_shape(data: &[u8]) -> anyhow::Result<TraceShape> {
 
                 let shape_schema = ShapeSchema {
                     name: sanitized_name.clone(),
-                    has_timestamp: ev.schema.has_timestamp(),
+                    has_timestamp: true,
                     fields,
                     annotations,
                 };
@@ -1815,9 +1813,7 @@ pub(crate) fn extract_shape(data: &[u8]) -> anyhow::Result<TraceShape> {
             let schema_idx = schema_index_map[original_name];
 
             // Require timestamp
-            let ts = ev.timestamp_ns.ok_or_else(|| {
-                anyhow::anyhow!("event for schema '{}' has no timestamp", original_name)
-            })?;
+            let ts = ev.timestamp_ns;
             let offset = quantize_ns(ts.saturating_sub(source_base_ts));
 
             // Remap field values using active pools from the RawEvent
@@ -3334,8 +3330,7 @@ fn generate_to_writer_with_bases<W: Write>(
                     FieldAnnotation::new(ann.field_index, ann.key.clone(), ann.value.clone())
                 })
                 .collect();
-            let entry =
-                SchemaEntry::with_annotations(&ss.name, ss.has_timestamp, fields, annotations);
+            let entry = SchemaEntry::with_annotations(&ss.name, fields, annotations);
             Schema::from_entry(entry)
         })
         .collect();
@@ -3370,8 +3365,7 @@ fn generate_to_writer_with_bases<W: Write>(
                 .and_then(|timestamp| timestamp.checked_add(time_shift))
                 .ok_or_else(|| anyhow::anyhow!("timestamp overflow at rep={rep}"))?;
 
-            let mut values = Vec::with_capacity(shape_schema.fields.len() + 1);
-            values.push(FieldValue::Varint(ts_ns)); // timestamp as first value
+            let mut values = Vec::with_capacity(shape_schema.fields.len());
 
             for (fi, sv) in event.values.iter().enumerate() {
                 let field = &shape_schema.fields[fi];
@@ -3390,7 +3384,7 @@ fn generate_to_writer_with_bases<W: Write>(
             }
 
             encoder
-                .write_event(schema, &values)
+                .write_event(schema, ts_ns, &values)
                 .with_context(|| format!("write event for schema '{}'", schema.name()))?;
         }
     }
@@ -3686,8 +3680,8 @@ mod tests {
         let spawn_loc = enc.intern_string("test/source.rs").unwrap();
         enc.write_event(
             schema,
+            ts,
             &[
-                FieldValue::Varint(ts),
                 FieldValue::Varint(worker),
                 FieldValue::Varint(0),
                 FieldValue::Varint(task),
@@ -3713,8 +3707,8 @@ mod tests {
         let spawn_loc = enc.intern_string("test/source.rs").unwrap();
         enc.write_event(
             schema,
+            ts,
             &[
-                FieldValue::Varint(ts),
                 FieldValue::Varint(task),
                 FieldValue::PooledString(spawn_loc),
                 FieldValue::Bool(true),
@@ -3757,8 +3751,8 @@ mod tests {
         let spawn_loc = enc.intern_string("private/source.rs").unwrap();
         enc.write_event(
             &poll_start,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(0),
                 FieldValue::Varint(1),
                 FieldValue::Varint(10),
@@ -3766,15 +3760,12 @@ mod tests {
             ],
         )
         .unwrap();
-        enc.write_event(
-            &poll_end,
-            &[FieldValue::Varint(BASE_TS + 50_000), FieldValue::Varint(0)],
-        )
-        .unwrap();
+        enc.write_event(&poll_end, BASE_TS + 50_000, &[FieldValue::Varint(0)])
+            .unwrap();
         enc.write_event(
             &custom,
+            BASE_TS + 100_000,
             &[
-                FieldValue::Varint(BASE_TS + 100_000),
                 FieldValue::String("password-123".into()),
                 FieldValue::Varint(42),
                 FieldValue::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
@@ -3783,8 +3774,8 @@ mod tests {
         .unwrap();
         enc.write_event(
             &poll_start,
+            BASE_TS + 200_000,
             &[
-                FieldValue::Varint(BASE_TS + 200_000),
                 FieldValue::Varint(1),
                 FieldValue::Varint(2),
                 FieldValue::Varint(11),
@@ -3818,20 +3809,14 @@ mod tests {
 
         enc.write_event(
             &enter,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(7),
-                FieldValue::Varint(999),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(7), FieldValue::Varint(999)],
         )
         .unwrap();
         enc.write_event(
             &exit,
-            &[
-                FieldValue::Varint(BASE_TS + 100_000),
-                FieldValue::Varint(7),
-                FieldValue::Varint(999),
-            ],
+            BASE_TS + 100_000,
+            &[FieldValue::Varint(7), FieldValue::Varint(999)],
         )
         .unwrap();
         enc.finish()
@@ -4019,19 +4004,10 @@ mod tests {
             )
             .unwrap();
 
-        enc.write_event(
-            &spawn,
-            &[FieldValue::Varint(BASE_TS), FieldValue::Varint(100)],
-        )
-        .unwrap();
-        enc.write_event(
-            &spawn,
-            &[
-                FieldValue::Varint(BASE_TS + 10_000),
-                FieldValue::Varint(200),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&spawn, BASE_TS, &[FieldValue::Varint(100)])
+            .unwrap();
+        enc.write_event(&spawn, BASE_TS + 10_000, &[FieldValue::Varint(200)])
+            .unwrap();
         let trace = enc.finish();
 
         let shape = extract_shape(&trace).unwrap();
@@ -4076,8 +4052,8 @@ mod tests {
         let real_addrs = vec![0x7fff_dead_beef_u64, 0x5555_cafe_babe_u64];
         enc.write_event(
             &cpu,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(0),
                 FieldValue::Varint(12345),
                 FieldValue::StackFrames(real_addrs.into()),
@@ -4112,18 +4088,12 @@ mod tests {
             .unwrap();
 
         let real_id = 0xABCD_1234_u64;
-        enc.write_event(
-            &spawn,
-            &[FieldValue::Varint(BASE_TS), FieldValue::Varint(real_id)],
-        )
-        .unwrap();
+        enc.write_event(&spawn, BASE_TS, &[FieldValue::Varint(real_id)])
+            .unwrap();
         enc.write_event(
             &wake,
-            &[
-                FieldValue::Varint(BASE_TS + 10_000),
-                FieldValue::Varint(real_id),
-                FieldValue::Varint(real_id),
-            ],
+            BASE_TS + 10_000,
+            &[FieldValue::Varint(real_id), FieldValue::Varint(real_id)],
         )
         .unwrap();
         let trace = enc.finish();
@@ -4165,10 +4135,10 @@ mod tests {
         // Write event with valid pooled string
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::PooledString(dial9_trace_format::types::InternedString::from_raw(0)),
-            ],
+            BASE_TS,
+            &[FieldValue::PooledString(
+                dial9_trace_format::types::InternedString::from_raw(0),
+            )],
         )
         .unwrap();
         let trace = enc.finish();
@@ -4189,10 +4159,10 @@ mod tests {
         // Write event with pool ID 999 (never interned)
         enc2.write_event(
             &schema2,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::PooledString(dial9_trace_format::types::InternedString::from_raw(999)),
-            ],
+            BASE_TS,
+            &[FieldValue::PooledString(
+                dial9_trace_format::types::InternedString::from_raw(999),
+            )],
         )
         .unwrap();
         let trace2 = enc2.finish();
@@ -4220,21 +4190,12 @@ mod tests {
             .unwrap();
 
         // Events out of order: second event has earliest timestamp
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS + 200_000), FieldValue::Varint(0)],
-        )
-        .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS), FieldValue::Varint(0)],
-        )
-        .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS + 100_000), FieldValue::Varint(0)],
-        )
-        .unwrap();
+        enc.write_event(&schema, BASE_TS + 200_000, &[FieldValue::Varint(0)])
+            .unwrap();
+        enc.write_event(&schema, BASE_TS, &[FieldValue::Varint(0)])
+            .unwrap();
+        enc.write_event(&schema, BASE_TS + 100_000, &[FieldValue::Varint(0)])
+            .unwrap();
         let trace = enc.finish();
 
         let shape = extract_shape(&trace).unwrap();
@@ -4548,20 +4509,14 @@ mod tests {
 
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(42),
-                FieldValue::None,
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(42), FieldValue::None],
         )
         .unwrap();
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS + 10_000),
-                FieldValue::Varint(7),
-                FieldValue::Varint(99),
-            ],
+            BASE_TS + 10_000,
+            &[FieldValue::Varint(7), FieldValue::Varint(99)],
         )
         .unwrap();
         let trace = enc.finish();
@@ -4601,13 +4556,11 @@ mod tests {
 
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::StringMap(vec![
-                    (b"key1".to_vec(), b"val1".to_vec()),
-                    (b"secret_key".to_vec(), b"secret_val".to_vec()),
-                ]),
-            ],
+            BASE_TS,
+            &[FieldValue::StringMap(vec![
+                (b"key1".to_vec(), b"val1".to_vec()),
+                (b"secret_key".to_vec(), b"secret_val".to_vec()),
+            ])],
         )
         .unwrap();
         let trace = enc.finish();
@@ -4643,11 +4596,8 @@ mod tests {
             .unwrap();
 
         let real_epoch = 1_700_000_000_000_000_000u64;
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS), FieldValue::Varint(real_epoch)],
-        )
-        .unwrap();
+        enc.write_event(&schema, BASE_TS, &[FieldValue::Varint(real_epoch)])
+            .unwrap();
         let trace = enc.finish();
 
         let shape = extract_shape(&trace).unwrap();
@@ -4717,8 +4667,8 @@ mod tests {
         // alloc_timestamp = BASE_TS + 50_000 (same timebase as events)
         enc.write_event(
             &schema,
+            BASE_TS + 100_000,
             &[
-                FieldValue::Varint(BASE_TS + 100_000),
                 FieldValue::Varint(1001),
                 FieldValue::Varint(0xCAFE),
                 FieldValue::Varint(1024),
@@ -4741,9 +4691,7 @@ mod tests {
                     timestamp_ns,
                     ..
                 }) => {
-                    if let Some(ts) = timestamp_ns {
-                        event_ts_values.push(ts);
-                    }
+                    event_ts_values.push(timestamp_ns);
                     // alloc_timestamp_ns is at field index 3 (tid, addr, size, alloc_timestamp_ns)
                     if let Some(FieldValue::Varint(v)) = values.get(3) {
                         alloc_ts_values.push(*v);
@@ -4889,14 +4837,12 @@ mod tests {
 
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::List(vec![
-                    FieldValue::Varint(1),
-                    FieldValue::String("hello".into()),
-                    FieldValue::Bool(true),
-                ]),
-            ],
+            BASE_TS,
+            &[FieldValue::List(vec![
+                FieldValue::Varint(1),
+                FieldValue::String("hello".into()),
+                FieldValue::Bool(true),
+            ])],
         )
         .unwrap();
         let trace = enc.finish();
@@ -4942,11 +4888,8 @@ mod tests {
         let pooled = enc.intern_stack_frames(&frames).unwrap();
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(0),
-                FieldValue::PooledStackFrames(pooled),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(0), FieldValue::PooledStackFrames(pooled)],
         )
         .unwrap();
         let trace = enc.finish();
@@ -4991,11 +4934,8 @@ mod tests {
 
         enc.write_event(
             &sym,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(0x1000),
-                FieldValue::Varint(0x100),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(0x1000), FieldValue::Varint(0x100)],
         )
         .unwrap();
         let trace = enc.finish();
@@ -5077,21 +5017,13 @@ mod tests {
 
         // Use a recognizable source realtime
         let source_realtime = 1_700_000_000_123_456_789u64;
-        enc.write_event(
-            &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(source_realtime),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&schema, BASE_TS, &[FieldValue::Varint(source_realtime)])
+            .unwrap();
         // Second event later
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS + 100_000),
-                FieldValue::Varint(source_realtime + 100_000),
-            ],
+            BASE_TS + 100_000,
+            &[FieldValue::Varint(source_realtime + 100_000)],
         )
         .unwrap();
         let trace = enc.finish();
@@ -5166,8 +5098,8 @@ mod tests {
         let frames = enc.intern_stack_frames(&[0x1000]).unwrap();
         enc.write_event(
             &schema,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(1001),
                 FieldValue::Varint(1024),
                 FieldValue::Varint(0xCAFE),
@@ -5178,12 +5110,13 @@ mod tests {
         // Free references the alloc_timestamp
         enc.write_event(
             &free_schema,
+            BASE_TS + 50_000,
             &[
-                FieldValue::Varint(BASE_TS + 50_000),
                 FieldValue::Varint(1001),
                 FieldValue::Varint(0xCAFE),
                 FieldValue::Varint(512),
-                FieldValue::Varint(BASE_TS), // alloc_timestamp_ns = BASE_TS (same as alloc event)
+                FieldValue::Varint(BASE_TS),
+                // alloc_timestamp_ns = BASE_TS (same as alloc event),
             ],
         )
         .unwrap();
@@ -5225,11 +5158,8 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(0),
-                FieldValue::Varint(42),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(0), FieldValue::Varint(42)],
         )
         .unwrap();
         let trace = enc.finish();
@@ -5270,8 +5200,8 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(0),
                 FieldValue::String("John Doe".into()),
                 FieldValue::Varint(12345),
@@ -5303,11 +5233,8 @@ mod tests {
             )
             .unwrap();
         let real_addr = 0x7FFF_DEAD_BEEF_u64;
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS), FieldValue::Varint(real_addr)],
-        )
-        .unwrap();
+        enc.write_event(&schema, BASE_TS, &[FieldValue::Varint(real_addr)])
+            .unwrap();
         let trace = enc.finish();
 
         let shape = extract_shape(&trace).unwrap();
@@ -5339,10 +5266,12 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(3), // small value
-                FieldValue::Varint(7), // small value
+                FieldValue::Varint(3),
+                // small value
+                FieldValue::Varint(7),
+                // small value,
             ],
         )
         .unwrap();
@@ -5389,11 +5318,8 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(999),
-                FieldValue::Varint(888),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(999), FieldValue::Varint(888)],
         )
         .unwrap();
         let trace = enc.finish();
@@ -5438,8 +5364,8 @@ mod tests {
             .unwrap();
         enc.write_event(
             &enter,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(0),
                 FieldValue::Varint(42),
                 FieldValue::Varint(0),
@@ -5478,15 +5404,13 @@ mod tests {
 
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::List(vec![
-                    FieldValue::Varint(42),
-                    FieldValue::PooledString(ps_id),
-                    FieldValue::PooledStackFrames(stack_id),
-                    FieldValue::String("inline_str".into()),
-                ]),
-            ],
+            BASE_TS,
+            &[FieldValue::List(vec![
+                FieldValue::Varint(42),
+                FieldValue::PooledString(ps_id),
+                FieldValue::PooledStackFrames(stack_id),
+                FieldValue::String("inline_str".into()),
+            ])],
         )
         .unwrap();
         let trace = enc.finish();
@@ -5571,19 +5495,17 @@ mod tests {
 
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Map(vec![
-                    (
-                        FieldValue::PooledString(ps_key),
-                        FieldValue::PooledStackFrames(stack_id),
-                    ),
-                    (
-                        FieldValue::String("inline_key".into()),
-                        FieldValue::PooledString(ps_val),
-                    ),
-                ]),
-            ],
+            BASE_TS,
+            &[FieldValue::Map(vec![
+                (
+                    FieldValue::PooledString(ps_key),
+                    FieldValue::PooledStackFrames(stack_id),
+                ),
+                (
+                    FieldValue::String("inline_key".into()),
+                    FieldValue::PooledString(ps_val),
+                ),
+            ])],
         )
         .unwrap();
         let trace = enc.finish();
@@ -6242,17 +6164,11 @@ mod tests {
 
         // Two sequential polls on worker 0
         write_poll_start(&mut enc, &start, BASE_TS, 0, 1);
-        enc.write_event(
-            &end,
-            &[FieldValue::Varint(BASE_TS + 100_000), FieldValue::Varint(0)],
-        )
-        .unwrap();
+        enc.write_event(&end, BASE_TS + 100_000, &[FieldValue::Varint(0)])
+            .unwrap();
         write_poll_start(&mut enc, &start, BASE_TS + 200_000, 0, 1);
-        enc.write_event(
-            &end,
-            &[FieldValue::Varint(BASE_TS + 400_000), FieldValue::Varint(0)],
-        )
-        .unwrap();
+        enc.write_event(&end, BASE_TS + 400_000, &[FieldValue::Varint(0)])
+            .unwrap();
 
         let trace = enc.finish();
         let shape = extract_shape(&trace).unwrap();
@@ -6288,38 +6204,26 @@ mod tests {
         // Two enter/exit cycles for span 42
         enc.write_event(
             &enter,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(0),
-                FieldValue::Varint(42),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(0), FieldValue::Varint(42)],
         )
         .unwrap();
         enc.write_event(
             &exit,
-            &[
-                FieldValue::Varint(BASE_TS + 100_000),
-                FieldValue::Varint(0),
-                FieldValue::Varint(42),
-            ],
+            BASE_TS + 100_000,
+            &[FieldValue::Varint(0), FieldValue::Varint(42)],
         )
         .unwrap();
         enc.write_event(
             &enter,
-            &[
-                FieldValue::Varint(BASE_TS + 200_000),
-                FieldValue::Varint(0),
-                FieldValue::Varint(42),
-            ],
+            BASE_TS + 200_000,
+            &[FieldValue::Varint(0), FieldValue::Varint(42)],
         )
         .unwrap();
         enc.write_event(
             &exit,
-            &[
-                FieldValue::Varint(BASE_TS + 500_000),
-                FieldValue::Varint(0),
-                FieldValue::Varint(42),
-            ],
+            BASE_TS + 500_000,
+            &[FieldValue::Varint(0), FieldValue::Varint(42)],
         )
         .unwrap();
 
@@ -6369,8 +6273,8 @@ mod tests {
         // target_worker=5 should NOT be counted as a worker
         enc.write_event(
             &wake,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(1),
                 FieldValue::Varint(2),
                 FieldValue::Varint(5),
@@ -6402,14 +6306,8 @@ mod tests {
                 vec![FieldDef::new("field_a", FieldType::String)],
             )
             .unwrap();
-        enc1.write_event(
-            &schema1,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::String("hello".into()),
-            ],
-        )
-        .unwrap();
+        enc1.write_event(&schema1, BASE_TS, &[FieldValue::String("hello".into())])
+            .unwrap();
         let part1 = enc1.finish();
 
         let mut enc2 = Encoder::new();
@@ -6419,14 +6317,8 @@ mod tests {
                 vec![FieldDef::new("field_a", FieldType::Varint)],
             )
             .unwrap();
-        enc2.write_event(
-            &schema2,
-            &[
-                FieldValue::Varint(BASE_TS + 100_000),
-                FieldValue::Varint(42),
-            ],
-        )
-        .unwrap();
+        enc2.write_event(&schema2, BASE_TS + 100_000, &[FieldValue::Varint(42)])
+            .unwrap();
         let part2 = enc2.finish();
 
         // Concatenate: simulates a reset (new header mid-stream)
@@ -6459,11 +6351,8 @@ mod tests {
             )
             .unwrap();
         let ps1 = enc1.intern_string("pooled_val").unwrap();
-        enc1.write_event(
-            &schema1,
-            &[FieldValue::Varint(BASE_TS), FieldValue::PooledString(ps1)],
-        )
-        .unwrap();
+        enc1.write_event(&schema1, BASE_TS, &[FieldValue::PooledString(ps1)])
+            .unwrap();
         let part1 = enc1.finish();
 
         let mut enc2 = Encoder::new();
@@ -6477,10 +6366,8 @@ mod tests {
         let ps2 = enc2.intern_string("another_val").unwrap();
         enc2.write_event(
             &schema2,
-            &[
-                FieldValue::Varint(BASE_TS + 100_000),
-                FieldValue::PooledString(ps2),
-            ],
+            BASE_TS + 100_000,
+            &[FieldValue::PooledString(ps2)],
         )
         .unwrap();
         let part2 = enc2.finish();
@@ -6505,16 +6392,10 @@ mod tests {
                 vec![FieldDef::new("worker_id", FieldType::Varint)],
             )
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS), FieldValue::Varint(3)],
-        )
-        .unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS + 10_000), FieldValue::Varint(5)],
-        )
-        .unwrap();
+        enc.write_event(&schema, BASE_TS, &[FieldValue::Varint(3)])
+            .unwrap();
+        enc.write_event(&schema, BASE_TS + 10_000, &[FieldValue::Varint(5)])
+            .unwrap();
         let trace = enc.finish();
 
         let shape = extract_shape(&trace).unwrap();
@@ -6553,7 +6434,7 @@ mod tests {
             .unwrap();
 
         write_poll_start(&mut enc, &start, BASE_TS, 0, 1);
-        enc.write_event(&end, &[FieldValue::Varint(BASE_TS), FieldValue::Varint(0)])
+        enc.write_event(&end, BASE_TS, &[FieldValue::Varint(0)])
             .unwrap();
 
         let trace = enc.finish();
@@ -6589,20 +6470,14 @@ mod tests {
 
         enc.write_event(
             &enter,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(0),
-                FieldValue::Varint(42),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(0), FieldValue::Varint(42)],
         )
         .unwrap();
         enc.write_event(
             &exit,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(0),
-                FieldValue::Varint(42),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(0), FieldValue::Varint(42)],
         )
         .unwrap();
 
@@ -6651,8 +6526,8 @@ mod tests {
         let source_realtime = 1_700_000_000_000_000_000u64;
         enc.write_event(
             &schema,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(source_realtime),
                 FieldValue::Varint(BASE_TS),
             ],
@@ -6685,14 +6560,8 @@ mod tests {
             .unwrap();
 
         let source_realtime = 1_700_000_000_000_000_000u64;
-        enc.write_event(
-            &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(source_realtime),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&schema, BASE_TS, &[FieldValue::Varint(source_realtime)])
+            .unwrap();
         let trace = enc.finish();
 
         let shape = extract_shape(&trace).unwrap();
@@ -6769,8 +6638,8 @@ mod tests {
 
         enc.write_event(
             &schema,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(0),
                 FieldValue::StackFrames(vec![0x1000u64, 0x2000].into()),
             ],
@@ -6820,8 +6689,8 @@ mod tests {
         let pooled = enc.intern_stack_frames(&[0x1010, 0x1020]).unwrap();
         enc.write_event(
             &schema,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::List(vec![FieldValue::StackFrames(vec![0x1000, 0x1010].into())]),
                 FieldValue::Map(vec![(
                     FieldValue::String("stack".into()),
@@ -6924,13 +6793,11 @@ mod tests {
 
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::List(vec![FieldValue::StringMap(vec![
-                    (b"key1".to_vec(), b"val1".to_vec()),
-                    (b"key2".to_vec(), b"val2".to_vec()),
-                ])]),
-            ],
+            BASE_TS,
+            &[FieldValue::List(vec![FieldValue::StringMap(vec![
+                (b"key1".to_vec(), b"val1".to_vec()),
+                (b"key2".to_vec(), b"val2".to_vec()),
+            ])])],
         )
         .unwrap();
         let trace = enc.finish();
@@ -7044,8 +6911,8 @@ mod tests {
         let spawn_loc = enc.intern_string("source.rs").unwrap();
         enc.write_event(
             &schema,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::String("not-a-worker".into()),
                 FieldValue::Varint(1),
                 FieldValue::Varint(2),
@@ -7086,8 +6953,8 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
+            BASE_TS,
             &[
-                FieldValue::Varint(BASE_TS),
                 FieldValue::Varint(0),
                 FieldValue::Varint(100),
                 FieldValue::Varint(500_000),
@@ -7255,14 +7122,12 @@ mod tests {
             .unwrap();
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::List(vec![
-                    FieldValue::Varint(1),
-                    FieldValue::Varint(2),
-                    FieldValue::String("hello".into()),
-                ]),
-            ],
+            BASE_TS,
+            &[FieldValue::List(vec![
+                FieldValue::Varint(1),
+                FieldValue::Varint(2),
+                FieldValue::String("hello".into()),
+            ])],
         )
         .unwrap();
         let trace = enc.finish();
@@ -7433,16 +7298,13 @@ mod tests {
             FieldAnnotation::new(0, "kind", "counter"),
             FieldAnnotation::new(1, "kind", "histogram"),
         ];
-        let entry = SchemaEntry::with_annotations("TestEvent", true, fields, annotations);
+        let entry = SchemaEntry::with_annotations("TestEvent", fields, annotations);
         let schema = dial9_trace_format::encoder::Schema::from_entry(entry);
         enc.register_existing(&schema).unwrap();
         enc.write_event(
             &schema,
-            &[
-                FieldValue::Varint(BASE_TS),
-                FieldValue::Varint(1000),
-                FieldValue::Varint(5),
-            ],
+            BASE_TS,
+            &[FieldValue::Varint(1000), FieldValue::Varint(5)],
         )
         .unwrap();
         let trace = enc.finish();
@@ -7476,14 +7338,11 @@ mod tests {
         let mut enc = Encoder::new();
         let fields = vec![FieldDef::new("timeout_s", FieldType::Varint)];
         let annotations = vec![FieldAnnotation::new(0, "unit", "s")];
-        let entry = SchemaEntry::with_annotations("TestEvent", true, fields, annotations);
+        let entry = SchemaEntry::with_annotations("TestEvent", fields, annotations);
         let schema = dial9_trace_format::encoder::Schema::from_entry(entry);
         enc.register_existing(&schema).unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS), FieldValue::Varint(30)],
-        )
-        .unwrap();
+        enc.write_event(&schema, BASE_TS, &[FieldValue::Varint(30)])
+            .unwrap();
         let trace = enc.finish();
 
         let shape = extract_shape(&trace).unwrap();
@@ -7763,11 +7622,8 @@ mod tests {
             )
             .unwrap();
         let id = enc.intern_string("test_pool_value").unwrap();
-        enc.write_event(
-            &schema,
-            &[FieldValue::Varint(BASE_TS), FieldValue::PooledString(id)],
-        )
-        .unwrap();
+        enc.write_event(&schema, BASE_TS, &[FieldValue::PooledString(id)])
+            .unwrap();
         let trace = enc.finish();
 
         let shape = extract_shape(&trace).unwrap();

--- a/dial9-viewer/tests/aggregate_test.rs
+++ b/dial9-viewer/tests/aggregate_test.rs
@@ -104,11 +104,8 @@ fn mini_trace() -> (Vec<u8>, MiniCounts) {
     for (ts, worker, tid) in [(10u64, 0u64, 100u64), (11, 1, 101)] {
         enc.write_event(
             &park,
-            &[
-                FieldValue::Varint(ts),
-                FieldValue::Varint(worker),
-                FieldValue::Varint(tid),
-            ],
+            ts,
+            &[FieldValue::Varint(worker), FieldValue::Varint(tid)],
         )
         .unwrap();
     }
@@ -131,8 +128,8 @@ fn mini_trace() -> (Vec<u8>, MiniCounts) {
     for &(ts, tid, source, frames) in events {
         enc.write_event(
             &cpu,
+            ts,
             &[
-                FieldValue::Varint(ts),
                 FieldValue::Varint(tid),
                 FieldValue::Varint(source),
                 FieldValue::StackFrames(frames.to_vec().into()),
@@ -218,31 +215,21 @@ fn poll_trace_gz() -> Vec<u8> {
 
     // Bind tid 100 -> worker 0 early (before any poll), so the binding doesn't
     // close an open poll span. The first varint of every event is its timestamp.
-    enc.write_event(
-        &park,
-        &[
-            FieldValue::Varint(1),
-            FieldValue::Varint(0),
-            FieldValue::Varint(100),
-        ],
-    )
-    .unwrap();
+    enc.write_event(&park, 1, &[FieldValue::Varint(0), FieldValue::Varint(100)])
+        .unwrap();
 
     // Fast poll on worker 0: [1_000_000, 1_500_000) → 500_000 ns (0.5 ms).
     enc.write_event(
         &poll_start,
-        &[
-            FieldValue::Varint(1_000_000),
-            FieldValue::Varint(0),
-            FieldValue::Varint(7),
-        ],
+        1_000_000,
+        &[FieldValue::Varint(0), FieldValue::Varint(7)],
     )
     .unwrap();
     for ts in [1_100_000u64, 1_300_000] {
         enc.write_event(
             &cpu,
+            ts,
             &[
-                FieldValue::Varint(ts),
                 FieldValue::Varint(100),
                 FieldValue::Varint(0),
                 FieldValue::StackFrames(vec![0x1000u64, 0x2000].into()),
@@ -250,27 +237,21 @@ fn poll_trace_gz() -> Vec<u8> {
         )
         .unwrap();
     }
-    enc.write_event(
-        &poll_end,
-        &[FieldValue::Varint(1_500_000), FieldValue::Varint(0)],
-    )
-    .unwrap();
+    enc.write_event(&poll_end, 1_500_000, &[FieldValue::Varint(0)])
+        .unwrap();
 
     // Slow poll on worker 0: [10_000_000, 60_000_000) → 50_000_000 ns (50 ms).
     enc.write_event(
         &poll_start,
-        &[
-            FieldValue::Varint(10_000_000),
-            FieldValue::Varint(0),
-            FieldValue::Varint(8),
-        ],
+        10_000_000,
+        &[FieldValue::Varint(0), FieldValue::Varint(8)],
     )
     .unwrap();
     for ts in [20_000_000u64, 30_000_000, 40_000_000] {
         enc.write_event(
             &cpu,
+            ts,
             &[
-                FieldValue::Varint(ts),
                 FieldValue::Varint(100),
                 FieldValue::Varint(0),
                 FieldValue::StackFrames(vec![0x1000u64, 0x3000].into()),
@@ -278,18 +259,15 @@ fn poll_trace_gz() -> Vec<u8> {
         )
         .unwrap();
     }
-    enc.write_event(
-        &poll_end,
-        &[FieldValue::Varint(60_000_000), FieldValue::Varint(0)],
-    )
-    .unwrap();
+    enc.write_event(&poll_end, 60_000_000, &[FieldValue::Varint(0)])
+        .unwrap();
 
     // One off-worker sample (tid 999 is never bound) → no enclosing poll, so its
     // poll_duration_ns is null and any band excludes it.
     enc.write_event(
         &cpu,
+        70_000_000,
         &[
-            FieldValue::Varint(70_000_000),
             FieldValue::Varint(999),
             FieldValue::Varint(0),
             FieldValue::StackFrames(vec![0x1000u64, 0x2000].into()),

--- a/dial9/tests/cli_trace_shape.rs
+++ b/dial9/tests/cli_trace_shape.rs
@@ -32,11 +32,8 @@ fn make_test_trace() -> Vec<u8> {
     let schema = enc
         .register_schema("TestEvent", vec![FieldDef::new("value", FieldType::Varint)])
         .unwrap();
-    enc.write_event(
-        &schema,
-        &[FieldValue::Varint(1_000), FieldValue::Varint(42)],
-    )
-    .unwrap();
+    enc.write_event(&schema, 1_000, &[FieldValue::Varint(42)])
+        .unwrap();
     enc.finish()
 }
 

--- a/perf-self-profile/src/cpu_source.rs
+++ b/perf-self-profile/src/cpu_source.rs
@@ -566,7 +566,7 @@ mod cpu_sample_round_trip_tests {
 
     /// Encode a `CpuSampleEvent` with the given `cpu` and decode it back to the
     /// event frame's `(timestamp, field values)`.
-    fn round_trip(cpu: Option<u64>) -> (Option<u64>, Vec<FieldValue>) {
+    fn round_trip(cpu: Option<u64>) -> (u64, Vec<FieldValue>) {
         let mut enc = Encoder::new();
         let thread_name = enc.intern_string("tokio-runtime-worker").unwrap();
         let callchain = enc
@@ -602,7 +602,7 @@ mod cpu_sample_round_trip_tests {
     #[test]
     fn cpu_sample_event_round_trips_with_cpu() {
         let (timestamp_ns, values) = round_trip(Some(3));
-        assert_eq!(timestamp_ns, Some(7_000_000));
+        assert_eq!(timestamp_ns, 7_000_000);
         assert_eq!(values[1], FieldValue::Varint(9999)); // tid
         // `cpu` is the last field; `Some(3)` encodes as an OptionalVarint.
         assert_eq!(*values.last().unwrap(), FieldValue::Varint(3));

--- a/perf-self-profile/src/offline_symbolize.rs
+++ b/perf-self-profile/src/offline_symbolize.rs
@@ -571,7 +571,7 @@ mod tests {
         let schema = enc
             .register_schema("Ev", vec![FieldDef::new("count", FieldType::Varint)])
             .unwrap();
-        enc.write_event(&schema, &[FieldValue::Varint(0), FieldValue::Varint(42)])
+        enc.write_event(&schema, 0, &[FieldValue::Varint(42)])
             .unwrap();
         let buf = enc.finish();
 
@@ -592,14 +592,8 @@ mod tests {
         let schema = enc
             .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[
-                FieldValue::Varint(0),
-                FieldValue::StackFrames(vec![0x1000].into()),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&schema, 0, &[FieldValue::StackFrames(vec![0x1000].into())])
+            .unwrap();
         let buf = enc.finish();
 
         let mut output = Vec::new();
@@ -631,14 +625,8 @@ mod tests {
             let schema = enc
                 .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
                 .unwrap();
-            enc.write_event(
-                &schema,
-                &[
-                    FieldValue::Varint(0),
-                    FieldValue::StackFrames(vec![addr].into()),
-                ],
-            )
-            .unwrap();
+            enc.write_event(&schema, 0, &[FieldValue::StackFrames(vec![addr].into())])
+                .unwrap();
             segs.push(enc.finish());
         }
 
@@ -674,14 +662,8 @@ mod tests {
             let schema = enc
                 .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
                 .unwrap();
-            enc.write_event(
-                &schema,
-                &[
-                    FieldValue::Varint(0),
-                    FieldValue::StackFrames(vec![addr].into()),
-                ],
-            )
-            .unwrap();
+            enc.write_event(&schema, 0, &[FieldValue::StackFrames(vec![addr].into())])
+                .unwrap();
             segs.push(enc.finish());
         }
 
@@ -712,14 +694,8 @@ mod tests {
         let schema = enc
             .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[
-                FieldValue::Varint(0),
-                FieldValue::StackFrames(vec![addr].into()),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&schema, 0, &[FieldValue::StackFrames(vec![addr].into())])
+            .unwrap();
         let buf = enc.finish();
 
         let symbolizer = OfflineSymbolizer::new();

--- a/perf-self-profile/src/sys/linux/offline_symbolize.rs
+++ b/perf-self-profile/src/sys/linux/offline_symbolize.rs
@@ -324,11 +324,8 @@ mod tests {
             )
             .unwrap();
         let id_a = enc1.intern_stack_frames(&[addr_a]).unwrap();
-        enc1.write_event(
-            &schema1,
-            &[FieldValue::Varint(0), FieldValue::PooledStackFrames(id_a)],
-        )
-        .unwrap();
+        enc1.write_event(&schema1, 0, &[FieldValue::PooledStackFrames(id_a)])
+            .unwrap();
         let seg1 = enc1.finish();
 
         // Segment 2: contains addr_b.
@@ -340,11 +337,8 @@ mod tests {
             )
             .unwrap();
         let id_b = enc2.intern_stack_frames(&[addr_b]).unwrap();
-        enc2.write_event(
-            &schema2,
-            &[FieldValue::Varint(0), FieldValue::PooledStackFrames(id_b)],
-        )
-        .unwrap();
+        enc2.write_event(&schema2, 0, &[FieldValue::PooledStackFrames(id_b)])
+            .unwrap();
         let seg2 = enc2.finish();
 
         let mut concatenated = seg1;
@@ -378,14 +372,8 @@ mod tests {
         let schema = enc
             .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[
-                FieldValue::Varint(0),
-                FieldValue::StackFrames(vec![addr].into()),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&schema, 0, &[FieldValue::StackFrames(vec![addr].into())])
+            .unwrap();
         let buf = enc.finish();
 
         let mut output = Vec::new();
@@ -428,14 +416,8 @@ mod tests {
         let schema = enc
             .register_schema("Ev", vec![FieldDef::new("frames", FieldType::StackFrames)])
             .unwrap();
-        enc.write_event(
-            &schema,
-            &[
-                FieldValue::Varint(0),
-                FieldValue::StackFrames(vec![addr].into()),
-            ],
-        )
-        .unwrap();
+        enc.write_event(&schema, 0, &[FieldValue::StackFrames(vec![addr].into())])
+            .unwrap();
         let buf = enc.finish();
 
         let mut output = Vec::new();

--- a/perf-self-profile/src/tracepoint.rs
+++ b/perf-self-profile/src/tracepoint.rs
@@ -236,10 +236,7 @@ impl TracepointDef {
     ) -> io::Result<()> {
         let extracted = self.extract_fields(raw)?;
         let field_values = self.to_trace_format_values(&extracted);
-        let mut values = Vec::with_capacity(1 + field_values.len());
-        values.push(FieldValue::Varint(timestamp_ns));
-        values.extend(field_values);
-        encoder.write_event(schema, &values)
+        encoder.write_event(schema, timestamp_ns, &field_values)
     }
 }
 
@@ -634,7 +631,6 @@ print fmt: "prev_comm=%s prev_pid=%d prev_prio=%d prev_state=%s%s ==> next_comm=
             match frame {
                 DecodedFrame::Schema(entry) => {
                     assert_eq!(entry.name(), "sched_switch");
-                    assert!(entry.has_timestamp());
                     assert_eq!(entry.fields().len(), 7);
                     assert_eq!(entry.fields()[0].name(), "prev_comm");
                     found_schema = true;
@@ -644,7 +640,7 @@ print fmt: "prev_comm=%s prev_pid=%d prev_prio=%d prev_state=%s%s ==> next_comm=
                     values,
                     ..
                 } => {
-                    assert_eq!(timestamp_ns, Some(5_000_000));
+                    assert_eq!(timestamp_ns, 5_000_000);
                     // prev_comm
                     assert_eq!(values[0], FieldValue::String("bash".to_string()));
                     // prev_pid

--- a/perf-self-profile/tests/tracepoint_e2e.rs
+++ b/perf-self-profile/tests/tracepoint_e2e.rs
@@ -91,7 +91,6 @@ fn tracepoint_sched_switch_e2e() {
         match frame {
             DecodedFrame::Schema(entry) => {
                 assert_eq!(entry.name(), "sched_switch");
-                assert!(entry.has_timestamp());
                 assert_eq!(entry.fields().len(), tp.fields.len());
                 schema_count += 1;
             }
@@ -100,7 +99,7 @@ fn tracepoint_sched_switch_e2e() {
                 values,
                 ..
             } => {
-                assert!(timestamp_ns.is_some());
+                assert!(*timestamp_ns > 0);
                 assert_eq!(values.len(), tp.fields.len());
                 if values
                     .iter()


### PR DESCRIPTION
## Summary
Cleanup a long-annoying behavior where you had to front-pack a u64 at the front of your schema and we would magically interpret it as a timestamp. All events need timestamps.


## Changes

- **SchemaEntry**: removed `has_timestamp` field; `new()` and `with_annotations()` no longer accept the bool parameter
- **TraceEvent trait**: removed `has_timestamp()` method
- **Decoded types**: `DecodedFrame::Event`, `DecodedFrameRef::Event`, and `RawEvent` `timestamp_ns` is now `u64` (was `Option<u64>`)
- **Encoder**: always writes `has_timestamp=1` on the wire
- **Decoder**: reads the wire byte; if `0` (legacy), assigns current timestamp base instead of `None`

No wire format version bump. The byte is preserved for forward compatibility.

## Testing

- All 1344 workspace tests pass
- `cargo fmt --check` clean
- `cargo clippy --all-targets --all-features` clean

## Breaking Change

`SchemaEntry::new()`, `SchemaEntry::with_annotations()` lost the `has_timestamp: bool` parameter. `timestamp_ns` fields changed from `Option<u64>` to `u64`.