### PR TITLE
refactor(tokio): record events through Dial9Handle

### DIFF
--- a/dial9-core/src/handle.rs
+++ b/dial9-core/src/handle.rs
@@ -223,6 +223,20 @@ impl Dial9Handle {
         }
     }
 
+    /// Record an event that is only built when recording is on.
+    ///
+    /// Reach for this over [`record_event`](Self::record_event) when building
+    /// the event costs something you would rather not pay while recording is
+    /// paused, such as a clock read or a lookup. `make` runs only if the event
+    /// will be recorded.
+    pub fn record_event_with<E: Encodable>(&self, make: impl FnOnce() -> E) {
+        if let Some(inner) = &self.inner {
+            inner
+                .shared
+                .if_enabled(|buf| buf.record_encodable_event(&make()));
+        }
+    }
+
     /// Run a closure with direct access to the thread-local encoder.
     ///
     /// The closure is only invoked if telemetry is enabled.

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -29,18 +29,15 @@ pub use recorder_tokio::{
 use handle::InstrumentedSpawnGuard;
 
 use dial9_core::handle::{clear_tl_handle, set_tl_handle};
-use runtime_context::{make_worker_park, make_worker_unpark};
 
 use crate::primitives::sync::Arc;
-#[cfg(tokio_unstable)]
-use crate::telemetry::format::TaskTerminateEvent;
 #[cfg(tokio_unstable)]
 use crate::telemetry::task_metadata::TaskId;
 #[cfg(tokio_unstable)]
 use handle::INSTRUMENTED_SPAWN;
 #[cfg(not(tokio_unstable))]
 pub(crate) use recorder_tokio::current_runtime_ctx;
-pub(crate) use runtime_context::{clear_poll_span, make_poll_end, make_poll_start, poll_span_open};
+pub(crate) use runtime_context::{clear_poll_span, poll_span_open};
 
 /// Register a tokio hook, composing with an optional user callback.
 /// When `$user_hook` is None, registers only the dial9 closure (zero-cost).
@@ -75,12 +72,13 @@ macro_rules! register_hook {
 }
 
 /// Register telemetry callbacks on a runtime builder.
-/// Closures capture `Arc<RuntimeContext>` (runtime-specific) and `Arc<SharedState>` (recording core).
+/// Closures capture `Arc<RuntimeContext>`, which owns both the runtime-specific
+/// state and the handle events are recorded through.
 ///
 /// # Worker ID resolution
 ///
 /// `WORKER_ID` TLS is populated lazily on the first `on_thread_unpark` / `on_before_task_poll`
-/// call via [`resolve_worker_id`](runtime_context::resolve_worker_id), not in `on_thread_start`.
+/// call via `RuntimeContext::resolve_worker`, not in `on_thread_start`.
 /// This is intentional: `on_thread_start` fires before `RuntimeMetrics` is available, so we
 /// cannot yet call `metrics.worker_thread_id(i)` to determine which worker index we are.
 /// By the time any waker calls `current_worker_id()`, at least one unpark or poll has occurred
@@ -88,7 +86,6 @@ macro_rules! register_hook {
 fn register_hooks(
     builder: &mut tokio::runtime::Builder,
     ctx: &Arc<RuntimeContext>,
-    shared: &Arc<SharedState>,
     handle: &Dial9Handle,
     #[cfg_attr(not(tokio_unstable), allow(unused_variables))] task_tracking_enabled: bool,
     tokio_hooks: TokioHooks,
@@ -96,33 +93,19 @@ fn register_hooks(
         crate::telemetry::task_dump_config::TaskDumpConfig,
     >,
 ) {
-    // TODO: these should rely on public APIs instead of utilizing `SharedState`
-
     let c1 = ctx.clone();
-    let s1 = shared.clone();
     let c2 = ctx.clone();
-    let s2 = shared.clone();
     #[cfg(tokio_unstable)]
     let c3 = ctx.clone();
     #[cfg(tokio_unstable)]
-    let s3 = shared.clone();
-    #[cfg(tokio_unstable)]
     let c4 = ctx.clone();
-    #[cfg(tokio_unstable)]
-    let s4 = shared.clone();
 
     register_hook!(builder, on_thread_park, tokio_hooks.on_thread_park, {
-        s1.if_enabled(|buf| {
-            let event = make_worker_park(&c1, &s1);
-            buf.record_encodable_event(&event);
-        })
+        c1.record_worker_park()
     });
 
     register_hook!(builder, on_thread_unpark, tokio_hooks.on_thread_unpark, {
-        s2.if_enabled(|buf| {
-            let event = make_worker_unpark(&c2, &s2);
-            buf.record_encodable_event(&event);
-        })
+        c2.record_worker_unpark()
     });
 
     #[cfg(tokio_unstable)]
@@ -130,14 +113,7 @@ fn register_hooks(
         meta: builder,
         on_before_task_poll,
         tokio_hooks.on_before_task_poll,
-        |meta| {
-            s3.if_enabled(|buf| {
-                let task_id = TaskId::from(meta.id());
-                let location = meta.spawned_at();
-                let event = make_poll_start(Some(&c3), &s3, location, task_id);
-                buf.record_encodable_event(&event);
-            })
-        }
+        |meta| { c3.record_poll_start(meta.spawned_at(), TaskId::from(meta.id())) }
     );
 
     #[cfg(tokio_unstable)]
@@ -145,45 +121,25 @@ fn register_hooks(
         meta: builder,
         on_after_task_poll,
         tokio_hooks.on_after_task_poll,
-        |_meta| {
-            s4.if_enabled(|buf| {
-                let event = make_poll_end(Some(&c4), &s4);
-                buf.record_encodable_event(&event);
-            })
-        }
+        |_meta| { c4.record_poll_end() }
     );
 
     #[cfg(tokio_unstable)]
     if task_tracking_enabled {
-        let s5 = shared.clone();
+        let c5 = ctx.clone();
         register_hook!(meta: builder, on_task_spawn, tokio_hooks.on_task_spawn, |meta| {
-            s5.if_enabled(|buf| {
-                let task_id = TaskId::from(meta.id());
-                let location = meta.spawned_at();
-                let instrumented = INSTRUMENTED_SPAWN.with(|f| f.get()) > 0;
-                let timestamp_ns = crate::telemetry::events::clock_monotonic_ns();
-                buf.record_encodable_event(&runtime_context::TaskSpawn {
-                    timestamp_ns,
-                    task_id,
-                    location,
-                    instrumented,
-                });
-            })
+            c5.record_task_spawn(
+                meta.spawned_at(),
+                TaskId::from(meta.id()),
+                INSTRUMENTED_SPAWN.with(|f| f.get()) > 0,
+            )
         });
-        let s6 = shared.clone();
+        let c6 = ctx.clone();
         register_hook!(
             meta: builder,
             on_task_terminate,
             tokio_hooks.on_task_terminate,
-            |meta| {
-                s6.if_enabled(|buf| {
-                    let task_id = TaskId::from(meta.id());
-                    buf.record_encodable_event(&TaskTerminateEvent {
-                        timestamp_ns: crate::telemetry::events::clock_monotonic_ns(),
-                        task_id,
-                    });
-                })
-            }
+            |meta| { c6.record_task_terminate(TaskId::from(meta.id())) }
         );
     } else {
         // When task tracking is disabled, still register user hooks if provided
@@ -247,7 +203,6 @@ fn register_hooks(
 /// Register telemetry hooks and return a runtime context.
 /// Worker IDs are reserved lazily on the first poll.
 fn register_runtime_hooks(
-    shared: &Arc<SharedState>,
     builder: &mut tokio::runtime::Builder,
     runtime_name: Option<String>,
     handle: &Dial9Handle,
@@ -259,7 +214,6 @@ fn register_runtime_hooks(
     register_hooks(
         builder,
         &ctx,
-        shared,
         handle,
         task_tracking_enabled,
         tokio_hooks,
@@ -310,7 +264,6 @@ mod tests {
         let mut builder = tokio::runtime::Builder::new_current_thread();
 
         let ctx = register_runtime_hooks(
-            &shared,
             &mut builder,
             Some("aborted".to_string()),
             rec.handle(),
@@ -482,6 +435,56 @@ mod tests {
     #[test]
     fn test_shared_state_no_spawn_location_fields() {
         let _shared = SharedState::new(crate::telemetry::events::clock_monotonic_ns());
+    }
+
+    /// A paused recorder does none of the work a recorded poll needs: no worker
+    /// ID reserved, no poll span left open. Building the event before the
+    /// enabled check would do both with nothing to show for it.
+    #[test]
+    fn paused_recorder_does_no_poll_work() {
+        use std::collections::HashSet;
+
+        let rec = recorder(MemoryBuffer::new(CAPTURE_SIZE).unwrap()).build();
+        rec.disable();
+
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder.enable_all().worker_threads(1);
+        let rt = rec
+            .handle()
+            .attach_tokio_runtime(
+                builder,
+                TokioAttachOptions::builder()
+                    .runtime_name("paused")
+                    .task_tracking_enabled(true)
+                    .build(),
+            )
+            .unwrap();
+
+        // Read the marker on the worker thread itself: it is thread-local.
+        let span_open = rt.block_on(async {
+            crate::telemetry::spawn(async { poll_span_open() })
+                .await
+                .unwrap()
+        });
+        assert!(!span_open, "a paused recorder should not open a poll span");
+
+        let reserved: HashSet<u64> = {
+            let registry = recorder_tokio::runtime_registry(rec.shared().unwrap())
+                .expect("enabled recorder has a context registry");
+            let registry = registry.lock().unwrap();
+            registry
+                .iter()
+                .find(|c| c.runtime_name.as_deref() == Some("paused"))
+                .map(|c| c.worker_ids.lock().unwrap().iter().copied().collect())
+                .unwrap_or_default()
+        };
+        assert!(
+            reserved.is_empty(),
+            "a paused recorder should not resolve workers: {reserved:?}"
+        );
+
+        drop(rt);
+        rec.graceful_shutdown(Duration::from_secs(1));
     }
 
     /// A disabled recorder attaches inertly: the runtime you build is a plain

--- a/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
@@ -371,7 +371,6 @@ impl Dial9HandleTokioExt for Dial9Handle {
         // runtime's samples with its identity.
         let runtime_name = options.runtime_name.clone();
         let ctx = register_runtime_hooks(
-            shared,
             &mut builder,
             options.runtime_name,
             self,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -5,11 +5,11 @@ use crate::primitives::sync::Weak;
 use crate::primitives::sync::{Arc, Mutex};
 use crate::telemetry::encoder::{Encodable, ThreadLocalEncoder};
 use crate::telemetry::events::{SchedStat, clock_monotonic_ns};
-#[cfg(tokio_unstable)]
-use crate::telemetry::format::TaskSpawnEvent;
 use crate::telemetry::format::{
     PollEndEvent, PollStartEvent, RuntimeMetricsEvent, WorkerId, WorkerParkEvent, WorkerUnparkEvent,
 };
+#[cfg(tokio_unstable)]
+use crate::telemetry::format::{TaskSpawnEvent, TaskTerminateEvent};
 use crate::telemetry::task_metadata::TaskId;
 use dial9_core::handle::{Dial9Handle, set_tl_handle};
 use metrique_timesource::{Instant, time_source};
@@ -33,9 +33,9 @@ pub(crate) struct RuntimeContext {
     runtime_id: OnceLock<tokio::runtime::Id>,
     /// Optional human-readable name, set via `with_runtime_name`.
     pub runtime_name: Option<String>,
-    /// Recorder handle, installed on each of this runtime's threads (TL) so
+    /// Installed on each of this runtime's threads (TL) so
     /// `Dial9Handle::current()`, the tracing layer, and `dial9::spawn` resolve.
-    pub session_handle: Dial9Handle,
+    pub recorder_handle: Dial9Handle,
     /// Base worker ID for this runtime, reserved on the first worker resolve.
     #[cfg(tokio_unstable)]
     pub worker_id_base: OnceLock<u64>,
@@ -114,17 +114,17 @@ fn worker_metrics<R>(f: impl FnOnce(&RuntimeMetrics) -> R) -> R {
 /// Keyed by runtime: a thread that drives a second runtime claims a fresh ID
 /// there rather than reusing the one it holds in another runtime's block.
 #[cfg(not(tokio_unstable))]
-fn claim_thread_worker_id(ctx: &RuntimeContext, shared: &SharedState) -> u64 {
-    let id = CLAIMED_WORKER_IDS.with(|claimed| {
+fn claim_thread_worker_id(ctx: &RuntimeContext) -> Option<u64> {
+    let shared = ctx.recorder_handle.shared()?;
+    CLAIMED_WORKER_IDS.with(|claimed| {
         let mut claimed = claimed.borrow_mut();
         if let Some((_, id)) = claimed.iter().find(|(owner, _)| *owner == ctx.id) {
-            return *id;
+            return Some(*id);
         }
         let id = shared.reserve_worker_ids(1);
         claimed.push((ctx.id, id));
-        id
-    });
-    id
+        Some(id)
+    })
 }
 
 /// Local queue depth for the current worker.
@@ -375,17 +375,68 @@ impl Source for TokioRuntimesSource {
 }
 
 impl RuntimeContext {
-    pub(crate) fn new(runtime_name: Option<String>, session_handle: Dial9Handle) -> Self {
+    pub(crate) fn new(runtime_name: Option<String>, recorder_handle: Dial9Handle) -> Self {
         static NEXT_ID: AtomicU64 = AtomicU64::new(1);
         Self {
             id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
             runtime_id: OnceLock::new(),
             runtime_name,
-            session_handle,
+            recorder_handle,
             #[cfg(tokio_unstable)]
             worker_id_base: OnceLock::new(),
             worker_ids: Mutex::new(BTreeSet::new()),
         }
+    }
+
+    /// Record an event for this runtime, if recording is on.
+    ///
+    /// Lazy on purpose: building one of these events can resolve the worker and
+    /// read the clock, which a paused recorder must not pay for.
+    fn record<E: Encodable>(&self, make: impl FnOnce() -> E) {
+        self.recorder_handle.record_event_with(make);
+    }
+
+    pub(crate) fn record_worker_park(&self) {
+        self.record(|| make_worker_park(self));
+    }
+
+    pub(crate) fn record_worker_unpark(&self) {
+        self.record(|| make_worker_unpark(self));
+    }
+
+    pub(crate) fn record_poll_start(
+        &self,
+        location: &'static std::panic::Location<'static>,
+        task_id: TaskId,
+    ) {
+        self.record(|| make_poll_start(self, location, task_id));
+    }
+
+    pub(crate) fn record_poll_end(&self) {
+        self.record(|| make_poll_end(self));
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(crate) fn record_task_spawn(
+        &self,
+        location: &'static std::panic::Location<'static>,
+        task_id: TaskId,
+        instrumented: bool,
+    ) {
+        self.record(|| TaskSpawn {
+            timestamp_ns: clock_monotonic_ns(),
+            task_id,
+            location,
+            instrumented,
+        });
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(crate) fn record_task_terminate(&self, task_id: TaskId) {
+        self.record(|| TaskTerminateEvent {
+            timestamp_ns: clock_monotonic_ns(),
+            task_id,
+        });
     }
 
     /// Bind this context to the runtime it instruments, once that runtime is
@@ -421,11 +472,11 @@ impl RuntimeContext {
     /// Called from the runtime hooks, where a scheduler context is current.
     /// `None` means no worker context (shouldn't happen from a hook); skip
     /// rather than misattribute to worker 0.
-    fn resolve_worker(&self, shared: &SharedState) -> Option<WorkerId> {
+    fn resolve_worker(&self) -> Option<WorkerId> {
         #[cfg(tokio_unstable)]
-        let global_id = self.claim_worker_id(shared)?;
+        let global_id = self.claim_worker_id()?;
         #[cfg(not(tokio_unstable))]
-        let global_id = claim_thread_worker_id(self, shared);
+        let global_id = claim_thread_worker_id(self)?;
 
         // Always update TLS so current_worker_id() returns the global ID.
         GLOBAL_WORKER_ID.with(|cell| cell.set(Some(global_id)));
@@ -441,8 +492,9 @@ impl RuntimeContext {
     /// `current_thread` runtime's driver thread), so the whole runtime's IDs
     /// can be reserved as one contiguous block on the first resolve.
     #[cfg(tokio_unstable)]
-    fn claim_worker_id(&self, shared: &SharedState) -> Option<u64> {
+    fn claim_worker_id(&self) -> Option<u64> {
         let local_index = tokio::runtime::worker_index()?;
+        let shared = self.recorder_handle.shared()?;
         let base = self.worker_id_base.get_or_init(|| {
             let num_workers = worker_metrics(|m| m.num_workers()) as u64;
             shared.reserve_worker_ids(num_workers)
@@ -455,7 +507,7 @@ impl RuntimeContext {
 fn enroll_thread(ctx: &RuntimeContext, global_id: u64) {
     register_worker_if_needed(ctx, global_id);
     #[cfg(feature = "cpu-profiling")]
-    start_sched_sampling_if_needed(&ctx.session_handle);
+    start_sched_sampling_if_needed(&ctx.recorder_handle);
 }
 
 /// Record global_id in the context's set (once per thread).
@@ -470,7 +522,7 @@ fn register_worker_if_needed(ctx: &RuntimeContext, global_id: u64) {
             // Install the recorder handle on this thread. `on_thread_start` also
             // does this for pool threads, but a `current_thread` runtime's driver
             // thread gets no `on_thread_start`, so set it here on first poll.
-            set_tl_handle(ctx.session_handle.clone());
+            set_tl_handle(ctx.recorder_handle.clone());
             cell.set(Some(key));
         }
     });
@@ -588,24 +640,20 @@ impl Encodable for TaskSpawn {
 
 /// The worker id to stamp on an event this thread is about to record.
 ///
-/// `ctx` is the runtime the event belongs to: a tokio hook closes over it, the
-/// `TracedFuture` wrapper resolves it from the runtime its task runs on.
-fn event_worker_id(ctx: Option<&RuntimeContext>, shared: &SharedState) -> WorkerId {
-    match ctx {
-        Some(ctx) => ctx.resolve_worker(shared).unwrap_or(WorkerId::UNKNOWN),
-        None => WorkerId::UNKNOWN,
-    }
+/// `UNKNOWN` when the thread has no worker context, rather than misattributing
+/// the event to worker 0.
+fn event_worker_id(ctx: &RuntimeContext) -> WorkerId {
+    ctx.resolve_worker().unwrap_or(WorkerId::UNKNOWN)
 }
 
 /// Poll-start event, from tokio's `on_before_task_poll` hook when it exists and
 /// from the `TracedFuture` wrapper when it does not.
-pub(crate) fn make_poll_start(
-    ctx: Option<&RuntimeContext>,
-    shared: &SharedState,
+fn make_poll_start(
+    ctx: &RuntimeContext,
     location: &'static std::panic::Location<'static>,
     task_id: TaskId,
 ) -> PollStart {
-    let worker_id = event_worker_id(ctx, shared);
+    let worker_id = event_worker_id(ctx);
     let worker_local_queue_depth = current_local_queue_depth();
     let timestamp_ns = clock_monotonic_ns();
     POLL_START_TS.with(|c| c.set(NonZeroU64::new(timestamp_ns)));
@@ -619,11 +667,11 @@ pub(crate) fn make_poll_start(
 }
 
 /// Poll-end counterpart to [`make_poll_start`].
-pub(crate) fn make_poll_end(ctx: Option<&RuntimeContext>, shared: &SharedState) -> PollEndEvent {
+fn make_poll_end(ctx: &RuntimeContext) -> PollEndEvent {
     POLL_START_TS.with(|c| c.set(None));
     PollEndEvent {
         timestamp_ns: clock_monotonic_ns(),
-        worker_id: event_worker_id(ctx, shared),
+        worker_id: event_worker_id(ctx),
     }
 }
 
@@ -662,8 +710,8 @@ pub(crate) fn clear_poll_span() {
     POLL_START_TS.with(|c| c.set(None));
 }
 
-pub(super) fn make_worker_park(ctx: &RuntimeContext, shared: &SharedState) -> WorkerParkEvent {
-    let worker_id = event_worker_id(Some(ctx), shared);
+fn make_worker_park(ctx: &RuntimeContext) -> WorkerParkEvent {
+    let worker_id = event_worker_id(ctx);
     let worker_local_queue_depth = current_local_queue_depth();
     let cpu_time_nanos = crate::telemetry::events::thread_cpu_time_nanos();
     // Only read schedstat on 1-in-N parks. The counter and the "sampled this
@@ -693,8 +741,8 @@ pub(super) fn make_worker_park(ctx: &RuntimeContext, shared: &SharedState) -> Wo
     }
 }
 
-pub(super) fn make_worker_unpark(ctx: &RuntimeContext, shared: &SharedState) -> WorkerUnparkEvent {
-    let worker_id = event_worker_id(Some(ctx), shared);
+fn make_worker_unpark(ctx: &RuntimeContext) -> WorkerUnparkEvent {
+    let worker_id = event_worker_id(ctx);
     let worker_local_queue_depth = current_local_queue_depth();
     let cpu_time_nanos = crate::telemetry::events::thread_cpu_time_nanos();
     // Only read schedstat on unpark if the matching park sampled it, so the

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -301,29 +301,21 @@ impl<F: Future> Future for WakeTraced<F> {
         let traced_waker = make_traced_waker(this.waker_data.clone());
         let mut traced_cx = Context::from_waker(&traced_waker);
 
-        use crate::telemetry::recorder::{make_poll_start, poll_span_open};
-
         // Only record polls this wrapper owns: a task on a runtime dial9 is not
         // attached to has nothing to attribute them to, and poll events claim
         // worker occupancy, so emitting inside an open span (tokio's hooks, or
         // an outer wrapper) would claim the same time twice.
-        let Some(ctx) = this.runtime_ctx.as_deref().filter(|_| !poll_span_open()) else {
+        let Some(ctx) = this
+            .runtime_ctx
+            .as_deref()
+            .filter(|_| !crate::telemetry::recorder::poll_span_open())
+        else {
             return this.inner.poll(&mut traced_cx);
         };
         // Closes the span on the way out, panic or not. A panicking future
         // unwinds past the rest of this function and tokio catches it above us.
-        let _guard = PollSpanGuard {
-            ctx,
-            shared: &this.waker_data.shared,
-        };
-        this.waker_data.shared.if_enabled(|buf| {
-            buf.record_encodable_event(&make_poll_start(
-                Some(ctx),
-                &this.waker_data.shared,
-                this.spawn_loc,
-                this.waker_data.woken_task_id,
-            ));
-        });
+        let _guard = PollSpanGuard { ctx };
+        ctx.record_poll_start(this.spawn_loc, this.waker_data.woken_task_id);
         this.inner.poll(&mut traced_cx)
     }
 }
@@ -333,17 +325,11 @@ impl<F: Future> Future for WakeTraced<F> {
 /// marker set.
 struct PollSpanGuard<'a> {
     ctx: &'a RuntimeContext,
-    shared: &'a SharedState,
 }
 
 impl Drop for PollSpanGuard<'_> {
     fn drop(&mut self) {
-        self.shared.if_enabled(|buf| {
-            buf.record_encodable_event(&crate::telemetry::recorder::make_poll_end(
-                Some(self.ctx),
-                self.shared,
-            ));
-        });
+        self.ctx.record_poll_end();
         crate::telemetry::recorder::clear_poll_span();
     }
 }


### PR DESCRIPTION
Closes a `SharedState` TODO in `register_hooks`.

Every tokio hook closure cloned an `Arc<SharedState>` and built its event by hand. `SharedState` is dial9-core's internals, and the tokio layer should record through the handle it already holds.

### Changes

Recording moves onto `RuntimeContext` as `record_worker_park`, `record_poll_start` and friends, so each hook body is one call. The six `Arc<SharedState>` clones go with them.

`Dial9Handle` gains `record_event_with` which takes in a closure.

Renamed `RuntimeContext::session_handle` to `recorder_handle` (leftover from when we had `SessionHandle` type)