### PR TITLE
refactor(tokio): drop SharedState from the future wrappers

### DIFF
--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -162,11 +162,11 @@ impl SharedState {
 
     /// Check whether recording is currently enabled.
     ///
-    /// Prefer [`Dial9Handle::record_event_with`](crate::handle::Dial9Handle::record_event_with)
-    /// for event-recording paths — it builds the event only when it will be
-    /// recorded, so a paused recorder pays nothing. Use `is_enabled()` only for
-    /// control-flow decisions that don't directly record events (e.g.
-    /// deciding whether to wrap a waker in wake-tracking polls).
+    /// For recording paths prefer
+    /// [`Dial9Handle::record_event_with`](crate::handle::Dial9Handle::record_event_with),
+    /// which builds the event inside the check. Use `is_enabled()` for
+    /// control-flow decisions that don't record, such as whether to wrap a
+    /// waker in wake-tracking polls.
     pub fn is_enabled(&self) -> bool {
         self.state.load(Ordering::Relaxed) == State::Enabled as u8
     }

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -162,9 +162,9 @@ impl SharedState {
 
     /// Check whether recording is currently enabled.
     ///
-    /// Prefer [`if_enabled`](Self::if_enabled) for event-recording paths — it
-    /// provides an [`EventBuffer`] that makes it structurally impossible to
-    /// record without checking first. Use `is_enabled()` only for
+    /// Prefer [`Dial9Handle::record_event_with`](crate::handle::Dial9Handle::record_event_with)
+    /// for event-recording paths — it builds the event only when it will be
+    /// recorded, so a paused recorder pays nothing. Use `is_enabled()` only for
     /// control-flow decisions that don't directly record events (e.g.
     /// deciding whether to wrap a waker in wake-tracking polls).
     pub fn is_enabled(&self) -> bool {
@@ -174,7 +174,7 @@ impl SharedState {
     /// Run `f` only when recording is enabled, passing an [`EventBuffer`]
     /// that provides `record_event` / `record_encodable_event`. Returns
     /// `None` when disabled (no work is done).
-    pub fn if_enabled<R>(&self, f: impl FnOnce(&EventBuffer<'_>) -> R) -> Option<R> {
+    pub(crate) fn if_enabled<R>(&self, f: impl FnOnce(&EventBuffer<'_>) -> R) -> Option<R> {
         if !self.is_enabled() {
             return None;
         }
@@ -291,12 +291,11 @@ impl SharedState {
 /// Handle provided by [`SharedState::if_enabled`] that proves recording is
 /// active. All event-recording calls should go through this type so that
 /// callers cannot accidentally emit events without an enabled check.
-#[doc(hidden)]
 #[derive(Debug)]
-pub struct EventBuffer<'a>(&'a SharedState);
+pub(crate) struct EventBuffer<'a>(&'a SharedState);
 
 impl EventBuffer<'_> {
-    pub fn record_encodable_event(&self, event: &dyn encoder::Encodable) {
+    pub(crate) fn record_encodable_event(&self, event: &dyn encoder::Encodable) {
         if let Some(handle) =
             encoder::record_encodable_event(event, &self.0.collector, &self.0.drain_epoch)
         {
@@ -304,7 +303,7 @@ impl EventBuffer<'_> {
         }
     }
 
-    pub fn with_encoder(&self, f: impl FnOnce(&mut encoder::ThreadLocalEncoder<'_>)) {
+    pub(crate) fn with_encoder(&self, f: impl FnOnce(&mut encoder::ThreadLocalEncoder<'_>)) {
         if let Some(handle) = encoder::with_encoder(f, &self.0.collector, &self.0.drain_epoch) {
             self.0.tl_buffers.lock().unwrap().push(handle);
         }

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -33,17 +33,16 @@
 
 use crate::sampling::SplitMix64;
 use crate::telemetry::format::TaskDumpEvent;
-use crate::telemetry::recorder::SharedState;
 use crate::telemetry::task_dump_config::TaskDumpConfig;
 use crate::telemetry::task_metadata::TaskId;
 use crate::telemetry::{Encodable, ThreadLocalEncoder};
+use dial9_core::handle::Dial9Handle;
 use pin_project_lite::pin_project;
 use smallvec::SmallVec;
 use std::cell::Cell;
 use std::future::Future;
 use std::num::NonZeroU64;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 /// Initial heap reservation for the instruction-pointer buffer on first capture.
@@ -76,7 +75,7 @@ pin_project! {
     pub(crate) struct TaskDumped<F> {
         #[pin]
         inner: F,
-        shared: Arc<SharedState>,
+        handle: Dial9Handle,
         task_id: TaskId,
         frames: FrameBuf,
         // Monotonic nanoseconds when the frames in `frames` were captured.
@@ -105,11 +104,11 @@ pin_project! {
 }
 
 impl<F> TaskDumped<F> {
-    pub(crate) fn new(inner: F, shared: Arc<SharedState>, task_id: TaskId) -> Self {
+    pub(crate) fn new(inner: F, handle: Dial9Handle, task_id: TaskId) -> Self {
         // Config is read lazily on the first poll.
         Self {
             inner,
-            shared,
+            handle,
             task_id,
             frames: FrameBuf::new(),
             pending_capture_ts: None,
@@ -153,7 +152,7 @@ impl<F: Future> Future for TaskDumped<F> {
 
         // Fast path: forward without any capture work when either task dumps
         // are disabled, or telemetry as a whole is paused.
-        if !enabled || !this.shared.is_enabled() {
+        if !enabled || !this.handle.is_enabled() {
             if this.frames.has_data() {
                 this.frames.clear();
                 *this.pending_capture_ts = None;
@@ -180,7 +179,7 @@ impl<F: Future> Future for TaskDumped<F> {
                 .pending_capture_ts
                 .expect("checked in match above")
                 .get();
-            this.frames.emit(this.shared, *this.task_id, ts);
+            this.frames.emit(this.handle, *this.task_id, ts);
             *this.next_sample_ns = this.rng.draw_exponential(*this.sample_mean_ns) as i64;
         }
         match &result {
@@ -256,28 +255,26 @@ impl FrameBuf {
     /// Emit one `TaskDumpEvent` per recorded callchain, then clear.
     /// Trimming via `_Unwind_FindEnclosingFunction` happens here (emit path)
     /// rather than during capture, keeping the hot path lock-free.
-    fn emit(&mut self, shared: &SharedState, task_id: TaskId, capture_ts: u64) {
-        shared.if_enabled(|buf| {
-            for (i, meta) in self.chains.iter().enumerate() {
-                let ip_end = self
-                    .chains
-                    .get(i + 1)
-                    .map(|next| next.ip_start)
-                    .unwrap_or(self.ips.len());
-                let raw = &self.ips[meta.ip_start..ip_end];
-                let chain = match meta.leaf_addr {
-                    Some(leaf) => crate::unwind::trim_frames(raw, meta.root_addr, leaf),
-                    None => &[],
-                };
-                if !chain.is_empty() {
-                    buf.record_encodable_event(&TaskDumpData {
-                        timestamp_ns: capture_ts,
-                        task_id,
-                        callchain: chain,
-                    });
-                }
+    fn emit(&mut self, handle: &Dial9Handle, task_id: TaskId, capture_ts: u64) {
+        for (i, meta) in self.chains.iter().enumerate() {
+            let ip_end = self
+                .chains
+                .get(i + 1)
+                .map(|next| next.ip_start)
+                .unwrap_or(self.ips.len());
+            let raw = &self.ips[meta.ip_start..ip_end];
+            let chain = match meta.leaf_addr {
+                Some(leaf) => crate::unwind::trim_frames(raw, meta.root_addr, leaf),
+                None => &[],
+            };
+            if !chain.is_empty() {
+                handle.record_event_with(|| TaskDumpData {
+                    timestamp_ns: capture_ts,
+                    task_id,
+                    callchain: chain,
+                });
             }
-        });
+        }
         self.clear();
     }
 

--- a/dial9-tokio-telemetry/src/telemetry/recorder/handle.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/handle.rs
@@ -1,5 +1,4 @@
 use crate::TracedFuture;
-use crate::traced::TracedHandle;
 use dial9_core::handle::Dial9Handle;
 use std::cell::Cell;
 
@@ -9,13 +8,10 @@ crate::primitives::thread_local! {
     pub(super) static INSTRUMENTED_SPAWN: Cell<u32> = const { Cell::new(0) };
 }
 
-/// Wake-tracking handle for a [`Dial9Handle`], or `None` when the handle is
-/// disabled. The waker wrapping is tokio-specific, so it lives here rather
-/// than on the runtime-agnostic `Dial9Handle`.
-pub(crate) fn traced_handle(handle: &Dial9Handle) -> Option<TracedHandle> {
-    handle.shared().map(|shared| TracedHandle {
-        shared: shared.clone(),
-    })
+/// The handle to instrument with, or `None` when it is not connected to a
+/// recorder.
+pub(crate) fn traced_handle(handle: &Dial9Handle) -> Option<Dial9Handle> {
+    handle.shared().is_some().then(|| handle.clone())
 }
 
 /// Tokio handle for spawning instrumented tasks.
@@ -31,7 +27,7 @@ pub struct Dial9TokioHandle {
     /// `None` spawns on the current runtime (`tokio::spawn`), `Some` targets a
     /// specific runtime and works from any thread.
     runtime: Option<tokio::runtime::Handle>,
-    traced: Option<TracedHandle>,
+    traced: Option<Dial9Handle>,
 }
 
 impl std::fmt::Debug for Dial9TokioHandle {
@@ -67,7 +63,7 @@ impl Dial9TokioHandle {
     #[cfg(test)]
     pub(crate) fn for_runtime(
         runtime: tokio::runtime::Handle,
-        traced: Option<crate::traced::TracedHandle>,
+        traced: Option<Dial9Handle>,
     ) -> Self {
         Self {
             runtime: Some(runtime),

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -1875,9 +1875,10 @@ mod tests {
 
         // Drain thread-local buffers before shutdown.
         test_util::drain_thread_local(
-            &traced_handle(rec.handle())
-                .expect("enabled handle must yield a TracedHandle")
-                .shared,
+            traced_handle(rec.handle())
+                .expect("enabled recorder must yield a handle")
+                .shared()
+                .unwrap(),
         );
 
         drop(runtime);

--- a/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
@@ -408,12 +408,12 @@ impl Dial9HandleTokioExt for Dial9Handle {
 /// running on, if dial9 is attached to it. Resolved by runtime id, so a thread
 /// that drives several runtimes gets the right one every time.
 #[cfg(not(tokio_unstable))]
-pub(crate) fn current_runtime_ctx(shared: &Arc<SharedState>) -> Option<Arc<RuntimeContext>> {
+pub(crate) fn current_runtime_ctx(handle: &Dial9Handle) -> Option<Arc<RuntimeContext>> {
     let id = tokio::runtime::Handle::try_current().ok()?.id();
     if let Some(ctx) = super::runtime_context::cached_runtime_ctx(id) {
         return Some(ctx);
     }
-    let registry = runtime_registry(shared)?;
+    let registry = runtime_registry(handle.shared()?)?;
     let ctx = {
         let registry = registry.lock().ok()?;
         registry.iter().find(|c| c.is_runtime(id)).cloned()?

--- a/dial9-tokio-telemetry/src/traced.rs
+++ b/dial9-tokio-telemetry/src/traced.rs
@@ -2,7 +2,7 @@
 
 use crate::rate_limit::rate_limited;
 use crate::telemetry::format::WakeEventEvent;
-use crate::telemetry::recorder::{RuntimeContext, SharedState};
+use crate::telemetry::recorder::RuntimeContext;
 use crate::telemetry::task_metadata::TaskId;
 use dial9_core::handle::Dial9Handle;
 use futures_util::task::{ArcWake, AtomicWaker, waker as arc_waker};
@@ -13,18 +13,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 use std::time::Duration;
-
-/// Handle used by instrumented futures to emit events into the telemetry system.
-#[derive(Clone)]
-pub(crate) struct TracedHandle {
-    pub(crate) shared: Arc<SharedState>,
-}
-
-impl std::fmt::Debug for TracedHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TracedHandle").finish_non_exhaustive()
-    }
-}
 
 #[cfg(feature = "taskdump")]
 type MaybeTaskDumped<F> = crate::task_dumped::TaskDumped<F>;
@@ -59,7 +47,7 @@ impl<F> std::fmt::Debug for TracedFuture<F> {
 enum HandleSource {
     /// Instrument with this handle when a Tokio task context is present.
     /// Captured eagerly at spawn time on the spawning thread.
-    Eager(TracedHandle),
+    Eager(Dial9Handle),
     /// Never instrument, run as a transparent passthrough.
     Passthrough,
     /// Resolve the handle from the polling thread's current dial9 runtime at
@@ -72,7 +60,7 @@ enum HandleSource {
 
 impl<F> TracedFuture<F> {
     #[track_caller]
-    pub(crate) fn new(inner: F, handle: Option<TracedHandle>) -> Self {
+    pub(crate) fn new(inner: F, handle: Option<Dial9Handle>) -> Self {
         let source = match handle {
             Some(handle) => HandleSource::Eager(handle),
             None => HandleSource::Passthrough,
@@ -137,7 +125,7 @@ pin_project! {
 impl<F> WakeTraced<F> {
     pub(crate) fn new(
         inner: F,
-        handle: TracedHandle,
+        handle: Dial9Handle,
         task_id: TaskId,
         spawn_loc: &'static Location<'static>,
     ) -> Self {
@@ -146,11 +134,11 @@ impl<F> WakeTraced<F> {
         #[cfg(tokio_unstable)]
         let runtime_ctx = None;
         #[cfg(not(tokio_unstable))]
-        let runtime_ctx = crate::telemetry::recorder::current_runtime_ctx(&handle.shared);
+        let runtime_ctx = crate::telemetry::recorder::current_runtime_ctx(&handle);
         let waker_data = Arc::new(TracedWakerData {
             inner: AtomicWaker::new(),
             woken_task_id: task_id,
-            shared: handle.shared.clone(),
+            handle: handle.clone(),
         });
         Self {
             inner,
@@ -171,7 +159,7 @@ impl<F> WakeTraced<F> {
 struct TracedWakerData {
     inner: AtomicWaker,
     woken_task_id: TaskId,
-    shared: Arc<SharedState>,
+    handle: Dial9Handle,
 }
 
 impl ArcWake for TracedWakerData {
@@ -182,7 +170,7 @@ impl ArcWake for TracedWakerData {
 }
 
 fn record_wake_event(data: &TracedWakerData) {
-    data.shared.if_enabled(|buf| {
+    data.handle.record_event_with(|| {
         // The worker issuing the wake — not the worker that will execute the woken task
         // (which is unknowable at wake time). Stored in the event as `target_worker`.
         let waking_worker_id = crate::telemetry::recorder::current_worker_id();
@@ -194,13 +182,12 @@ fn record_wake_event(data: &TracedWakerData) {
             255
         };
         let waker_task_id = tokio::task::try_id().map(TaskId::from).unwrap_or_default();
-        let event = WakeEventEvent {
+        WakeEventEvent {
             timestamp_ns: crate::telemetry::events::clock_monotonic_ns(),
             waker_task_id,
             woken_task_id: data.woken_task_id,
             target_worker: waking_worker_u8,
-        };
-        buf.record_encodable_event(&event);
+        }
     });
 }
 
@@ -210,18 +197,15 @@ fn make_traced_waker(data: Arc<TracedWakerData>) -> Waker {
 
 fn make_instrumented<F>(
     inner: F,
-    handle: TracedHandle,
+    handle: Dial9Handle,
     task_id: TaskId,
     spawn_loc: &'static std::panic::Location<'static>,
 ) -> InstrumentedFuture<F>
 where
     F: Future,
 {
-    let shared = handle.shared.clone();
     #[cfg(feature = "taskdump")]
-    let inner = crate::task_dumped::TaskDumped::new(inner, shared, task_id);
-    #[cfg(not(feature = "taskdump"))]
-    let _ = shared;
+    let inner = crate::task_dumped::TaskDumped::new(inner, handle.clone(), task_id);
 
     WakeTraced::new(inner, handle, task_id, spawn_loc)
 }
@@ -288,7 +272,7 @@ impl<F: Future> Future for WakeTraced<F> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
 
-        if !this.waker_data.shared.is_enabled() {
+        if !this.waker_data.handle.is_enabled() {
             return this.inner.poll(cx);
         }
 
@@ -354,7 +338,7 @@ mod tests {
     #[test]
     fn traced_future_falls_back_after_missing_task_context() {
         let rec = recorder(MemoryBuffer::new(16 * 1024 * 1024).unwrap()).build();
-        let handle = traced_handle(rec.handle()).expect("enabled handle yields TracedHandle");
+        let handle = traced_handle(rec.handle()).expect("enabled recorder yields a handle");
 
         let mut future = TracedFuture::new(std::future::pending::<()>(), Some(handle));
         let waker = noop_waker();
@@ -429,8 +413,8 @@ mod tests {
         // Wake events land in the thread-local buffer (capacity 1_024), so a
         // single event will not auto-flush.  Manually drain the buffer into the
         // collector so that the guard flush below picks it up.
-        let th = traced_handle(rec.handle()).expect("enabled handle yields TracedHandle");
-        test_util::drain_thread_local(&th.shared);
+        let th = traced_handle(rec.handle()).expect("enabled recorder yields a handle");
+        test_util::drain_thread_local(th.shared().unwrap());
 
         // Dropping the runtime + recorder stops the background flush thread, joins
         // it, then performs a final flush: collector → DiskBuffer → trace file.


### PR DESCRIPTION
Depends on #784, similar TODO, for the other two holders.

`TracedHandle` was `struct TracedHandle { shared: Arc<SharedState> }` a newtype over the thing we are removing, so it collapses into `Dial9Handle` outright. The `Option` still carries its meaning: `None` is "not connected to a recorder, spawn plainly". `TaskDumped` holds a handle for the same reason. Both record through `record_event_with`.

`current_runtime_ctx` takes a `&Dial9Handle` and resolves the state itself.

### emit

`TaskDumped::emit` recorded every callchain under a single `if_enabled`. `record_event_with` records one event, so the gate is per event now. The poll fast path already returns early when recording is paused, so trimming still only happens while recording, and the per-event gate keeps `disable` an exact boundary.