### PR TITLE
feat: JoinSet extension trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `JoinSetExt` adds dial9-instrumented `spawn_traced` and `spawn_traced_on`
+  methods to Tokio `JoinSet`s while preserving caller locations.
+
 ### Changed
 
 - **Breaking:** `dial9-viewer` exposes its S3 APIs through a default-on `s3`

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -48,8 +48,9 @@ pub use format::{
 #[cfg(feature = "worker-s3")]
 pub use recorder::RecorderS3ClientExt;
 pub use recorder::{
-    AttachedRuntime, Dial9Handle, Dial9HandleTokioExt, Dial9TokioHandle, RecorderPipelineExt,
-    TokioAttachOptions, TokioHooks, block_on, current_worker_id, spawn, spawn_in,
+    AttachedRuntime, Dial9Handle, Dial9HandleTokioExt, Dial9TokioHandle, JoinSetExt,
+    RecorderPipelineExt, TokioAttachOptions, TokioHooks, block_on, current_worker_id, spawn,
+    spawn_in,
 };
 pub use task_dump_config::TaskDumpConfig;
 pub use task_metadata::{TaskId, UNKNOWN_TASK_ID};

--- a/dial9-tokio-telemetry/src/telemetry/recorder/handle.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/handle.rs
@@ -151,6 +151,25 @@ impl Dial9TokioHandle {
             None => spawn_fn(future),
         }
     }
+
+    #[track_caller]
+    pub(super) fn spawn_in_join_set<F, T>(
+        &self,
+        set: &mut tokio::task::JoinSet<T>,
+        future: F,
+    ) -> tokio::task::AbortHandle
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        match &self.traced {
+            Some(traced) => {
+                let _guard = InstrumentedSpawnGuard::enter();
+                set.spawn(TracedFuture::new(future, Some(traced.clone())))
+            }
+            None => set.spawn(future),
+        }
+    }
 }
 
 /// Spawn a traced task on the current tokio runtime.

--- a/dial9-tokio-telemetry/src/telemetry/recorder/handle.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/handle.rs
@@ -117,18 +117,19 @@ impl Dial9TokioHandle {
     /// [`tokio::task::JoinHandle`], [`tokio::task::AbortHandle`], or whatever
     /// the spawn function returns.
     ///
+    /// For [`tokio::task::JoinSet`], prefer
+    /// [`JoinSetExt::spawn_traced`](crate::telemetry::JoinSetExt::spawn_traced).
+    ///
     /// # Examples
     ///
-    /// Spawn into a [`tokio::task::JoinSet`]:
+    /// Spawn while retaining the task's [`tokio::task::AbortHandle`]:
     ///
     /// ```rust,no_run
     /// # use dial9_tokio_telemetry::telemetry::Dial9TokioHandle;
-    /// # use tokio::task::JoinSet;
     /// # async fn work() {}
     /// # async fn demo() {
     /// let handle = Dial9TokioHandle::current();
-    /// let mut set: JoinSet<()> = JoinSet::new();
-    /// handle.spawn_with(work(), |f| set.spawn(f));
+    /// let abort_handle = handle.spawn_with(work(), |f| tokio::spawn(f).abort_handle());
     /// # }
     /// ```
     ///

--- a/dial9-tokio-telemetry/src/telemetry/recorder/join_set.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/join_set.rs
@@ -1,0 +1,30 @@
+use super::handle::Dial9TokioHandle;
+use std::future::Future;
+use tokio::task::{AbortHandle, JoinSet};
+
+/// Dial9 instrumentation for [`JoinSet`].
+pub trait JoinSetExt<T>: private::Sealed {
+    /// Spawn a task into this set with dial9 instrumentation.
+    #[track_caller]
+    fn spawn_traced<F>(&mut self, future: F) -> AbortHandle
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static;
+}
+
+impl<T> JoinSetExt<T> for JoinSet<T> {
+    #[track_caller]
+    fn spawn_traced<F>(&mut self, future: F) -> AbortHandle
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        Dial9TokioHandle::current().spawn_in_join_set(self, future)
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl<T> Sealed for tokio::task::JoinSet<T> {}
+}

--- a/dial9-tokio-telemetry/src/telemetry/recorder/join_set.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/join_set.rs
@@ -1,5 +1,7 @@
-use super::handle::Dial9TokioHandle;
+use super::handle::{Dial9TokioHandle, InstrumentedSpawnGuard};
+use crate::TracedFuture;
 use std::future::Future;
+use tokio::runtime::Handle;
 use tokio::task::{AbortHandle, JoinSet};
 
 /// Dial9 instrumentation for [`JoinSet`].
@@ -7,6 +9,13 @@ pub trait JoinSetExt<T>: private::Sealed {
     /// Spawn a task into this set with dial9 instrumentation.
     #[track_caller]
     fn spawn_traced<F>(&mut self, future: F) -> AbortHandle
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static;
+
+    /// Spawn a task into this set on `runtime` with dial9 instrumentation.
+    #[track_caller]
+    fn spawn_traced_on<F>(&mut self, future: F, runtime: &Handle) -> AbortHandle
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static;
@@ -20,6 +29,16 @@ impl<T> JoinSetExt<T> for JoinSet<T> {
         T: Send + 'static,
     {
         Dial9TokioHandle::current().spawn_in_join_set(self, future)
+    }
+
+    #[track_caller]
+    fn spawn_traced_on<F>(&mut self, future: F, runtime: &Handle) -> AbortHandle
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let _guard = InstrumentedSpawnGuard::enter();
+        self.spawn_on(TracedFuture::new_lazy(future), runtime)
     }
 }
 

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1,4 +1,5 @@
 mod handle;
+mod join_set;
 mod recorder_tokio;
 mod runtime_context;
 pub(crate) use dial9_core::shared_state::SharedState;
@@ -12,6 +13,7 @@ pub(crate) use runtime_context::poll_start_ts_monotonic;
 pub use dial9_core::handle::Dial9Handle;
 pub(crate) use handle::traced_handle;
 pub use handle::{Dial9TokioHandle, block_on, spawn, spawn_in};
+pub use join_set::JoinSetExt;
 
 mod tokio_hooks;
 pub use tokio_hooks::TokioHooks;

--- a/dial9-tokio-telemetry/tests/join_set_ext.rs
+++ b/dial9-tokio-telemetry/tests/join_set_ext.rs
@@ -7,7 +7,7 @@ use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
 use dial9_core::recording::Recorder;
 use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
 use dial9_tokio_telemetry::telemetry::{
-    MemoryBuffer, RecorderPipelineExt, TokioAttachOptions, recorder,
+    MemoryBuffer, RecorderPipelineExt, TaskId, TokioAttachOptions, recorder,
 };
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -28,7 +28,13 @@ fn build_runtime() -> (Recorder, tokio::runtime::Runtime, Arc<Mutex<Vec<Vec<u8>>
     (recorder, runtime, batches)
 }
 
-fn assert_instrumented_spawn_at(batches: &Mutex<Vec<Vec<u8>>>, call_line: u32) {
+async fn yielding_task() -> TaskId {
+    let task_id = tokio::task::try_id().map(TaskId::from).unwrap();
+    tokio::task::yield_now().await;
+    task_id
+}
+
+fn assert_instrumented_spawn_at(batches: &Mutex<Vec<Vec<u8>>>, task_id: TaskId, call_line: u32) {
     let events: Vec<Dial9Event> = decode_all(&batches.lock().unwrap());
     let expected_loc = format!("join_set_ext.rs:{call_line}:");
 
@@ -36,7 +42,15 @@ fn assert_instrumented_spawn_at(batches: &Mutex<Vec<Vec<u8>>>, call_line: u32) {
         matches!(
             event,
             Dial9Event::TaskSpawnEvent(event)
-                if event.instrumented && event.spawn_loc.contains(&expected_loc)
+                if event.task_id == task_id.to_u64()
+                    && event.instrumented
+                    && event.spawn_loc.contains(&expected_loc)
+        )
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            Dial9Event::WakeEvent(event) if event.woken_task_id == task_id.to_u64()
         )
     }));
 }
@@ -45,18 +59,18 @@ fn assert_instrumented_spawn_at(batches: &Mutex<Vec<Vec<u8>>>, call_line: u32) {
 fn join_set_ext_preserves_caller_through_helper() {
     let (recorder, runtime, batches) = build_runtime();
 
-    let call_line = runtime.block_on(async move {
+    let (task_id, call_line) = runtime.block_on(async move {
         let mut set = JoinSet::new();
         let call_line = line!() + 1;
-        join_set_helper::spawn_traced(&mut set, async {});
-        set.join_next().await.unwrap().unwrap();
-        call_line
+        join_set_helper::spawn_traced(&mut set, yielding_task());
+        let task_id = set.join_next().await.unwrap().unwrap();
+        (task_id, call_line)
     });
 
     drop(runtime);
     recorder.graceful_shutdown(Duration::from_secs(1));
 
-    assert_instrumented_spawn_at(&batches, call_line);
+    assert_instrumented_spawn_at(&batches, task_id, call_line);
 }
 
 #[test]
@@ -65,11 +79,11 @@ fn join_set_ext_on_preserves_caller_through_helper() {
     let mut set = JoinSet::new();
 
     let call_line = line!() + 1;
-    join_set_helper::spawn_traced_on(&mut set, async {}, runtime.handle());
-    runtime.block_on(async { set.join_next().await.unwrap().unwrap() });
+    join_set_helper::spawn_traced_on(&mut set, yielding_task(), runtime.handle());
+    let task_id = runtime.block_on(async { set.join_next().await.unwrap().unwrap() });
 
     drop(runtime);
     recorder.graceful_shutdown(Duration::from_secs(1));
 
-    assert_instrumented_spawn_at(&batches, call_line);
+    assert_instrumented_spawn_at(&batches, task_id, call_line);
 }

--- a/dial9-tokio-telemetry/tests/join_set_ext.rs
+++ b/dial9-tokio-telemetry/tests/join_set_ext.rs
@@ -28,6 +28,19 @@ fn build_runtime() -> (Recorder, tokio::runtime::Runtime, Arc<Mutex<Vec<Vec<u8>>
     (recorder, runtime, batches)
 }
 
+fn assert_instrumented_spawn_at(batches: &Mutex<Vec<Vec<u8>>>, call_line: u32) {
+    let events: Vec<Dial9Event> = decode_all(&batches.lock().unwrap());
+    let expected_loc = format!("join_set_ext.rs:{call_line}:");
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            Dial9Event::TaskSpawnEvent(event)
+                if event.instrumented && event.spawn_loc.contains(&expected_loc)
+        )
+    }));
+}
+
 #[test]
 fn join_set_ext_preserves_caller_through_helper() {
     let (recorder, runtime, batches) = build_runtime();
@@ -43,14 +56,20 @@ fn join_set_ext_preserves_caller_through_helper() {
     drop(runtime);
     recorder.graceful_shutdown(Duration::from_secs(1));
 
-    let events: Vec<Dial9Event> = decode_all(&batches.lock().unwrap());
-    let expected_loc = format!("join_set_ext.rs:{call_line}:");
+    assert_instrumented_spawn_at(&batches, call_line);
+}
 
-    assert!(events.iter().any(|event| {
-        matches!(
-            event,
-            Dial9Event::TaskSpawnEvent(event)
-                if event.instrumented && event.spawn_loc.contains(&expected_loc)
-        )
-    }));
+#[test]
+fn join_set_ext_on_preserves_caller_through_helper() {
+    let (recorder, runtime, batches) = build_runtime();
+    let mut set = JoinSet::new();
+
+    let call_line = line!() + 1;
+    join_set_helper::spawn_traced_on(&mut set, async {}, runtime.handle());
+    runtime.block_on(async { set.join_next().await.unwrap().unwrap() });
+
+    drop(runtime);
+    recorder.graceful_shutdown(Duration::from_secs(1));
+
+    assert_instrumented_spawn_at(&batches, call_line);
 }

--- a/dial9-tokio-telemetry/tests/join_set_ext.rs
+++ b/dial9-tokio-telemetry/tests/join_set_ext.rs
@@ -1,0 +1,56 @@
+mod common;
+
+#[path = "support/join_set_helper.rs"]
+mod join_set_helper;
+
+use common::{CAPTURE_BUFFER_SIZE, capture_processor, decode_all};
+use dial9_core::recording::Recorder;
+use dial9_tokio_telemetry::telemetry::analysis_events::Dial9Event;
+use dial9_tokio_telemetry::telemetry::{
+    MemoryBuffer, RecorderPipelineExt, TokioAttachOptions, recorder,
+};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::task::JoinSet;
+
+fn build_runtime() -> (Recorder, tokio::runtime::Runtime, Arc<Mutex<Vec<Vec<u8>>>>) {
+    let (capture, batches) = capture_processor();
+    let recorder = recorder(MemoryBuffer::new(CAPTURE_BUFFER_SIZE).unwrap())
+        .with_custom_pipeline(|pipeline| pipeline.pipe(capture))
+        .build();
+    let runtime = common::attach(
+        &recorder,
+        2,
+        TokioAttachOptions::builder()
+            .task_tracking_enabled(true)
+            .build(),
+    );
+    (recorder, runtime, batches)
+}
+
+#[test]
+fn join_set_ext_preserves_caller_through_helper() {
+    let (recorder, runtime, batches) = build_runtime();
+
+    let call_line = runtime.block_on(async move {
+        let mut set = JoinSet::new();
+        let call_line = line!() + 1;
+        join_set_helper::spawn_traced(&mut set, async {});
+        set.join_next().await.unwrap().unwrap();
+        call_line
+    });
+
+    drop(runtime);
+    recorder.graceful_shutdown(Duration::from_secs(1));
+
+    let events: Vec<Dial9Event> = decode_all(&batches.lock().unwrap());
+    let expected_loc = format!("join_set_ext.rs:{call_line}:");
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            Dial9Event::TaskSpawnEvent(event)
+                if event.instrumented && event.spawn_loc.contains(&expected_loc)
+        )
+    }));
+}

--- a/dial9-tokio-telemetry/tests/support/join_set_helper.rs
+++ b/dial9-tokio-telemetry/tests/support/join_set_helper.rs
@@ -12,3 +12,18 @@ where
 {
     set.spawn_traced(future)
 }
+
+// Kept in a separate file to make the `#[track_caller]` test exercise a
+// realistic helper boundary.
+#[track_caller]
+pub fn spawn_traced_on<T, F>(
+    set: &mut JoinSet<T>,
+    future: F,
+    runtime: &tokio::runtime::Handle,
+) -> AbortHandle
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    set.spawn_traced_on(future, runtime)
+}

--- a/dial9-tokio-telemetry/tests/support/join_set_helper.rs
+++ b/dial9-tokio-telemetry/tests/support/join_set_helper.rs
@@ -1,0 +1,14 @@
+use dial9_tokio_telemetry::telemetry::JoinSetExt;
+use std::future::Future;
+use tokio::task::{AbortHandle, JoinSet};
+
+// Kept in a separate file to make the `#[track_caller]` test exercise a
+// realistic helper boundary.
+#[track_caller]
+pub fn spawn_traced<T, F>(set: &mut JoinSet<T>, future: F) -> AbortHandle
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    set.spawn_traced(future)
+}

--- a/dial9/src/lib.rs
+++ b/dial9/src/lib.rs
@@ -85,8 +85,8 @@ pub use dial9_tokio_telemetry::{TracedFuture, block_on, spawn, spawn_in};
 pub use dial9_tokio_telemetry::telemetry::RecorderS3ClientExt;
 #[cfg(feature = "tokio")]
 pub use dial9_tokio_telemetry::telemetry::{
-    AttachedRuntime, Dial9HandleTokioExt, Dial9TokioHandle, RecorderPipelineExt, TaskDumpConfig,
-    TokioAttachOptions, TokioHooks,
+    AttachedRuntime, Dial9HandleTokioExt, Dial9TokioHandle, JoinSetExt, RecorderPipelineExt,
+    TaskDumpConfig, TokioAttachOptions, TokioHooks,
 };
 
 /// Offline trace reading and analysis.


### PR DESCRIPTION
# Changes
- Adds a `JoinSetExt` sealed extension trait that is implemented by Tokio `JoinSet`s, giving them two traced methods, `spawn_traced` and `spawn_traced_on`.
- Add a couple of very specific tests to ensure `#[track_caller]` propagates correctly through an external helper function.

# Note

I exposed `JoinSetExt` from `dial9_tokio_telemetry::telemetry::JoinSetExt` and from `dial9::JoinSetExt` but not from `dial9_tokio_telemetry::JoinSetExt` as it seems to expose very specific stuff. 