### PR TITLE
fix(viewer): keep span duration axis labels visible

### DIFF
--- a/dial9-viewer/ui/src/pages/viewer/spans-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/spans-track.test.ts
@@ -1,4 +1,4 @@
-// Store-integration tests for the spans track. The three checks that live at
+// Store-integration tests for the spans track. The checks that live at
 // the store/render-input boundary (the browser-driven halves - row-walker, perf
 // probe, visual - are covered elsewhere):
 //   1. derived-cache invalidation: the trace-invariant span data recomputes
@@ -8,6 +8,8 @@
 //      per frame - never a synchronous renderAll per keypress.
 //   3. selection-driven dimming: drawSpansCanvas's render input reacts to the
 //      selection slice - non-highlighted clusters recede.
+//   4. duration-axis fallback: sub-decade and single-duration ranges retain a
+//      visible label.
 
 import { describe, it, expect } from "vitest";
 import { createStore } from "../../store/store.js";
@@ -119,14 +121,16 @@ describe("filter typing coalescing", () => {
   });
 });
 
-// ── 3. Selection-driven dimming render input ──────────────────────────────
+// ── 3–4. Canvas rendering ─────────────────────────────────────────────────
 
 /** A minimal recording 2d context: captures each fillRect's y + alpha. */
 function recordingCtx(): {
   ctx: CanvasRenderingContext2D;
   fills: { y: number; alpha: number }[];
+  labels: { text: string; y: number }[];
 } {
   const fills: { y: number; alpha: number }[] = [];
+  const labels: { text: string; y: number }[] = [];
   const ctx = {
     globalAlpha: 1,
     fillStyle: "",
@@ -137,14 +141,16 @@ function recordingCtx(): {
     fillRect(_x: number, y: number, _w: number, _h: number) {
       fills.push({ y, alpha: (this as CanvasRenderingContext2D).globalAlpha });
     },
-    fillText() {},
+    fillText(text: string, _x: number, y: number) {
+      labels.push({ text, y });
+    },
     beginPath() {},
     moveTo() {},
     lineTo() {},
     stroke() {},
     setTransform() {},
   } as unknown as CanvasRenderingContext2D;
-  return { ctx, fills };
+  return { ctx, fills, labels };
 }
 
 function bucket(id: string, y: number): SpanDrawBucket {
@@ -182,6 +188,28 @@ function stateWithFocus(spanFocus: StoreState["selection"]["spanFocus"]): StoreS
   const base = initialViewerState();
   return { ...base, selection: { ...base.selection, spanFocus } };
 }
+
+describe("drawSpansCanvas duration axis", () => {
+  it("keeps fallback endpoint labels visible when no decade tick fits", () => {
+    const canvasH = 120;
+    const model = { ...twoBucketModel(), minDur: 120_000, maxDur: 180_000 };
+    const { ctx, labels } = recordingCtx();
+
+    drawSpansCanvas(ctx, model, emptyData, stateWithFocus(null), 400, canvasH, 0, 400, colorOf);
+
+    expect(labels.map((label) => label.text)).toEqual(["120.0µs", "180.0µs"]);
+    expect(labels.every((label) => label.y >= 9 && label.y <= canvasH - 2)).toBe(true);
+  });
+
+  it("draws one fallback label for a single-duration range", () => {
+    const model = { ...twoBucketModel(), minDur: 150_000, maxDur: 150_000 };
+    const { ctx, labels } = recordingCtx();
+
+    drawSpansCanvas(ctx, model, emptyData, stateWithFocus(null), 400, 120, 0, 400, colorOf);
+
+    expect(labels.map((label) => label.text)).toEqual(["150.0µs"]);
+  });
+});
 
 describe("drawSpansCanvas dimming", () => {
   it("draws every cluster at full weight when nothing is selected", () => {

--- a/dial9-viewer/ui/src/pages/viewer/spans-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/spans-track.ts
@@ -704,16 +704,19 @@ export function drawSpansCanvas(
     }
     if (ticks.length < 2) {
       ticks.length = 0;
-      ticks.push(model.minDur, model.maxDur);
+      ticks.push(model.minDur);
+      if (model.maxDur !== model.minDur) ticks.push(model.maxDur);
     }
     for (const dur of ticks) {
       const norm = (Math.log(dur) - minL) / range;
       const y = PAD_TOP + (1 - norm) * usableH;
-      if (y < 2 || y > canvasH - 8) continue;
       ctx.globalAlpha = 0.4;
       ctx.fillRect(0, y, drawW, 0.5);
       ctx.globalAlpha = 0.7;
-      ctx.fillText(formatHumanDuration(dur), 2, y - 2);
+      // Fallback ticks sit on the scale endpoints. Keep their baselines inside
+      // the canvas or a sub-decade range loses every visible axis label.
+      const labelY = Math.max(0, Math.min(canvasH - 2, Math.max(9, y - 2)));
+      ctx.fillText(formatHumanDuration(dur), 2, labelY);
     }
     ctx.globalAlpha = 1;
   }


### PR DESCRIPTION
## Screenshots

Using `/new/viewer.html?trace=demo-trace.bin&start=20041636256&end=20043636256&span-names=v1%3Arecord_metric` URL path and [this trace file](https://github.com/dial9-rs/dial9/blob/ecebd5967d3bdf48d9299745c88d69d1ede0d33d/dial9-viewer/ui/public/demo-trace.bin).

### Before

<img width="601" height="161" alt="Screenshot 2026-08-10 at 10 00 05 PM" src="https://github.com/user-attachments/assets/0f8a306c-7a26-45d9-b300-9e0c361d383f" />


### After


<img width="608" height="161" alt="Screenshot 2026-08-10 at 10 00 21 PM" src="https://github.com/user-attachments/assets/55fbed8e-2e9a-4788-85b1-142085616309" />

## Other

Closes #749 