### PR TITLE
feat(viewer): default dial9-traces prefix and open picker on multi-bucket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,19 @@ rate_limited!(Duration::from_secs(60), {
 ```
 Unguarded logging in loops causes log spam that degrades observability and can itself become a performance problem. One-time paths (startup, shutdown, per-thread init) are exempt.
 
+## Viewer UI
+
+The viewer UI is mid-migration (ADR-0004): every page exists in two versions —
+a **legacy** one (inline `<script>` in `dial9-viewer/ui/*.html`, e.g.
+`index.html`) served at its canonical URL, and a **new** Vite/TypeScript one
+(`dial9-viewer/ui/src/pages/**`, served under `/new/…`) that is now the
+default. **Make behavior changes in the new UI only** (`src/`). Do NOT edit the
+legacy pages/scripts — they are frozen for the migration and are not what users
+load. Shared logic lives in the frozen-core modules at the `ui/` root (e.g.
+`prefix_detect.js`), imported into the new UI through the `src/lib/**` seams;
+change those when the behavior is genuinely shared, and expose new exports via
+the seam rather than reaching into the legacy pages.
+
 ## Testing
 
 ### Local viewer server

--- a/dial9-viewer/ui/prefix_detect.js
+++ b/dial9-viewer/ui/prefix_detect.js
@@ -37,6 +37,25 @@ function isDateLayer(prefixes) {
   return dateCount * 2 > prefixes.length;
 }
 
+// The conventional default key prefix dial9 writes traces under. When a bucket
+// exposes several key prefixes we can't otherwise disambiguate, prefer this one
+// if it's present rather than leaving the user to pick.
+const DEFAULT_TRACE_PREFIX = "dial9-traces";
+
+// Pick a sensible prefix to pre-select from a discovered listing, or undefined
+// when the user should choose. Returns `dial9-traces` if the listing offers it
+// (the conventional default), otherwise the sole prefix when there is exactly
+// one. With multiple non-default prefixes we return undefined so the picker
+// stays neutral. Prefixes may carry a trailing slash; the returned value never
+// does.
+function preferredPrefix(prefixes) {
+  if (!prefixes || prefixes.length === 0) return undefined;
+  const labels = prefixes.map((p) => String(p).replace(/\/+$/, ""));
+  if (labels.includes(DEFAULT_TRACE_PREFIX)) return DEFAULT_TRACE_PREFIX;
+  if (labels.length === 1) return labels[0];
+  return undefined;
+}
+
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { lastSegment, isDateLayer };
+  module.exports = { lastSegment, isDateLayer, preferredPrefix };
 }

--- a/dial9-viewer/ui/src/lib/trace/index.ts
+++ b/dial9-viewer/ui/src/lib/trace/index.ts
@@ -34,7 +34,7 @@ export type { IdentityField, ReconciledIdentity } from "./segment-metadata.js";
 export { formatFieldValue } from "./format.js";
 
 // prefixes.ts - S3 prefix-discovery heuristics (frozen prefix_detect.js).
-export { isDateLayer, lastSegment } from "./prefixes.js";
+export { isDateLayer, lastSegment, preferredPrefix } from "./prefixes.js";
 
 // load.ts - load orchestration + the trace_parser.js surface.
 export {

--- a/dial9-viewer/ui/src/lib/trace/prefixes.ts
+++ b/dial9-viewer/ui/src/lib/trace/prefixes.ts
@@ -1,4 +1,4 @@
 // Typed re-exports of the frozen core's S3 prefix-discovery heuristics
 // (prefix_detect.js). lib/trace is the sanctioned import seam.
 
-export { isDateLayer, lastSegment } from "../../../prefix_detect.js";
+export { isDateLayer, lastSegment, preferredPrefix } from "../../../prefix_detect.js";

--- a/dial9-viewer/ui/src/pages/browser/actions.ts
+++ b/dial9-viewer/ui/src/pages/browser/actions.ts
@@ -17,7 +17,7 @@ import {
   makeSourceScope,
   type SourceScope,
 } from "../../lib/trace/source-scope.js";
-import { isDateLayer } from "../../lib/trace/prefixes.js";
+import { isDateLayer, preferredPrefix } from "../../lib/trace/prefixes.js";
 import { DRAG_INTENT_PX } from "../../lib/interact/pointer.js";
 import {
   apiFetch,
@@ -495,11 +495,16 @@ export function createActions(store: BrowserStore, els: BrowserEls): BrowserActi
         syncUrl();
         return;
       }
-      // If there's exactly one prefix and the input is empty, auto-select it
-      if (prefixes.length === 1 && !els.prefixInput.value) {
-        els.prefixInput.value = prefixes[0]!.replace(/\/$/, "");
-        mirrorPrefix();
-        syncUrl();
+      // Pre-select a prefix when the input is empty: `dial9-traces` if the
+      // bucket offers it (the conventional default), otherwise the sole
+      // prefix. With several non-default prefixes we leave it to the user.
+      if (!els.prefixInput.value) {
+        const preferred = preferredPrefix(prefixes);
+        if (preferred) {
+          els.prefixInput.value = preferred;
+          mirrorPrefix();
+          syncUrl();
+        }
       }
       const labels = prefixes.map((p) => p.replace(/\/$/, ""));
       const current = els.prefixInput.value;

--- a/dial9-viewer/ui/src/pages/browser/creds-panel.test.ts
+++ b/dial9-viewer/ui/src/pages/browser/creds-panel.test.ts
@@ -246,6 +246,95 @@ describe("mountCredsPanel", () => {
     expect(discoverServices).toHaveBeenCalledOnce();
   });
 
+  it("opens the panel and picks nothing when several buckets are available", async () => {
+    const creds = {
+      has: vi.fn(() => false),
+      get: vi.fn(() => ({ kind: "ambient" })),
+      set: vi.fn(async () => ({ ok: true, error: null })),
+      setRegion: vi.fn(),
+      check: vi.fn(),
+      listBuckets: vi.fn(async () => [
+        { name: "dial9-traces-one", region: "us-east-1" },
+        { name: "dial9-traces-two", region: "us-east-1" },
+      ]),
+      clear: vi.fn(),
+      parse: vi.fn(),
+    } as unknown as Dial9CredsApi;
+    vi.stubGlobal("window", {
+      Dial9Creds: creds,
+      addEventListener: vi.fn(),
+    });
+    vi.stubGlobal("document", {
+      createElement: () => new FakeElement(),
+      createTextNode: (text: string) => {
+        const node = new FakeElement();
+        node.textContent = text;
+        return node;
+      },
+    });
+
+    const discoverServices = vi.fn(async () => {});
+    const actions = {
+      syncUrl: vi.fn(),
+      discoverPrefixes: vi.fn(async () => {}),
+      discoverServices,
+    } as unknown as BrowserActions;
+    const store = createBrowserStore();
+    const els = fakeEls();
+    const panel = mountCredsPanel({ store, els, actions });
+    panel.init();
+
+    els.credsAkid.value = "AK";
+    els.credsSecret.value = "SK";
+    els.credsApply.click();
+    await drainMicrotasks();
+
+    // Neither bucket is auto-selected — the user must choose — and the panel
+    // is opened so the picker is in view.
+    expect(els.bucketInput.value).toBe("");
+    expect(store.getState().creds.panelOpen).toBe(true);
+    expect(discoverServices).not.toHaveBeenCalled();
+  });
+
+  it("does not force the panel open when a bucket is already selected", async () => {
+    const creds = {
+      has: vi.fn(() => true),
+      get: vi.fn(() => ({ kind: "role", roleArn: "arn:aws:iam::123456789012:role/R" })),
+      listBuckets: vi.fn(async () => [
+        { name: "dial9-traces-one", region: "us-east-1" },
+        { name: "dial9-traces-two", region: "us-east-1" },
+      ]),
+    } as unknown as Dial9CredsApi;
+    vi.stubGlobal("window", {
+      Dial9Creds: creds,
+      addEventListener: vi.fn(),
+    });
+    vi.stubGlobal("document", {
+      createElement: () => new FakeElement(),
+      createTextNode: (text: string) => {
+        const node = new FakeElement();
+        node.textContent = text;
+        return node;
+      },
+    });
+
+    const actions = {
+      syncUrl: vi.fn(),
+      discoverPrefixes: vi.fn(async () => {}),
+      discoverServices: vi.fn(async () => {}),
+    } as unknown as BrowserActions;
+    const store = createBrowserStore();
+    const els = fakeEls();
+    // A bucket restored from a shared link is already pinned before boot.
+    els.bucketInput.value = "dial9-traces-one";
+    const panel = mountCredsPanel({ store, els, actions });
+    panel.init();
+    // Returning user: has() is true, so boot re-lists their buckets.
+    await drainMicrotasks();
+
+    expect(store.getState().creds.panelOpen).toBe(false);
+  });
+
   it("discovers services when userscript credentials arrive for a picked bucket", async () => {
     let active = false;
     let credentialsChanged: Listener | undefined;

--- a/dial9-viewer/ui/src/pages/browser/creds-panel.ts
+++ b/dial9-viewer/ui/src/pages/browser/creds-panel.ts
@@ -112,14 +112,20 @@ export function mountCredsPanel({ store, els, actions }: PageCtx): CredsPanel {
 
   // Auto-select when there's exactly one filter-matching bucket - the
   // common case - but not in the "show all" view, where the user is
-  // browsing.
+  // browsing. With several buckets to choose from and none selected yet,
+  // open the panel so the picker is in view (skipped when a bucket is
+  // already chosen, e.g. restored from a shared link).
   function autoSelectSingleMatch(): void {
     const s = store.getState().creds;
     if (s.showAll) return;
     const matches = [...s.buckets]
       .sort((a, b) => a.name.localeCompare(b.name))
       .filter(isTraceBucket);
-    if (matches.length === 1) void selectBucket(matches[0]!);
+    if (matches.length === 1) {
+      void selectBucket(matches[0]!);
+    } else if (matches.length > 1 && !els.bucketInput.value.trim()) {
+      togglePanel(true);
+    }
   }
 
   // List the buckets the stored credentials can see and render the picker.

--- a/dial9-viewer/ui/src/types/prefix_detect.d.ts
+++ b/dial9-viewer/ui/src/types/prefix_detect.d.ts
@@ -17,4 +17,14 @@ declare module "*/prefix_detect.js" {
   export function isDateLayer(
     prefixes: readonly string[] | null | undefined
   ): boolean;
+
+  /**
+   * The prefix to pre-select from a discovered listing, or `undefined` when
+   * the user should choose. Returns `dial9-traces` when the listing offers it
+   * (the conventional default), otherwise the sole prefix when there is
+   * exactly one. Trailing slashes are stripped from the result.
+   */
+  export function preferredPrefix(
+    prefixes: readonly string[] | null | undefined
+  ): string | undefined;
 }

--- a/dial9-viewer/ui/tests/core/prefix_detection.test.ts
+++ b/dial9-viewer/ui/tests/core/prefix_detection.test.ts
@@ -14,8 +14,9 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
-const { isDateLayer } = require("../../prefix_detect.js") as {
+const { isDateLayer, preferredPrefix } = require("../../prefix_detect.js") as {
   isDateLayer: (children: string[]) => boolean;
+  preferredPrefix: (children: string[]) => string | undefined;
 };
 
 describe("isDateLayer", () => {
@@ -84,5 +85,36 @@ describe("isDateLayer", () => {
   // Things that merely start with digits but aren't dates.
   it("partial date-like segments -> not a date layer", () => {
     expect(isDateLayer(["2026/", "2026-06/"])).toBe(false);
+  });
+});
+
+describe("preferredPrefix", () => {
+  // Empty / missing listings have nothing to pre-select.
+  it("empty list -> undefined", () => {
+    expect(preferredPrefix([])).toBeUndefined();
+    expect(preferredPrefix(undefined as unknown as string[])).toBeUndefined();
+  });
+
+  // A single prefix is auto-selected (trailing slash stripped).
+  it("single prefix -> that prefix", () => {
+    expect(preferredPrefix(["traces/"])).toBe("traces");
+    expect(preferredPrefix(["checkout-api"])).toBe("checkout-api");
+  });
+
+  // With several prefixes and no dial9-traces among them, stay neutral.
+  it("multiple non-default prefixes -> undefined", () => {
+    expect(preferredPrefix(["traces/", "checkout-api/"])).toBeUndefined();
+  });
+
+  // dial9-traces wins whenever it's one of the offered prefixes.
+  it("dial9-traces present among many -> dial9-traces", () => {
+    expect(
+      preferredPrefix(["checkout-api/", "dial9-traces/", "other/"]),
+    ).toBe("dial9-traces");
+  });
+
+  // Even as the sole prefix, dial9-traces comes back without its slash.
+  it("dial9-traces alone -> dial9-traces", () => {
+    expect(preferredPrefix(["dial9-traces/"])).toBe("dial9-traces");
   });
 });


### PR DESCRIPTION
In the new-UI trace browser:
- Pre-select the `dial9-traces` prefix when a bucket offers it (the conventional default), falling back to the sole prefix otherwise. Extracted as `preferredPrefix()` in the frozen core, exposed through the lib/trace seam.
- Open the credentials panel when credentials reveal several buckets and none is selected yet, so the picker is in view (skipped for link-pinned buckets).

Also document the legacy-vs-new UI split in AGENTS.md: behavior changes go in the new UI (src/) only.