### PR TITLE
feat(core): one recorder per process

### DIFF
--- a/.github/actions/rust-build/action.yml
+++ b/.github/actions/rust-build/action.yml
@@ -62,3 +62,6 @@ runs:
               else
                   cargo test --all-targets --features __nonlinux_all_features
               fi
+              # dial9-core alone: `test-util` is off here, so the single-recorder
+              # guard is compiled in.
+              cargo test -p dial9-core --lib

--- a/.github/actions/rust-build/action.yml
+++ b/.github/actions/rust-build/action.yml
@@ -63,5 +63,6 @@ runs:
                   cargo test --all-targets --features __nonlinux_all_features
               fi
               # dial9-core alone: `test-util` is off here, so the single-recorder
-              # guard is compiled in.
-              cargo test -p dial9-core --lib
+              # guard is compiled in. Serial because the guard allows one
+              # recorder at a time, and thread-per-test would overlap them.
+              cargo test -p dial9-core --lib -- --test-threads=1

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -17,6 +17,8 @@
 //! recording state with sources already registered. The Tokio integration
 //! reuses the same builder.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use crate::buffer::{BufferMode, Disk, SegmentWriter};
 use crate::clock;
 use crate::handle::Dial9Handle;
@@ -107,6 +109,31 @@ fn builder_with<M: BufferMode>(writer: Option<SegmentWriter<M>>) -> RecorderBuil
 pub fn recorder_disabled() -> crate::recording::Recorder {
     crate::recording::Recorder::new(crate::handle::Dial9Handle::disabled(), None)
 }
+
+/// Proof that this recorder is the only one in the process, released on drop.
+#[derive(Debug)]
+pub(crate) struct SoleRecorderGuard;
+
+impl SoleRecorderGuard {
+    /// Claim the process, or `None` if another recorder holds it.
+    ///
+    /// Always granted under `test-util`, where the suite runs many recorders at
+    /// once.
+    pub(crate) fn claim() -> Option<Self> {
+        match cfg!(feature = "test-util") || !RECORDER_TAKEN.swap(true, Ordering::SeqCst) {
+            true => Some(Self),
+            false => None,
+        }
+    }
+}
+
+impl Drop for SoleRecorderGuard {
+    fn drop(&mut self) {
+        RECORDER_TAKEN.store(false, Ordering::SeqCst);
+    }
+}
+
+static RECORDER_TAKEN: AtomicBool = AtomicBool::new(false);
 
 /// Assemble dial9's default pipeline: source-requested stages
 /// (for example symbolization), then compression, then a terminal stage —
@@ -240,6 +267,14 @@ impl<M: BufferMode> RecorderBuilder<M> {
             return recorder_disabled();
         };
 
+        let Some(sole_recorder) = SoleRecorderGuard::claim() else {
+            tracing::error!(
+                target: "dial9",
+                "dial9: this process already has a recorder, this one will run without telemetry."
+            );
+            return recorder_disabled();
+        };
+
         let shared = Arc::new(SharedState::new(clock::clock_monotonic_ns()));
 
         // Install the on-demand dump trigger so `Dial9Handle::dump_trigger` can
@@ -315,6 +350,7 @@ impl<M: BufferMode> RecorderBuilder<M> {
         let hook = self.thread_init.clone();
         #[allow(unused_mut)]
         let mut recorder = Recorder::start(shared, writer, self.metrics_sink, move || hook());
+        recorder.hold_process(sole_recorder);
 
         #[cfg(feature = "pipeline")]
         if let Some(worker) = worker {
@@ -617,6 +653,7 @@ mod tests {
         assert_eq!(runs.load(Ordering::SeqCst), 1, "hook runs at build");
         live.enable();
         assert_eq!(runs.load(Ordering::SeqCst), 1, "hook runs at most once");
+        drop(live);
 
         let paused_runs = StdArc::new(AtomicUsize::new(0));
         let paused_hook = StdArc::clone(&paused_runs);
@@ -880,6 +917,33 @@ mod tests {
         assert_eq!(
             started, stopped,
             "every thread that ran the hook should run its teardown"
+        );
+    }
+}
+
+#[cfg(all(test, not(feature = "test-util")))]
+mod single_recorder_tests {
+    use super::*;
+    use crate::buffer::MemoryBuffer;
+
+    #[test]
+    fn a_second_recorder_in_the_process_is_refused() {
+        let first = recorder(MemoryBuffer::new(1 << 20).unwrap()).build();
+        assert!(first.handle().is_connected(), "the first one records");
+
+        let second = recorder(MemoryBuffer::new(1 << 20).unwrap()).build();
+        assert!(
+            !second.handle().is_connected(),
+            "the process already has a recorder, so this one is inert"
+        );
+
+        drop(second);
+        drop(first);
+
+        let after = recorder(MemoryBuffer::new(1 << 20).unwrap()).build();
+        assert!(
+            after.handle().is_connected(),
+            "the slot frees up once the holder stops"
         );
     }
 }

--- a/dial9-core/src/recording.rs
+++ b/dial9-core/src/recording.rs
@@ -3,6 +3,7 @@ use crate::flush_loop::run_flush_loop;
 use crate::handle::{ControlCommand, Dial9Handle, InstallGlobalHandleError};
 use crate::primitives::sync::{Arc, Mutex};
 use crate::primitives::{sync::mpsc, thread::JoinHandle};
+use crate::recorder::SoleRecorderGuard;
 use crate::shared_state::SharedState;
 use std::time::Duration;
 
@@ -41,6 +42,8 @@ pub struct Recorder {
     flush_thread: Option<JoinHandle<()>>,
     /// Hooks run once, with the handle, on the first `enable()`.
     recording_start_hooks: Mutex<Vec<RecordingStartHook>>,
+    /// Held while this is the process's recorder. Dropping it frees the slot.
+    sole_recorder: Option<SoleRecorderGuard>,
     #[cfg(feature = "pipeline")]
     worker: Option<WorkerHandle>,
 }
@@ -65,9 +68,15 @@ impl Recorder {
             handle,
             flush_thread,
             recording_start_hooks: Mutex::new(Vec::new()),
+            sole_recorder: None,
             #[cfg(feature = "pipeline")]
             worker: None,
         }
+    }
+
+    /// Hold the process's recorder slot for this recorder's lifetime.
+    pub(crate) fn hold_process(&mut self, guard: crate::recorder::SoleRecorderGuard) {
+        self.sole_recorder = Some(guard);
     }
 
     /// Install the one-shot hooks to run on the first `enable()`.

--- a/dial9/Cargo.toml
+++ b/dial9/Cargo.toml
@@ -152,7 +152,7 @@ dial9 = { path = ".", features = [
     "unstable-events",
     "worker-s3",
 ] }
-dial9-core = { workspace = true }
+dial9-core = { workspace = true, features = ["test-util"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = [
     "rt-multi-thread",


### PR DESCRIPTION
Stops a single process ending up with two recorders by accident. Running several processes that each have their own is unaffected.

Within one process the second recorder wouldn't work properly: it cannot claim the memory profiler, the allocator, CPU profiling or the process-global handle, since the first already holds them, and a thread that records into both mixes their
events into one trace.

### Changes
`build` now refuses building a second recorder for a thread which already has one. The second recorder comes back disabled with an `error!` saying what happened. A `SoleRecorderGuard` frees the slot when the recorder drops, so tearing one down and starting another still works.

Tests build many recorders at once, so the guard is off under `test-util`, which every workspace test run enables. A new CI step runs `cargo test -p dial9-core --lib` without it, where the guard is live and covered by a test.
