### PR TITLE
docs: document frame-pointer requirement for memory profiling

### DIFF
--- a/dial9/README.md
+++ b/dial9/README.md
@@ -24,14 +24,14 @@ If you are integrating dial9 into a production service, see the [`production_use
 
 You can also find a full [example service](https://github.com/dial9-rs/dial9/blob/HEAD/examples).
 
-Tokio relies on `tokio_unstable` for Tokio runtime hooks and frame pointers for efficient profiling.
+Tokio relies on `tokio_unstable` for Tokio runtime hooks. Frame pointers are required by the `cpu-profiling` and `memory-profiling` features, which capture stacks with a frame-pointer unwinder. These flags go in your [Cargo build configuration](https://doc.rust-lang.org/cargo/reference/config.html) (for example `.cargo/config.toml` or the `RUSTFLAGS` environment variable), not in `Cargo.toml`.
 
 ```toml
 # .cargo/config.toml
 [build]
 rustflags = [
   "--cfg", "tokio_unstable",
-  # For profiling, you also need:
+  # Required by the cpu-profiling and memory-profiling features:
   "-C", "force-frame-pointers=yes"
 ]
 ```
@@ -426,6 +426,13 @@ dial9 can sample heap allocations using [probabilistic sampling](https://github.
 ```toml
 [dependencies]
 dial9 = { version = "0.5", features = ["memory-profiling"] }
+```
+
+**Enable frame pointers** (allocation stacks are captured with a frame-pointer unwinder):
+```toml
+# .cargo/config.toml
+[build]
+rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
 ```
 
 **Install the allocator and profiler:**

--- a/perf-self-profile/src/memory_profiling/profiler.rs
+++ b/perf-self-profile/src/memory_profiling/profiler.rs
@@ -134,6 +134,14 @@ impl std::error::Error for InstallError {
 /// `MemoryProfiler::with_defaults().install(handle)`.
 ///
 /// Install is permanent for the life of the process.
+///
+/// # Requirements
+/// - Frame pointers: allocation stacks are captured with a frame-pointer
+///   unwinder, so the binary must be built with
+///   `-C force-frame-pointers=yes`.
+/// - [`Dial9Allocator`](crate::memory_profiling::Dial9Allocator) must be
+///   installed as the `#[global_allocator]` for allocations to reach the
+///   sampling hook.
 #[derive(Debug)]
 pub struct MemoryProfiler {
     config: MemoryProfilingConfig,
@@ -151,6 +159,9 @@ impl MemoryProfiler {
     }
 
     /// Install the profiler with the given handle.
+    ///
+    /// Requires a binary built with `-C force-frame-pointers=yes`; see the
+    /// [type-level requirements](MemoryProfiler#requirements).
     ///
     /// On a disconnected handle, install is a no-op (returns `Ok` but does
     /// not publish state). `ACTIVE.get()` remains `None` so the allocator


### PR DESCRIPTION
Our docs were not particularly clear that memory profiling requires frame pointers. It was only mentioned in our design doc. Leaving it off is particularly concerning since it causes segfaults, unlike cpu profiling which gracefully degrades.