### PR TITLE
refactor(core): seal SharedState behind test-util

### DIFF
--- a/dial9-core/src/handle.rs
+++ b/dial9-core/src/handle.rs
@@ -1,8 +1,17 @@
 use crate::encoder::{Encodable, ThreadLocalEncoder};
 use crate::primitives::sync::Arc;
 use crate::shared_state::SharedState;
+use crate::source::Source;
 use crate::thread::ThreadTrackingGuard;
+use std::any::Any;
 use std::cell::RefCell;
+
+/// First registered source of type `T`, if any.
+fn find_source<T: Source>(sources: &mut [Box<dyn Source>]) -> Option<&mut T> {
+    sources
+        .iter_mut()
+        .find_map(|source| (&mut **source as &mut dyn Any).downcast_mut::<T>())
+}
 
 crate::primitives::thread_local! {
     /// Per-thread [`Dial9Handle`], populated via [`set_tl_handle`] and cleared
@@ -82,16 +91,16 @@ impl Dial9Handle {
     /// skipped, exactly as if it had arrived a moment earlier or later).
     ///
     /// To ask only whether the handle is connected at all, regardless of
-    /// pause state, use [`shared`](Self::shared)`().is_some()`.
+    /// pause state, use [`is_connected`](Self::is_connected).
     pub fn is_enabled(&self) -> bool {
         self.inner.as_ref().is_some_and(|i| i.shared.is_enabled())
     }
 
-    /// Access this handle's [`SharedState`].
-    ///
-    /// You can use it to subscribe new sources via [`push_source`](SharedState::push_source)
-    pub fn shared(&self) -> Option<&Arc<SharedState>> {
-        self.inner.as_ref().map(|i| &i.shared)
+    crate::test_util_pub! {
+        /// Access this handle's [`SharedState`].
+        fn shared(&self) -> Option<&Arc<SharedState>> {
+            self.inner.as_ref().map(|i| &i.shared)
+        }
     }
 
     pub(crate) fn control_tx(
@@ -208,6 +217,70 @@ impl Dial9Handle {
             Some(Err(e)) => Err(e),
             None => Err(std::io::Error::other("dial9: sources lock poisoned")),
         }
+    }
+
+    /// Whether this handle is wired to a recorder at all, regardless of whether
+    /// recording is currently paused.
+    ///
+    /// [`is_enabled`](Self::is_enabled) answers the narrower question of whether
+    /// a record right now would land.
+    pub fn is_connected(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Reserve `count` consecutive global worker IDs.
+    ///
+    /// IDs are unique across every runtime attached to this recorder, so each
+    /// runtime can hand its workers a block of its own. `None` on a disabled
+    /// handle, which has no counter to draw from.
+    pub fn reserve_worker_ids(&self, count: u64) -> Option<u64> {
+        Some(self.inner.as_ref()?.shared.reserve_worker_ids(count))
+    }
+
+    /// Whether the recorder behind this handle has shut down.
+    ///
+    /// Terminal: a stopped recorder never records again. Returns `false` for a
+    /// handle that is merely paused (see [`disable`](Self::disable)) and for a
+    /// disabled handle, neither of which is stopped.
+    pub fn is_stopped(&self) -> bool {
+        self.inner.as_ref().is_some_and(|i| i.shared.is_stopped())
+    }
+
+    /// Run `f` against this recorder's source of type `T`.
+    ///
+    /// `None` when the handle is disabled, no `T` is registered, or the source
+    /// lock is poisoned.
+    pub fn with_source<T: Source, R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R> {
+        let inner = self.inner.as_ref()?;
+        inner
+            .shared
+            .with_sources_mut(|sources| Some(f(find_source::<T>(sources)?)))
+            .flatten()
+    }
+
+    /// Run `f` against this recorder's source of type `T`, registering the one
+    /// `make` builds if there is not one yet.
+    ///
+    /// `None` when the handle is disabled, the recorder has shut down, or the
+    /// source lock is poisoned.
+    pub fn i<T: Source, R>(
+        &self,
+        make: impl FnOnce() -> T,
+        f: impl FnOnce(&mut T) -> R,
+    ) -> Option<R> {
+        let inner = self.inner.as_ref()?;
+        inner
+            .shared
+            .with_sources_vec(|sources| {
+                if inner.shared.is_stopped() {
+                    return None;
+                }
+                if find_source::<T>(sources).is_none() {
+                    sources.push(Box::new(make()));
+                }
+                Some(f(find_source::<T>(sources).expect("just registered")))
+            })
+            .flatten()
     }
 
     /// Record a custom event into the trace.

--- a/dial9-core/src/handle.rs
+++ b/dial9-core/src/handle.rs
@@ -228,15 +228,6 @@ impl Dial9Handle {
         self.inner.is_some()
     }
 
-    /// Reserve `count` consecutive global worker IDs.
-    ///
-    /// IDs are unique across every runtime attached to this recorder, so each
-    /// runtime can hand its workers a block of its own. `None` on a disabled
-    /// handle, which has no counter to draw from.
-    pub fn reserve_worker_ids(&self, count: u64) -> Option<u64> {
-        Some(self.inner.as_ref()?.shared.reserve_worker_ids(count))
-    }
-
     /// Whether the recorder behind this handle has shut down.
     ///
     /// Terminal: a stopped recorder never records again. Returns `false` for a

--- a/dial9-core/src/handle.rs
+++ b/dial9-core/src/handle.rs
@@ -263,7 +263,7 @@ impl Dial9Handle {
     ///
     /// `None` when the handle is disabled, the recorder has shut down, or the
     /// source lock is poisoned.
-    pub fn i<T: Source, R>(
+    pub fn with_source_or_insert<T: Source, R>(
         &self,
         make: impl FnOnce() -> T,
         f: impl FnOnce(&mut T) -> R,

--- a/dial9-core/src/lib.rs
+++ b/dial9-core/src/lib.rs
@@ -69,9 +69,10 @@ pub mod sampling;
 pub mod schema_extensions;
 /// Sealed-segment detection. The segment types are public via [`pipeline`].
 pub(crate) mod sealed;
-/// Runtime-agnostic recording state shared across threads.
-#[doc(hidden)]
-pub mod shared_state;
+test_util_pub! {
+    /// Runtime-agnostic recording state shared across threads.
+    mod shared_state;
+}
 /// `Source` trait: pluggable flush-thread data sources.
 pub mod source;
 /// Test-only record/drain/write helpers.

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -13,9 +13,9 @@
 //! # Ok::<(), std::io::Error>(())
 //! ```
 //!
-//! This wraps low-level `Recorder::start`, which expects a pre-built
-//! [`SharedState`](crate::shared_state::SharedState) with sources already
-//! registered. The Tokio integration reuses the same builder.
+//! This wraps low-level `Recorder::start`, which expects pre-built shared
+//! recording state with sources already registered. The Tokio integration
+//! reuses the same builder.
 
 use crate::buffer::{BufferMode, Disk, SegmentWriter};
 use crate::clock;

--- a/dial9-core/src/recording.rs
+++ b/dial9-core/src/recording.rs
@@ -128,9 +128,11 @@ impl Recorder {
         self.worker = Some(worker);
     }
 
-    /// The shared recording state.
-    pub fn shared(&self) -> Option<&Arc<SharedState>> {
-        self.handle.shared()
+    crate::test_util_pub! {
+        /// The shared recording state.
+        fn shared(&self) -> Option<&Arc<SharedState>> {
+            self.handle.shared()
+        }
     }
 
     /// Monotonic start time of the recorder in nanoseconds.

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -23,9 +23,6 @@ struct SharedState {
     pub(crate) collector: Arc<CentralCollector>,
     /// Absolute `CLOCK_MONOTONIC` nanosecond timestamp captured at trace start.
     pub(crate) start_time_ns: u64,
-    /// Global worker ID counter. Each runtime reserves a contiguous block
-    /// via `fetch_add(num_workers)` so worker IDs don't collide.
-    pub(crate) next_worker_id: AtomicU64,
     /// Epoch counter bumped by the flush thread every ~30s. Thread-local
     /// buffers stamp this value on each self-flush so the flush thread can
     /// skip busy workers when draining.
@@ -59,7 +56,6 @@ impl SharedState {
                 state: AtomicU8::new(State::Disabled as u8),
                 collector: Arc::new(CentralCollector::new()),
                 start_time_ns,
-                next_worker_id: AtomicU64::new(0),
                 drain_epoch: AtomicU64::new(0),
                 tl_buffers: Mutex::new(Vec::new()),
                 sources: Mutex::new(Vec::new()),
@@ -112,11 +108,6 @@ impl SharedState {
     /// Trace-start `CLOCK_MONOTONIC` timestamp.
     pub(crate) fn start_time_ns(&self) -> u64 {
         self.start_time_ns
-    }
-
-    /// Reserve a contiguous block of `count` worker IDs, returning the first.
-    pub(crate) fn reserve_worker_ids(&self, count: u64) -> u64 {
-        self.next_worker_id.fetch_add(count, Ordering::Relaxed)
     }
 
     crate::test_util_pub! {

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -15,9 +15,9 @@ enum State {
     Stopped = 2,
 }
 
+crate::test_util_pub! {
 /// Runtime-agnostic core recording state.
-#[doc(hidden)]
-pub struct SharedState {
+struct SharedState {
     /// Recording lifecycle: `Disabled ⇄ Enabled → Stopped` (terminal).
     state: AtomicU8,
     pub(crate) collector: Arc<CentralCollector>,
@@ -40,6 +40,7 @@ pub struct SharedState {
     /// [`Dial9Handle::dump_trigger`](super::handle::Dial9Handle::dump_trigger).
     #[cfg(feature = "pipeline")]
     dump_trigger: std::sync::OnceLock<crate::dump::DumpTrigger>,
+}
 }
 
 impl std::fmt::Debug for SharedState {
@@ -68,18 +69,22 @@ impl SharedState {
         }
     }
 
-    /// Register a data source to be drained by the flush thread each cycle.
-    pub fn push_source(&self, source: Box<dyn crate::source::Source>) {
-        self.sources.lock().unwrap().push(source);
+    crate::test_util_pub! {
+        /// Register a data source to be drained by the flush thread each cycle.
+        fn push_source(&self, source: Box<dyn crate::source::Source>) {
+            self.sources.lock().unwrap().push(source);
+        }
     }
 
-    /// Run `f` against the registered sources. Returns `None` if the lock is
-    /// poisoned. Used to drive the per-thread source lifecycle hooks.
-    pub fn with_sources_mut<R>(
-        &self,
-        f: impl FnOnce(&mut [Box<dyn crate::source::Source>]) -> R,
-    ) -> Option<R> {
-        self.sources.lock().ok().map(|mut sources| f(&mut sources))
+    crate::test_util_pub! {
+        /// Run `f` against the registered sources. Returns `None` if the lock is
+        /// poisoned. Used to drive the per-thread source lifecycle hooks.
+        fn with_sources_mut<R>(
+            &self,
+            f: impl FnOnce(&mut [Box<dyn crate::source::Source>]) -> R,
+        ) -> Option<R> {
+            self.sources.lock().ok().map(|mut sources| f(&mut sources))
+        }
     }
 
     /// Drop every registered source.
@@ -97,7 +102,7 @@ impl SharedState {
 
     /// Like [`with_sources_mut`](Self::with_sources_mut), but `f` receives the
     /// list itself so it can register sources too.
-    pub fn with_sources_vec<R>(
+    pub(crate) fn with_sources_vec<R>(
         &self,
         f: impl FnOnce(&mut Vec<Box<dyn crate::source::Source>>) -> R,
     ) -> Option<R> {
@@ -105,27 +110,29 @@ impl SharedState {
     }
 
     /// Trace-start `CLOCK_MONOTONIC` timestamp.
-    pub fn start_time_ns(&self) -> u64 {
+    pub(crate) fn start_time_ns(&self) -> u64 {
         self.start_time_ns
     }
 
     /// Reserve a contiguous block of `count` worker IDs, returning the first.
-    pub fn reserve_worker_ids(&self, count: u64) -> u64 {
+    pub(crate) fn reserve_worker_ids(&self, count: u64) -> u64 {
         self.next_worker_id.fetch_add(count, Ordering::Relaxed)
     }
 
-    /// Turn recording on. No-op once stopped.
-    pub fn enable(&self) {
-        let _ = self.state.compare_exchange(
-            State::Disabled as u8,
-            State::Enabled as u8,
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-        );
+    crate::test_util_pub! {
+        /// Turn recording on. No-op once stopped.
+        fn enable(&self) {
+            let _ = self.state.compare_exchange(
+                State::Disabled as u8,
+                State::Enabled as u8,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+        }
     }
 
     /// Turn recording off. No-op once stopped.
-    pub fn disable(&self) {
+    pub(crate) fn disable(&self) {
         let _ = self.state.compare_exchange(
             State::Enabled as u8,
             State::Disabled as u8,
@@ -141,7 +148,7 @@ impl SharedState {
     }
 
     /// Whether the recorder has shut down for good.
-    pub fn is_stopped(&self) -> bool {
+    pub(crate) fn is_stopped(&self) -> bool {
         self.state.load(Ordering::Relaxed) == State::Stopped as u8
     }
 
@@ -149,7 +156,7 @@ impl SharedState {
     /// facade builder; later calls are ignored. `pub` so the facade (a
     /// sibling crate) can wire the trigger in.
     #[cfg(feature = "pipeline")]
-    pub fn set_dump_trigger(&self, trigger: crate::dump::DumpTrigger) {
+    pub(crate) fn set_dump_trigger(&self, trigger: crate::dump::DumpTrigger) {
         let _ = self.dump_trigger.set(trigger);
     }
 
@@ -167,7 +174,7 @@ impl SharedState {
     /// which builds the event inside the check. Use `is_enabled()` for
     /// control-flow decisions that don't record, such as whether to wrap a
     /// waker in wake-tracking polls.
-    pub fn is_enabled(&self) -> bool {
+    pub(crate) fn is_enabled(&self) -> bool {
         self.state.load(Ordering::Relaxed) == State::Enabled as u8
     }
 
@@ -269,22 +276,26 @@ impl SharedState {
         self.drain_epoch.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Drain data sources and write their events into the collector.
-    pub fn flush_sources(&self) {
-        let ctx = self.flush_context();
-        let mut sources = self.sources.lock().unwrap();
-        for source in sources.iter_mut() {
-            source.flush(&ctx);
+    crate::test_util_pub! {
+        /// Drain data sources and write their events into the collector.
+        fn flush_sources(&self) {
+            let ctx = self.flush_context();
+            let mut sources = self.sources.lock().unwrap();
+            for source in sources.iter_mut() {
+                source.flush(&ctx);
+            }
         }
     }
 
-    /// Build a [`FlushContext`] for this state.
-    ///
-    /// Used by `flush_sources` and by tests that construct a ctx directly.
-    ///
-    /// [`FlushContext`]: crate::source::FlushContext
-    pub fn flush_context(&self) -> crate::source::FlushContext<'_> {
-        crate::source::FlushContext::new(&self.collector, &self.drain_epoch)
+    crate::test_util_pub! {
+        /// Build a [`FlushContext`] for this state.
+        ///
+        /// Used by `flush_sources` and by tests that construct a ctx directly.
+        ///
+        /// [`FlushContext`]: crate::source::FlushContext
+        fn flush_context(&self) -> crate::source::FlushContext<'_> {
+            crate::source::FlushContext::new(&self.collector, &self.drain_epoch)
+        }
     }
 }
 

--- a/dial9-core/src/source.rs
+++ b/dial9-core/src/source.rs
@@ -55,11 +55,11 @@ impl<'a> FlushContext<'a> {
 /// A data source drained by the flush thread each cycle.
 ///
 /// Implement this trait to feed custom events into the dial9 trace. Register
-/// the source with [`SharedState::push_source`] before starting the flush
+/// the source with [`RecorderBuilder::source`] before starting the flush
 /// thread; the flush thread calls [`flush`] once per cycle.
 ///
 /// [`flush`]: Source::flush
-/// [`SharedState::push_source`]: crate::shared_state::SharedState::push_source
+/// [`RecorderBuilder::source`]: crate::recorder::RecorderBuilder::source
 pub trait Source: Any + Send {
     /// Drain pending data into the trace. Called once per flush cycle.
     fn flush(&mut self, ctx: &FlushContext<'_>);

--- a/dial9-tokio-telemetry/src/telemetry/recorder/handle.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/handle.rs
@@ -11,7 +11,7 @@ crate::primitives::thread_local! {
 /// The handle to instrument with, or `None` when it is not connected to a
 /// recorder.
 pub(crate) fn traced_handle(handle: &Dial9Handle) -> Option<Dial9Handle> {
-    handle.shared().is_some().then(|| handle.clone())
+    handle.is_connected().then(|| handle.clone())
 }
 
 /// Tokio handle for spawning instrumented tasks.

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -207,11 +207,16 @@ fn register_runtime_hooks(
     builder: &mut tokio::runtime::Builder,
     runtime_name: Option<String>,
     handle: &Dial9Handle,
+    worker_ids: runtime_context::WorkerIdCounter,
     task_tracking_enabled: bool,
     tokio_hooks: TokioHooks,
     taskdump_config: Option<crate::telemetry::task_dump_config::TaskDumpConfig>,
 ) -> Arc<RuntimeContext> {
-    let ctx = Arc::new(RuntimeContext::new(runtime_name, handle.clone()));
+    let ctx = Arc::new(RuntimeContext::new(
+        runtime_name,
+        handle.clone(),
+        worker_ids,
+    ));
     register_hooks(
         builder,
         &ctx,
@@ -260,13 +265,15 @@ mod tests {
     fn runtime_hooks_do_not_publish_before_build() {
         clear_tl_handle();
         let rec = recorder(MemoryBuffer::new(CAPTURE_SIZE).unwrap()).build();
-        let registry = recorder_tokio::runtime_registry(rec.handle()).unwrap();
+        let state = recorder_tokio::tokio_attach_state(rec.handle()).unwrap();
+        let registry = state.registry;
         let mut builder = tokio::runtime::Builder::new_current_thread();
 
         let ctx = register_runtime_hooks(
             &mut builder,
             Some("aborted".to_string()),
             rec.handle(),
+            state.worker_ids,
             false,
             TokioHooks::default(),
             None,
@@ -468,7 +475,8 @@ mod tests {
         assert!(!span_open, "a paused recorder should not open a poll span");
 
         let reserved: HashSet<u64> = {
-            let registry = recorder_tokio::runtime_registry(rec.handle())
+            let registry = recorder_tokio::tokio_attach_state(rec.handle())
+                .map(|s| s.registry)
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             registry
@@ -947,7 +955,8 @@ mod tests {
         // Blocks are reserved when a runtime's workers first resolve, so which
         // runtime holds the lower block is not fixed.
         let (main_ids, attached_ids) = {
-            let registry = recorder_tokio::runtime_registry(rec.handle())
+            let registry = recorder_tokio::tokio_attach_state(rec.handle())
+                .map(|s| s.registry)
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             let block = |name: &str| -> std::collections::HashSet<u64> {
@@ -1306,7 +1315,8 @@ mod tests {
         // of assuming absolute ranges: IDs are reserved when a runtime's workers
         // first poll, so the blocks depend on drive order.
         let (main_ids, io_ids) = {
-            let registry = recorder_tokio::runtime_registry(rec.handle())
+            let registry = recorder_tokio::tokio_attach_state(rec.handle())
+                .map(|s| s.registry)
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             let block = |name: &str| -> HashSet<u64> {
@@ -1432,7 +1442,8 @@ mod tests {
         // Read the worker set before shutdown: the registry goes away with the
         // recorder.
         let enrolled: HashSet<u64> = {
-            let registry = recorder_tokio::runtime_registry(rec.handle())
+            let registry = recorder_tokio::tokio_attach_state(rec.handle())
+                .map(|s| s.registry)
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             registry
@@ -1521,7 +1532,8 @@ mod tests {
         });
 
         let block = |name: &str| -> HashSet<u64> {
-            let registry = recorder_tokio::runtime_registry(rec.handle())
+            let registry = recorder_tokio::tokio_attach_state(rec.handle())
+                .map(|s| s.registry)
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             registry
@@ -1582,7 +1594,8 @@ mod tests {
         }
 
         let (main_ids, io_ids) = {
-            let registry = recorder_tokio::runtime_registry(rec.handle())
+            let registry = recorder_tokio::tokio_attach_state(rec.handle())
+                .map(|s| s.registry)
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             let block = |name: &str| -> HashSet<u64> {
@@ -1830,7 +1843,9 @@ mod tests {
         }
 
         assert_eq!(source_count(), 1, "every attach shares one source");
-        let registry = recorder_tokio::runtime_registry(rec.handle()).expect("registry");
+        let registry = recorder_tokio::tokio_attach_state(rec.handle())
+            .map(|s| s.registry)
+            .expect("registry");
         assert_eq!(
             registry.lock().unwrap().len(),
             3,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/mod.rs
@@ -2,6 +2,7 @@ mod handle;
 mod join_set;
 mod recorder_tokio;
 mod runtime_context;
+#[cfg(test)]
 pub(crate) use dial9_core::shared_state::SharedState;
 pub(crate) use dial9_core::source;
 
@@ -259,8 +260,7 @@ mod tests {
     fn runtime_hooks_do_not_publish_before_build() {
         clear_tl_handle();
         let rec = recorder(MemoryBuffer::new(CAPTURE_SIZE).unwrap()).build();
-        let shared = rec.shared().unwrap().clone();
-        let registry = recorder_tokio::runtime_registry(&shared).unwrap();
+        let registry = recorder_tokio::runtime_registry(rec.handle()).unwrap();
         let mut builder = tokio::runtime::Builder::new_current_thread();
 
         let ctx = register_runtime_hooks(
@@ -370,7 +370,6 @@ mod tests {
             .unwrap();
 
         assert!(rec.handle().is_enabled());
-        assert!(rec.shared().unwrap().is_enabled());
         let runtime_meta = rec
             .shared()
             .unwrap()
@@ -469,7 +468,7 @@ mod tests {
         assert!(!span_open, "a paused recorder should not open a poll span");
 
         let reserved: HashSet<u64> = {
-            let registry = recorder_tokio::runtime_registry(rec.shared().unwrap())
+            let registry = recorder_tokio::runtime_registry(rec.handle())
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             registry
@@ -948,7 +947,7 @@ mod tests {
         // Blocks are reserved when a runtime's workers first resolve, so which
         // runtime holds the lower block is not fixed.
         let (main_ids, attached_ids) = {
-            let registry = recorder_tokio::runtime_registry(rec.shared().unwrap())
+            let registry = recorder_tokio::runtime_registry(rec.handle())
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             let block = |name: &str| -> std::collections::HashSet<u64> {
@@ -1307,7 +1306,7 @@ mod tests {
         // of assuming absolute ranges: IDs are reserved when a runtime's workers
         // first poll, so the blocks depend on drive order.
         let (main_ids, io_ids) = {
-            let registry = recorder_tokio::runtime_registry(rec.shared().unwrap())
+            let registry = recorder_tokio::runtime_registry(rec.handle())
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             let block = |name: &str| -> HashSet<u64> {
@@ -1433,7 +1432,7 @@ mod tests {
         // Read the worker set before shutdown: the registry goes away with the
         // recorder.
         let enrolled: HashSet<u64> = {
-            let registry = recorder_tokio::runtime_registry(rec.shared().unwrap())
+            let registry = recorder_tokio::runtime_registry(rec.handle())
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             registry
@@ -1522,7 +1521,7 @@ mod tests {
         });
 
         let block = |name: &str| -> HashSet<u64> {
-            let registry = recorder_tokio::runtime_registry(rec.shared().unwrap())
+            let registry = recorder_tokio::runtime_registry(rec.handle())
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             registry
@@ -1583,7 +1582,7 @@ mod tests {
         }
 
         let (main_ids, io_ids) = {
-            let registry = recorder_tokio::runtime_registry(rec.shared().unwrap())
+            let registry = recorder_tokio::runtime_registry(rec.handle())
                 .expect("enabled recorder has a context registry");
             let registry = registry.lock().unwrap();
             let block = |name: &str| -> HashSet<u64> {
@@ -1831,7 +1830,7 @@ mod tests {
         }
 
         assert_eq!(source_count(), 1, "every attach shares one source");
-        let registry = recorder_tokio::runtime_registry(&shared).expect("registry");
+        let registry = recorder_tokio::runtime_registry(rec.handle()).expect("registry");
         assert_eq!(
             registry.lock().unwrap().len(),
             3,

--- a/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
@@ -59,7 +59,6 @@ use dial9_core::buffer::BufferMode;
 use dial9_core::handle::{Dial9Handle, set_tl_handle};
 use dial9_core::recorder::RecorderBuilder;
 use dial9_core::recording::Recorder;
-use dial9_core::shared_state::SharedState;
 #[cfg(feature = "worker-s3")]
 use dial9_destinations_s3::S3Config;
 use std::io;
@@ -348,10 +347,10 @@ impl Dial9HandleTokioExt for Dial9Handle {
         mut builder: tokio::runtime::Builder,
         options: TokioAttachOptions,
     ) -> io::Result<tokio::runtime::Runtime> {
-        let Some(shared) = self.shared() else {
+        if !self.is_connected() {
             return builder.build();
-        };
-        if shared.is_stopped() {
+        }
+        if self.is_stopped() {
             return Err(io::Error::other(
                 "recorder has shut down; attach runtimes before graceful_shutdown",
             ));
@@ -359,7 +358,7 @@ impl Dial9HandleTokioExt for Dial9Handle {
         if !options.tokio_instrumentation_enabled {
             return builder.build();
         }
-        let Some(registry) = runtime_registry(shared) else {
+        let Some(registry) = runtime_registry(self) else {
             return Err(io::Error::other(
                 "dial9 source registry unavailable; Tokio runtime not attached",
             ));
@@ -399,7 +398,7 @@ impl Dial9HandleTokioExt for Dial9Handle {
         if let Some(config) = task_dump_config {
             crate::task_dumped::set_taskdump_config(config);
         }
-        register_runtime_metrics(shared, runtime_name, runtime.handle().metrics());
+        register_runtime_metrics(self, runtime_name, runtime.handle().metrics());
         Ok(runtime)
     }
 }
@@ -413,7 +412,7 @@ pub(crate) fn current_runtime_ctx(handle: &Dial9Handle) -> Option<Arc<RuntimeCon
     if let Some(ctx) = super::runtime_context::cached_runtime_ctx(id) {
         return Some(ctx);
     }
-    let registry = runtime_registry(handle.shared()?)?;
+    let registry = runtime_registry(handle)?;
     let ctx = {
         let registry = registry.lock().ok()?;
         registry.iter().find(|c| c.is_runtime(id)).cloned()?
@@ -426,22 +425,9 @@ pub(crate) fn current_runtime_ctx(handle: &Dial9Handle) -> Option<Arc<RuntimeCon
 /// owns it on first use. Find-or-insert under one lock, so racing attaches share
 /// one source. `None` if the source lock is poisoned or the recorder has shut
 /// down.
-pub(crate) fn runtime_registry(shared: &Arc<SharedState>) -> Option<RuntimeContextRegistry> {
-    shared
-        .with_sources_vec(|sources| {
-            if shared.is_stopped() {
-                return None;
-            }
-            let existing = sources.iter_mut().find_map(|source| {
-                let any: &mut dyn std::any::Any = &mut **source;
-                any.downcast_mut::<TokioRuntimesSource>()
-            });
-            if let Some(source) = existing {
-                return Some(source.registry().clone());
-            }
-            let registry: RuntimeContextRegistry = Arc::new(Mutex::new(Vec::new()));
-            sources.push(Box::new(TokioRuntimesSource::new(registry.clone())));
-            Some(registry)
-        })
-        .flatten()
+pub(crate) fn runtime_registry(handle: &Dial9Handle) -> Option<RuntimeContextRegistry> {
+    handle.with_source_or_insert(
+        || TokioRuntimesSource::new(Arc::new(Mutex::new(Vec::new()))),
+        |source| source.registry().clone(),
+    )
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
@@ -51,7 +51,7 @@
 use super::register_runtime_hooks;
 #[cfg(not(tokio_unstable))]
 use super::runtime_context::RuntimeContext;
-use super::runtime_context::{RuntimeContextRegistry, TokioRuntimesSource};
+use super::runtime_context::{RuntimeContextRegistry, TokioRuntimesSource, WorkerIdCounter};
 use crate::primitives::sync::{Arc, Mutex};
 use crate::telemetry::recorder::runtime_context::register_runtime_metrics;
 use crate::telemetry::task_dump_config::TaskDumpConfig;
@@ -358,7 +358,7 @@ impl Dial9HandleTokioExt for Dial9Handle {
         if !options.tokio_instrumentation_enabled {
             return builder.build();
         }
-        let Some(registry) = runtime_registry(self) else {
+        let Some(state) = tokio_attach_state(self) else {
             return Err(io::Error::other(
                 "dial9 source registry unavailable; Tokio runtime not attached",
             ));
@@ -373,6 +373,7 @@ impl Dial9HandleTokioExt for Dial9Handle {
             &mut builder,
             options.runtime_name,
             self,
+            state.worker_ids,
             options.task_tracking_enabled,
             options.tokio_hooks,
             task_dump_config,
@@ -388,7 +389,7 @@ impl Dial9HandleTokioExt for Dial9Handle {
         // `WakeTraced` wrapper, which finds this context by the runtime id it
         // is running on.
         ctx.bind_runtime(runtime.handle().id());
-        registry.lock().unwrap().push(ctx);
+        state.registry.lock().unwrap().push(ctx);
         // The current-thread driver does not fire `on_thread_start`, so without
         // this the tracing layer and `dial9::spawn` find no handle until the
         // first poll.
@@ -412,7 +413,7 @@ pub(crate) fn current_runtime_ctx(handle: &Dial9Handle) -> Option<Arc<RuntimeCon
     if let Some(ctx) = super::runtime_context::cached_runtime_ctx(id) {
         return Some(ctx);
     }
-    let registry = runtime_registry(handle)?;
+    let registry = tokio_attach_state(handle)?.registry;
     let ctx = {
         let registry = registry.lock().ok()?;
         registry.iter().find(|c| c.is_runtime(id)).cloned()?
@@ -421,13 +422,23 @@ pub(crate) fn current_runtime_ctx(handle: &Dial9Handle) -> Option<Arc<RuntimeCon
     Some(ctx)
 }
 
-/// The recorder's runtime registry, installing the [`TokioRuntimesSource`] that
-/// owns it on first use. Find-or-insert under one lock, so racing attaches share
-/// one source. `None` if the source lock is poisoned or the recorder has shut
-/// down.
-pub(crate) fn runtime_registry(handle: &Dial9Handle) -> Option<RuntimeContextRegistry> {
+/// What every runtime attached to a recorder shares, owned by its
+/// [`TokioRuntimesSource`].
+pub(crate) struct TokioAttachState {
+    /// The runtimes attached to this recorder.
+    pub registry: RuntimeContextRegistry,
+    /// Hands out this recorder's global worker-ID blocks.
+    pub worker_ids: WorkerIdCounter,
+}
+
+/// This recorder's [`TokioAttachState`], installing the source that owns it on
+/// first use.`None` once the recorder has shut down, or if its lock is poisoned.
+pub(crate) fn tokio_attach_state(handle: &Dial9Handle) -> Option<TokioAttachState> {
     handle.with_source_or_insert(
         || TokioRuntimesSource::new(Arc::new(Mutex::new(Vec::new()))),
-        |source| source.registry().clone(),
+        |source| TokioAttachState {
+            registry: source.registry().clone(),
+            worker_ids: source.worker_id_counter(),
+        },
     )
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -35,6 +35,9 @@ pub(crate) struct RuntimeContext {
     /// Installed on each of this runtime's threads (TL) so
     /// `Dial9Handle::current()`, the tracing layer, and `dial9::spawn` resolve.
     pub recorder_handle: Dial9Handle,
+    /// Global worker-ID counter, shared with every other runtime on this
+    /// recorder so their blocks never overlap.
+    worker_id_counter: WorkerIdCounter,
     /// Base worker ID for this runtime, reserved on the first worker resolve.
     #[cfg(tokio_unstable)]
     pub worker_id_base: OnceLock<u64>,
@@ -119,7 +122,7 @@ fn claim_thread_worker_id(ctx: &RuntimeContext) -> Option<u64> {
         if let Some((_, id)) = claimed.iter().find(|(owner, _)| *owner == ctx.id) {
             return Some(*id);
         }
-        let id = reserve_worker_ids(&ctx.recorder_handle, 1)?;
+        let id = ctx.worker_id_counter.fetch_add(1, Ordering::Relaxed);
         claimed.push((ctx.id, id));
         Some(id)
     })
@@ -236,10 +239,17 @@ pub(crate) struct TokioRuntimesSource {
     /// never change, so they are emitted exactly once (the writer keeps them in
     /// its merged cache and re-emits them on every rotation).
     fixed_metadata_emitted: bool,
-    /// Next unclaimed global worker ID. Every runtime on a recorder shares this
-    /// source, so it is what keeps their worker-ID blocks from overlapping.
-    next_worker_id: AtomicU64,
+    /// Next unclaimed global worker ID, shared with every [`RuntimeContext`] on
+    /// this recorder. Handing each context a clone at attach keeps the claim
+    /// path off the source lock.
+    next_worker_id: WorkerIdCounter,
 }
+
+/// Hands out the global worker IDs for one recorder.
+///
+/// Every runtime attached to a recorder shares one counter, which is what keeps
+/// their worker-ID blocks from overlapping.
+pub(crate) type WorkerIdCounter = Arc<AtomicU64>;
 
 impl TokioRuntimesSource {
     pub(crate) fn new(contexts: RuntimeContextRegistry) -> Self {
@@ -250,7 +260,7 @@ impl TokioRuntimesSource {
             sample_interval: Duration::from_millis(10),
             last_fingerprint: 0,
             fixed_metadata_emitted: false,
-            next_worker_id: AtomicU64::new(0),
+            next_worker_id: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -259,17 +269,11 @@ impl TokioRuntimesSource {
     pub(crate) fn registry(&self) -> &RuntimeContextRegistry {
         &self.contexts
     }
-}
 
-/// Reserve `count` consecutive global worker IDs, returning the first.
-///
-/// The counter lives on this recorder's [`TokioRuntimesSource`], which every
-/// attached runtime shares, so blocks handed to different runtimes never
-/// overlap. `None` before the source exists, or on a handle with no recorder.
-fn reserve_worker_ids(handle: &Dial9Handle, count: u64) -> Option<u64> {
-    handle.with_source(|source: &mut TokioRuntimesSource| {
-        source.next_worker_id.fetch_add(count, Ordering::Relaxed)
-    })
+    /// This recorder's worker-ID counter, for a context being attached.
+    pub(crate) fn worker_id_counter(&self) -> WorkerIdCounter {
+        self.next_worker_id.clone()
+    }
 }
 
 /// Give the source the metrics of a freshly built runtime (paired with its
@@ -381,13 +385,18 @@ impl Source for TokioRuntimesSource {
 }
 
 impl RuntimeContext {
-    pub(crate) fn new(runtime_name: Option<String>, recorder_handle: Dial9Handle) -> Self {
+    pub(crate) fn new(
+        runtime_name: Option<String>,
+        recorder_handle: Dial9Handle,
+        worker_id_counter: WorkerIdCounter,
+    ) -> Self {
         static NEXT_ID: AtomicU64 = AtomicU64::new(1);
         Self {
             id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
             runtime_id: OnceLock::new(),
             runtime_name,
             recorder_handle,
+            worker_id_counter,
             #[cfg(tokio_unstable)]
             worker_id_base: OnceLock::new(),
             worker_ids: Mutex::new(BTreeSet::new()),
@@ -500,16 +509,13 @@ impl RuntimeContext {
     #[cfg(tokio_unstable)]
     fn claim_worker_id(&self) -> Option<u64> {
         let local_index = tokio::runtime::worker_index()?;
-        let base = match self.worker_id_base.get() {
-            Some(base) => *base,
-            // Reserving is fallible, so it happens outside `get_or_init`, which
-            // then settles any race by handing every caller the winner's block.
-            None => {
-                let num_workers = worker_metrics(|m| m.num_workers()) as u64;
-                let reserved = reserve_worker_ids(&self.recorder_handle, num_workers)?;
-                *self.worker_id_base.get_or_init(|| reserved)
-            }
-        };
+        // `get_or_init` runs its closure exactly once, so the block is reserved
+        // once however many workers resolve at the same moment.
+        let base = self.worker_id_base.get_or_init(|| {
+            let num_workers = worker_metrics(|m| m.num_workers()) as u64;
+            self.worker_id_counter
+                .fetch_add(num_workers, Ordering::Relaxed)
+        });
         Some(base + local_index as u64)
     }
 }
@@ -789,6 +795,7 @@ mod tests {
         let ctx = Arc::new(RuntimeContext::new(
             Some(name.to_string()),
             Dial9Handle::disabled(),
+            Arc::new(AtomicU64::new(0)),
         ));
         ctx.worker_ids.lock().unwrap().insert(worker_id);
         contexts.lock().unwrap().push(ctx);

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -1,4 +1,3 @@
-use super::SharedState;
 use super::source::{FlushContext, Source};
 #[cfg(not(tokio_unstable))]
 use crate::primitives::sync::Weak;
@@ -115,13 +114,12 @@ fn worker_metrics<R>(f: impl FnOnce(&RuntimeMetrics) -> R) -> R {
 /// there rather than reusing the one it holds in another runtime's block.
 #[cfg(not(tokio_unstable))]
 fn claim_thread_worker_id(ctx: &RuntimeContext) -> Option<u64> {
-    let shared = ctx.recorder_handle.shared()?;
     CLAIMED_WORKER_IDS.with(|claimed| {
         let mut claimed = claimed.borrow_mut();
         if let Some((_, id)) = claimed.iter().find(|(owner, _)| *owner == ctx.id) {
             return Some(*id);
         }
-        let id = shared.reserve_worker_ids(1);
+        let id = ctx.recorder_handle.reserve_worker_ids(1)?;
         claimed.push((ctx.id, id));
         Some(id)
     })
@@ -265,21 +263,14 @@ impl TokioRuntimesSource {
 ///
 /// Called once per attach, after the caller's runtime exists.
 pub(crate) fn register_runtime_metrics(
-    shared: &SharedState,
+    handle: &Dial9Handle,
     runtime_name: Option<String>,
     metrics: RuntimeMetrics,
 ) {
-    let mut entry = Some((runtime_name, metrics));
-    shared.with_sources_mut(|sources| {
-        for source in sources.iter_mut() {
-            let any: &mut dyn std::any::Any = &mut **source;
-            if let Some(source) = any.downcast_mut::<TokioRuntimesSource>() {
-                source.runtime_metrics.extend(entry.take());
-                return;
-            }
-        }
+    let registered = handle.with_source(|source: &mut TokioRuntimesSource| {
+        source.runtime_metrics.push((runtime_name, metrics));
     });
-    if entry.is_some() {
+    if registered.is_none() {
         tracing::warn!("Tokio source missing; queue depth will not be sampled");
     }
 }
@@ -494,10 +485,16 @@ impl RuntimeContext {
     #[cfg(tokio_unstable)]
     fn claim_worker_id(&self) -> Option<u64> {
         let local_index = tokio::runtime::worker_index()?;
-        let shared = self.recorder_handle.shared()?;
+        // Checked up front so the `OnceLock` init below stays infallible and
+        // the whole runtime's block is reserved exactly once.
+        if !self.recorder_handle.is_connected() {
+            return None;
+        }
         let base = self.worker_id_base.get_or_init(|| {
             let num_workers = worker_metrics(|m| m.num_workers()) as u64;
-            shared.reserve_worker_ids(num_workers)
+            self.recorder_handle
+                .reserve_worker_ids(num_workers)
+                .expect("handle checked above")
         });
         Some(base + local_index as u64)
     }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -119,7 +119,7 @@ fn claim_thread_worker_id(ctx: &RuntimeContext) -> Option<u64> {
         if let Some((_, id)) = claimed.iter().find(|(owner, _)| *owner == ctx.id) {
             return Some(*id);
         }
-        let id = ctx.recorder_handle.reserve_worker_ids(1)?;
+        let id = reserve_worker_ids(&ctx.recorder_handle, 1)?;
         claimed.push((ctx.id, id));
         Some(id)
     })
@@ -236,6 +236,9 @@ pub(crate) struct TokioRuntimesSource {
     /// never change, so they are emitted exactly once (the writer keeps them in
     /// its merged cache and re-emits them on every rotation).
     fixed_metadata_emitted: bool,
+    /// Next unclaimed global worker ID. Every runtime on a recorder shares this
+    /// source, so it is what keeps their worker-ID blocks from overlapping.
+    next_worker_id: AtomicU64,
 }
 
 impl TokioRuntimesSource {
@@ -247,6 +250,7 @@ impl TokioRuntimesSource {
             sample_interval: Duration::from_millis(10),
             last_fingerprint: 0,
             fixed_metadata_emitted: false,
+            next_worker_id: AtomicU64::new(0),
         }
     }
 
@@ -255,6 +259,17 @@ impl TokioRuntimesSource {
     pub(crate) fn registry(&self) -> &RuntimeContextRegistry {
         &self.contexts
     }
+}
+
+/// Reserve `count` consecutive global worker IDs, returning the first.
+///
+/// The counter lives on this recorder's [`TokioRuntimesSource`], which every
+/// attached runtime shares, so blocks handed to different runtimes never
+/// overlap. `None` before the source exists, or on a handle with no recorder.
+fn reserve_worker_ids(handle: &Dial9Handle, count: u64) -> Option<u64> {
+    handle.with_source(|source: &mut TokioRuntimesSource| {
+        source.next_worker_id.fetch_add(count, Ordering::Relaxed)
+    })
 }
 
 /// Give the source the metrics of a freshly built runtime (paired with its
@@ -485,17 +500,16 @@ impl RuntimeContext {
     #[cfg(tokio_unstable)]
     fn claim_worker_id(&self) -> Option<u64> {
         let local_index = tokio::runtime::worker_index()?;
-        // Checked up front so the `OnceLock` init below stays infallible and
-        // the whole runtime's block is reserved exactly once.
-        if !self.recorder_handle.is_connected() {
-            return None;
-        }
-        let base = self.worker_id_base.get_or_init(|| {
-            let num_workers = worker_metrics(|m| m.num_workers()) as u64;
-            self.recorder_handle
-                .reserve_worker_ids(num_workers)
-                .expect("handle checked above")
-        });
+        let base = match self.worker_id_base.get() {
+            Some(base) => *base,
+            // Reserving is fallible, so it happens outside `get_or_init`, which
+            // then settles any race by handing every caller the winner's block.
+            None => {
+                let num_workers = worker_metrics(|m| m.num_workers()) as u64;
+                let reserved = reserve_worker_ids(&self.recorder_handle, num_workers)?;
+                *self.worker_id_base.get_or_init(|| reserved)
+            }
+        };
         Some(base + local_index as u64)
     }
 }

--- a/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs
@@ -122,7 +122,7 @@ fn claim_thread_worker_id(ctx: &RuntimeContext) -> Option<u64> {
         if let Some((_, id)) = claimed.iter().find(|(owner, _)| *owner == ctx.id) {
             return Some(*id);
         }
-        let id = ctx.worker_id_counter.fetch_add(1, Ordering::Relaxed);
+        let id = ctx.reserve_worker_ids(1);
         claimed.push((ctx.id, id));
         Some(id)
     })
@@ -501,6 +501,11 @@ impl RuntimeContext {
         Some(WorkerId::from(global_id as usize))
     }
 
+    /// Reserve a block of `count` global worker IDs, returning the first.
+    fn reserve_worker_ids(&self, count: u64) -> u64 {
+        self.worker_id_counter.fetch_add(count, Ordering::Relaxed)
+    }
+
     /// This thread's global worker ID within this runtime.
     ///
     /// Tokio's `worker_index()` gives the runtime-local slot (0 for a
@@ -513,8 +518,7 @@ impl RuntimeContext {
         // once however many workers resolve at the same moment.
         let base = self.worker_id_base.get_or_init(|| {
             let num_workers = worker_metrics(|m| m.num_workers()) as u64;
-            self.worker_id_counter
-                .fetch_add(num_workers, Ordering::Relaxed)
+            self.reserve_worker_ids(num_workers)
         });
         Some(base + local_index as u64)
     }

--- a/perf-self-profile/src/memory_profiling/profiler.rs
+++ b/perf-self-profile/src/memory_profiling/profiler.rs
@@ -168,7 +168,7 @@ impl MemoryProfiler {
     /// hook short-circuits. A connected-but-paused recorder installs
     /// normally, so sampling starts when recording is enabled.
     pub fn install(self, handle: Dial9Handle) -> Result<MemoryProfilerGuard, InstallError> {
-        if handle.shared().is_none() {
+        if !handle.is_connected() {
             return Ok(MemoryProfilerGuard { _private: () });
         }
 
@@ -207,10 +207,11 @@ impl MemoryProfiler {
             .set(inner)
             .map_err(|_| InstallError::AlreadyInstalled)?;
 
-        let shared = handle.shared().expect("checked is_enabled above");
-        let source =
-            MemoryProfileSource::new(rings, source_liveset, self.config.sample_rate_bytes());
-        shared.push_source(Box::new(source));
+        // Registered once: `ACTIVE.set` above already refuses a second install.
+        handle.with_source_or_insert(
+            || MemoryProfileSource::new(rings, source_liveset, self.config.sample_rate_bytes()),
+            |_| (),
+        );
 
         Ok(MemoryProfilerGuard { _private: () })
     }


### PR DESCRIPTION
Last of the series. #784 moves recording onto the handle, #786 did the future wrappers, this one closes out the remaining reach-throughs and takes the type off the public API.

Three things still went through `SharedState`: the source registry, worker-id reservation, and a connectivity check. Each gets a `Dial9Handle` method.

### Source registry

`runtime_registry` and `register_runtime_metrics` both open-coded the same thing, find my source of type `T` (or insert one), via `with_sources_vec`/`with_sources_mut` plus a manual `downcast_mut`. `Dial9Handle::with_source` and `with_source_or_insert` do it once.

`push_source` gets a handle method too. It was already advertised as an extension point in `Dial9Handle::shared`'s own doc, so it needed a real home regardless. The memory profiler was the one production caller.

### Worker IDs

`Dial9Handle::reserve_worker_ids`. `claim_worker_id` checks the handle up front so the `OnceLock` init stays infallible, making the init fallible instead would let two first-resolving threads each reserve a block and leak the loser's.

### is_connected

Three call sites wanted "connected to a recorder, regardless of pause", spelled `shared().is_some()`. `is_enabled`'s docs pointed at that spelling and the memory profiler's `install` doc already described its argument as a "disconnected handle", so the concept was there without a name.

### Visibility

`shared_state`, `SharedState`, `Dial9Handle::shared` and `Recorder::shared` move behind `test_util_pub!`, the macro already in `lib.rs` for this. They stay `pub` under `test-util` and go `pub(crate)` otherwise. Both `#[doc(hidden)]` markers are deleted.